### PR TITLE
Remove quotes from cli alias docs

### DIFF
--- a/packages/celotool/README.md
+++ b/packages/celotool/README.md
@@ -15,7 +15,7 @@ yarn
 
 If you want to use this tool from anywhere, add an alias to your ~/.bash_profile.
 
-`alias celotooljs="<YOUR_PATH_TO_MONOREPO>/packages/celotool/bin/celotooljs.sh"`
+`alias celotooljs=<YOUR_PATH_TO_MONOREPO>/packages/celotool/bin/celotooljs.sh`
 
 ## Usage
 


### PR DESCRIPTION
### Description

This failed for me with quotes, so I fixed it

### Tested

I have the alias without quotes
