### PR TITLE
Fix stability fee bug in StableToken.transferFrom

### DIFF
--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -295,7 +295,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable, Initiali
 
     balances[to] = balances[to].add(units);
     balances[from] = balances[from].sub(units);
-    allowed[from][msg.sender] = allowed[from][msg.sender].sub(units);
+    allowed[from][msg.sender] = allowed[from][msg.sender].sub(value);
     emit Transfer(from, to, value);
     return true;
   }

--- a/packages/protocol/test/stability/stabletoken.ts
+++ b/packages/protocol/test/stability/stabletoken.ts
@@ -421,10 +421,11 @@ contract('StableToken', (accounts: string[]) => {
       const receiver = accounts[1]
       const inflationRateNumerator = 201
       const inflationRateDenominator = 200
+      const amount = new BigNumber(10000000000000000000)
 
       beforeEach(async () => {
         await stableToken.setMinter(sender)
-        await stableToken.mint(sender, 1000)
+        await stableToken.mint(sender, amount.times(2))
         await stableToken.setInflationParameters(
           inflationRateNumerator,
           inflationRateDenominator,
@@ -433,10 +434,10 @@ contract('StableToken', (accounts: string[]) => {
         await timeTravel(SECONDS_IN_A_WEEK, web3)
       })
 
-      async function assertInflationUpdatedEvent(log, requestBlockTime) {
+      async function assertInflationUpdatedEvent(log, requestBlockTime, inflationPeriods = 1) {
         assertLogMatches(log, 'InflationFactorUpdated', {
-          numerator: inflationRateNumerator,
-          denominator: inflationRateDenominator,
+          numerator: Math.pow(inflationRateNumerator, inflationPeriods),
+          denominator: Math.pow(inflationRateDenominator, inflationPeriods),
           lastUpdated: requestBlockTime,
         })
       }
@@ -447,7 +448,7 @@ contract('StableToken', (accounts: string[]) => {
       })
 
       it('approve', async () => {
-        const res = await stableToken.approve(receiver, 1)
+        const res = await stableToken.approve(receiver, amount)
         await assertInflationUpdatedEvent(res.logs[0], initializationTime + SECONDS_IN_A_WEEK)
       })
 
@@ -457,22 +458,24 @@ contract('StableToken', (accounts: string[]) => {
       })
 
       it('transferWithComment', async () => {
-        const res = await stableToken.transferWithComment(receiver, 1, 'hi')
+        const res = await stableToken.transferWithComment(receiver, amount, 'hi')
         await assertInflationUpdatedEvent(res.logs[0], initializationTime + SECONDS_IN_A_WEEK)
       })
 
       it('burn', async () => {
-        const res = await stableToken.mint(sender, 1)
+        const res = await stableToken.mint(sender, amount)
         await assertInflationUpdatedEvent(res.logs[0], initializationTime + SECONDS_IN_A_WEEK)
       })
 
-      it('transferFrom', async () => {
-        // force inflation factor to be updated, don't change value
-        await stableToken.approve(receiver, 1)
-        await stableToken.setInflationParameters(1, 1, SECONDS_IN_A_WEEK)
+      it.only('transferFrom', async () => {
+        await stableToken.approve(receiver, amount)
         await timeTravel(SECONDS_IN_A_WEEK, web3)
-        const res = await stableToken.transferFrom(sender, receiver, 1, { from: receiver })
-        await assertInflationUpdatedEvent(res.logs[0], initializationTime + SECONDS_IN_A_WEEK * 2)
+        const res = await stableToken.transferFrom(sender, receiver, amount, { from: receiver })
+        await assertInflationUpdatedEvent(
+          res.logs[0],
+          initializationTime + SECONDS_IN_A_WEEK * 2,
+          2
+        )
       })
 
       it('transfer', async () => {


### PR DESCRIPTION
### Description

Fixes a bug preventing `transferFrom` from succeeding due to integer underflow when inflationFactor > 0.

### Tested

Added a unit test, deployed to Alfajores and confirmed that bugs were fixed.

### Other changes

None
### Related issues

- Fixes #170 

### Backwards compatibility

Backwards compatible