### PR TITLE
Get rid of "Remote debugger is in a background tab" banner

### DIFF
--- a/packages/mobile/index.js
+++ b/packages/mobile/index.js
@@ -6,6 +6,10 @@ import App from 'src/app/App'
 import { installSentry } from 'src/sentry/Sentry'
 import { Sentry } from 'react-native-sentry'
 import { onBackgroundNotification } from 'src/firebase/firebase'
+import { YellowBox } from 'react-native'
+
+// To avoid "Remote debugger in background tab" warning
+YellowBox.ignoreWarnings(['Remote debugger'])
 
 // Set this to true, if you are modifying Sentry and want to test your changes
 const enableSentryOnDebugBuild = false

--- a/packages/mobile/index.js
+++ b/packages/mobile/index.js
@@ -6,10 +6,6 @@ import App from 'src/app/App'
 import { installSentry } from 'src/sentry/Sentry'
 import { Sentry } from 'react-native-sentry'
 import { onBackgroundNotification } from 'src/firebase/firebase'
-import { YellowBox } from 'react-native'
-
-// To avoid "Remote debugger in background tab" warning
-YellowBox.ignoreWarnings(['Remote debugger'])
 
 // Set this to true, if you are modifying Sentry and want to test your changes
 const enableSentryOnDebugBuild = false

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -21,7 +21,11 @@ import Logger from 'src/utils/Logger'
 // useScreens()
 
 Logger.debug('App/init', 'Current Language: ' + i18n.language)
-YellowBox.ignoreWarnings(['Warning: isMounted(...) is deprecated', 'Setting a timer'])
+YellowBox.ignoreWarnings([
+  'Warning: isMounted(...) is deprecated',
+  'Setting a timer',
+  'Remote debugger', // To avoid "Remote debugger in background tab" warning
+])
 
 // TODO(cmcewen) Figure out why this is crashing and fix
 // configureBackgroundSync(store)

--- a/packages/verifier/src/App.tsx
+++ b/packages/verifier/src/App.tsx
@@ -24,7 +24,10 @@ import { initializeFirebase } from 'src/services/FirebaseDb'
 import ErrorBoundary from 'src/shared/ErrorBoundary'
 import ErrorScreen from 'src/shared/ErrorScreen'
 
-YellowBox.ignoreWarnings(['Warning: isMounted(...) is deprecated'])
+YellowBox.ignoreWarnings([
+  'Warning: isMounted(...) is deprecated',
+  'Remote debugger', // To avoid "Remote debugger in background tab" warning
+])
 
 const commonScreens = {
   [Screens.Error]: ErrorScreen,


### PR DESCRIPTION
### Description

Remove "Remote debugger is in a background tab" yellow banner

### Tested

Banner is gone 🎉 

### Other changes

- 

### Related issues

- 

### Backwards compatibility

- 
