### PR TITLE
Reduced logging and failure messages on decrypt script

### DIFF
--- a/scripts/key_placer.sh
+++ b/scripts/key_placer.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
 
 # Note: Encryption includes changing the metadata with a timestamp of when
 # the file was encrypted, so every time you run this it will produce a diff
@@ -8,7 +6,7 @@ set -euo pipefail
 
 # files to be processed
 
-echo "Processing ecrypted files"
+echo "Processing encrypted files"
 
 files=(
   "packages/mobile/android/app/google-services.json"
@@ -38,14 +36,27 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 cd ..
 
+
+command -v gcloud > /dev/null 2>&1
+
+if [[ $? -eq 1 ]]; then
+  echo "gcloud is not installed - skipping decryption"
+  exit 0
+fi
+
 for file_path in "${files[@]}"; do
   file_path_without_extension=`echo "$file_path" | sed "s/.*\///"`
   file_dir=$(dirname "${file_path}")
-  echo $file_path_without_extension
   encrypted="$file_dir/$file_path_without_extension.enc"
 
-  echo "Processing $file_path to $encrypted"
-  gcloud kms $1 --ciphertext-file=$encrypted --plaintext-file=$file_path --key=github-key --keyring=celo-keyring --location=global --project celo-testnet \
-  || echo "Could not process file, maybe you don't have access to KMS? Note only C-labs keys would be able to decrypt files in this repo." \
-  || true # this makes the script return 0 even if the gcloud kms command failed
+  if test -f "$encrypted"; then
+    gcloud kms $1 --ciphertext-file=$encrypted --plaintext-file=$file_path --key=github-key --keyring=celo-keyring --location=global --project celo-testnet > /dev/null 2>&1
+    if [[ $? -eq 1 ]]; then
+      echo "Only C Labs employees can decrypt keys - skipping decryption"
+      exit 0
+    fi
+  fi
 done
+
+echo "Encrypted files decrypted"
+exit 0


### PR DESCRIPTION
### Description

The decryption script added some unnecessary messages and failures being logged

### Tested

Ran with no gcloud, a different account logged in, and my account logged in
