### PR TITLE
[Wallet] Various fixes in prep for staging release

### DIFF
--- a/packages/blockchain-api/README.md
+++ b/packages/blockchain-api/README.md
@@ -24,7 +24,7 @@ Build and start:
 Deploy your app. The project will be built automatically by Google Cloud Build:
 
     using celotool:
-        yarn run cli deploy upgrade blockchain-api --config CONFIG_FILE --verbose --celo-env CELO_ENV
+        celotool deploy upgrade blockchain-api --config CONFIG_FILE --verbose --celo-env CELO_ENV
 
     Config files per env:
     Prod:

--- a/packages/mobile/.env.alfajoresstaging
+++ b/packages/mobile/.env.alfajoresstaging
@@ -1,0 +1,8 @@
+ENVIRONMENT=alfajoresstaging
+DEFAULT_TESTNET=alfajoresstaging
+BLOCKCHAIN_API_URL=https://alfajoresstaging-dot-celo-testnet.appspot.com/
+DEV_SETTINGS_ACTIVE_INITIALLY=true
+FIREBASE_ENABLED=true
+SECRETS_KEY=integration
+INSTABUG_TOKEN=
+INSTABUG_EVENTS=button,shake

--- a/packages/mobile/.env.alfajoresstaging
+++ b/packages/mobile/.env.alfajoresstaging
@@ -1,8 +1,0 @@
-ENVIRONMENT=alfajoresstaging
-DEFAULT_TESTNET=alfajoresstaging
-BLOCKCHAIN_API_URL=https://alfajoresstaging-dot-celo-testnet.appspot.com/
-DEV_SETTINGS_ACTIVE_INITIALLY=true
-FIREBASE_ENABLED=true
-SECRETS_KEY=integration
-INSTABUG_TOKEN=
-INSTABUG_EVENTS=button,shake

--- a/packages/mobile/.env.staging
+++ b/packages/mobile/.env.staging
@@ -1,6 +1,6 @@
 ENVIRONMENT=staging
-DEFAULT_TESTNET=argentinastaging
-BLOCKCHAIN_API_URL=https://argentinastaging-dot-celo-testnet.appspot.com/
+DEFAULT_TESTNET=alfajoresstaging
+BLOCKCHAIN_API_URL=https://alfajoresstaging-dot-celo-testnet.appspot.com/
 DEV_SETTINGS_ACTIVE_INITIALLY=true
 FIREBASE_ENABLED=true
 SECRETS_KEY=staging

--- a/packages/mobile/src/backup/BackupComplete.tsx
+++ b/packages/mobile/src/backup/BackupComplete.tsx
@@ -1,9 +1,10 @@
 import Button, { BtnTypes } from '@celo/react-components/components/Button'
+import SmallButton from '@celo/react-components/components/SmallButton'
 import colors from '@celo/react-components/styles/colors'
 import { fontStyles } from '@celo/react-components/styles/fonts'
 import * as React from 'react'
 import { WithNamespaces, withNamespaces } from 'react-i18next'
-import { Clipboard, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Clipboard, StyleSheet, Text, View } from 'react-native'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
 import { CustomEventNames } from 'src/analytics/constants'
 import componentWithAnalytics from 'src/analytics/wrapper'
@@ -50,9 +51,13 @@ class BackupComplete extends React.Component<Props, State> {
           <NuxLogo />
           <Text style={[fontStyles.h1, styles.h1]}>{t('backupKeySet')}</Text>
           <Text style={fontStyles.body}>{t('dontLoseIt')}</Text>
-          <TouchableOpacity style={styles.copyToClipboardContainer} onPress={this.copyToClipboard}>
-            <Text style={fontStyles.h2}>{t('copyToClipboard')}</Text>
-          </TouchableOpacity>
+          <SmallButton
+            text={t('copyToClipboard')}
+            testID={'pasteMessageButton'}
+            onPress={this.copyToClipboard}
+            solid={false}
+            style={styles.copyToClipboardButton}
+          />
         </View>
         <Button onPress={this.onDone} text={t('done')} standard={true} type={BtnTypes.PRIMARY} />
       </View>
@@ -76,8 +81,10 @@ const styles = StyleSheet.create({
     color: colors.dark,
     paddingTop: 35,
   },
-  copyToClipboardContainer: {
-    marginTop: 40,
+  copyToClipboardButton: {
+    marginTop: 50,
+    alignSelf: 'center',
+    fontSize: 14,
   },
 })
 

--- a/packages/mobile/src/backup/__snapshots__/BackupComplete.test.tsx.snap
+++ b/packages/mobile/src/backup/__snapshots__/BackupComplete.test.tsx.snap
@@ -79,6 +79,14 @@ exports[`renders correctly 1`] = `
     </Text>
     <View
       accessible={true}
+      hitSlop={
+        Object {
+          "bottom": 7,
+          "left": 7,
+          "right": 7,
+          "top": 7,
+        }
+      }
       isTVSelectable={true}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -88,18 +96,40 @@ exports[`renders correctly 1`] = `
       onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "marginTop": 40,
+          "alignItems": "center",
+          "alignSelf": "center",
+          "backgroundColor": "transparent",
+          "borderColor": "#42D689",
+          "borderRadius": 2,
+          "borderWidth": 2,
+          "fontSize": 14,
+          "marginTop": 50,
+          "minWidth": 160,
           "opacity": 1,
+          "paddingHorizontal": 16,
+          "paddingVertical": 6,
+          "textAlign": "center",
         }
       }
+      testID="pasteMessageButton"
     >
       <Text
         style={
-          Object {
-            "fontFamily": "Hind-Light",
-            "fontSize": 18,
-            "textAlign": "center",
-          }
+          Array [
+            Object {
+              "color": "#81868B",
+              "fontFamily": "Hind-SemiBold",
+              "fontSize": 13,
+              "lineHeight": 17,
+            },
+            Object {
+              "lineHeight": 20,
+            },
+            Object {
+              "color": "#42D689",
+            },
+            undefined,
+          ]
         }
       >
         copyToClipboard

--- a/packages/mobile/src/escrow/saga.ts
+++ b/packages/mobile/src/escrow/saga.ts
@@ -14,7 +14,7 @@ import {
 } from 'src/escrow/actions'
 import { SHORT_CURRENCIES } from 'src/geth/consts'
 import i18n from 'src/i18n'
-import { Actions as IdentityActions } from 'src/identity/actions'
+import { Actions as IdentityActions, EndVerificationAction } from 'src/identity/actions'
 import { NUM_ATTESTATIONS_REQUIRED } from 'src/identity/verification'
 import { inviteesSelector } from 'src/invite/reducer'
 import { TEMP_PW } from 'src/invite/saga'
@@ -66,7 +66,15 @@ function* transferStableTokenToEscrow(action: TransferPaymentAction) {
   }
 }
 
-function* withdrawFromEscrow() {
+function* withdrawFromEscrow(action: EndVerificationAction) {
+  if (!action.success) {
+    Logger.debug(
+      TAG + '@withdrawFromEscrow',
+      'Skipping escrow withdrawal because verification failed'
+    )
+    return
+  }
+
   try {
     const escrow = yield call(getEscrowContract, web3)
     const account = yield call(getConnectedUnlockedAccount)

--- a/packages/mobile/src/icons/BackupIcon.tsx
+++ b/packages/mobile/src/icons/BackupIcon.tsx
@@ -7,7 +7,7 @@ interface Props {
   style?: any
 }
 
-export default class VerifyAddressBook extends React.PureComponent<Props> {
+export default class BackupIcon extends React.PureComponent<Props> {
   static defaultProps = {
     height: 70,
     width: 80,

--- a/packages/mobile/src/import/ImportContacts.tsx
+++ b/packages/mobile/src/import/ImportContacts.tsx
@@ -138,8 +138,9 @@ const style = StyleSheet.create({
     marginVertical: 10,
   },
   loadingLabel: {
-    marginVertical: 20,
+    marginTop: 20,
     textAlign: 'center',
+    color: colors.darkSecondary,
   },
   pincodeFooter: {
     flexDirection: 'column',
@@ -159,7 +160,7 @@ const style = StyleSheet.create({
     flexDirection: 'row',
   },
   activity: {
-    marginTop: 10,
+    marginTop: 15,
   },
 })
 

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -213,7 +213,7 @@ export function* redeemInviteSaga(action: RedeemInviteAction) {
         throw e
       }
     }
-    Logger.debug(TAG + '@redeemInviteCode', 'Added temp account to wallet: ' + tempAccount)
+    Logger.debug(TAG + '@redeemInviteCode', 'Added temp account to wallet')
 
     // Check that the balance of the new account is not 0
     const StableToken = yield call(getStableTokenContract, web3)

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -213,7 +213,7 @@ export function* redeemInviteSaga(action: RedeemInviteAction) {
         throw e
       }
     }
-    Logger.debug(TAG + '@redeemInviteCode', 'Added temp account to wallet')
+    Logger.debug(TAG + '@redeemInviteCode', 'Added temp account to wallet', tempAccount)
 
     // Check that the balance of the new account is not 0
     const StableToken = yield call(getStableTokenContract, web3)

--- a/packages/mobile/src/pincode/__snapshots__/Pincode.test.tsx.snap
+++ b/packages/mobile/src/pincode/__snapshots__/Pincode.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`Pincode renders correctly for pin enter 1`] = `
         </Link>
       </View>
     </View>
-    <VerifyAddressBook
+    <BackupIcon
       height={70}
       style={
         Object {
@@ -438,7 +438,7 @@ exports[`Pincode renders correctly for pin re-enter 1`] = `
         </Link>
       </View>
     </View>
-    <VerifyAddressBook
+    <BackupIcon
       height={70}
       style={
         Object {

--- a/packages/mobile/src/redux/sagas.ts
+++ b/packages/mobile/src/redux/sagas.ts
@@ -27,6 +27,7 @@ const loggerBlacklist = [
   'WEB3/SET_COMMENT_KEY',
   'IDENTITY/UPDATE_E164_PHONE_NUMBER_ADDRESSES',
   'IDENTITY/FETCH_PHONE_ADDRESSES',
+  'INVITE/REDEEM_INVITE',
 ]
 
 function* loggerSaga() {

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -16,5 +16,5 @@
     "target": "es2015",
     "strict": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vendor", ".bundle"]
 }

--- a/packages/mobile/tslint.json
+++ b/packages/mobile/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": ["@celo/typescript/tslint.json"],
   "linterOptions": {
-    "exclude": ["**/__mocks__/**", "**/lcov-report/**"]
+    "exclude": ["**/__mocks__/**", "**/lcov-report/**", "vendor", ".bundle"]
   },
   "rules": {
     "no-relative-imports": true,

--- a/packages/verifier/tsconfig.json
+++ b/packages/verifier/tsconfig.json
@@ -15,5 +15,5 @@
     "baseUrl": ".",
     "lib": ["es7", "esnext", "dom"]
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vendor", ".bundle"]
 }

--- a/packages/verifier/tslint.json
+++ b/packages/verifier/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": ["@celo/typescript/tslint.json"],
   "linterOptions": {
-    "exclude": ["**/__mocks__/**", "**/lcov-report/**", "**/*.json"]
+    "exclude": ["**/__mocks__/**", "**/lcov-report/**", "**/*.json", "vendor", ".bundle"]
   },
   "rules": {
     "no-relative-imports": true,


### PR DESCRIPTION
### Description

* Add .env.staging to use alfajoresstaging
* Use button instead of text for copy button on backup screen (see screenshot)
* Don't write temp wallet address to logs
* Skip escrow withdrawal if verification fails
* Minor style improvement for import contacts screen
* Ignore ruby artifacts while linting and compiling

### Tested

Ran through onboarding flow and key send/exchange flows for alfajoresstaging

### Backwards compatibility

Compatible

![improved-copy-button](https://user-images.githubusercontent.com/710751/61719526-6176f980-ad65-11e9-8f4d-0c9298cae656.png)

