### PR TITLE
Improve Home cover animation on slow mobile devices

### DIFF
--- a/packages/web/src/home/HomeAnimation.tsx
+++ b/packages/web/src/home/HomeAnimation.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { StyleSheet } from 'react-native'
 import { createElement } from 'react-native-web'
+import { ScreenProps, ScreenSizes, withScreenSize } from 'src/layout/ScreenSize'
 import Responsive from 'src/shared/Responsive'
 import { HEADER_HEIGHT } from 'src/shared/Styles'
-
 const Video = React.forwardRef((props, ref) => createElement('video', { ...props, ref }))
 const Source = (props) => createElement('source', props)
 
@@ -12,7 +12,7 @@ interface Props {
   onFinished: () => void
 }
 
-export default class HomeAnimation extends React.Component<Props> {
+class HomeAnimation extends React.Component<Props & ScreenProps> {
   video: any
   started = false
 
@@ -46,6 +46,14 @@ export default class HomeAnimation extends React.Component<Props> {
     }, 200)
   }
 
+  source = () => {
+    if (this.props.screen === ScreenSizes.MOBILE) {
+      return '//storage.googleapis.com/celo-website/celo-animation-mobile.mp4'
+    }
+
+    return '//storage.googleapis.com/celo-website/celo-animation.mp4'
+  }
+
   render() {
     return (
       <Responsive large={styles.video}>
@@ -58,12 +66,14 @@ export default class HomeAnimation extends React.Component<Props> {
           muted={true}
           playsInline={true}
         >
-          <Source src="//storage.googleapis.com/celo-website/celo-animation.mp4" type="video/mp4" />
+          <Source src={this.source()} type="video/mp4" />
         </Video>
       </Responsive>
     )
   }
 }
+
+export default withScreenSize(HomeAnimation)
 
 const styles = StyleSheet.create({
   video: {

--- a/packages/web/src/home/TextAnimation.tsx
+++ b/packages/web/src/home/TextAnimation.tsx
@@ -106,9 +106,15 @@ interface Props {
   playing: boolean
 }
 
-class TextAnimation extends React.PureComponent<Props> {
+interface State {
+  currentWord: number
+  initial: boolean
+}
+
+class TextAnimation extends React.PureComponent<Props, State> {
   state = {
     currentWord: 0,
+    initial: true,
   }
 
   timeout: number
@@ -129,7 +135,7 @@ class TextAnimation extends React.PureComponent<Props> {
     const duration = timings[word].length + timings[word].pause
     this.timeout = setTimeout(() => {
       if (this.state.currentWord !== 4) {
-        this.setState({ currentWord: (this.state.currentWord + 1) % 5 })
+        this.setState({ currentWord: (this.state.currentWord + 1) % 5, initial: false })
         this.changeWord()
       }
     }, duration)
@@ -160,8 +166,13 @@ class TextAnimation extends React.PureComponent<Props> {
             Let's make money{' '}
           </H1>
           <View>
-            <View style={[styles.mask, fadeOut]} key={`${this.state.currentWord}-mask1`} />
-            <View style={[styles.mask2, fadeIn]} key={`${this.state.currentWord}-mask2`} />
+            <>
+              <View style={[styles.mask, fadeOut]} key={`${this.state.currentWord}-mask1`} />
+              {!this.state.initial && (
+                <View style={[styles.mask2, fadeIn]} key={`${this.state.currentWord}-mask2`} />
+              )}
+            </>
+
             <H1
               accessibilityRole={'heading'}
               style={[styles.white, textStyles.heavy, textStyles.center]}


### PR DESCRIPTION


### Description


- use smaller video for mobile devices
- start initial word as already visible and then fade in out the rest


### Tested
1) Used Chrome's network throttling feature to simulate a slow network.
2) Confirmed there was  a long delay where the text just read "lets make money" 
3) made the change so word is not hidden on load 
4) confirmed the full sentence shows up all together and animations work as intended after
5) checked i still looks nice on fast networks

### Other change

added State interface to TextAnimation

### Related issues

- Fixes #264 
### Backwards compatibility

