### PR TITLE
Fix LaTeX multiplication signs

### DIFF
--- a/packages/docs/celo-codebase/protocol/transactions/gas-pricing.md
+++ b/packages/docs/celo-codebase/protocol/transactions/gas-pricing.md
@@ -10,7 +10,7 @@ This approach, which is based on [EIP-1559](https://eips.ethereum.org/EIPS/eip-1
 
 The minimum gas price is calculated as follows:
 
-$$MinGasPrice_1 = MinGasPrice_0 ∗ ( 1 + ( BlockDensity_0 − TargetDensity ) \* AdjustementSpeed )$$
+$$MinGasPrice_1 = MinGasPrice_0 \times ( 1 + ( BlockDensity_0 − TargetDensity ) \times AdjustementSpeed )$$
 
 With:
 


### PR DESCRIPTION
### Description

The formula for min gas price used a weird low asterisk for one multiplication symbol, and a `\*` for another, the latter of which is not valid LaTeX. Replacing both with `\times` should work. 

### Tested

Not tested.