### PR TITLE
Switch fastlane gem source back to default (RubyGems)

### DIFF
--- a/packages/mobile/Gemfile
+++ b/packages/mobile/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
-# TODO(yerdua) [#53]: remove the git source here and switch back to RubyGems
-# when the new version is released to RubyGems. This is expected to happen
-# sometime in the week starting 2019-07-22.
-gem "fastlane", git: "https://github.com/fastlane/fastlane.git"
+gem "fastlane"

--- a/packages/mobile/Gemfile.lock
+++ b/packages/mobile/Gemfile.lock
@@ -1,8 +1,33 @@
-GIT
-  remote: https://github.com/fastlane/fastlane.git
-  revision: da84b370190d75e6edcb6ae13e3e8f62e0ab354f
+GEM
+  remote: https://rubygems.org/
   specs:
-    fastlane (2.127.1)
+    CFPropertyList (3.0.0)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    atomos (0.1.3)
+    babosa (1.0.2)
+    claide (1.0.2)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander-fastlane (4.4.6)
+      highline (~> 1.7.2)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    digest-crc (0.4.1)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.4)
+    emoji_regex (1.0.1)
+    excon (0.65.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
+    fastimage (2.1.5)
+    fastlane (2.128.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -39,36 +64,6 @@ GIT
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    CFPropertyList (3.0.0)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
-    atomos (0.1.3)
-    babosa (1.0.2)
-    claide (1.0.2)
-    colored (1.2)
-    colored2 (3.1.2)
-    commander-fastlane (4.4.6)
-      highline (~> 1.7.2)
-    declarative (0.0.10)
-    declarative-option (0.1.0)
-    digest-crc (0.4.1)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.4)
-    emoji_regex (1.0.1)
-    excon (0.64.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
-    faraday-cookie_jar (0.0.6)
-      faraday (>= 0.7.4)
-      http-cookie (~> 1.0.0)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.5)
     gh_inspector (1.1.3)
     google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
@@ -158,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane!
+  fastlane
 
 BUNDLED WITH
    1.17.2

--- a/packages/verifier/Gemfile
+++ b/packages/verifier/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
-# TODO(yerdua) [#53]: remove the git source here and switch back to RubyGems
-# when the new version is released to RubyGems. This is expected to happen
-# sometime in the week starting 2019-07-22.
-gem "fastlane", git: "https://github.com/fastlane/fastlane.git"
+gem "fastlane"

--- a/packages/verifier/Gemfile.lock
+++ b/packages/verifier/Gemfile.lock
@@ -1,8 +1,33 @@
-GIT
-  remote: https://github.com/fastlane/fastlane.git
-  revision: da84b370190d75e6edcb6ae13e3e8f62e0ab354f
+GEM
+  remote: https://rubygems.org/
   specs:
-    fastlane (2.127.1)
+    CFPropertyList (3.0.0)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    atomos (0.1.3)
+    babosa (1.0.2)
+    claide (1.0.2)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander-fastlane (4.4.6)
+      highline (~> 1.7.2)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    digest-crc (0.4.1)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.4)
+    emoji_regex (1.0.1)
+    excon (0.65.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
+    fastimage (2.1.5)
+    fastlane (2.128.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -39,36 +64,6 @@ GIT
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    CFPropertyList (3.0.0)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
-    atomos (0.1.3)
-    babosa (1.0.2)
-    claide (1.0.2)
-    colored (1.2)
-    colored2 (3.1.2)
-    commander-fastlane (4.4.6)
-      highline (~> 1.7.2)
-    declarative (0.0.10)
-    declarative-option (0.1.0)
-    digest-crc (0.4.1)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.4)
-    emoji_regex (1.0.1)
-    excon (0.64.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
-    faraday-cookie_jar (0.0.6)
-      faraday (>= 0.7.4)
-      http-cookie (~> 1.0.0)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.5)
     gh_inspector (1.1.3)
     google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
@@ -158,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane!
+  fastlane
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
### Description

Switch fastlane gem source back to rubygems fastlane's latest master, which includes updating its mini_magick version, has been released and is available on RubyGems. This commit removes the github source override for that gem.

### Related issues

- Fixes #53
