### PR TITLE
Move proxies to subdirectories

### DIFF
--- a/packages/protocol/contracts/common/MultiSigProxy.sol
+++ b/packages/protocol/contracts/common/MultiSigProxy.sol
@@ -1,8 +1,0 @@
-pragma solidity ^0.5.8;
-
-import "./Proxy.sol";
-
-
-/* solhint-disable no-empty-blocks */
-contract MultiSigProxy is Proxy {
-}

--- a/packages/protocol/contracts/common/proxies/GasCurrencyWhitelistProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GasCurrencyWhitelistProxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */

--- a/packages/protocol/contracts/common/proxies/GasPriceMinimumProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GasPriceMinimumProxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */

--- a/packages/protocol/contracts/common/proxies/GoldTokenProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GoldTokenProxy.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */
-contract ExchangeProxy is Proxy {
+contract GoldTokenProxy is Proxy {
 }

--- a/packages/protocol/contracts/common/proxies/MultiSigProxy.sol
+++ b/packages/protocol/contracts/common/proxies/MultiSigProxy.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */
-contract ReserveProxy is Proxy {
+contract MultiSigProxy is Proxy {
 }

--- a/packages/protocol/contracts/common/proxies/RegistryProxy.sol
+++ b/packages/protocol/contracts/common/proxies/RegistryProxy.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */
-contract EscrowProxy is Proxy {
+contract RegistryProxy is Proxy {
 }

--- a/packages/protocol/contracts/governance/proxies/BondedDepositsProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/BondedDepositsProxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */

--- a/packages/protocol/contracts/governance/proxies/GovernanceProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/GovernanceProxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */

--- a/packages/protocol/contracts/governance/proxies/ValidatorsProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ValidatorsProxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */

--- a/packages/protocol/contracts/identity/proxies/AttestationsProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/AttestationsProxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */

--- a/packages/protocol/contracts/identity/proxies/EscrowProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/EscrowProxy.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */
-contract GoldTokenProxy is Proxy {
+contract EscrowProxy is Proxy {
 }

--- a/packages/protocol/contracts/identity/proxies/RandomProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/RandomProxy.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.8;
 
-import "./Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */
-contract RegistryProxy is Proxy {
+contract RandomProxy is Proxy {
 }

--- a/packages/protocol/contracts/stability/proxies/ExchangeProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ExchangeProxy.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */
-contract RandomProxy is Proxy {
+contract ExchangeProxy is Proxy {
 }

--- a/packages/protocol/contracts/stability/proxies/ReserveProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ReserveProxy.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */
-contract StableTokenProxy is Proxy {
+contract ReserveProxy is Proxy {
 }

--- a/packages/protocol/contracts/stability/proxies/SortedOraclesProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/SortedOraclesProxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../common/Proxy.sol";
+import "../../common/Proxy.sol";
 
 
 /* solhint-disable no-empty-blocks */

--- a/packages/protocol/contracts/stability/proxies/StableTokenProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/StableTokenProxy.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.8;
+
+import "../../common/Proxy.sol";
+
+
+/* solhint-disable no-empty-blocks */
+contract StableTokenProxy is Proxy {
+}


### PR DESCRIPTION
### Description

- Cleans up contract file structure to have separate directories for proxies
- Leaves `common/Proxy.sol` as primitive

### Tested

Protocol `yarn test:local` passes