### PR TITLE
[wallet] Fix amount input decimal max length

### DIFF
--- a/packages/react-components/components/ValidatedTextInput.tsx
+++ b/packages/react-components/components/ValidatedTextInput.tsx
@@ -72,9 +72,7 @@ export default class ValidatedTextInput extends React.Component<Props> {
       return undefined
     }
 
-    if (decimalPos) {
-      return decimalPos + this.props.numberOfDecimals + 1
-    }
+    return decimalPos + this.props.numberOfDecimals + 1
   }
 
   render() {


### PR DESCRIPTION
### Description

Prevents decimal inputs after the set max length for numbers that begin with a decimal point.  Removed an unnecessary truthy check which caused the problem.

### Tested

Tested with inputs starting with a decimal and a number, both kinds of inputs are limited to 2 numbers past the decimal point.

### Other changes

N/A

### Related issues

- Fixes #775 
