### PR TITLE
Add a note on conduct to SDK Intro Documentation

### DIFF
--- a/packages/docs/developer-resources/introduction.md
+++ b/packages/docs/developer-resources/introduction.md
@@ -7,3 +7,7 @@ Welcome to the Celo SDK Docs Homepage! Here, you can find resources for DAppKit 
 - **[DAppKit](dappkit/README.md)** is a lightweight set of functions that allow mobile DApps to work with the Celo Wallet to sign transactions and access the user's account. This allows for a better user experience: DApps can focus on a great native experience without having to worry about key management. It also provides a simpler development experience, as no state or connection management is necessary.
 
 If you'd like to see the Celo SDK expanded to support your favorite technology or application, please join the conversation on the [Celo Forum](https://forum.celo.org/c/applications-and-ecosystem-development) or [Discord](https://discordapp.com/channels/600834479145353243/600839784700837926) and tell us what you'd like to build- we highly encourage contributions!
+
+{% hint style="info" %}
+Please note, financial products built on the Celo protocol may be regulated in their respective jurisdictions, so it is important that developers are responsible and attentive to their end consumers and the regulations that may apply. This commitment is also part of the [Celo Code of Conduct](https://celo.org/code-of-conduct).
+{% endhint %}


### PR DESCRIPTION
### Description

Adds a note linking to the Celo Code of Conduct (https://celo.org/code-of-conduct) for developers

### Tested

uses "hint" markdown supported by gitbook

### Other changes

n/a

### Related issues

No issue created

### Backwards compatibility

Backwards Compatible.
