### PR TITLE
[circleci]Add `build-all-packages` job back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,42 @@ jobs:
 
       - run: yarn run ci-lint
 
+  build-all-packages:
+     <<: *defaults
+     steps:
+       - attach_workspace:
+          at: ~/app
+
+       - run:
+           name: Build SDK
+           command: |
+              set -e
+              yarn --cwd=packages/contractkit build alfajores
+
+       - run:
+          name: Build CLI
+          command: |
+            yarn --cwd=packages/cli setup:environment alfajores
+            yarn --cwd=packages/cli build
+
+       - run:
+          name: Build mobile
+          command: yarn --cwd=packages/mobile build
+
+       - run:
+          name: Build Verification Pool
+          command: yarn --cwd=packages/verification-pool-api compile-typescript
+
+       - run:
+          name: Build Verifier
+          command: yarn --cwd=packages/verifier build:typescript
+
+       - run:
+          name: Build Web
+          command: |
+              set -e
+              yarn --cwd=packages/web build
+
   general-test:
     <<: *defaults
     steps:
@@ -300,6 +336,9 @@ workflows:
       - install_dependencies
       - lint-checks:
           requires:
+            - install_dependencies
+      - build-all-packages:
+           requires:
             - install_dependencies
       - general-test:
           requires:


### PR DESCRIPTION
### Description

Build most of our packages. This prevents bugs like the one fixed in
https://github.com/celo-org/celo-monorepo/pull/131

### Tested

```
yarn --cwd=packages/contractkit build integration
yarn --cwd=packages/cli setup:environment alfajores
yarn --cwd=packages/cli build
yarn --cwd=packages/mobile build
yarn --cwd=packages/verification-pool-api compile-typescript
yarn --cwd=packages/verifier build:typescript
yarn --cwd=packages/web build
```