### PR TITLE
[Wallet] delete redeemcomplete from assignAccountFromPrivateKey

### DIFF
--- a/packages/mobile/src/web3/saga.ts
+++ b/packages/mobile/src/web3/saga.ts
@@ -14,7 +14,6 @@ import { getWordlist } from 'src/backup/utils'
 import { UNLOCK_DURATION } from 'src/geth/consts'
 import { deleteChainData } from 'src/geth/geth'
 import { waitForGethConnectivity } from 'src/geth/saga'
-import { redeemComplete } from 'src/invite/actions'
 import { navigateToError } from 'src/navigator/NavigationService'
 import { waitWeb3LastBlock } from 'src/networkInfo/saga'
 import Logger from 'src/utils/Logger'
@@ -167,7 +166,6 @@ export function* assignAccountFromPrivateKey(key: string) {
     )
 
     yield put(setAccount(account))
-    yield put(redeemComplete(true))
     yield put(setAccountCreationTime())
     yield call(assignDataKeyFromPrivateKey, key)
 
@@ -175,7 +173,6 @@ export function* assignAccountFromPrivateKey(key: string) {
     return account
   } catch (e) {
     Logger.error(TAG, `@assignAccountFromPrivateKey: ${e}`)
-    yield put(redeemComplete(false))
     return null
   }
 }


### PR DESCRIPTION
### Description
Removed redeemComplete(true) - bug introduced from previous cleanup. Being called in the wrong function too early.

### Related issues
- bug introduced from #144 

### Backwards compatibility
Yes
