### PR TITLE
[CI] fix: contractkit wasn't included

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,6 +479,9 @@ workflows:
       - cli-test:
           requires:
             - install_dependencies
+      - contractkit-test:
+          requires:
+            - install_dependencies      
       - mobile-test:
           requires:
             - lint-checks


### PR DESCRIPTION
### Description

The job was described, but it wasn't included in the workflow. Thus, it didn't run

### Tested

ci