### PR TITLE
[NotificationService] Re-enable app notifications

### DIFF
--- a/packages/notification-service/src/firebase.ts
+++ b/packages/notification-service/src/firebase.ts
@@ -9,10 +9,13 @@ let lastBlockRef: admin.database.Reference
 let pendingRequestsRef: admin.database.Reference
 
 export interface Registrations {
-  [address: string]: {
-    fcmToken: string
-    language?: string
-  }
+  [address: string]:
+    | {
+        fcmToken: string
+        language?: string
+      }
+    | undefined
+    | null
 }
 
 export enum PaymentRequestStatuses {
@@ -99,15 +102,17 @@ export function initializeDb() {
 }
 
 export function getTokenFromAddress(address: string) {
-  if (address in registrations) {
-    return registrations[address].fcmToken
+  const registration = registrations[address]
+  if (registration) {
+    return registration.fcmToken
   } else {
     return null
   }
 }
 
 export function getTranslatorForAddress(address: string) {
-  const language = registrations[address].language
+  const registration = registrations[address]
+  const language = registration && registration.language
   // Language is set and i18next has the proper config
   if (language) {
     console.info(`Language resolved as ${language} for user address ${address}`)

--- a/packages/notification-service/src/polling.ts
+++ b/packages/notification-service/src/polling.ts
@@ -1,10 +1,10 @@
 import AsyncPolling from 'async-polling'
-// import { handleTransferNotifications } from './blockscout/transfers'
+import { handleTransferNotifications } from './blockscout/transfers'
 import { POLLING_INTERVAL } from './config'
 import { handlePaymentRequests } from './handlers'
 
 export const notificationPolling = AsyncPolling(async (end) => {
-  // await handleTransferNotifications()
+  await handleTransferNotifications()
   await handlePaymentRequests()
   end()
 }, POLLING_INTERVAL)

--- a/packages/notification-service/tsconfig.json
+++ b/packages/notification-service/tsconfig.json
@@ -14,5 +14,6 @@
     "target": "es6",
     "lib": ["es7", "esnext"]
   },
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "vendor", ".bundle"]
 }


### PR DESCRIPTION
### Description

Re-enable app notifications that had been disabled because of https://github.com/celo-org/celo-monorepo-old2/issues/7

### Tested

Updated firebase DB `lastBlockNotified` to a recent block.
Deployed the service.
Notifications are received again.

### Other changes

Fixed build not populating the `dist` folder.
Fixed undefined or null registration stopping the loop completely.

### Related issues

- Fixes #145

### Backwards compatibility

Backward compatible.
