### PR TITLE
Fix navigation to QR code scanner from send flow

### DIFF
--- a/packages/mobile/locales/en-US/sendFlow7.json
+++ b/packages/mobile/locales/en-US/sendFlow7.json
@@ -54,7 +54,7 @@
     "Storage write permission is needed for downloading the QR code",
   "ScanCodeByPlacingItInTheBox": "Scan code by placing it in the box",
   "needCameraPermissionToScan": "App needs camera permission to scan QR codes",
-  "backToYourQRCode": "Back to your QR Code",
+  "showYourQRCode": "Show your QR code",
   "toSentOrRequestPayment": "to send or request payment",
   "requestSent": "Request Sent",
   "reclaimPayment": "Reclaim Payment",

--- a/packages/mobile/locales/es-AR/sendFlow7.json
+++ b/packages/mobile/locales/es-AR/sendFlow7.json
@@ -55,7 +55,7 @@
   "ScanCodeByPlacingItInTheBox": "Escanee el código colocándolo en la caja",
   "needCameraPermissionToScan":
     "La aplicación necesita permiso de la cámara para escanear códigos QR",
-  "backToYourQRCode": "Volver a su código QR",
+  "showYourQRCode": "Muestra su código QR",
   "toSentOrRequestPayment": "enviar o solicitar pago",
   "requestSent": "Solicitud Enviada",
   "reclaimPayment": "Reclamar el Pago",

--- a/packages/mobile/src/qrcode/QRScanner.tsx
+++ b/packages/mobile/src/qrcode/QRScanner.tsx
@@ -13,7 +13,7 @@ import { headerWithBackButton } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { handleBarcodeDetected } from 'src/send/actions'
-import { checkCameraPermission, requestCameraPermission } from 'src/utils/androidPermissions'
+import { requestCameraPermission } from 'src/utils/androidPermissions'
 import Logger from 'src/utils/Logger'
 
 interface DispatchProps {
@@ -27,10 +27,10 @@ const goToQrCodeScreen = () => {
 }
 
 class QRScanner extends React.Component<Props> {
-  static navigationOptions = {
+  static navigationOptions = () => ({
     ...headerWithBackButton,
     headerTitle: i18n.t('sendFlow7:scanCode'),
-  }
+  })
 
   camera: RNCamera | null = null
 
@@ -40,10 +40,7 @@ class QRScanner extends React.Component<Props> {
 
   async componentDidMount() {
     const { t } = this.props
-    let cameraPermission = await checkCameraPermission()
-    if (!cameraPermission) {
-      cameraPermission = await requestCameraPermission()
-    }
+    const cameraPermission = await requestCameraPermission()
 
     if (!cameraPermission) {
       Logger.showMessage(t('needCameraPermissionToScan'))
@@ -88,7 +85,7 @@ class QRScanner extends React.Component<Props> {
                 <QRCode />
               </View>
               <TouchableOpacity onPress={goToQrCodeScreen}>
-                <Text style={styles.footerText}> {t('backToYourQRCode')} </Text>
+                <Text style={styles.footerText}> {t('showYourQRCode')} </Text>
               </TouchableOpacity>
             </View>
           </RNCamera>
@@ -101,7 +98,6 @@ class QRScanner extends React.Component<Props> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    flexDirection: 'column',
   },
   preview: {
     flex: 1,

--- a/packages/mobile/src/recipients/RecipientPicker.tsx
+++ b/packages/mobile/src/recipients/RecipientPicker.tsx
@@ -42,7 +42,7 @@ import Logger from 'src/utils/Logger'
 import { assertUnreachable } from 'src/utils/typescript'
 
 const goToQrCodeScreen = () => {
-  navigate(Screens.QRCode)
+  navigate(Screens.QRScanner)
 }
 
 const QRCodeCTA = ({ t }: { t: TranslationFunction }) => (


### PR DESCRIPTION
### Description

Fix navigation to QR code scanner from send flow. Now goes straight to scanner.

### Tested

Tested flows to QR code from send flow and from wallet home.

### Related issues

- Fixes #581 

### Backwards compatibility

Yes
