### PR TITLE
Add sorted linked list key precomputes and oracle reports to contract kit

### DIFF
--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -14,7 +14,7 @@
     "lint-checks": "yarn run lint && yarn run build alfajores",
     "postinstall": "yarn run build alfajores",
     "prettify": "yarn run prettier --config ../../.prettierrc.js --write '{contracts,types}/**/*.+(ts|tsx|js|jsx)'",
-    "test": "export TZ=UTC && jest --ci --silent --coverage --runInBand test/attestations.test.ts test/erc20-utils.test.ts test/google-storage-utils.test.ts test/start_geth.sh test/transaction-utils.test.ts",
+    "test": "export TZ=UTC && jest --ci --silent --coverage --runInBand test/attestations.test.ts test/erc20-utils.test.ts test/google-storage-utils.test.ts test/start_geth.sh test/transaction-utils.test.ts test/sortedlinkedlist.test.ts test/oracle.test.ts",
     "test:verbose": "export TZ=UTC && jest --ci --verbose --runInBand  test/attestations.test.ts test/erc20-utils.test.ts test/google-storage-utils.test.ts test/start_geth.sh test/transaction-utils.test.ts",
     "test-licenses": "yarn licenses list --prod | grep '\\(─ GPL\\|─ (GPL-[1-9]\\.[0-9]\\+ OR GPL-[1-9]\\.[0-9]\\+)\\)' && echo 'Found GPL license(s). Use 'yarn licenses list --prod' to look up the offending package' || echo 'No GPL licenses found'"
   },

--- a/packages/contractkit/src/contracts.ts
+++ b/packages/contractkit/src/contracts.ts
@@ -4,12 +4,14 @@ import Escrow from '../contracts/Escrow'
 import Exchange from '../contracts/Exchange'
 import GasPriceMinimum from '../contracts/GasPriceMinimum'
 import GoldToken from '../contracts/GoldToken'
+import SortedOracles from '../contracts/SortedOracles'
 import StableToken from '../contracts/StableToken'
 import { Attestations as AttestationsType } from '../types/Attestations'
 import { Escrow as EscrowType } from '../types/Escrow'
 import { Exchange as ExchangeType } from '../types/Exchange'
 import { GasPriceMinimum as GasPriceMinimumType } from '../types/GasPriceMinimum'
 import { GoldToken as GoldTokenType } from '../types/GoldToken'
+import { SortedOracles as SortedOraclesType } from '../types/SortedOracles'
 import { StableToken as StableTokenType } from '../types/StableToken'
 
 let attestationsContract: AttestationsType | null = null
@@ -18,6 +20,7 @@ let exchangeContract: ExchangeType | null = null
 let gasPriceMinimumContract: GasPriceMinimumType | null = null
 let goldTokenContract: GoldTokenType | null = null
 let stableTokenContract: StableTokenType | null = null
+let sortedOraclesContract: SortedOraclesType | null = null
 
 export async function getAttestationsContract(web3: Web3): Promise<AttestationsType> {
   if (attestationsContract === null) {
@@ -75,4 +78,15 @@ export async function getStableTokenContract(web3: Web3): Promise<StableTokenTyp
     }
   }
   return stableTokenContract
+}
+
+export async function getSortedOraclesContract(web3: Web3): Promise<SortedOraclesType> {
+  if (sortedOraclesContract === null) {
+    try {
+      sortedOraclesContract = await SortedOracles(web3)
+    } catch (error) {
+      throw new Error(`Fail to get SortedOracles contract ${error}`)
+    }
+  }
+  return sortedOraclesContract
 }

--- a/packages/contractkit/src/oracle.ts
+++ b/packages/contractkit/src/oracle.ts
@@ -34,7 +34,7 @@ function getValuesFromFractions(fractionElements: FractionElements) {
  */
 export async function makeReportTx(
   web3: Web3,
-  from: string,
+  oracleAddress: string,
   tokenAddress: string,
   numerator: BigNumber,
   denominator: BigNumber
@@ -46,7 +46,7 @@ export async function makeReportTx(
   const sortedValues = getValuesFromFractions(sortedFractions)
 
   const { lesserKey, greaterKey } = await getLesserAndGreaterKeys(
-    { key: from, value: rate },
+    { key: oracleAddress, value: rate },
     sortedValues
   )
   return oracles.methods.report(

--- a/packages/contractkit/src/oracle.ts
+++ b/packages/contractkit/src/oracle.ts
@@ -1,0 +1,59 @@
+import { BigNumber } from 'bignumber.js'
+import Web3 from 'web3'
+import { getSortedOraclesContract } from './contracts'
+import { getLesserAndGreaterKeys } from './sortedlinkedlist'
+
+interface FractionElements {
+  0: string[]
+  1: string[]
+  2: string[]
+  3: string[]
+}
+
+/**
+ * Zips up arrays returned from SortedOracles getRates() for easy use.
+ * @param keys Key array returned from getRates
+ * @param numerators Numerators array returned from getRates
+ * @param denominators Denominators array return from getRates
+ */
+function parseFractionElements(fractionElements: FractionElements) {
+  const { 0: keys, 1: numerators, 2: denominators } = fractionElements
+  return keys.map((key, i) => ({
+    key: key.toLowerCase(),
+    value: new BigNumber(numerators[i]).div(new BigNumber(denominators[i])),
+  }))
+}
+
+/**
+ * Makes an oracle exchange rate report TX object. Calls but does not send transactions.
+ * Handles figuring out where to insert the report in the sorted linked list.
+ * @param web3 Web3 provider of the node the TX will be sent from.
+ * @param tokenAddress Token address to make the report on.
+ * @param numerator Token's portion of the exchange rate.
+ * @param denominator Gold's portion of the exchange rate.
+ */
+export async function makeReportTx(
+  web3: Web3,
+  from: string,
+  tokenAddress: string,
+  numerator: BigNumber,
+  denominator: BigNumber
+) {
+  const rate = numerator.div(denominator)
+
+  const oracles = await getSortedOraclesContract(web3)
+  const sortedFractions = await oracles.methods.getRates(tokenAddress).call()
+  const sorted = parseFractionElements(sortedFractions)
+
+  const { lesserKey, greaterKey } = await getLesserAndGreaterKeys(
+    { key: from, value: rate },
+    sorted
+  )
+  return oracles.methods.report(
+    tokenAddress,
+    numerator.toString(),
+    denominator.toString(),
+    lesserKey,
+    greaterKey
+  )
+}

--- a/packages/contractkit/src/oracle.ts
+++ b/packages/contractkit/src/oracle.ts
@@ -16,7 +16,7 @@ interface FractionElements {
  * @param numerators Numerators array returned from getRates
  * @param denominators Denominators array return from getRates
  */
-function parseFractionElements(fractionElements: FractionElements) {
+function getValuesFromFractions(fractionElements: FractionElements) {
   const { 0: keys, 1: numerators, 2: denominators } = fractionElements
   return keys.map((key, i) => ({
     key: key.toLowerCase(),
@@ -43,11 +43,11 @@ export async function makeReportTx(
 
   const oracles = await getSortedOraclesContract(web3)
   const sortedFractions = await oracles.methods.getRates(tokenAddress).call()
-  const sorted = parseFractionElements(sortedFractions)
+  const sortedValues = getValuesFromFractions(sortedFractions)
 
   const { lesserKey, greaterKey } = await getLesserAndGreaterKeys(
     { key: from, value: rate },
-    sorted
+    sortedValues
   )
   return oracles.methods.report(
     tokenAddress,

--- a/packages/contractkit/src/sortedlinkedlist.ts
+++ b/packages/contractkit/src/sortedlinkedlist.ts
@@ -9,13 +9,13 @@ interface ListElement {
 
 /**
  * Returns the two keys around element
- * @param newElement Element to find lesser and greater keys for
- * @param sortedElements Descending sorted list
+ * @param elem Element to find lesser and greater keys for
+ * @param sorted Descending sorted list
  */
-export function getLesserAndGreaterKeys(newElement: ListElement, sortedElements: ListElement[]) {
-  const lesserElem = sortedElements.find((elem) => elem.value < newElement.value)
+export function getLesserAndGreaterKeys(elem: ListElement, sorted: ListElement[]) {
+  const lesserElem = sorted.find((e) => e.value < elem.value && e.key !== elem.key)
   const lesserKey = lesserElem === undefined ? NULL_ADDRESS : lesserElem.key
-  const greaterElem = sortedElements.reverse().find((elem) => elem.value > newElement.value)
+  const greaterElem = sorted.reverse().find((e) => e.value > elem.value && e.key !== elem.key)
   const greaterKey = greaterElem === undefined ? NULL_ADDRESS : greaterElem.key
   return { lesserKey, greaterKey }
 }

--- a/packages/contractkit/src/sortedlinkedlist.ts
+++ b/packages/contractkit/src/sortedlinkedlist.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from 'bignumber.js'
 
-const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
+export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-interface ListElement {
+export interface ListElement {
   key: string
   value: BigNumber
 }
@@ -13,9 +13,9 @@ interface ListElement {
  * @param sorted Descending sorted list
  */
 export function getLesserAndGreaterKeys(elem: ListElement, sorted: ListElement[]) {
-  const lesserElem = sorted.find((e) => e.value < elem.value && e.key !== elem.key)
+  const lesserElem = sorted.find((e) => e.value.lt(elem.value) && e.key !== elem.key)
   const lesserKey = lesserElem === undefined ? NULL_ADDRESS : lesserElem.key
-  const greaterElem = sorted.reverse().find((e) => e.value > elem.value && e.key !== elem.key)
+  const greaterElem = sorted.reverse().find((e) => e.value.gt(elem.value) && e.key !== elem.key)
   const greaterKey = greaterElem === undefined ? NULL_ADDRESS : greaterElem.key
   return { lesserKey, greaterKey }
 }

--- a/packages/contractkit/src/sortedlinkedlist.ts
+++ b/packages/contractkit/src/sortedlinkedlist.ts
@@ -1,0 +1,21 @@
+import { BigNumber } from 'bignumber.js'
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+interface ListElement {
+  key: string
+  value: BigNumber
+}
+
+/**
+ * Returns the two keys around element
+ * @param newElement Element to find lesser and greater keys for
+ * @param sortedElements Descending sorted list
+ */
+export function getLesserAndGreaterKeys(newElement: ListElement, sortedElements: ListElement[]) {
+  const lesserElem = sortedElements.find((elem) => elem.value < newElement.value)
+  const lesserKey = lesserElem === undefined ? NULL_ADDRESS : lesserElem.key
+  const greaterElem = sortedElements.reverse().find((elem) => elem.value > newElement.value)
+  const greaterKey = greaterElem === undefined ? NULL_ADDRESS : greaterElem.key
+  return { lesserKey, greaterKey }
+}

--- a/packages/contractkit/test/oracle.test.ts
+++ b/packages/contractkit/test/oracle.test.ts
@@ -1,5 +1,14 @@
+import { BigNumber } from 'bignumber.js'
+
+import { CURRENCY_ENUM } from '@celo/utils'
+
+import { NETWORK_NAME } from '../contracts/network-name'
+import ContractUtils from '../src/contract-utils-v2'
 import { Logger, LogLevel } from '../src/logger'
-import { makeReportTx } from 'src/oracle'
+import { makeReportTx } from '../src/oracle'
+import { NULL_ADDRESS } from '../src/sortedlinkedlist'
+import { Web3Utils } from '../src/web3-utils'
+import { getIpAddressOfTxnNode, getMiner0AccountAddress, getMiner0PrivateKey } from '../test/utils'
 
 beforeAll(() => {
   Logger.setLogLevel(LogLevel.VERBOSE)
@@ -7,9 +16,29 @@ beforeAll(() => {
 
 describe('Oracle', () => {
   describe('#makeReportTx', () => {
-    makeReportTx()
-    // it('Should get the right keys in a long list', async () => {
+    it('Should construct report tx correctly', async () => {
+      jest.setTimeout(25 * 1000)
+      const oraclePrivKey = getMiner0PrivateKey(NETWORK_NAME)
+      const oracleAddress = getMiner0AccountAddress(NETWORK_NAME)
 
-    // })
+      const txNodeIp = await getIpAddressOfTxnNode(NETWORK_NAME)
+      const web3 = await Web3Utils.getWeb3WithSigningAbility('http', txNodeIp, 8545, oraclePrivKey)
+
+      const tokenAddress = await ContractUtils.getAddressForCurrencyContract(
+        web3,
+        CURRENCY_ENUM.DOLLAR
+      )
+
+      const rateNum = new BigNumber(10)
+      const rateDenom = new BigNumber(1)
+      const tx = await makeReportTx(web3, oracleAddress, tokenAddress, rateNum, rateDenom)
+      expect(tx.arguments).toStrictEqual([
+        tokenAddress,
+        rateNum.toString(),
+        rateDenom.toString(),
+        NULL_ADDRESS,
+        NULL_ADDRESS,
+      ])
+    })
   })
 })

--- a/packages/contractkit/test/oracle.test.ts
+++ b/packages/contractkit/test/oracle.test.ts
@@ -1,0 +1,15 @@
+import { Logger, LogLevel } from '../src/logger'
+import { makeReportTx } from 'src/oracle'
+
+beforeAll(() => {
+  Logger.setLogLevel(LogLevel.VERBOSE)
+})
+
+describe('Oracle', () => {
+  describe('#makeReportTx', () => {
+    makeReportTx()
+    // it('Should get the right keys in a long list', async () => {
+
+    // })
+  })
+})

--- a/packages/contractkit/test/sortedlinkedlist.test.ts
+++ b/packages/contractkit/test/sortedlinkedlist.test.ts
@@ -1,0 +1,81 @@
+import BigNumber from 'bignumber.js'
+import { getLesserAndGreaterKeys, ListElement, NULL_ADDRESS } from '../src/sortedlinkedlist'
+
+import { Logger, LogLevel } from '../src/logger'
+
+beforeAll(() => {
+  Logger.setLogLevel(LogLevel.VERBOSE)
+})
+
+describe('SortedLinkedList', () => {
+  let sortedElems: ListElement[]
+  beforeEach(() => {
+    const n: number = 100
+    const numbers1toN = Array.from(Array(n).keys())
+    const sortedValues = numbers1toN.reverse().map<BigNumber>((e) => new BigNumber(e))
+    sortedElems = sortedValues.map<ListElement>((val) => {
+      return {
+        key: '0x' + val.toString(),
+        value: val,
+      }
+    })
+  })
+
+  describe('#getLesserAndGreaterKeys', () => {
+    it('Should get the right keys in a long list', async () => {
+      const { lesserKey, greaterKey } = getLesserAndGreaterKeys(
+        {
+          key: 'newKey',
+          value: new BigNumber(50),
+        },
+        sortedElems
+      )
+      expect(lesserKey).toBe('0x49')
+      expect(greaterKey).toBe('0x51')
+    })
+
+    it('Should get NULL_ADDRESS when no key is lesser', async () => {
+      const { lesserKey } = getLesserAndGreaterKeys(
+        {
+          key: 'newKey',
+          value: new BigNumber(0),
+        },
+        sortedElems
+      )
+      expect(lesserKey).toBe(NULL_ADDRESS)
+    })
+
+    it('Should get NULL_ADDRESS when no key is greater', async () => {
+      const { greaterKey } = getLesserAndGreaterKeys(
+        {
+          key: 'newKey',
+          value: new BigNumber(100),
+        },
+        sortedElems
+      )
+      expect(greaterKey).toBe(NULL_ADDRESS)
+    })
+
+    it('Should not return lesser which has equal key', async () => {
+      const { lesserKey } = getLesserAndGreaterKeys(
+        {
+          key: '0x49',
+          value: new BigNumber(50),
+        },
+        sortedElems
+      )
+      expect(lesserKey).toBe('0x48')
+    })
+
+    it('Should not return greater which has equal key', async () => {
+      const { greaterKey } = getLesserAndGreaterKeys(
+        {
+          key: '0x51',
+          value: new BigNumber(50),
+        },
+        sortedElems
+      )
+      expect(greaterKey).toBe('0x52')
+    })
+  })
+})


### PR DESCRIPTION
### Description

Makes a generic interface for getting lesser and greater keys from sorted linked lists and also implements parsing fractions for the same value comparison

### Tested

`yarn test` in `contractkit`

### Related issues

- Prepares #167 
