### PR TITLE
Add command to output validator set

### DIFF
--- a/packages/cli/src/commands/validatorset.ts
+++ b/packages/cli/src/commands/validatorset.ts
@@ -1,0 +1,21 @@
+import { BaseCommand } from '../base'
+
+export default class ValidatorSet extends BaseCommand {
+  static description = 'Outputs the current validator set'
+
+  static flags = {
+    ...BaseCommand.flags,
+  }
+
+  static examples = ['validatorset']
+
+  async run() {
+    const validators = await this.kit.contracts.getValidators()
+    const numberValidators = await validators.numberValidatorsInCurrentSet()
+
+    for (let i = 0; i < numberValidators; i++) {
+      const validatorAddress = await validators.validatorAddressFromCurrentSet(i)
+      console.log(validatorAddress)
+    }
+  }
+}

--- a/packages/cli/src/commands/validatorset.ts
+++ b/packages/cli/src/commands/validatorset.ts
@@ -11,11 +11,8 @@ export default class ValidatorSet extends BaseCommand {
 
   async run() {
     const validators = await this.kit.contracts.getValidators()
-    const numberValidators = await validators.numberValidatorsInCurrentSet()
+    const validatorSet = await validators.validatorSetAddresses()
 
-    for (let i = 0; i < numberValidators; i++) {
-      const validatorAddress = await validators.validatorAddressFromCurrentSet(i)
-      console.log(validatorAddress)
-    }
+    validatorSet.forEach((validator: string) => console.log(validator))
   }
 }

--- a/packages/cli/src/commands/validatorset.ts
+++ b/packages/cli/src/commands/validatorset.ts
@@ -11,7 +11,7 @@ export default class ValidatorSet extends BaseCommand {
 
   async run() {
     const validators = await this.kit.contracts.getValidators()
-    const validatorSet = await validators.validatorSetAddresses()
+    const validatorSet = await validators.getValidatorSetAddresses()
 
     validatorSet.forEach((validator: string) => console.log(validator))
   }

--- a/packages/contractkit/src/wrappers/Validators.ts
+++ b/packages/contractkit/src/wrappers/Validators.ts
@@ -48,19 +48,6 @@ export class ValidatorsWrapper extends BaseWrapper<Validators> {
     toNumber
   )
 
-  async validatorSetAddresses(): Promise<string[]> {
-    const numberValidators = await this.numberValidatorsInCurrentSet()
-
-    const validators = []
-
-    for (let i = 0; i < numberValidators; i++) {
-      const validatorAddress = await this.validatorAddressFromCurrentSet(i)
-      validators.push(validatorAddress)
-    }
-
-    return validators
-  }
-
   getVoteFrom: (validatorAddress: Address) => Promise<Address | null> = proxyCall(
     this.contract.methods.voters
   )
@@ -69,6 +56,18 @@ export class ValidatorsWrapper extends BaseWrapper<Validators> {
     const vgAddresses = await this.contract.methods.getRegisteredValidators().call()
 
     return Promise.all(vgAddresses.map((addr) => this.getValidator(addr)))
+  }
+
+  async getValidatorSetAddresses(): Promise<string[]> {
+    const numberValidators = await this.numberValidatorsInCurrentSet()
+
+    const validatorAddressPromises = []
+
+    for (let i = 0; i < numberValidators; i++) {
+      validatorAddressPromises.push(this.validatorAddressFromCurrentSet(i))
+    }
+
+    return Promise.all(validatorAddressPromises)
   }
 
   async getValidator(address: Address): Promise<Validator> {

--- a/packages/contractkit/src/wrappers/Validators.ts
+++ b/packages/contractkit/src/wrappers/Validators.ts
@@ -48,6 +48,19 @@ export class ValidatorsWrapper extends BaseWrapper<Validators> {
     toNumber
   )
 
+  async validatorSetAddresses(): Promise<string[]> {
+    const numberValidators = await this.numberValidatorsInCurrentSet()
+
+    const validators = []
+
+    for (let i = 0; i < numberValidators; i++) {
+      const validatorAddress = await this.validatorAddressFromCurrentSet(i)
+      validators.push(validatorAddress)
+    }
+
+    return validators
+  }
+
   getVoteFrom: (validatorAddress: Address) => Promise<Address | null> = proxyCall(
     this.contract.methods.voters
   )

--- a/packages/docs/command-line-interface/validatorset.md
+++ b/packages/docs/command-line-interface/validatorset.md
@@ -1,0 +1,19 @@
+---
+description: Outputs the current validator set
+---
+
+## Commands
+
+### Validatorset
+
+Outputs the current validator set
+
+```
+USAGE
+  $ celocli validatorset
+
+EXAMPLE
+  validatorset
+```
+
+_See code: [packages/cli/src/commands/validatorset.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/validatorset.ts)_


### PR DESCRIPTION
### Description

`celocli validatorset` will print the addresses of the current validator set.

### Tested

Against a dev testnet with most recent celo-blockchain and contracts.

### Other changes

Added `validatorSetAddresses` to contractkit wrapper.

### Related issues

- Fixes #1048 