### PR TITLE
Fix Event Dates on Community Page

### DIFF
--- a/packages/web/fullstack/EventProps.ts
+++ b/packages/web/fullstack/EventProps.ts
@@ -1,13 +1,13 @@
 // Processed Event with typed values
 export interface EventProps {
   name: string
-  startDate: Date
+  startDate: string
   location: string
   link: string
   celoHosted: boolean
   celoSpeaking: boolean
   celoAttending: boolean
-  endDate?: Date
+  endDate?: string
   recap?: string
   description?: string
 }

--- a/packages/web/server/EventHelpers.ts
+++ b/packages/web/server/EventHelpers.ts
@@ -97,8 +97,8 @@ function convertValues(event: IncomingEvent): EventProps {
     celoHosted: event.celoHosted === 'TRUE',
     celoSpeaking: event.celoSpeaking === 'TRUE',
     celoAttending: event.celoAttending === 'TRUE',
-    startDate: parseDate(event.startDate),
-    endDate: event.endDate && parseDate(event.endDate),
+    startDate: event.startDate,
+    endDate: event.endDate,
   }
 }
 
@@ -109,7 +109,7 @@ export function splitEvents(normalizedEvents): State {
   const pastEvents = []
 
   normalizedEvents.forEach((event: EventProps) => {
-    const willHappen = event.startDate.valueOf() > today
+    const willHappen = parseDate(event.startDate).valueOf() > today
 
     if (willHappen) {
       upcomingEvents.unshift(event)
@@ -131,7 +131,7 @@ function removeEmpty(event: IncomingEvent): boolean {
 }
 
 function orderByDate(eventA: EventProps, eventB: EventProps) {
-  return eventA.startDate.valueOf() > eventB.startDate.valueOf() ? -1 : 1
+  return parseDate(eventA.startDate).valueOf() > parseDate(eventB.startDate).valueOf() ? -1 : 1
 }
 
 function celoFirst(eventA: EventProps, eventB: EventProps) {

--- a/packages/web/src/community/connect/EventRow.tsx
+++ b/packages/web/src/community/connect/EventRow.tsx
@@ -4,7 +4,7 @@ import { I18nProps, withNamespaces } from 'src/i18n'
 import { ScreenProps, ScreenSizes, withScreenSize } from 'src/layout/ScreenSize'
 import Button, { BTN } from 'src/shared/Button.3'
 import OvalCoin from 'src/shared/OvalCoin'
-import { printDuration } from 'src/shared/PlaceDate'
+import { printDuration, parseDate } from 'src/shared/PlaceDate'
 import { colors, fonts, standardStyles } from 'src/styles'
 
 import { EventProps } from 'fullstack/EventProps'
@@ -42,8 +42,6 @@ class EventRow extends React.PureComponent<Props> {
       screen,
       recap,
     } = this.props
-    const beginDate = new Date(startDate)
-    const stopDate = endDate ? new Date(endDate) : null
 
     const isMobile = screen === ScreenSizes.MOBILE
     const isHighlightEvent = section === 'Highlight Event'
@@ -84,7 +82,7 @@ class EventRow extends React.PureComponent<Props> {
         </View>
         <View style={!isMobile && styles.row}>
           <Text style={fonts.p}>
-            {location} — {printDuration(beginDate, stopDate)}
+            {location} — {printDuration(parseDate(startDate), parseDate(endDate))}
           </Text>
           <EventLink
             link={link}

--- a/packages/web/src/community/connect/EventRow.tsx
+++ b/packages/web/src/community/connect/EventRow.tsx
@@ -4,7 +4,7 @@ import { I18nProps, withNamespaces } from 'src/i18n'
 import { ScreenProps, ScreenSizes, withScreenSize } from 'src/layout/ScreenSize'
 import Button, { BTN } from 'src/shared/Button.3'
 import OvalCoin from 'src/shared/OvalCoin'
-import { printDuration, parseDate } from 'src/shared/PlaceDate'
+import { parseDate, printDuration } from 'src/shared/PlaceDate'
 import { colors, fonts, standardStyles } from 'src/styles'
 
 import { EventProps } from 'fullstack/EventProps'

--- a/packages/web/src/shared/PlaceDate.tsx
+++ b/packages/web/src/shared/PlaceDate.tsx
@@ -13,6 +13,13 @@ export function printDuration(date: Date, endDate: Date | null): string {
   }
 }
 
+export function parseDate(date: string | undefined) {
+  if (date) {
+    return fecha.parse(date, 'MM-DD-YY')
+  }
+  return null
+}
+
 export default function PlaceDate({
   location = '',
   startDate,


### PR DESCRIPTION
### Description

JS dates are parsed as local to their execution environment but stored as just ms since epoch. However When we parse on server it converts to UTC which when then reparse on client mean there is a unneeded and incorrect conversation of the date in UTC to the Date in local timezone.  And an off by one date error  depending on the timezone you are in

### Tested

So far ive only be able to reproduce the bug on non local environments. so technically havent tested yet. 

### Related issues

there was technically a mistype as we had start and endDate typed as Date but when they were moved to parsing on server what was really coming thru json was not a date but a string. 

- Fixes #174 
### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
