### PR TITLE
[CLI]Unlock account forever

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@celo/celocli",
   "description": "CLI Tool for transacting with the Celo protocol",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": "Celo",
   "license": "Apache-2.0",
   "repository": "celo-org/celo-monorepo",

--- a/packages/cli/src/commands/account/unlock.ts
+++ b/packages/cli/src/commands/account/unlock.ts
@@ -15,6 +15,9 @@ export default class Unlock extends BaseCommand {
 
   async run() {
     const res = this.parse(Unlock)
-    this.web3.eth.personal.unlockAccount(res.flags.account, res.flags.password, 604800)
+    // Unlock till geth exits
+    // Source: https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_unlockaccount
+    const unlockDurationInMs = 0
+    this.web3.eth.personal.unlockAccount(res.flags.account, res.flags.password, unlockDurationInMs)
   }
 }


### PR DESCRIPTION
### Description

Unlock account forever with CLI. Earlier, it had an in-built timeout.

### Tested

```
$ git checkout alfajores
packages/walletkit $ yarn build:for-env alfajores
packages/cli $ yarn build
packages/cli $ yarn run celocli account:new

geth $ ./build/bin/geth account proof-of-possession $CELO_VALIDATOR_ADDRESS

geth $ ./build/bin/geth --datadir /tmp/tmp1 account new
Address: {f6d5e2c40f4b033c1a1143b66a59f3344bb41efb}

geth $ ./build/bin/geth --datadir /tmp/tmp1 attach
web3.eth.sign("0xf6d5e2c40f4b033c1a1143b66a59f3344bb41efb", "0x1234")  # Works
web3.personal.lockAccount("0xf6d5e2c40f4b033c1a1143b66a59f3344bb41efb")
web3.eth.sign("0xf6d5e2c40f4b033c1a1143b66a59f3344bb41efb", "0x1234")  # Fails

# On a different terminal
packages/cli $ yarn run celocli account:unlock --account f6d5e2c40f4b033c1a1143b66a59f3344bb41efb --password testing

# Back in geth console
web3.eth.sign("0xf6d5e2c40f4b033c1a1143b66a59f3344bb41efb", "0x1234")  # Works
```