### PR TITLE
[Wallet] Speed up jest tests

### DIFF
--- a/packages/mobile/jest.config.js
+++ b/packages/mobile/jest.config.js
@@ -21,6 +21,6 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest_setup.ts'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|react-native-(.*)|@react-navigation|redux-persist|date-fns|@celo/react-native-sms-retriever)/)',
+    'node_modules/(?!(@celo/)?react-native|@react-navigation|redux-persist|date-fns)',
   ],
 }

--- a/packages/mobile/jest.config.js
+++ b/packages/mobile/jest.config.js
@@ -4,6 +4,11 @@ module.exports = {
   ...defaultConfig,
   globals: {
     navigator: true,
+    'ts-jest': {
+      // Disables type-check when running tests as it takes valuable time
+      // and is redundant with the tsc build step
+      isolatedModules: true,
+    },
     window: true,
   },
   moduleNameMapper: {

--- a/packages/mobile/jest.config.js
+++ b/packages/mobile/jest.config.js
@@ -15,5 +15,7 @@ module.exports = {
   preset: 'react-native',
   setupFilesAfterEnv: ['<rootDir>/jest_setup.ts'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
-  transformIgnorePatterns: ['node_modules/(?!react-native|react-navigation|)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|react-native-(.*)|@react-navigation|redux-persist|date-fns|@celo/react-native-sms-retriever)/)',
+  ],
 }

--- a/packages/react-components/jest.config.js
+++ b/packages/react-components/jest.config.js
@@ -5,10 +5,15 @@ module.exports = {
   collectCoverageFrom: ['**/*.ts?(x)', '!**/*.d.ts'],
   globals: {
     navigator: true,
+    'ts-jest': {
+      // Disables type-check when running tests as it takes valuable time
+      // and is redundant with the tsc build step
+      isolatedModules: true,
+    },
     window: true,
   },
   modulePathIgnorePatterns: ['<rootDir>/node_modules/(.*)/node_modules/react-native'],
   preset: 'react-native',
   setupFilesAfterEnv: ['<rootDir>/jest_setup'],
-  transformIgnorePatterns: ['node_modules/(?!react-native|react-navigation|)'],
+  transformIgnorePatterns: ['node_modules/(?!(@celo/)?react-native|@react-navigation)'],
 }

--- a/packages/verifier/jest.config.js
+++ b/packages/verifier/jest.config.js
@@ -4,6 +4,11 @@ module.exports = {
   ...defaultConfig,
   globals: {
     navigator: true,
+    'ts-jest': {
+      // Disables type-check when running tests as it takes valuable time
+      // and is redundant with the tsc build step
+      isolatedModules: true,
+    },
     window: true,
   },
   moduleNameMapper: {
@@ -15,5 +20,5 @@ module.exports = {
     '\\.(ts|tsx)$': 'ts-jest',
     '^.+\\.(js)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!react-native|react-navigation|)'],
+  transformIgnorePatterns: ['node_modules/(?!(react-native|react-native-(.*))/)'],
 }

--- a/packages/verifier/jest.config.js
+++ b/packages/verifier/jest.config.js
@@ -20,5 +20,5 @@ module.exports = {
     '\\.(ts|tsx)$': 'ts-jest',
     '^.+\\.(js)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!(react-native|react-native-(.*))/)'],
+  transformIgnorePatterns: ['node_modules/(?!(@celo/)?react-native|@react-navigation)'],
 }


### PR DESCRIPTION
### Description

This PR speeds up the jest tests for the wallet (and verifier and react-components):
- 1st run with a clean cache is roughly 5x faster!!
- 2nd run with a populated cache is roughly 2x faster!

Memory usage is also cut down in half. (with a clean cache, from almost 1GB to ~500MB on my machine).

The main problem was with the `transformIgnorePatterns` in the jest config. It was matching all required node modules and transforming them which was taking a significant time with a clean cache. This explains the stall of over a minute before anything else could execute.

The second speed up fix was also done in the jest config and disables type-checking when running tests. Type-checking takes some valuable time there and is redundant with the `tsc` build step of the project.

Nice side effect is you can now have type errors in your tests while you write them and experiment ;)
Though you still have to fix those type errors before committing as they will be caught by the typescript build step 😺 

### Tested

Ran the tests.

#### Before the changes

1st run with a clean cache:
[![asciicast](https://asciinema.org/a/E31FzG05mtpjO5ET18og2yEEE.svg)](https://asciinema.org/a/E31FzG05mtpjO5ET18og2yEEE)
2nd run with a populated cache:
[![asciicast](https://asciinema.org/a/Suf89exuFklUwxdHkscXjtwvs.svg)](https://asciinema.org/a/Suf89exuFklUwxdHkscXjtwvs)

#### After the changes

1st run with a clean cache:
[![asciicast](https://asciinema.org/a/5NQPM75qiigkC93uJSK21cHXv.svg)](https://asciinema.org/a/5NQPM75qiigkC93uJSK21cHXv)
2nd run with a populated cache:
[![asciicast](https://asciinema.org/a/v5XtPqjH4zbfWEFgWgUCDnYol.svg)](https://asciinema.org/a/v5XtPqjH4zbfWEFgWgUCDnYol)

### Other changes

Applied the same speed up fixes to react-components and verifier.

### Related issues

- Fixes #880

### Backwards compatibility

Yes.
