### PR TITLE
Disable CLI code coverage

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "tslint -p . -t stylish",
     "prepack": "tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "export TZ=UTC && jest --ci --silent --coverage",
+    "test": "export TZ=UTC && jest --ci --silent",
     "version": "oclif-dev readme && git add README.md"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

For some reason `../../node_modules/jest/node_modules/.bin/jest --ci --silent` works on Circle CI but `../../node_modules/jest/node_modules/.bin/jest --ci --silent --coverage` stays stuck forever. Disable the coverage for now.
