### PR TITLE
Spanish tweaks

### DIFF
--- a/packages/mobile/locales/es-AR/nuxVerification2.json
+++ b/packages/mobile/locales/es-AR/nuxVerification2.json
@@ -14,7 +14,7 @@
   "country": "País",
   "phoneNumber": "Número de teléfono",
   "invalidPhone": "Número de teléfono inválido",
-  "allowSmsPermissions": "Permitir que la billetera de Celo envíe y vea mensajes SMS",
+  "allowSmsPermissions": "Permitir que la billetera de Celo envíe y vea mensajes de texto (SMS)",
   "dontAsk": "No volver a preguntar",
   "deny": "Denegar",
   "allow": "Permitir",

--- a/packages/mobile/locales/es-AR/walletFlow5.json
+++ b/packages/mobile/locales/es-AR/walletFlow5.json
@@ -62,5 +62,5 @@
     "1":
       "Un recordatorio amistoso de que está utilizando una compilación de Testnet - los saldos aquí no son reales."
   },
-  "dismiss": "Despedir"
+  "dismiss": "Ocultar"
 }


### PR DESCRIPTION
### Description

Small tweaks to the spanish copy, separated out from #49 because they are unrelated to changing the translation of `wallet`