### PR TITLE
Add getExchangeRate to ContractKit

### DIFF
--- a/packages/contractkit/src/wrappers/Exchange.test.ts
+++ b/packages/contractkit/src/wrappers/Exchange.test.ts
@@ -10,6 +10,8 @@ TEST NOTES:
 testWithGanache('Exchange Wrapper', (web3) => {
   const ONE = web3.utils.toWei('1', 'ether')
 
+  const LARGE_BUY_AMOUNT = web3.utils.toWei('1000', 'ether')
+
   const kit = newKitFromWeb3(web3)
   let accounts: string[] = []
   let exchange: ExchangeWrapper
@@ -54,12 +56,12 @@ testWithGanache('Exchange Wrapper', (web3) => {
   })
 
   test('SBAT getExchangeRate for selling gold', async () => {
-    const sellGoldRate = await exchange.getExchangeRate(true)
+    const sellGoldRate = await exchange.getExchangeRate(LARGE_BUY_AMOUNT, true)
     expect(sellGoldRate.toNumber()).toBeGreaterThan(0)
   })
 
   test('SBAT getExchangeRate for selling dollars', async () => {
-    const sellGoldRate = await exchange.getExchangeRate(false)
+    const sellGoldRate = await exchange.getUsdExchangeRate(LARGE_BUY_AMOUNT)
     expect(sellGoldRate.toNumber()).toBeGreaterThan(0)
   })
 })

--- a/packages/contractkit/src/wrappers/Exchange.test.ts
+++ b/packages/contractkit/src/wrappers/Exchange.test.ts
@@ -52,4 +52,14 @@ testWithGanache('Exchange Wrapper', (web3) => {
     const sellTx = await exchange.sellGold(ONE, usdAmount).send()
     await sellTx.waitReceipt()
   })
+
+  test('SBAT getExchangeRate for selling gold', async () => {
+    const sellGoldRate = await exchange.getExchangeRate(true)
+    expect(sellGoldRate.toNumber()).toBeGreaterThan(0)
+  })
+
+  test('SBAT getExchangeRate for selling dollars', async () => {
+    const sellGoldRate = await exchange.getExchangeRate(false)
+    expect(sellGoldRate.toNumber()).toBeGreaterThan(0)
+  })
 })

--- a/packages/contractkit/src/wrappers/Exchange.ts
+++ b/packages/contractkit/src/wrappers/Exchange.ts
@@ -123,4 +123,19 @@ export class ExchangeWrapper extends BaseWrapper<Exchange> {
    * @return The corresponding cUsd amount.
    */
   quoteGoldBuy = (buyAmount: NumberLike) => this.getSellTokenAmount(buyAmount, true)
+
+  /**
+   * Returns the exchange rate estimated at buyAmount.
+   * @param sellGold `true` if gold is the sell token
+   * @param buyAmount The amount of buyToken to estimate the exchange rate at (optional,
+   * defaults to large buyAmount to show worst case rate)
+   * @return The exchange rate (number of sellTokens received for one buyToken).
+   */
+  async getExchangeRate(
+    sellGold: boolean,
+    buyAmount: NumberLike = new BigNumber(1000 * 1000000000000000000) // in Wei
+  ): Promise<BigNumber> {
+    const takerAmount = new BigNumber(await this.getBuyTokenAmount(buyAmount, sellGold))
+    return new BigNumber(buyAmount).dividedBy(takerAmount) // Number of sellTokens received for one buyToken
+  }
 }

--- a/packages/contractkit/src/wrappers/Exchange.ts
+++ b/packages/contractkit/src/wrappers/Exchange.ts
@@ -126,16 +126,26 @@ export class ExchangeWrapper extends BaseWrapper<Exchange> {
 
   /**
    * Returns the exchange rate estimated at buyAmount.
+   * @param buyAmount The amount of buyToken in wei to estimate the exchange rate at
    * @param sellGold `true` if gold is the sell token
-   * @param buyAmount The amount of buyToken to estimate the exchange rate at (optional,
-   * defaults to large buyAmount to show worst case rate)
    * @return The exchange rate (number of sellTokens received for one buyToken).
    */
-  async getExchangeRate(
-    sellGold: boolean,
-    buyAmount: NumberLike = new BigNumber(1000 * 1000000000000000000) // in Wei
-  ): Promise<BigNumber> {
-    const takerAmount = new BigNumber(await this.getBuyTokenAmount(buyAmount, sellGold))
+  async getExchangeRate(buyAmount: NumberLike, sellGold: boolean): Promise<BigNumber> {
+    const takerAmount = await this.getBuyTokenAmount(buyAmount, sellGold)
     return new BigNumber(buyAmount).dividedBy(takerAmount) // Number of sellTokens received for one buyToken
   }
+
+  /**
+   * Returns the exchange rate for cUsd estimated at the buyAmount
+   * @param buyAmount The amount of cUsd in wei to estimate the exchange rate at
+   * @return The exchange rate (number of cGold received for one cUsd)
+   */
+  getUsdExchangeRate = (buyAmount: NumberLike) => this.getExchangeRate(buyAmount, false)
+
+  /**
+   * Returns the exchange rate for cGold estimated at the buyAmount
+   * @param buyAmount The amount of cGold in wei to estimate the exchange rate at
+   * @return The exchange rate (number of cUsd received for one cGold)
+   */
+  getGoldExchangeRate = (buyAmount: NumberLike) => this.getExchangeRate(buyAmount, true)
 }


### PR DESCRIPTION
### Description

Add `getExchangeRate()` function to ContractKit. Already exists in the WalletKit but moving it over as we deprecate WalletKit. This will be used in the app and in the exchange rate polling service. 

### Tested

Added tests. 

### Related issues

- Fixes #1026

### Backwards compatibility

Only adding a function, so fully backwards compatible 
