### PR TITLE
[protocol] migrations: process cmdline args only once

### DIFF
--- a/packages/protocol/lib/web3-utils.ts
+++ b/packages/protocol/lib/web3-utils.ts
@@ -15,6 +15,7 @@ import {
   StableTokenInstance,
 } from 'types'
 import { TransactionObject } from 'web3/eth/types'
+import { build_directory } from '../migrationsConfig'
 
 import Web3 = require('web3')
 
@@ -316,19 +317,16 @@ export function deployImplementationAndRepointProxy<
       // Hack to create build artifact.
       .deploy(ContractProxy)
       .then(async () => {
-        const argv = require('minimist')(process.argv.slice(2))
-        if (argv.build_directory) {
-          const artifact = ContractProxy._json
-          artifact.networks[await web3.eth.net.getId()] = {
-            address: deployedProxyAddress,
-            // @ts-ignore
-            transactionHash: '0x',
-          }
-          const contractsDir = argv.build_directory + '/contracts'
-          const artifactor = new Artifactor(contractsDir)
-
-          await artifactor.save(artifact)
+        const artifact = ContractProxy._json
+        artifact.networks[await web3.eth.net.getId()] = {
+          address: deployedProxyAddress,
+          // @ts-ignore
+          transactionHash: '0x',
         }
+        const contractsDir = build_directory + '/contracts'
+        const artifactor = new Artifactor(contractsDir)
+
+        await artifactor.save(artifact)
       })
       .then(() => {
         return deployer.deploy(Contract)

--- a/packages/protocol/migrations/13_attestations.ts
+++ b/packages/protocol/migrations/13_attestations.ts
@@ -9,7 +9,6 @@ import {
   setInRegistry,
 } from '@celo/protocol/lib/web3-utils'
 import { config } from '@celo/protocol/migrationsConfig'
-import * as minimist from 'minimist'
 import { AttestationsInstance, RegistryInstance, StableTokenInstance } from 'types'
 import { TransactionObject } from 'web3/eth/types'
 const initializeArgs = async (): Promise<[string, string, string[], string[]]> => {
@@ -55,11 +54,7 @@ module.exports = deployProxyAndImplementation<AttestationsInstance>(
   'Attestations',
   initializeArgs,
   async (attestations: AttestationsInstance) => {
-    const argv = minimist(process.argv, {
-      string: ['keys'],
-      default: { keys: '' },
-    })
-    const valKeys: string[] = argv.keys ? argv.keys.split(',') : []
+    const valKeys: string[] = config.validators.validatorKeys
 
     await Promise.all(valKeys.map((key) => setDataEncryptionKey(attestations, key)))
 

--- a/packages/protocol/migrations/16_elect_validators.ts
+++ b/packages/protocol/migrations/16_elect_validators.ts
@@ -11,15 +11,9 @@ import {
 import { config } from '@celo/protocol/migrationsConfig'
 import { BigNumber } from 'bignumber.js'
 import * as bls12377js from 'bls12377js'
-import * as minimist from 'minimist'
 import { BondedDepositsInstance, ValidatorsInstance } from 'types'
 
 const Web3 = require('web3')
-
-const argv = minimist(process.argv, {
-  string: ['keys'],
-  default: { keys: '' },
-})
 
 function serializeKeystore(keystore: any) {
   return Buffer.from(JSON.stringify(keystore)).toString('base64')
@@ -136,7 +130,7 @@ module.exports = async (_deployer: any) => {
     BondedDepositsInstance
   >('BondedDeposits', artifacts)
 
-  const valKeys: string[] = argv.keys ? argv.keys.split(',') : []
+  const valKeys: string[] = config.validators.validatorKeys
 
   if (valKeys.length === 0) {
     console.log('  No validators to register')

--- a/packages/protocol/migrationsConfig.js
+++ b/packages/protocol/migrationsConfig.js
@@ -1,6 +1,7 @@
-const argv = require('minimist')(process.argv.slice(2), { string: ['migration_override'] })
+const minimist = require('minimist')
+const path = require('path')
 
-const defaultConfig = {
+const DefaultConfig = {
   attestations: {
     attestationExpirySeconds: 60 * 60, // 1 hour,
     attestationRequestFeeInDollars: 0.05,
@@ -67,6 +68,7 @@ const defaultConfig = {
     minBondedDepositValue: '1000000000000000000', // 1 gold
     minBondedDepositNoticePeriod: 60 * 24 * 60 * 60, // 60 days
 
+    validatorKeys: [],
     // We register a single validator group during the migration.
     groupName: 'C-Labs',
     groupUrl: 'https://www.celo.org',
@@ -88,13 +90,26 @@ const linkedLibraries = {
   Signatures: ['BondedDeposits', 'Escrow'],
 }
 
+const argv = minimist(process.argv.slice(2), {
+  string: ['migration_override', 'keys', 'build_directory'],
+  default: {
+    keys: '',
+    build_directory: path.join(__dirname, 'build'),
+  },
+})
+const validatorKeys = argv.keys ? argv.keys.split(',') : []
+
 const migrationOverride = argv.migration_override ? JSON.parse(argv.migration_override) : {}
-config = {}
-for (const key in defaultConfig) {
-  config[key] = { ...defaultConfig[key], ...migrationOverride[key] }
+const config = {}
+
+for (const key of Object.keys(DefaultConfig)) {
+  config[key] = { ...DefaultConfig[key], ...migrationOverride[key] }
 }
 
+config.validators.validatorKeys = validatorKeys
+
 module.exports = {
+  build_directory: argv.build_directory,
   config,
   linkedLibraries,
 }


### PR DESCRIPTION
### Description

cmdline arguments were parsed several times accross migrations and
related libs. And not always with the same keys. This is confusing, for
any other developer, since it's not clear what are the possible keys,
and also hard to change.

Now, all argument are read in `migrationsConfigs`.

### Tested

`yarn ganache-dev` & `yarn init-network -n development` (without the registry bug)

