### PR TITLE
Points CI back to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ jobs:
             go version
             cd packages/celotool
             mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-            ./ci_test_transfers.sh checkout kobigurk/bls
+            ./ci_test_transfers.sh checkout master
 
   end-to-end-geth-governance-test:
     <<: *defaults
@@ -346,7 +346,7 @@ jobs:
             go version
             cd packages/celotool
             mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-            ./ci_test_governance.sh checkout kobigurk/bls
+            ./ci_test_governance.sh checkout master
 
   end-to-end-geth-sync-test:
     <<: *defaults
@@ -384,7 +384,7 @@ jobs:
             go version
             cd packages/celotool
             mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-            ./ci_test_sync.sh checkout kobigurk/bls
+            ./ci_test_sync.sh checkout master
 
   end-to-end-geth-integration-sync-test:
     <<: *defaults


### PR DESCRIPTION
The BLS PR https://github.com/celo-org/celo-monorepo/pull/47 pointed the CI to a specific branch in order to pass tests.