### PR TITLE
Remove redundant copy in RedeemInvite and use 'billetera Celo' everywhere

### DIFF
--- a/packages/mobile/locales/en-US/nuxNamePin1.json
+++ b/packages/mobile/locales/en-US/nuxNamePin1.json
@@ -11,9 +11,9 @@
   "welcomeCelo": "Welcome to Celo",
   "inviteText": {
     "0":
-      "Enter your invitation code. If you do not have one, ask someone in the Celo Community to invite you. You can paste the entire invite message as your invite code.",
+      "Enter your invitation code. You can also paste the entire invite message as your invite code.",
     "1":
-      "By joining this network, you agree to allow us to collect anonymized information about how you use the app. Additionally, if you verify your phone number, an obfuscated opy of it will be stored on the Celo Network. Learn more at ",
+      "By joining this network, you agree to allow us to collect anonymized information about how you use the app. Additionally, if you verify your phone number, an obfuscated copy of it will be stored on the Celo Network. Learn more at ",
     "2": "celo.org/terms",
     "askForInvite": {
       "0": "Don't have a code? ",

--- a/packages/mobile/locales/es-AR/backupKeyFlow6.json
+++ b/packages/mobile/locales/es-AR/backupKeyFlow6.json
@@ -79,7 +79,7 @@
     "No pierda esta clave. Es de suma importancia que la mantenga en un lugar seguro, ya que es la única forma de desbloquear su billetera si pierde su celular.",
   "done": "Listo",
   "whatsappMessage":
-    "Importante: por favor mantenga esto privado. \n\nTe estoy enviando la frase de respaldo a mi Billetera de Celo: ",
+    "Importante: por favor mantenga esto privado. \n\nTe estoy enviando la frase de respaldo a mi billetera Celo: ",
   "backupPrompt":
     "Para la seguridad de sus fondos, su cuenta está congelada hasta que obtenga su clave de respaldo",
   "copyToClipboard": "Copiar al portapapeles",

--- a/packages/mobile/locales/es-AR/global.json
+++ b/packages/mobile/locales/es-AR/global.json
@@ -32,7 +32,7 @@
   "startEarning": "Comenzar a ganar",
   "backToWallet": "Volver a la Billetera",
   "exchangeForGold": "Cambiar a Oro",
-  "restoreCeloWallet": "Restaurar la billetera de Celo",
+  "restoreCeloWallet": "Restaurar la billetera Celo",
   "invalidKey": "Clave de respaldo inválida ",
   "invalidPhone": "Número de teléfono inválido",
   "invalidAmount": "Monto invalido",

--- a/packages/mobile/locales/es-AR/nuxCurrencyPhoto4.json
+++ b/packages/mobile/locales/es-AR/nuxCurrencyPhoto4.json
@@ -20,8 +20,7 @@
   "addressPhotos": "Celo usa sus contactos para mostrar fotos",
   "changePhotos": "Puede cambiar una foto si actualiza los contactos",
   "localPhotos": "Solo usted puede ver estas fotos desde su teléfono",
-  "allowContactAccess":
-    "Permita que la Billetera de Celo tenga acceso a las fotos de sus contactos",
+  "allowContactAccess": "Permita que la billetera Celo tenga acceso a las fotos de sus contactos",
   "deny": "Denegar",
   "allow": "Permitir"
 }

--- a/packages/mobile/locales/es-AR/nuxNamePin1.json
+++ b/packages/mobile/locales/es-AR/nuxNamePin1.json
@@ -12,13 +12,13 @@
   "welcomeCelo": "Le damos la bienvenida a Celo",
   "inviteText": {
     "0":
-      "Ingrese su código de invitación. Si no tiene uno, pídale a alguien de la comunidad de Celo que lo invite. Puede pegar el mensaje de invitación completo como su código de invitación.",
+      "Ingrese su código de invitación. También puede pegar el mensaje de invitación completo como su código de invitación.",
     "1":
       "Al aceptar la solicitud, usted acepta permitirnos recopilar información que nos ayude a mejorar la experiencia. Obtenga más información en ",
     "2": "celo.org",
     "askForInvite": {
       "1":
-        "Solicite una invitación a alguien con Celo Wallet o regístrese para obtener una cuenta de testnet en",
+        "Solicite una invitación a alguien con billetera Celo o regístrese para obtener una cuenta de testnet en",
       "2": "celo.org/build/wallet"
     }
   },
@@ -30,14 +30,14 @@
   "redeemingInvite": "Confirmando invitación",
   "redeemingDescription":
     "Por favor espere. Esto puede tomar algunos miniutos. Por favor dejá la aplicación abierta.",
-  "haveWallet": "¿Ya tiene una billetera de Celo? ",
+  "haveWallet": "¿Ya tiene una billetera Celo? ",
   "importIt": "Importar",
   "invalidInvite": "Código de invitación inválido",
   "cancel": "Cancelar",
   "important": "Importante",
   "createPin": {
     "title": "Crear un código PIN de 6 dígitos",
-    "intro": "Cree un PIN para proteger su billetera de Celo.",
+    "intro": "Cree un PIN para proteger su billetera Celo.",
     "why": "En ciertos casos, necesitará este PIN para enviar Celo Dólares a sus amigos.",
     "warn":
       "escriba su código PIN de 6 dígitos en un papel y guárdelo en algún sitio seguro. Se lo solicitaremos más tarde para acceder a su billetera.",

--- a/packages/mobile/locales/es-AR/nuxRestoreWallet3.json
+++ b/packages/mobile/locales/es-AR/nuxRestoreWallet3.json
@@ -5,12 +5,12 @@
   "fullName": "Nombre completo",
   "invitationCode": "Código de invitación",
   "submit": "Enviar",
-  "alreadyHaveWallet": "¿Ya tiene una billetera de Celo? Restáurela",
-  "restoreWallet": "Restaurar la billetera de Celo",
+  "alreadyHaveWallet": "¿Ya tiene una billetera Celo? Restáurela",
+  "restoreWallet": "Restaurar la billetera Celo",
   "restoreYourWallet": {
-    "title": "Restaurar su billetera de Celo",
+    "title": "Restaurar su billetera Celo",
     "userYourBackupKey":
-      "¿Ya tiene una billetera de Celo? Use su clave de respaldo segura para restaurar su billetera a este teléfono.",
+      "¿Ya tiene una billetera Celo? Use su clave de respaldo segura para restaurar su billetera a este teléfono.",
     "warning": "¡Cuidado! ",
     "restoreInPrivate": "Hágalo en privado"
   },

--- a/packages/mobile/locales/es-AR/nuxVerification2.json
+++ b/packages/mobile/locales/es-AR/nuxVerification2.json
@@ -14,7 +14,7 @@
   "country": "País",
   "phoneNumber": "Número de teléfono",
   "invalidPhone": "Número de teléfono inválido",
-  "allowSmsPermissions": "Permitir que la billetera de Celo envíe y vea mensajes SMS",
+  "allowSmsPermissions": "Permitir que la billetera Celo envíe y vea mensajes SMS",
   "dontAsk": "No volver a preguntar",
   "deny": "Denegar",
   "allow": "Permitir",


### PR DESCRIPTION
### Description

Remove `If you do not have one, ask someone in the Celo Community to invite you.` from Redeem Invite screen as similar info is on bottom of screen.

Use `billetera Celo` instead of `billetera de Celo` everywhere in the Spanish ver of app.

### Tested

![Screenshot_20190717-134106_Celo (DEV)](https://user-images.githubusercontent.com/15326838/61373051-0e9acf00-a899-11e9-8ecb-8164a02cf559.jpg)
