### PR TITLE
Fix typo and add playstore link in faucet message

### DIFF
--- a/packages/faucet/src/database-helper.ts
+++ b/packages/faucet/src/database-helper.ts
@@ -122,7 +122,7 @@ function buildHandleInvite(request: RequestRecord, snap: DataSnapshot, config: N
     await escrowTx.waitReceipt()
 
     if (config.twilioClient) {
-      const messageText = `Hello! Thanks you for joining the Celo payments network. Your invite code is: ${inviteCode}`
+      const messageText = `Hello! Thank you for joining the Celo network. Your invite code is: ${inviteCode}. Download the app at https://play.google.com/store/apps/details?id=org.celo.mobile.alfajores`
       await config.twilioClient.messages.create({
         body: messageText,
         from: config.twilioPhoneNumber,


### PR DESCRIPTION
### Description

The invite message contained a typo and didn't include the playstore link.

### Tested

- Deployed them to `alfajores` and received the new message
