### PR TITLE
Update TypeChain commit hash dependency

### DIFF
--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -35,7 +35,7 @@
     "prettier": "1.13.5",
     "sleep-promise": "^8.0.1",
     "ts-jest": "^24.0.0",
-    "typechain": "git+https://github.com/celo-org/TypeChain.git#ce6a33b",
+    "typechain": "git+https://github.com/celo-org/TypeChain.git#832e628",
     "typescript": "^3.3.3",
     "web3": "1.0.0-beta.37",
     "web3-utils": "1.0.0-beta.37"
@@ -54,7 +54,7 @@
     "jest": "^24.8.0",
     "prettier": "1.13.5",
     "ts-jest": "^24.0.0",
-    "typechain": "git+https://github.com/celo-org/TypeChain.git#ce6a33b",
+    "typechain": "git+https://github.com/celo-org/TypeChain.git#832e628",
     "typescript": "^3.3.3"
   },
   "files": [

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -63,7 +63,7 @@
     "truffle-resolver": "^4.0.4",
     "truffle-security": "^1.3.7",
     "twilio": "^3.23.2",
-    "typechain": "git+https://github.com/celo-org/TypeChain.git#ce6a33b",
+    "typechain": "git+https://github.com/celo-org/TypeChain.git#832e628",
     "weak-map": "^1.0.5",
     "web3": "1.0.0-beta.37"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -29295,9 +29295,9 @@ type-is@~1.6.17:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-"typechain@git+https://github.com/celo-org/TypeChain.git#ce6a33b":
+"typechain@git+https://github.com/celo-org/TypeChain.git#832e628":
   version "0.3.11"
-  resolved "git+https://github.com/celo-org/TypeChain.git#ce6a33b06af43da8c3997a9d0ed1d27683d24bd9"
+  resolved "git+https://github.com/celo-org/TypeChain.git#832e628fab8f7d9946d46047afe73958d527c262"
   dependencies:
     command-line-args "^4.0.7"
     debug "^3.0.1"


### PR DESCRIPTION
### Description

Points to [yorhodes/upstream-inherit](https://github.com/celo-org/TypeChain/commits/yorhodes/upstream-inherit)

### Tested

`yarn install` works.
