### PR TITLE
[ContractKit]Add code to enable local signing of transactions

### DIFF
--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -29,7 +29,9 @@
     "@types/debug": "^4.1.5",
     "bignumber.js": "^7.2.0",
     "debug": "^4.1.1",
+    "eth-lib": "^0.2.8",
     "web3": "1.0.0-beta.37",
+    "web3-core-helpers": "1.0.0-beta.37",
     "web3-utils": "1.0.0-beta.37"
   },
   "devDependencies": {

--- a/packages/contractkit/src/utils/signing-utils.ts
+++ b/packages/contractkit/src/utils/signing-utils.ts
@@ -1,0 +1,135 @@
+import debugFactory from 'debug'
+// @ts-ignore-next-line
+import { account as Account, bytes as Bytes, hash as Hash, nat as Nat, RLP } from 'eth-lib'
+// @ts-ignore-next-line
+import * as helpers from 'web3-core-helpers'
+
+const debug = debugFactory('kit:tx:sign')
+
+// Original code taken from
+// https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth-accounts/src/index.js
+
+function isNullOrUndefined(value: any): boolean {
+  return value === null || value === undefined
+}
+
+function trimLeadingZero(hex: string) {
+  while (hex && hex.startsWith('0x0')) {
+    hex = '0x' + hex.slice(3)
+  }
+  return hex
+}
+
+function makeEven(hex: string) {
+  if (hex.length % 2 === 1) {
+    hex = hex.replace('0x', '0x0')
+  }
+  return hex
+}
+
+export async function signTransaction(txn: any, privateKey: string) {
+  let result: any
+
+  if (!txn) {
+    throw new Error('No transaction object given!')
+  }
+
+  const signed = (tx: any) => {
+    if (!tx.gas && !tx.gasLimit) {
+      throw new Error('"gas" is missing')
+    }
+
+    if (tx.nonce < 0 || tx.gas < 0 || tx.gasPrice < 0 || tx.chainId < 0) {
+      throw new Error('Gas, gasPrice, nonce or chainId is lower than 0')
+    }
+
+    try {
+      tx = helpers.formatters.inputCallFormatter(tx)
+
+      const transaction = tx
+      transaction.to = tx.to || '0x'
+      transaction.data = tx.data || '0x'
+      transaction.value = tx.value || '0x'
+      transaction.chainId = '0x' + Number(tx.chainId).toString(16)
+      transaction.gasCurrency = tx.gasCurrency || '0x'
+      transaction.gasFeeRecipient = tx.gasFeeRecipient || '0x'
+
+      const rlpEncoded = RLP.encode([
+        Bytes.fromNat(transaction.nonce),
+        Bytes.fromNat(transaction.gasPrice),
+        Bytes.fromNat(transaction.gas),
+        transaction.gasCurrency.toLowerCase(),
+        transaction.gasFeeRecipient.toLowerCase(),
+        transaction.to.toLowerCase(),
+        Bytes.fromNat(transaction.value),
+        transaction.data,
+        Bytes.fromNat(transaction.chainId || '0x1'),
+        '0x',
+        '0x',
+      ])
+
+      const hash = Hash.keccak256(rlpEncoded)
+
+      const signature = Account.makeSigner(Nat.toNumber(transaction.chainId || '0x1') * 2 + 35)(
+        Hash.keccak256(rlpEncoded),
+        privateKey
+      )
+
+      const rawTx = RLP.decode(rlpEncoded)
+        .slice(0, 8)
+        .concat(Account.decodeSignature(signature))
+
+      rawTx[8] = makeEven(trimLeadingZero(rawTx[8]))
+      rawTx[9] = makeEven(trimLeadingZero(rawTx[9]))
+      rawTx[10] = makeEven(trimLeadingZero(rawTx[10]))
+
+      const rawTransaction = RLP.encode(rawTx)
+
+      const values = RLP.decode(rawTransaction)
+      result = {
+        messageHash: hash,
+        v: trimLeadingZero(values[8]),
+        r: trimLeadingZero(values[9]),
+        s: trimLeadingZero(values[10]),
+        rawTransaction,
+      }
+    } catch (e) {
+      throw e
+    }
+
+    return result
+  }
+
+  // Resolve immediately if nonce, chainId and price are provided
+  if (txn.nonce !== undefined && txn.chainId !== undefined && txn.gasPrice !== undefined) {
+    return signed(txn)
+  }
+
+  const chainId = txn.chainId
+  const gasPrice = txn.gasPrice
+  const nonce = txn.nonce
+
+  if (isNullOrUndefined(chainId) || isNullOrUndefined(gasPrice) || isNullOrUndefined(nonce)) {
+    throw new Error(
+      'One of the values "chainId", "gasPrice", or "nonce" couldn\'t be fetched: ' +
+        JSON.stringify({ chainId, gasPrice, nonce })
+    )
+  }
+  txn.chainId = chainId
+  txn.gasPrice = gasPrice
+  txn.nonce = nonce
+  return signed(txn)
+}
+
+// Recover sender address from a raw transaction.
+export function recoverTransaction(rawTx: string): string {
+  const values = RLP.decode(rawTx)
+  debug('signing-utils@recoverTransaction: values are %s', values)
+  const signature = Account.encodeSignature(values.slice(8, 11))
+  const recovery = Bytes.toNumber(values[8])
+  // tslint:disable-next-line:no-bitwise
+  const extraData = recovery < 35 ? [] : [Bytes.fromNumber((recovery - 35) >> 1), '0x', '0x']
+  const signingData = values.slice(0, 8).concat(extraData)
+  const signingDataHex = RLP.encode(signingData)
+  return Account.recover(Hash.keccak256(signingDataHex), signature)
+}

--- a/packages/contractkit/src/utils/tx-signing.test.ts
+++ b/packages/contractkit/src/utils/tx-signing.test.ts
@@ -1,0 +1,56 @@
+import debugFactory from 'debug'
+import Web3 from 'web3'
+import { testWithGanache } from '../test-utils/ganache-test'
+import { recoverTransaction } from './signing-utils'
+import { CeloTx, getRawTransaction } from './tx-signing'
+import { addLocalAccount } from './web3-utils'
+
+// Run this test with --forceExit on completion.
+// jest src/utils/tx-signing.test.ts --forceExit
+
+const debug = debugFactory('kit:txtest:sign')
+
+// A random private key
+const PRIVATE_KEY = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+const accountAddress = generateAccountAddressFromPrivateKey(PRIVATE_KEY)
+
+function generateAccountAddressFromPrivateKey(privateKey: string): string {
+  if (!privateKey.toLowerCase().startsWith('0x')) {
+    privateKey = '0x' + privateKey
+  }
+  // @ts-ignore-next-line
+  return new Web3.modules.Eth().accounts.privateKeyToAccount(privateKey).address
+}
+
+testWithGanache('Transaction Utils', (web3: Web3) => {
+  // describe('Transaction Utils', () => {
+  describe('Signer Testing', () => {
+    it('should be able to sign and get the signer back', async () => {
+      jest.setTimeout(20 * 1000)
+      await addLocalAccount(web3, PRIVATE_KEY)
+      debug('Signer Testing using Account: %s', accountAddress)
+      const gasPrice = await web3.eth.getGasPrice()
+      debug('Signer Testing, gas price is %s', gasPrice)
+      const from = accountAddress
+      const to = accountAddress
+      const amountInWei: string = Web3.utils.toWei('1', 'ether')
+      const gasFees: string = Web3.utils.toWei('1', 'mwei')
+      debug('Signer Testing, getting nonce for %s...', from)
+      const nonce = await web3.eth.getTransactionCount(from)
+      debug('Signer Testing, nonce is %s', nonce)
+
+      const celoTransaction: CeloTx = {
+        nonce,
+        from,
+        to,
+        value: amountInWei,
+        gas: gasFees,
+        gasPrice: gasPrice.toString(),
+      }
+      const rawTransaction: string = await getRawTransaction(web3, celoTransaction)
+      const recoveredSigner = recoverTransaction(rawTransaction)
+      debug('Transaction was signed by "%s", recovered signer is "%s"', from, recoveredSigner)
+      expect(recoveredSigner).toEqual(from)
+    })
+  })
+})

--- a/packages/contractkit/src/utils/tx-signing.ts
+++ b/packages/contractkit/src/utils/tx-signing.ts
@@ -1,0 +1,69 @@
+import { PartialTxParams, PrivateKeyWalletSubprovider } from '@0x/subproviders'
+import debugFactory from 'debug'
+import Web3 from 'web3'
+import { Tx } from 'web3/eth/types'
+import { signTransaction } from './signing-utils'
+
+const debug = debugFactory('kit:tx:sign')
+
+export interface CeloTx extends Tx {
+  gasCurrency?: string
+  gasFeeRecipient?: string
+}
+
+export interface CeloPartialTxParams extends PartialTxParams {
+  gasCurrency?: string
+  gasFeeRecipient?: string
+}
+
+function getPrivateKeyWithout0xPrefix(privateKey: string) {
+  return privateKey.toLowerCase().startsWith('0x') ? privateKey.substring(2) : privateKey
+}
+
+export class CeloProvider extends PrivateKeyWalletSubprovider {
+  private readonly celoPrivateKey: string // Always 0x prefixed
+  private _chainId: number | null = null
+
+  constructor(privateKey: string) {
+    // This won't accept a privateKey with 0x prefix and will call that an invalid key.
+    super(getPrivateKeyWithout0xPrefix(privateKey))
+    // Prefix 0x here or else the signed transaction produces dramatically different signer!!!
+    this.celoPrivateKey = '0x' + getPrivateKeyWithout0xPrefix(privateKey)
+  }
+
+  public async signTransactionAsync(txParams: CeloPartialTxParams): Promise<string> {
+    debug('signTransactionAsync: txParams are %o', txParams)
+    if (txParams.chainId === undefined || txParams.chainId === null) {
+      txParams.chainId = await this.getChainId()
+    }
+    const signedTx = await signTransaction(txParams, this.celoPrivateKey)
+    const rawTransaction = signedTx.rawTransaction.toString('hex')
+    return rawTransaction
+  }
+
+  private async getChainId(): Promise<number> {
+    if (this._chainId === null) {
+      debug('getChainId fetching chainId...')
+      const chainIdResult = await this.emitPayloadAsync({
+        method: 'net_version',
+        params: [],
+      })
+      this._chainId = parseInt(chainIdResult.result.toString(), 10)
+      debug('getChainId chain result ID is %s', this._chainId)
+    }
+    return this._chainId!
+  }
+}
+
+/**
+ * This method is primarily used for testing at this point.
+ * Returns a raw signed transaction which can be used for Celo gold transfer.
+ * It is the responsibility of the caller to submit it to the network.
+ */
+export async function getRawTransaction(web3: Web3, transaction: CeloTx): Promise<string> {
+  debug('getRawTransaction@Signing transaction...')
+  const signedTransaction = await web3.eth.signTransaction(transaction)
+  debug('getRawTransaction@Signing: Signed transaction %o', signedTransaction)
+  const rawTransaction = signedTransaction.raw
+  return rawTransaction
+}

--- a/packages/contractkit/src/utils/web3-utils.ts
+++ b/packages/contractkit/src/utils/web3-utils.ts
@@ -1,0 +1,73 @@
+import {
+  Callback,
+  ErrorCallback,
+  JSONRPCRequestPayload,
+  Subprovider,
+  Web3ProviderEngine,
+} from '@0x/subproviders'
+import debugFactory from 'debug'
+import Web3 from 'web3'
+import { JsonRPCResponse, Provider } from 'web3/providers'
+import { CeloProvider } from './tx-signing'
+
+const debug = debugFactory('kit:web3:utils')
+
+// This web3 has signing ability.
+export async function addLocalAccount(web3: Web3, privateKey: string): Promise<Web3> {
+  const celoProvider = new CeloProvider(privateKey)
+  // Create a Web3 Provider Engine
+  const providerEngine = new Web3ProviderEngine()
+  // Compose our Providers, order matters
+  // Celo provider provides signing
+  providerEngine.addProvider(celoProvider)
+  // Use the existing provider to route all other requests
+  const existingProvider = web3.currentProvider
+  const wrappingSubprovider = new WrappingSubprovider(existingProvider)
+
+  debug('Setting up providers...')
+  providerEngine.addProvider(wrappingSubprovider)
+  providerEngine.start()
+  web3.setProvider(providerEngine)
+  debug('Providers configured')
+  return web3
+}
+
+class WrappingSubprovider extends Subprovider {
+  private _provider: Provider
+
+  constructor(readonly provider: Provider) {
+    super()
+    this._provider = provider
+  }
+  /**
+   * @param payload JSON RPC request payload
+   * @param next A callback to pass the request to the next subprovider in the stack
+   * @param end A callback called once the subprovider is done handling the request
+   */
+  handleRequest(
+    payload: JSONRPCRequestPayload,
+    _next: Callback,
+    end: ErrorCallback
+  ): Promise<void> {
+    debug('WrappingSubprovider@handleRequest: %o', payload)
+    // Inspired from https://github.com/MetaMask/web3-provider-engine/pull/19/
+    return this._provider.send(payload, (err: null | Error, response?: JsonRPCResponse) => {
+      if (err != null) {
+        debug('WrappingSubprovider@response is error: %s', err)
+        end(err)
+        return
+      }
+      if (response == null) {
+        end(new Error(`Response is null for ${JSON.stringify(payload)}`))
+        return
+      }
+      if (response.error != null) {
+        debug('WrappingSubprovider@response includes error: %o', response)
+        end(new Error(response.error))
+        return
+      }
+      debug('WrappingSubprovider@response: %o', response)
+      end(null, response.result)
+    })
+  }
+}


### PR DESCRIPTION
### Description

Add code to enable local signing of transactions. Most of the code has been ported over from the walletkit. Note that the test interacts with an `integration` node since Ganache does not support our modified transaction structure.

### Tested

`$ jest src/utils/tx-signing.test.ts`

### Related issues

- Partially addresses #477