### PR TITLE
Add VM BASED param to fix faucet and invite

### DIFF
--- a/.env.alfajores
+++ b/.env.alfajores
@@ -2,6 +2,8 @@ ENV_TYPE="production"
 
 GETH_VERBOSITY=2
 
+VM_BASED=false
+
 KUBERNETES_CLUSTER_NAME="alfajores"
 KUBERNETES_CLUSTER_ZONE="us-west1-a"
 CLUSTER_DOMAIN_NAME="celo-testnet"

--- a/.env.alfajoresstaging
+++ b/.env.alfajoresstaging
@@ -4,6 +4,8 @@ ENV_TYPE="staging"
 
 GETH_VERBOSITY=2
 
+VM_BASED=false
+
 KUBERNETES_CLUSTER_NAME="alfajoresstaging"
 KUBERNETES_CLUSTER_ZONE="us-west1-a"
 CLUSTER_DOMAIN_NAME="celo-testnet"


### PR DESCRIPTION
### Description

The faucet and invite script were broken because the alfajores and alfajoresstaging env files were missing the new required VM_BASED parameter. This has been added. 

### Tested

Used celotooljs to faucet and invite on alfajores and alfajoresstaging. 

### Future work

Note that the website invite/faucet has not yet been fixed