### PR TITLE
CeloCLI sorted list of Validator Groups should not include groups with zero votes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@celo/celocli",
   "description": "CLI Tool for transacting with the Celo protocol",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "author": "Celo",
   "license": "Apache-2.0",
   "repository": "celo-org/celo-monorepo",

--- a/packages/cli/src/adapters/validators.ts
+++ b/packages/cli/src/adapters/validators.ts
@@ -132,7 +132,7 @@ export class ValidatorsAdapter {
     votedGroup: Address,
     voteWeight: BN
   ): Promise<{ lesser: Address; greater: Address }> {
-    const currentVotes = await this.getValidatorGroupsVotes()
+    const currentVotes = (await this.getValidatorGroupsVotes()).filter((g) => !g.votes.isZero())
 
     const selectedGroup = currentVotes.find((cv) => eqAddress(cv.address, votedGroup))
 


### PR DESCRIPTION
### Description

This PR fixes an inconsistency between the CLI and the Validators smart contract, which could lead to the CLI suggesting an incorrect `lesser` value when voting for a group.

The smart contract does not sort groups with 0 votes, whereas the CLI did.

### Tested

Ran through the validator tutorial in the docs with the deployed cli, vote tx failed. Tried to vote again with my local changes, succeeded.

### Other changes

None

### Related issues

- Fixes #888 

### Backwards compatibility

Backwards compatible