### PR TITLE
Fix fastlane config for deploying staging

### DIFF
--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -55,7 +55,7 @@ platform :android do
   desc 'Ship Staging to Playstore Alpha.'
   lane :staging do
     env = 'staging'
-    sdkEnv = 'alfajoresstaging'
+    sdkEnv = 'alfajores'
     clean
     build(environment: env, sdkEnv: sdkEnv)
     fastlane_supply(env, 'internal', env)


### PR DESCRIPTION
### Description

Makes staging deployments build SDK for alfajores network

### Tested

Deployed to staging and tested the app. Tested yesterday but didn't have time to push this fix yet
