### PR TITLE
[celotool]Store .env config on GCS after deployment

### DIFF
--- a/packages/celotool/src/cmds/deploy/initial/testnet.ts
+++ b/packages/celotool/src/cmds/deploy/initial/testnet.ts
@@ -1,6 +1,7 @@
 import { createClusterIfNotExists, setupCluster, switchToClusterFromEnv } from 'src/lib/cluster'
 import { createStaticIPs, installHelmChart, pollForBootnodeLoadBalancer } from 'src/lib/helm_deploy'
 import {
+  uploadEnvFileToGoogleStorage,
   uploadGenesisBlockToGoogleStorage,
   uploadStaticNodesToGoogleStorage,
 } from 'src/lib/testnet-utils'
@@ -37,4 +38,5 @@ export const handler = async (argv: TestnetInitialArgv) => {
 
   await uploadGenesisBlockToGoogleStorage(argv.celoEnv)
   await uploadStaticNodesToGoogleStorage(argv.celoEnv)
+  await uploadEnvFileToGoogleStorage(argv.celoEnv)
 }

--- a/packages/celotool/src/cmds/deploy/upgrade/testnet.ts
+++ b/packages/celotool/src/cmds/deploy/upgrade/testnet.ts
@@ -1,6 +1,7 @@
 import { switchToClusterFromEnv } from 'src/lib/cluster'
 import { resetAndUpgradeHelmChart, upgradeHelmChart, upgradeStaticIPs } from 'src/lib/helm_deploy'
 import {
+  uploadEnvFileToGoogleStorage,
   uploadGenesisBlockToGoogleStorage,
   uploadStaticNodesToGoogleStorage,
 } from 'src/lib/testnet-utils'
@@ -34,4 +35,5 @@ export const handler = async (argv: TestnetArgv) => {
   }
   await uploadGenesisBlockToGoogleStorage(argv.celoEnv)
   await uploadStaticNodesToGoogleStorage(argv.celoEnv)
+  await uploadEnvFileToGoogleStorage(argv.celoEnv)
 }

--- a/packages/celotool/src/lib/testnet-utils.ts
+++ b/packages/celotool/src/lib/testnet-utils.ts
@@ -1,20 +1,32 @@
 import { StaticNodeUtils } from '@celo/walletkit'
+import { GenesisBlocksGoogleStorageBucketName } from '@celo/walletkit/lib/src/genesis-block-utils'
 import { Storage } from '@google-cloud/storage'
-import { writeFileSync } from 'fs'
+import * as fs from 'fs'
+import { getEnvFile } from './env-utils'
 import { ensureAuthenticatedGcloudAccount } from './gcloud_utils'
 import { generateGenesisFromEnv } from './generate_utils'
 import { getEnodesWithExternalIPAddresses, sleep } from './geth'
+import { execCmdWithExitOnFailure } from './utils'
 
-const genesisBlocksBucketName = 'genesis_blocks'
+const genesisBlocksBucketName = GenesisBlocksGoogleStorageBucketName
 const staticNodesBucketName = StaticNodeUtils.getStaticNodesGoogleStorageBucketName()
+// Someone has taken env_files and I don't even has permission to modify it :/
+// See files in this bucket using `$ gsutil ls gs://env_config_files`
+const envBucketName = 'env_config_files'
 
 export async function uploadGenesisBlockToGoogleStorage(networkName: string) {
   console.info(`\nUploading genesis block for ${networkName} to Google cloud storage`)
-  const genesisBlockJsonData = await generateGenesisFromEnv()
+  const genesisBlockJsonData = generateGenesisFromEnv()
   console.debug(`Genesis block is ${genesisBlockJsonData} \n`)
   const localTmpFilePath = `/tmp/${networkName}_genesis-block`
-  writeFileSync(localTmpFilePath, genesisBlockJsonData)
-  await uploadFileToGoogleStorage(localTmpFilePath, genesisBlocksBucketName, networkName, true)
+  fs.writeFileSync(localTmpFilePath, genesisBlockJsonData)
+  await uploadFileToGoogleStorage(
+    localTmpFilePath,
+    genesisBlocksBucketName,
+    networkName,
+    true,
+    'application/json'
+  )
 }
 
 // This will throw an error if it fails to upload
@@ -43,8 +55,70 @@ export async function uploadStaticNodesToGoogleStorage(networkName: string) {
   }
   console.debug('Static nodes are ' + nodesJsonData + '\n')
   const localTmpFilePath = `/tmp/${networkName}_static-nodes`
-  writeFileSync(localTmpFilePath, nodesJsonData)
-  await uploadFileToGoogleStorage(localTmpFilePath, staticNodesBucketName, networkName, true)
+  fs.writeFileSync(localTmpFilePath, nodesJsonData)
+  await uploadFileToGoogleStorage(
+    localTmpFilePath,
+    staticNodesBucketName,
+    networkName,
+    true,
+    'application/json'
+  )
+}
+
+export async function uploadEnvFileToGoogleStorage(networkName: string) {
+  const envFileName = getEnvFile(networkName)
+  const gitUserInfo = `${await getGitUserName()} <${await getGitUserEmail()}>`
+  const repo = await getGitRepoName()
+  const commitHash = await getCommitHash()
+
+  console.info(
+    `\nUploading Env file ${envFileName} for network ${networkName} to Google cloud storage: ` +
+      `gs://${envBucketName}/${networkName}`
+  )
+  const envFileData = fs.readFileSync(getEnvFile(networkName)).toString()
+  const metaData =
+    `# .env file for network "${networkName}"\n` +
+    `# Last modified by "${gitUserInfo}"\n` +
+    `# Last modified on on ${Date()}\n` +
+    `# Base commit: "https://github.com/${repo}/commit/${commitHash}"\n`
+  const fullData = metaData + '\n' + envFileData
+  const localTmpFilePath = `/tmp/${networkName}_env-file`
+  fs.writeFileSync(localTmpFilePath, fullData)
+  await uploadFileToGoogleStorage(
+    localTmpFilePath,
+    envBucketName,
+    networkName,
+    false /* keep file private */,
+    'text/plain'
+  )
+}
+
+async function getGitUserName(): Promise<string> {
+  const cmd = 'git config --get user.name'
+  const stdout = (await execCmdWithExitOnFailure(cmd))[0]
+  return stdout.trim()
+}
+
+async function getGitUserEmail(): Promise<string> {
+  const cmd = 'git config --get user.email'
+  const stdout = (await execCmdWithExitOnFailure(cmd))[0]
+  return stdout.trim()
+}
+
+async function getGitRepoName(): Promise<string> {
+  const cmd = 'git config --get remote.origin.url'
+  let stdout = (await execCmdWithExitOnFailure(cmd))[0].trim()
+  stdout = stdout.split(':')[1]
+  if (stdout.endsWith('.git')) {
+    stdout = stdout.substring(0, stdout.length - '.git'.length)
+  }
+  return stdout
+}
+
+async function getCommitHash(): Promise<string> {
+  const cmd = 'git show | head -n 1'
+  const stdout = (await execCmdWithExitOnFailure(cmd))[0]
+  return stdout.split(' ')[1].trim()
 }
 
 // TODO(yerdua): make this communicate or handle auth issues reasonably. Ideally,
@@ -56,13 +130,14 @@ export async function uploadFileToGoogleStorage(
   localFilePath: string,
   googleStorageBucketName: string,
   googleStorageFileName: string,
-  makeFileWorldReadable: boolean
+  makeFileWorldReadable: boolean,
+  contentType: string
 ) {
   await ensureAuthenticatedGcloudAccount()
   const storage = new Storage()
   await storage.bucket(googleStorageBucketName).upload(localFilePath, {
     destination: googleStorageFileName,
-    contentType: 'application/json',
+    contentType,
     metadata: {
       cacheControl: 'private',
     },

--- a/packages/celotool/src/lib/utils.ts
+++ b/packages/celotool/src/lib/utils.ts
@@ -5,6 +5,7 @@ import { switchToClusterFromEnv } from './cluster'
 import { envVar, fetchEnv } from './env-utils'
 import { retrieveIPAddress } from './helm_deploy'
 
+// Returns a Promise which resolves to [stdout, stderr] array
 export function execCmd(
   cmd: string,
   execOptions: any = {},

--- a/packages/celotool/src/lib/vm-testnet-utils.ts
+++ b/packages/celotool/src/lib/vm-testnet-utils.ts
@@ -18,7 +18,11 @@ import {
   TerraformVars,
   untaintTerraformModuleResource,
 } from './terraform'
-import { uploadFileToGoogleStorage, uploadGenesisBlockToGoogleStorage } from './testnet-utils'
+import {
+  uploadEnvFileToGoogleStorage,
+  uploadFileToGoogleStorage,
+  uploadGenesisBlockToGoogleStorage,
+} from './testnet-utils'
 
 const secretsBucketName = 'celo-testnet-secrets'
 const testnetTerraformModule = 'testnet'
@@ -64,6 +68,7 @@ export async function deploy(celoEnv: string, onConfirmFailed?: () => Promise<vo
   })
 
   await uploadGenesisBlockToGoogleStorage(celoEnv)
+  await uploadEnvFileToGoogleStorage(celoEnv)
 }
 
 async function deployModule(
@@ -292,7 +297,13 @@ function uploadSecrets(celoEnv: string, secrets: string, resourceName: string) {
   const localTmpFilePath = `/tmp/${celoEnv}-${resourceName}-secrets`
   writeFileSync(localTmpFilePath, secrets)
   const cloudStorageFileName = `${secretsBasePath(celoEnv)}/.env.${resourceName}`
-  return uploadFileToGoogleStorage(localTmpFilePath, secretsBucketName, cloudStorageFileName, false)
+  return uploadFileToGoogleStorage(
+    localTmpFilePath,
+    secretsBucketName,
+    cloudStorageFileName,
+    false,
+    'text/plain'
+  )
 }
 
 function generateBootnodeSecretEnvVars() {


### PR DESCRIPTION
### Description

Store the `.env` config after deployment to GCS. This solves a few
issues

1. It tells us the last config file used for deployment
2. It tells us who last deployed it (well, there GitHub name)
3. It tells us what was the commit has of the monorepo, it was deployed
   from.
4. Just like source code, config files in celo-monorepo will become the leading indicator
   of what will be deployed as opposed to what has been deployed.

Note: `env_config_files` bucket is intentionally not world-readable or world-writeable.

### Tested

```
$ celotooljs deploy upgrade testnet -e ashishb2 --verbose

$ gsutil ls gs://env_config_files
gs://env_config_files/ashishb2

$ gsutil cat gs://env_config_files/ashishb2 | head -n 5
# .env file for network "ashishb2"
# Last modified by "Ashish Bhatia <ashishb@ashishb.net>"
# Last modified on on Mon Sep 23 2019 17:50:34 GMT-0700 (PDT)
# Base commit: "https://github.com/celo-org/celo-monorepo/commit/d83cd03b33d2babaea65d9fe4d4eec4546ea5801"
```

### Other changes

Added some missing comments. De-duplicating `genesis_blocks` GCS bucket.