### PR TITLE
Remove Celo Default Recipient

### DIFF
--- a/packages/mobile/locales/en-US/sendFlow7.json
+++ b/packages/mobile/locales/en-US/sendFlow7.json
@@ -37,6 +37,7 @@
   "total": "Total",
   "inviteFriends": "Invite Friends",
   "noResultsFor": "No results for",
+  "noContacts": "No contacts found",
   "searchForSomeone": "Search for someone using their name or phone number",
   "nameOrPhoneNumber": "Name or Phone Number",
   "pending": "Pending",

--- a/packages/mobile/locales/es-AR/sendFlow7.json
+++ b/packages/mobile/locales/es-AR/sendFlow7.json
@@ -36,6 +36,7 @@
   "total": "Total",
   "inviteFriends": "Invitar a amigos",
   "noResultsFor": "Sin resultados para",
+  "noContacts": "No se encontraron contactos",
   "searchForSomeone": "Busque a alguien según el nombre o el número de teléfono",
   "nameOrPhoneNumber": "Nombre o número de teléfono",
   "pending": "Pendiente",

--- a/packages/mobile/src/account/__snapshots__/Invite.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Invite.test.tsx.snap
@@ -155,24 +155,7 @@ exports[`Invite renders correctly 1`] = `
                 }
               }
             >
-              noResultsFor
-            </Text>
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2E3338",
-                    "fontFamily": "Hind-Regular",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                  },
-                  Object {
-                    "color": "#2E3338",
-                  },
-                ]
-              }
-            >
-               ""
+              noContacts
             </Text>
           </View>
           <Text

--- a/packages/mobile/src/send/RecipientPicker.tsx
+++ b/packages/mobile/src/send/RecipientPicker.tsx
@@ -100,10 +100,16 @@ export class RecipientPicker extends React.Component<RecipientProps> {
   renderNoContentEmptyView = () => (
     <View style={style.emptyView}>
       <View style={style.emptyViewBody}>
-        <Text style={fontStyles.body}>{this.props.t('noResultsFor')}</Text>
-        <Text style={[fontStyles.body, style.emptyViewBodyDark]}>
-          {` "${this.props.searchQuery}"`}
-        </Text>
+        {this.props.searchQuery !== '' ? (
+          <>
+            <Text style={fontStyles.body}>{this.props.t('noResultsFor')}</Text>
+            <Text style={[fontStyles.body, style.emptyViewBodyDark]}>
+              {` "${this.props.searchQuery}"`}
+            </Text>
+          </>
+        ) : (
+          <Text style={fontStyles.body}>{this.props.t('noContacts')}</Text>
+        )}
       </View>
       <Text style={[fontStyles.bodySmall, style.emptyViewBodySmall]}>
         {this.props.t('searchForSomeone')}

--- a/packages/mobile/src/send/Send.tsx
+++ b/packages/mobile/src/send/Send.tsx
@@ -27,8 +27,6 @@ import {
   filterRecipients,
   NumberToRecipient,
   Recipient,
-  RecipientKind,
-  RecipientWithQrCode,
 } from 'src/utils/recipient'
 
 interface State {
@@ -69,17 +67,6 @@ const mapStateToProps = (state: RootState): StateProps => ({
 let recentCache: Recipient[] | null = null
 
 const THROTTLE_TIME = 50
-
-const defaultRecipientPhoneNumber = '+10000000000'
-
-// For alfajores-net users to be able to send a small transaction to a sample address (remove post-alfajores)
-export const CeloDefaultRecipient: RecipientWithQrCode = {
-  address: '0xce10ce10ce10ce10ce10ce10ce10ce10ce10ce10',
-  displayName: 'Celo Default Recipient',
-  displayPhoneNumber: defaultRecipientPhoneNumber,
-  kind: RecipientKind.QrCode,
-  e164PhoneNumber: defaultRecipientPhoneNumber,
-}
 
 type FilterType = (searchQuery: string) => Recipient[]
 class Send extends React.Component<Props, State> {
@@ -124,7 +111,7 @@ class Send extends React.Component<Props, State> {
   updateFilters() {
     this.setState(
       {
-        recentRecipients: [CeloDefaultRecipient, ...this.state.recentRecipients],
+        recentRecipients: this.state.recentRecipients,
       },
       () => {
         this.recentRecipientsFilter = filterRecipientFactory(this.state.recentRecipients, false)
@@ -182,9 +169,7 @@ class Send extends React.Component<Props, State> {
       return
     }
 
-    if (recipient.e164PhoneNumber !== defaultRecipientPhoneNumber) {
-      this.props.storePhoneNumberInRecents(recipient.e164PhoneNumber)
-    }
+    this.props.storePhoneNumberInRecents(recipient.e164PhoneNumber)
     navigate(Screens.SendAmount, { recipient })
   }
 

--- a/packages/mobile/src/send/SendAmount.tsx
+++ b/packages/mobile/src/send/SendAmount.tsx
@@ -41,7 +41,6 @@ import { RootState } from 'src/redux/reducers'
 import { updateSuggestedFee } from 'src/send/actions'
 import LabeledTextInput from 'src/send/LabeledTextInput'
 import { getSuggestedFeeDollars } from 'src/send/selectors'
-import { CeloDefaultRecipient } from 'src/send/Send'
 import { ConfirmationInput } from 'src/send/SendConfirmation'
 import DisconnectBanner from 'src/shared/DisconnectBanner'
 import { fetchDollarBalance } from 'src/stableToken/actions'
@@ -138,7 +137,7 @@ export class SendAmount extends React.PureComponent<Props, State> {
     Logger.debug(TAG, 'Updating fee')
     const params = {
       // Just use a default here since it doesn't matter for fee estimation
-      recipientAddress: CeloDefaultRecipient.address!,
+      recipientAddress: '0xce10ce10ce10ce10ce10ce10ce10ce10ce10ce10',
       amount: parseInputAmount(this.state.amount).toString(),
       comment: this.state.reason,
     }


### PR DESCRIPTION
### Description

Removes the Celo Default Recipient for the ph pilot build.  Also added a `noContacts` message to show when both the contacts and search are empty to prevent `No results for ""` from showing.

Both of the following screenshots are after the Celo Default Recipient is removed.

| Before | After |
| ------ | ----- |
|  ![Screenshot_1563473866](https://user-images.githubusercontent.com/22536567/61482566-cb4f6780-a94f-11e9-93b0-2ad534f50ebf.png) | ![Screenshot_1563473696](https://user-images.githubusercontent.com/22536567/61482569-cd192b00-a94f-11e9-9d69-47d41c1df4a3.png) |

### Tested

Tests pass after updating the Invite snapshot.

### Other changes

N/A

### Related issues

- Fixes #8