### PR TITLE
Set security fee description translation in Spanish.

### DIFF
--- a/packages/mobile/locales/es-419/sendFlow7.json
+++ b/packages/mobile/locales/es-419/sendFlow7.json
@@ -20,7 +20,7 @@
   "securityFee": "Comisión de seguridad",
   "inviteAndSecurityFee": "Comisión de Invitación",
   "feeEducation":
-    "~Sending payments and making exchanges include a small fee for service security and maintenance.",
+    "Enviar pagos y hacer cambios incluye una pequeña comisión de seguridad y mantenimiento.",
   "learnMore": "Saber más",
   "inviteMoneyEscrow": "Mantendremos este dinero seguro hasta que tu amigo cree una cuenta en Celo",
   "reviewPayment": "Revisar pago",


### PR DESCRIPTION
### Description

_Set security fee description translation in Spanish._

### Tested

_Tested following these steps: create a new transaction, click to send, click on info of security fee, view education view_
![image](https://user-images.githubusercontent.com/1885747/65592398-caaa0180-df8e-11e9-848e-9d7027c78ac8.png)


### Related issues

- Fixes #950 

### Backwards compatibility

_This change doesn't affect compatibility_
