### PR TITLE
[Wallet] Fix Send handling of async recip cache updates

### DIFF
--- a/packages/mobile/src/send/Send.tsx
+++ b/packages/mobile/src/send/Send.tsx
@@ -134,6 +134,21 @@ class Send extends React.Component<Props, State> {
     this.setState({ hasGivenPermission })
   }
 
+  componentDidUpdate(prevPops: Props) {
+    const { recentRecipients, allRecipients } = this.props
+
+    if (
+      recentRecipients !== prevPops.recentRecipients ||
+      allRecipients !== prevPops.allRecipients
+    ) {
+      this.setState({
+        loading: false,
+        recentFiltered: filterRecipients(recentRecipients, this.state.searchQuery, false),
+        allFiltered: filterRecipients(allRecipients, this.state.searchQuery, true),
+      })
+    }
+  }
+
   onSearchQueryChanged = (searchQuery: string) => {
     this.props.hideAlert()
     this.setState({


### PR DESCRIPTION
### Description

The send screen only created its list on componentDidMount, meaning if a user got to the send screen before we were done importing, we wouldn't see contacts. Fixed by adding componentDidUpdate.

### Tested

Loaded send screen quickly after app launch.

