### PR TITLE
[blockchain-api] Listen on all interfaces by default

### DIFF
--- a/packages/blockchain-api/src/index.ts
+++ b/packages/blockchain-api/src/index.ts
@@ -11,7 +11,7 @@ declare var process: {
 const GRAPHQL_PATH: string = '/'
 
 const PORT: number = Number(process.env.PORT) || 8080
-const INTERFACE: string = process.env.INTERFACE || 'localhost'
+const INTERFACE: string = process.env.INTERFACE || '0.0.0.0'
 
 const app: any = express()
 


### PR DESCRIPTION
### Description

Listens on all interfaces instead of local host by default.

### Tested

Tested access from a different device on the same network.

### Other changes

N/A

### Related issues

- Fixes incorrect default from #649
