### PR TITLE
Add contractkit to celotool docker image

### DIFF
--- a/dockerfiles/celotool/Dockerfile
+++ b/dockerfiles/celotool/Dockerfile
@@ -18,6 +18,7 @@ COPY scripts/ scripts/
 COPY packages/utils/package.json packages/utils/
 COPY packages/typescript/package.json packages/typescript/
 COPY packages/walletkit/package.json packages/walletkit/
+COPY packages/contractkit/package.json packages/contractkit/
 COPY packages/verification-pool-api/package.json packages/verification-pool-api/
 COPY packages/celotool/package.json packages/celotool/
 
@@ -26,6 +27,7 @@ RUN yarn install --frozen-lockfile && yarn cache clean
 COPY packages/utils packages/utils/
 COPY packages/typescript packages/typescript/
 COPY packages/walletkit packages/walletkit/
+COPY packages/contractkit packages/contractkit/
 COPY packages/verification-pool-api packages/verification-pool-api/
 COPY packages/celotool packages/celotool/
 


### PR DESCRIPTION
### Description

We don't have contractkit source in the celotool docker image which will make celotool usee the npm version which may not have the most up-to-date code. We ideally should probably bump contractkit versions and update it in celotool's package.json, but for now, this is easier

### Tested

- Not tested


### Related issues

- Fixes #1105 
