### PR TITLE
yarn build in celotool Dockerfile

### DIFF
--- a/dockerfiles/celotool/Dockerfile
+++ b/dockerfiles/celotool/Dockerfile
@@ -29,7 +29,7 @@ COPY packages/walletkit packages/walletkit/
 COPY packages/verification-pool-api packages/verification-pool-api/
 COPY packages/celotool packages/celotool/
 
-# RUN yarn build
+RUN yarn build
 
 ENV PATH="/celo-monorepo/packages/celotool/bin:${PATH}"
 


### PR DESCRIPTION
### Description

Fixes issues when running a celotool docker container along the lines of:
```
/celo-monorepo/node_modules/ts-node/src/index.ts:245
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/lib/geth.ts:17:44 - error TS2307: Cannot find module '@celo/walletkit/types/GoldToken'.

17 import { GoldToken as GoldTokenType } from '@celo/walletkit/types/GoldToken'
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib/geth.ts:18:48 - error TS2307: Cannot find module '@celo/walletkit/types/StableToken'.

18 import { StableToken as StableTokenType } from '@celo/walletkit/types/StableToken'
```

### Tested

Ran commands in a locally built celotool Dockerfile with these changes

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

Yes
