### PR TITLE
Docker CLI file cleanup

### DIFF
--- a/dockerfiles/cli/Dockerfile.cli
+++ b/dockerfiles/cli/Dockerfile.cli
@@ -27,27 +27,18 @@ ARG geth_project=celo-testnet
 FROM us.gcr.io/$geth_project/geth:$geth_tag as geth
 
 ARG celo_env
-RUN echo "Env is ${celo_env}"
-RUN apk add curl
-RUN mkdir /celo
-RUN curl --fail https://www.googleapis.com/storage/v1/b/genesis_blocks/o/${celo_env}?alt=media > /celo/genesis.json
-RUN curl --fail https://www.googleapis.com/storage/v1/b/static_nodes/o/${celo_env}?alt=media > /celo/static-nodes.json
-RUN ls /usr/local/bin/geth
+RUN echo "Env is ${celo_env}" && apk add curl && mkdir /celo
+ADD https://www.googleapis.com/storage/v1/b/genesis_blocks/o/${celo_env}?alt=media /celo/genesis.json
+ADD https://www.googleapis.com/storage/v1/b/static_nodes/o/${celo_env}?alt=media /celo/static-nodes.json
 
 # Build Celocli
 FROM node:8-alpine as node
 
 ARG celo_env
-ARG network_id=44781
-ARG sync_mode=ultralight
 
-
-RUN echo "geth_tag is ${geth_tag}"
-RUN echo "Env is ${celo_env}"
-
-RUN apk update
+RUN echo "geth_tag is ${geth_tag}" && echo "Env is ${celo_env}"
 # Required for celocli
-RUN apk add python git make gcc g++
+RUN apk update && apk add python git make gcc g++
 
 WORKDIR /celo-monorepo/
 RUN npm install @celo/celocli
@@ -55,26 +46,22 @@ RUN npm install @celo/celocli
 # Build the combined image
 FROM node:8-alpine as final_image
 
-RUN apk update
-# Without this, geth will fail with a confusing "No such file or directory" error.
-RUN apk add musl-dev
-# Required for start_geth.sh
-RUN apk add bash
+ARG network_name="alfajores"
+ARG network_id="44781"
+
+# Without musl-dev, geth will fail with a confusing "No such file or directory" error.
+# bash is required for start_geth.sh
+RUN apk update && apk add musl-dev && apk add bash
 
 WORKDIR /celo-monorepo/
 
-RUN echo "Dir is ${PWD}"
-RUN echo "env is ${celo_env}"
-
+RUN echo "Dir is ${PWD}" && echo "env is ${celo_env}" && mkdir /celo
+COPY packages/cli/start_geth.sh /celo/start_geth.sh
 COPY --from=geth /usr/local/bin/geth /usr/local/bin/geth
-RUN mkdir /celo
 COPY --from=geth /celo/genesis.json /celo
 COPY --from=geth /celo/static-nodes.json /celo
-COPY packages/cli/start_geth.sh /celo/start_geth.sh
-RUN chmod ugo+x /celo/start_geth.sh
-RUN ls /usr/local/bin/geth
 COPY --from=node /celo-monorepo/node_modules /celo-monorepo/node_modules 
-RUN ln -s /celo-monorepo/node_modules/.bin/celocli /celocli
+RUN chmod ugo+x /celo/start_geth.sh && ln -s /celo-monorepo/node_modules/.bin/celocli /celocli
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["/celo/start_geth.sh", "/usr/local/bin/geth", "alfajores", "ultralight", "44781", "/root/.celo", "/celo/genesis.json", "/celo/static-nodes.json"]


### PR DESCRIPTION
### Description

1. Reduce the number from steps from 42 to 28
2. Use ADD instead of curl to eliminate curl installation

### Tested
```
$ docker build -f dockerfiles/cli/Dockerfile.cli -t gcr.io/celo-testnet/celocli:$USER . --build-arg celo_env=alfajores

$ docker rm cli_container; docker run --name cli_container -p 8545:8545 gcr.io/celo-testnet/celocli:$USER -v /

$ docker exec -it cli_container /celocli account:balance 0xa0Af2E71cECc248f4a7fD606F203467B500Dd53B
goldBalance: 0
dollarBalance: 100

 $ docker kill cli_container
```