### PR TITLE
[CLI]Unlock till the geth exits

### DIFF
--- a/packages/cli/src/commands/account/unlock.ts
+++ b/packages/cli/src/commands/account/unlock.ts
@@ -15,6 +15,9 @@ export default class Unlock extends BaseCommand {
 
   async run() {
     const res = this.parse(Unlock)
-    this.web3.eth.personal.unlockAccount(res.flags.account, res.flags.password, 604800)
+    // Unlock till geth exits
+    // Source: https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_unlockaccount
+    const unlockDurationInMs = 0
+    this.web3.eth.personal.unlockAccount(res.flags.account, res.flags.password, unlockDurationInMs)
   }
 }


### PR DESCRIPTION
### Description

Unlock till the geth exits. So, the key is always available to sign and send transactions. Note that the user can always forcefully lock the account back with `lockAccount`.