### PR TITLE
 Upgrade cli and walletkit package

### DIFF
--- a/packages/celotool/package.json
+++ b/packages/celotool/package.json
@@ -6,7 +6,7 @@
   "author": "Celo",
   "license": "Apache-2.0",
   "dependencies": {
-    "@celo/walletkit": "^0.0.14",
+    "@celo/walletkit": "^0.0.15",
     "@google-cloud/monitoring": "0.7.1",
     "@google-cloud/pubsub": "^0.28.1",
     "@google-cloud/storage": "^2.4.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@celo/celocli",
   "description": "CLI Tool for transacting with the Celo protocol",
-  "version": "0.0.18",
+  "version": "0.0.20",
   "author": "Celo",
   "license": "Apache-2.0",
   "repository": "celo-org/celo-monorepo",
@@ -28,7 +28,7 @@
     "test": "export TZ=UTC && jest --ci --silent"
   },
   "dependencies": {
-    "@celo/walletkit": "^0.0.14",
+    "@celo/walletkit": "^0.0.15",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -47,7 +47,7 @@
     "@celo/client": "f7095b7",
     "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#d3a2fdb",
     "@celo/utils": "^0.0.6-beta5",
-    "@celo/walletkit": "^0.0.14",
+    "@celo/walletkit": "^0.0.15",
     "@react-native-community/netinfo": "^2.0.4",
     "@segment/analytics-react-native": "^0.1.0-beta.0",
     "@segment/analytics-react-native-firebase": "^0.1.0-beta.0",

--- a/packages/transaction-metrics-exporter/package.json
+++ b/packages/transaction-metrics-exporter/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@celo/walletkit": "^0.0.14",
+    "@celo/walletkit": "^0.0.15",
     "express": "4.16.4",
     "lodash": "^4.17.14",
     "prom-client": "11.2.0",

--- a/packages/walletkit/package.json
+++ b/packages/walletkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/walletkit",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Celo's WalletKit to interact with Celo network",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
### Description

1. Upgrade walletkit package since it was missing `bin/build-sdk.js`
2. Publish a new version of CLI package since it was dependent on a broken
    version of walletkit package

### Tested

Both of these were failing earlier
```
# Inside a node:8 docker image
yarn install @celo/walletkit
yarn install @celo/celocli
```