### PR TITLE
[wallet] Log calculate fee errors

### DIFF
--- a/packages/mobile/src/fees/CalculateFee.tsx
+++ b/packages/mobile/src/fees/CalculateFee.tsx
@@ -9,6 +9,7 @@ import { getReclaimEscrowFee } from 'src/escrow/saga'
 import { FeeType } from 'src/fees/actions'
 import { getInvitationVerificationFee } from 'src/invite/saga'
 import { getSendFee } from 'src/send/saga'
+import Logger from 'src/utils/Logger'
 
 export type CalculateFeeChildren = (
   asyncResult: UseAsyncReturn<BigNumber, never>
@@ -73,6 +74,7 @@ function useAsyncShowError<R, Args extends any[]>(
     () => {
       // Generic error banner
       if (asyncResult.error) {
+        Logger.error(`CalculateFee`, 'Error calculating fee', asyncResult.error)
         showErrorFunction(ErrorMessages.CALCULATE_FEE_FAILED)
       }
     },

--- a/packages/mobile/src/fees/CalculateFee.tsx
+++ b/packages/mobile/src/fees/CalculateFee.tsx
@@ -74,7 +74,7 @@ function useAsyncShowError<R, Args extends any[]>(
     () => {
       // Generic error banner
       if (asyncResult.error) {
-        Logger.error(`CalculateFee`, 'Error calculating fee', asyncResult.error)
+        Logger.error('CalculateFee', 'Error calculating fee', asyncResult.error)
         showErrorFunction(ErrorMessages.CALCULATE_FEE_FAILED)
       }
     },


### PR DESCRIPTION
### Description

Investigating #245 showed calculate fee errors trigger the alert banner with the generic "Could not calculate fee" but don't log the actual underlying error. This fixes it.

### Tested

Calculate Fee errors are now logged.

### Other changes

N/A

### Related issues

- #245

### Backwards compatibility

Yes.
