### PR TITLE
Add fetch balance and send events for pilot analytics

### DIFF
--- a/packages/mobile/src/analytics/constants.ts
+++ b/packages/mobile/src/analytics/constants.ts
@@ -35,6 +35,8 @@ export enum CustomEventNames {
   send_dollar_transaction = 'send_dollar_transaction',
   send_dollar_transaction_confirmed = 'send_dollar_transaction_confirmed',
 
+  fetch_balance = 'fetch_balance',
+
   // Verification event and sub-events
   verification = 'verification',
   verification_setup = 'verification_setup',

--- a/packages/mobile/src/analytics/constants.ts
+++ b/packages/mobile/src/analytics/constants.ts
@@ -31,6 +31,10 @@ export enum CustomEventNames {
   send_invite = 'send_invite',
   edit_send_invite = 'edit_send_invite',
 
+  // Send events, separate from button tracking above
+  send_dollar_transaction = 'send_dollar_transaction',
+  send_dollar_transaction_confirmed = 'send_dollar_transaction_confirmed',
+
   // Verification event and sub-events
   verification = 'verification',
   verification_setup = 'verification_setup',

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -146,6 +146,7 @@ export function* sendPaymentOrInviteSaga({
 
     if (recipientAddress) {
       yield call(sendPayment, recipientAddress, amount, comment, CURRENCY_ENUM.DOLLAR)
+      CeloAnalytics.track(CustomEventNames.send_dollar_transaction)
     } else if (recipient.e164PhoneNumber) {
       yield call(
         sendInvite,

--- a/packages/mobile/src/tokens/saga.ts
+++ b/packages/mobile/src/tokens/saga.ts
@@ -13,6 +13,7 @@ import Logger from 'src/utils/Logger'
 import { web3 } from 'src/web3/contracts'
 import { getConnectedAccount, getConnectedUnlockedAccount } from 'src/web3/saga'
 import * as utf8 from 'utf8'
+
 interface TokenFetchFactory {
   actionName: string
   contractGetter: (web3: any) => any

--- a/packages/mobile/src/tokens/saga.ts
+++ b/packages/mobile/src/tokens/saga.ts
@@ -2,6 +2,8 @@ import { getErc20Balance, getGoldTokenContract, getStableTokenContract } from '@
 import BigNumber from 'bignumber.js'
 import { call, put, take, takeEvery } from 'redux-saga/effects'
 import { showError } from 'src/alert/actions'
+import CeloAnalytics from 'src/analytics/CeloAnalytics'
+import { CustomEventNames } from 'src/analytics/constants'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { CURRENCY_ENUM } from 'src/geth/consts'
 import { addStandbyTransaction, removeStandbyTransaction } from 'src/transactions/actions'
@@ -11,7 +13,6 @@ import Logger from 'src/utils/Logger'
 import { web3 } from 'src/web3/contracts'
 import { getConnectedAccount, getConnectedUnlockedAccount } from 'src/web3/saga'
 import * as utf8 from 'utf8'
-
 interface TokenFetchFactory {
   actionName: string
   contractGetter: (web3: any) => any
@@ -31,6 +32,7 @@ export const tokenFetchFactory = ({
       const account = yield call(getConnectedAccount)
       const tokenContract = yield call(contractGetter, web3)
       const balance = yield call(getErc20Balance, tokenContract, account, web3)
+      CeloAnalytics.track(CustomEventNames.fetch_balance)
       yield put(actionCreator(balance.toString()))
     } catch (error) {
       Logger.error(tag, 'Error fetching balance', error)

--- a/packages/mobile/src/transactions/saga.ts
+++ b/packages/mobile/src/transactions/saga.ts
@@ -1,5 +1,7 @@
 import { call, put, take } from 'redux-saga/effects'
 import { showError } from 'src/alert/actions'
+import CeloAnalytics from 'src/analytics/CeloAnalytics'
+import { CustomEventNames } from 'src/analytics/constants'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { CURRENCY_ENUM } from 'src/geth/consts'
 import { fetchGoldBalance } from 'src/goldToken/actions'
@@ -54,6 +56,7 @@ export function* sendAndMonitorTransaction(
     if (currency === CURRENCY_ENUM.GOLD) {
       yield put(fetchGoldBalance())
     } else if (currency === CURRENCY_ENUM.DOLLAR) {
+      CeloAnalytics.track(CustomEventNames.send_dollar_transaction_confirmed)
       yield put(fetchDollarBalance())
     } else {
       // Fetch both balances for exchange


### PR DESCRIPTION
### Description

Add Celo analytics events to track time to fetch balances and send dollars. 

Previously, only the send button presses were tracked. Now the send transaction and its confirmation are tracked, as well as the time to fetch balances. 

### Tested

Tested on device and confirmed analytics logging on bigquery. 

### Related issues

Fixes issues 73 and 74 in celo-labs

### Backwards compatibility

No events were removed so previous analytics using the button press still work. 