### PR TITLE
[wallet] Fix text error in Celo Gold faucet transfer confirmation

### DIFF
--- a/packages/react-components/components/MoneyAmount.tsx
+++ b/packages/react-components/components/MoneyAmount.tsx
@@ -15,8 +15,8 @@ export function MoneyAmount(props: Props) {
   const colorStyle = { color: color || colors.darkSecondary }
   return (
     <View style={style.container}>
-      {sign && <Text style={[style.plusSign, colorStyle]}>{sign}</Text>}
-      {symbol && <Text style={[style.currencySymbol, colorStyle]}>{symbol}</Text>}
+      {!!sign && <Text style={[style.plusSign, colorStyle]}>{sign}</Text>}
+      {!!symbol && <Text style={[style.currencySymbol, colorStyle]}>{symbol}</Text>}
       <Text style={[style.amount, colorStyle]} numberOfLines={1} ellipsizeMode="tail">
         {amount}
       </Text>


### PR DESCRIPTION
### Description

Coerces inline conditionals to a boolean.  If the condition is falsy, (e.g. empty string) it will return the condition instead of false -- causing an (empty) string to be outside of a `Text` component.  The sign prop does not currently seem to be passed as an empty string, but just to prevent any potential future problems, it is also coerced to a boolean.

### Tested

Selected a Celo Gold faucet transaction and viewed the TransferConfirmationCard without errors.

### Other changes

N/A

### Related issues

- Fixes #857

### Backwards compatibility

Yep