### PR TITLE
Use https for git checkout

### DIFF
--- a/packages/celotool/ci_test_integration_sync.sh
+++ b/packages/celotool/ci_test_integration_sync.sh
@@ -18,7 +18,7 @@ if [ "${1}" == "checkout" ]; then
     # this test will fail. This will force someone to keep updating the COMMIT_HASH_TO_TEST we are
     # testing. Clone up to 20 takes about 4 seconds on my machine and a full clone is
     # about 60 seconds as of May 20, 2019. The difference will only grow over time.
-    git clone --depth 20 git@github.com:celo-org/celo-blockchain.git ${GETH_DIR} && cd ${GETH_DIR} && git checkout ${COMMIT_HASH_TO_TEST} && cd -
+    git clone --depth 20 https://github.com/celo-org/celo-blockchain.git ${GETH_DIR} && cd ${GETH_DIR} && git checkout ${COMMIT_HASH_TO_TEST} && cd -
 elif [ "${1}" == "local" ]; then
     export GETH_DIR="${2}"
     echo "Testing using local geth dir ${GETH_DIR}..."

--- a/packages/celotool/geth_tests/src/lib/utils.ts
+++ b/packages/celotool/geth_tests/src/lib/utils.ts
@@ -149,7 +149,7 @@ export async function checkoutGethRepo(branch: string, path: string) {
     'clone',
     '--depth',
     '1',
-    'git@github.com:celo-org/celo-blockchain.git',
+    'https://github.com/celo-org/celo-blockchain.git',
     path,
     '-b',
     branch,

--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.14",
     "prettier": "1.13.5",
     "sleep-promise": "^8.0.1",
-    "typechain": "git+https://git@github.com/celo-org/TypeChain.git#ce6a33b",
+    "typechain": "git+https://github.com/celo-org/TypeChain.git#ce6a33b",
     "typescript": "^3.3.3"
   },
   "devDependencies": {
@@ -53,7 +53,7 @@
     "@types/web3": "^1.0.18",
     "chalk": "^2.4.2",
     "prettier": "1.13.5",
-    "typechain": "git+https://git@github.com/celo-org/TypeChain.git#ce6a33b",
+    "typechain": "git+https://github.com/celo-org/TypeChain.git#ce6a33b",
     "typescript": "^3.3.3",
     "babel-jest": "^24.8.0",
     "jest": "^24.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26094,18 +26094,8 @@ type-is@~1.6.17:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-"typechain@git+https://git@github.com/celo-org/TypeChain.git#ce6a33b":
-  version "0.3.11"
-  resolved "git+https://git@github.com/celo-org/TypeChain.git#ce6a33b06af43da8c3997a9d0ed1d27683d24bd9"
-  dependencies:
-    command-line-args "^4.0.7"
-    debug "^3.0.1"
-    fs-extra "^7.0.0"
-    ts-generator "^0.0.8"
-
 "typechain@git+https://github.com/celo-org/TypeChain.git#ce6a33b":
   version "0.3.11"
-  uid ce6a33b06af43da8c3997a9d0ed1d27683d24bd9
   resolved "git+https://github.com/celo-org/TypeChain.git#ce6a33b06af43da8c3997a9d0ed1d27683d24bd9"
   dependencies:
     command-line-args "^4.0.7"


### PR DESCRIPTION
### Description

Use https for git checkout given that all of our repositories are open-source.

### Tested

`$ yarn` works