### PR TITLE
[Wallet] Fix version code for wallet app v1.4.1

### DIFF
--- a/packages/mobile/android/gradle.properties
+++ b/packages/mobile/android/gradle.properties
@@ -20,4 +20,4 @@
 CELO_RELEASE_STORE_FILE=celo-release-key.keystore
 CELO_RELEASE_KEY_ALIAS=celo-key-alias
 # Setting this manually based on version number until we have this deploying via Cloud Build
-VERSION_CODE=1004000
+VERSION_CODE=100400100


### PR DESCRIPTION
Forgot to up the version code in PR #621 
It should be `1004001` but that was used already, possibly in a previous deployment attempt for v.1.4.0
So using `100400100` instead, allowing us 1000 version codes per actual app version in case we need multiple deployments.