### PR TITLE
Remove compiler warnings from Attestations struct shadow

### DIFF
--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -89,7 +89,7 @@ contract Attestations is IAttestations, Ownable, Initializable, UsingRegistry {
   }
 
   // Stores attestations state for a single (identifier, account address) pair.
-  struct Attestations {
+  struct AttestationsPair {
     // Number of completed attestations
     uint64 completed;
     // List of issuers responsible for attestations
@@ -101,7 +101,7 @@ contract Attestations is IAttestations, Ownable, Initializable, UsingRegistry {
   struct IdentifierState {
     // All account addresses associated with this identifier
     address[] accounts;
-    mapping(address => Attestations) attestations;
+    mapping(address => AttestationsPair) attestations;
   }
 
   mapping(bytes32 => IdentifierState) identifiers;
@@ -609,7 +609,7 @@ contract Attestations is IAttestations, Ownable, Initializable, UsingRegistry {
    */
   function addIncompleteAttestations(
     uint256 n,
-    Attestations storage state
+    AttestationsPair storage state
   )
     internal
   {

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -89,7 +89,7 @@ contract Attestations is IAttestations, Ownable, Initializable, UsingRegistry {
   }
 
   // Stores attestations state for a single (identifier, account address) pair.
-  struct AttestationsPair {
+  struct AttestationsMapping {
     // Number of completed attestations
     uint64 completed;
     // List of issuers responsible for attestations
@@ -101,7 +101,7 @@ contract Attestations is IAttestations, Ownable, Initializable, UsingRegistry {
   struct IdentifierState {
     // All account addresses associated with this identifier
     address[] accounts;
-    mapping(address => AttestationsPair) attestations;
+    mapping(address => AttestationsMapping) attestations;
   }
 
   mapping(bytes32 => IdentifierState) identifiers;
@@ -609,7 +609,7 @@ contract Attestations is IAttestations, Ownable, Initializable, UsingRegistry {
    */
   function addIncompleteAttestations(
     uint256 n,
-    AttestationsPair storage state
+    AttestationsMapping storage state
   )
     internal
   {


### PR DESCRIPTION
### Description

Fixes warning:
```
    > compilation warnings encountered:

/Users/yorhodes/celo/celo-monorepo/packages/protocol/contracts/identity/Attestations.sol:92:3: Warning: This declaration shadows an existing declaration.
  struct Attestations {
  ^ (Relevant source part starts here and spans across multiple lines).
/Users/yorhodes/celo/celo-monorepo/packages/protocol/contracts/identity/Attestations.sol:18:1: The shadowed declaration is here:
contract Attestations is IAttestations, Ownable, Initializable, UsingRegistry {
^ (Relevant source part starts here and spans across multiple lines).
```

### Tested

With `truffle compile`
