### PR TITLE
Use HTTPS instead of SSH for ethereumjs-vm

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -70,7 +70,7 @@
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
-    "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#224db21",
+    "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#816a475",
     "@celo/typescript": "0.0.1",
     "@celo/utils": "^0.0.6-beta5",
     "@types/bignumber.js": "^5.0.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -70,7 +70,7 @@
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
-    "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#98ad2ba",
+    "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#ace2397",
     "@celo/typescript": "0.0.1",
     "@celo/utils": "^0.0.6-beta5",
     "@types/bignumber.js": "^5.0.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -70,7 +70,7 @@
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
-    "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#ace2397",
+    "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#224db21",
     "@celo/typescript": "0.0.1",
     "@celo/utils": "^0.0.6-beta5",
     "@types/bignumber.js": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,6 +2033,14 @@
     qqjs "^0.3.10"
     tslib "^1.9.3"
 
+"@celo/ganache-cli@git+https://github.com/celo-org/ganache-cli.git#224db21":
+  version "6.6.0"
+  resolved "git+https://github.com/celo-org/ganache-cli.git#224db21eff76521175c08495ba1dcd0b6ffe6e4e"
+  dependencies:
+    ethereumjs-util "6.1.0"
+    source-map-support "0.5.12"
+    yargs "13.2.4"
+
 "@celo/ganache-cli@git+https://github.com/celo-org/ganache-cli.git#98ad2ba":
   version "6.6.0"
   resolved "git+https://github.com/celo-org/ganache-cli.git#98ad2ba3d813b399294492596058e067512d712b"
@@ -12269,7 +12277,7 @@ ethereumjs-block@2.1.0:
     ethereumjs-util "^5.0.0"
     merkle-patricia-tree "^2.1.2"
 
-ethereumjs-block@^1.2.2, ethereumjs-block@^1.4.1, ethereumjs-block@^1.6.0, ethereumjs-block@~1.7.0:
+ethereumjs-block@^1.2.2, ethereumjs-block@^1.4.1, ethereumjs-block@^1.6.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz#78b88e6cc56de29a6b4884ee75379b6860333c3f"
   integrity sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==
@@ -12316,11 +12324,6 @@ ethereumjs-common@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-1.1.0.tgz#5ec9086c314d619d8f05e79a0525829fcb0e93cb"
   integrity sha512-LUmYkKV/HcZbWRyu3OU9YOevsH3VJDXtI6kEd8VZweQec+JjDGKCmAVKUyzhYUHqxRJu7JNALZ3A/b3NXOP6tA==
-
-ethereumjs-common@~0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-0.4.1.tgz#27690a24a817b058cc3a2aedef9392e8d7d63984"
-  integrity sha512-ywYGsOeGCsMNWso5Y4GhjWI24FJv9FK7+VyVKiQgXg8ZRDPXJ7F/kJ1CnjtkjTvDF4e0yqU+FWswlqR3bmZQ9Q==
 
 ethereumjs-testrpc-sc@6.1.6:
   version "6.1.6"
@@ -12387,9 +12390,10 @@ ethereumjs-util@~6.0.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-ethereumjs-vm@2.6.0, ethereumjs-vm@^2.0.2, ethereumjs-vm@^2.1.0, ethereumjs-vm@^2.3.4, ethereumjs-vm@^2.6.0:
+ethereumjs-vm@2.6.0, ethereumjs-vm@^2.0.2, ethereumjs-vm@^2.1.0, ethereumjs-vm@^2.3.4, ethereumjs-vm@^2.4.0, ethereumjs-vm@^2.6.0:
   version "2.6.0"
-  resolved "git+ssh://git@github.com/celo-org/ethereumjs-vm.git#3ac144713c1bdfdb2f3b2ebe7feb759aad581cc2"
+  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz#76243ed8de031b408793ac33907fb3407fe400c6"
+  integrity sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==
   dependencies:
     async "^2.1.2"
     async-eventemitter "^0.2.2"
@@ -12405,7 +12409,8 @@ ethereumjs-vm@2.6.0, ethereumjs-vm@^2.0.2, ethereumjs-vm@^2.1.0, ethereumjs-vm@^
 
 ethereumjs-vm@3.0.0:
   version "3.0.0"
-  resolved "git+ssh://git@github.com/celo-org/ethereumjs-vm.git#6d7735eb6b09601b13692eab334d7905adeefe62"
+  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-3.0.0.tgz#70fea2964a6797724b0d93fe080f9984ad18fcdd"
+  integrity sha512-lNu+G/RWPRCrQM5s24MqgU75PEGiAhL4Ombw0ew6m08d+amsxf/vGAb98yDNdQqqHKV6JbwO/tCGfdqXGI6Cug==
   dependencies:
     async "^2.1.2"
     async-eventemitter "^0.2.2"
@@ -12417,23 +12422,6 @@ ethereumjs-vm@3.0.0:
     fake-merkle-patricia-tree "^1.0.1"
     functional-red-black-tree "^1.0.1"
     merkle-patricia-tree "^2.3.2"
-    rustbn.js "~0.2.0"
-    safe-buffer "^5.1.1"
-
-ethereumjs-vm@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-2.4.0.tgz#244f1e35f2755e537a13546111d1a4c159d34b13"
-  integrity sha512-MJ4lCWa5c6LhahhhvoDKW+YGjK00ZQn0RHHLh4L+WaH1k6Qv7/q3uTluew6sJGNCZdlO0yYMDXYW9qyxLHKlgQ==
-  dependencies:
-    async "^2.1.2"
-    async-eventemitter "^0.2.2"
-    ethereumjs-account "^2.0.3"
-    ethereumjs-block "~1.7.0"
-    ethereumjs-common "~0.4.0"
-    ethereumjs-util "^5.2.0"
-    fake-merkle-patricia-tree "^1.0.1"
-    functional-red-black-tree "^1.0.1"
-    merkle-patricia-tree "^2.1.2"
     rustbn.js "~0.2.0"
     safe-buffer "^5.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,9 +2033,9 @@
     qqjs "^0.3.10"
     tslib "^1.9.3"
 
-"@celo/ganache-cli@git+https://github.com/celo-org/ganache-cli.git#224db21":
+"@celo/ganache-cli@git+https://github.com/celo-org/ganache-cli.git#816a475":
   version "6.6.0"
-  resolved "git+https://github.com/celo-org/ganache-cli.git#224db21eff76521175c08495ba1dcd0b6ffe6e4e"
+  resolved "git+https://github.com/celo-org/ganache-cli.git#816a475d82535c05b59c4c43b3603c39dd31cd88"
   dependencies:
     ethereumjs-util "6.1.0"
     source-map-support "0.5.12"


### PR DESCRIPTION
### Description

This PR removes the transitive dependency on ethereumjs-vm via SSH by pointing to the version of ganache-cli that uses https instead.
### Tested

Pointed a celo-blockchain PR to this branch and saw that the monorepo was successfully checked out in circle.

### Other changes

None
