### PR TITLE
Fix connect page cover area to work on more screen sizes 

### DIFF
--- a/packages/web/src/community/connect/CoverArea.tsx
+++ b/packages/web/src/community/connect/CoverArea.tsx
@@ -157,6 +157,7 @@ const styles = StyleSheet.create({
   },
   circleContainerMedium: {
     width: '80vw',
+    maxWidth: '60vh',
   },
   circleContainerLarge: {
     width: '73vh',

--- a/packages/web/src/community/connect/CoverArea.tsx
+++ b/packages/web/src/community/connect/CoverArea.tsx
@@ -9,6 +9,7 @@ import { I18nProps, withNamespaces } from 'src/i18n'
 import Arrow from 'src/icons/Arrow'
 import { Cell, GridRow, Spans } from 'src/layout/GridRow'
 import { ScreenProps, ScreenSizes, withScreenSize } from 'src/layout/ScreenSize'
+import { HEADER_HEIGHT } from 'src/shared/Styles'
 import { colors, fonts, standardStyles, textStyles } from 'src/styles'
 
 type Props = ScreenProps & I18nProps
@@ -18,27 +19,15 @@ class CoverArea extends React.PureComponent<Props> {
     const isDesktop = screen === ScreenSizes.DESKTOP
     return (
       <View style={styles.darkBackground}>
-        <View style={[standardStyles.centered, styles.fullScreen]}>
+        <View
+          style={[standardStyles.centered, isDesktop ? styles.fullScreen : styles.economizeScreen]}
+        >
           <View style={[standardStyles.centered, styles.aboveFold]}>
             <View style={circleContainerStyle(screen)}>
               <FadeIn duration={0} unmountIfInvisible={true}>
                 {(load) => <FullCircle init={load} />}
               </FadeIn>
-              <View
-                style={[
-                  standardStyles.centered,
-                  isDesktop ? styles.fourWords : styles.fourWordsMobile,
-                ]}
-              >
-                <Text style={fonts.specialOneOff}>
-                  <Text style={styles.greenColor}>Developers. </Text>
-                  <Text style={styles.purpleColor}>Designers. </Text>
-                </Text>
-                <Text style={fonts.specialOneOff}>
-                  <Text style={styles.redColor}>Dreamers. </Text>
-                  <Text style={styles.blueColor}>Doers. </Text>
-                </Text>
-              </View>
+              {isDesktop && <FourWords screen={screen} />}
             </View>
           </View>
           <View
@@ -55,6 +44,11 @@ class CoverArea extends React.PureComponent<Props> {
           mobileStyle={standardStyles.sectionMarginBottomMobile}
         >
           <Cell span={Spans.half}>
+            {!isDesktop && (
+              <Fade bottom={true} distance={'40px'}>
+                <FourWords screen={screen} />
+              </Fade>
+            )}
             <Fade bottom={true} distance={'80px'}>
               <View style={[standardStyles.centered, isDesktop && styles.ctArea]}>
                 <H1
@@ -95,10 +89,40 @@ function circleContainerStyle(screen: ScreenSizes) {
   }
 }
 
+function fourWordsStyle(screen: ScreenSizes) {
+  switch (screen) {
+    case ScreenSizes.DESKTOP:
+      return styles.fourWords
+    case ScreenSizes.TABLET:
+      return styles.fourWordsMobile
+    default:
+      return styles.fourWordsMobile
+  }
+}
+
+function FourWords({ screen }: { screen: ScreenSizes }) {
+  return (
+    <View style={[standardStyles.centered, fourWordsStyle(screen)]}>
+      <Text style={[fonts.specialOneOff, textStyles.center]}>
+        <Text style={styles.greenColor}>Developers. </Text>
+        <Text style={styles.purpleColor}>Designers. </Text>
+      </Text>
+      <Text style={[fonts.specialOneOff, textStyles.center]}>
+        <Text style={styles.redColor}>Dreamers. </Text>
+        <Text style={styles.blueColor}>Doers. </Text>
+      </Text>
+    </View>
+  )
+}
+
 const styles = StyleSheet.create({
   fullScreen: {
     width: '100vw',
     height: '100vh',
+    maxHeight: '100vw', // so large tablets dont make the circle area oddly tall
+  },
+  economizeScreen: {
+    marginTop: HEADER_HEIGHT,
   },
   aboveFold: { justifyContent: 'space-around', width: '100%', padding: 20 },
   darkBackground: {
@@ -126,14 +150,13 @@ const styles = StyleSheet.create({
   },
   fourWordsMobile: {
     width: '100%',
-    marginTop: 50,
+    marginBottom: 50,
   },
   circleContainer: {
     width: '100%',
   },
   circleContainerMedium: {
     width: '80vw',
-    maxHeight: '70vh',
   },
   circleContainerLarge: {
     width: '73vh',


### PR DESCRIPTION
### Description

Our above the fold are of the Connect page was having some issues on some screen sizes (mostly tablets) this fixes that mostly by changing our Four D Words to be render in the dom at a different place depending on screen size rather than moving with just css. Also adds a few max heights and maxWidths to keep everything in place


### Tested

<img width="495" alt="Screen Shot 2019-08-08 at 10 03 54 AM" src="https://user-images.githubusercontent.com/3814795/62724673-60ca9e00-b9c8-11e9-84a7-3f0c8ce23d68.png">
<img width="939" alt="Screen Shot 2019-08-08 at 10 04 03 AM" src="https://user-images.githubusercontent.com/3814795/62724674-60ca9e00-b9c8-11e9-894d-d8209e6ba422.png">
<img width="517" alt="Screen Shot 2019-08-08 at 10 04 17 AM" src="https://user-images.githubusercontent.com/3814795/62724675-61633480-b9c8-11e9-865c-b8e52b57c3df.png">
<img width="515" alt="Screen Shot 2019-08-08 at 10 04 30 AM" src="https://user-images.githubusercontent.com/3814795/62724676-61633480-b9c8-11e9-95b1-4454e2cb81e8.png">
<img width="544" alt="Screen Shot 2019-08-08 at 10 04 37 AM" src="https://user-images.githubusercontent.com/3814795/62724677-61633480-b9c8-11e9-925d-41026c944fc6.png">
<img width="972" alt="Screen Shot 2019-08-08 at 10 04 45 AM" src="https://user-images.githubusercontent.com/3814795/62724678-61633480-b9c8-11e9-9605-03c2d2bdd898.png">
<img width="1580" alt="Screen Shot 2019-08-08 at 10 04 54 AM" src="https://user-images.githubusercontent.com/3814795/62724679-61633480-b9c8-11e9-881b-a5ed0e9460ac.png">
<img width="1467" alt="Screen Shot 2019-08-08 at 10 05 08 AM" src="https://user-images.githubusercontent.com/3814795/62724681-61fbcb00-b9c8-11e9-9e33-6488238b408d.png">
<img width="705" alt="Screen Shot 2019-08-08 at 10 05 17 AM" src="https://user-images.githubusercontent.com/3814795/62724682-61fbcb00-b9c8-11e9-90a5-6c9f14d24af4.png">
<img width="1103" alt="Screen Shot 2019-08-08 at 10 06 22 AM" src="https://user-images.githubusercontent.com/3814795/62724683-61fbcb00-b9c8-11e9-8fe7-bfef4f1c4cfc.png">
<img width="926" alt="Screen Shot 2019-08-08 at 10 06 57 AM" src="https://user-images.githubusercontent.com/3814795/62724684-61fbcb00-b9c8-11e9-9388-8592e2ec85d0.png">
<img width="856" alt="Screen Shot 2019-08-08 at 10 32 27 AM" src="https://user-images.githubusercontent.com/3814795/62724685-61fbcb00-b9c8-11e9-858b-80ca2d99a3f6.png">


### Related issues

- Fixes #390

### Backwards compatibility

N/A
