### PR TITLE
[wallet]Run geth in an infura-like mode

### DIFF
--- a/packages/mobile/.env
+++ b/packages/mobile/.env
@@ -1,5 +1,7 @@
 ENVIRONMENT=local
 DEFAULT_TESTNET=integration
+# -1 == ZeroSync, 5 == Ultralight, see src/geth/consts.ts for more info
+DEFAULT_SYNC_MODE=5
 DEV_SETTINGS_ACTIVE_INITIALLY=true
 FIREBASE_ENABLED=true
 SECRETS_KEY=debug

--- a/packages/mobile/index.js
+++ b/packages/mobile/index.js
@@ -1,5 +1,5 @@
 import 'node-libs-react-native/globals'
-import 'src/btoa'
+import 'src/missingGlobals'
 import { AppRegistry } from 'react-native'
 import Logger from 'src/utils/Logger'
 import App from 'src/app/App'

--- a/packages/mobile/src/account/Account.test.tsx
+++ b/packages/mobile/src/account/Account.test.tsx
@@ -12,6 +12,10 @@ import { createMockStore } from 'test/utils'
 
 jest.useFakeTimers()
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Account', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/account/DollarEducation.test.tsx
+++ b/packages/mobile/src/account/DollarEducation.test.tsx
@@ -5,6 +5,10 @@ import * as renderer from 'react-test-renderer'
 import DollarEducation from 'src/account/DollarEducation'
 import { createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('DollarEducation', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/account/EditProfile.test.tsx
+++ b/packages/mobile/src/account/EditProfile.test.tsx
@@ -6,6 +6,10 @@ import { setName } from 'src/account/actions'
 import { EditProfile } from 'src/account/EditProfile'
 import { createMockStore, getMockI18nProps } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 it('renders the EditProfile Component', () => {
   const store = createMockStore()
   const tree = renderer.create(

--- a/packages/mobile/src/account/Education.test.tsx
+++ b/packages/mobile/src/account/Education.test.tsx
@@ -26,6 +26,10 @@ const educationProps = {
   onFinish: jest.fn(),
 }
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Education', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/account/GoldEducation.test.tsx
+++ b/packages/mobile/src/account/GoldEducation.test.tsx
@@ -5,6 +5,10 @@ import * as renderer from 'react-test-renderer'
 import GoldEducation from 'src/account/GoldEducation'
 import { createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('GoldEducation', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/account/Invite.test.tsx
+++ b/packages/mobile/src/account/Invite.test.tsx
@@ -6,6 +6,10 @@ import Invite from 'src/account/Invite'
 import { createMockStore } from 'test/utils'
 import { mockE164NumberToInvitableRecipient, mockNavigation } from 'test/values'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Invite', () => {
   it('renders correctly with recipients', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/account/InviteReview.test.tsx
+++ b/packages/mobile/src/account/InviteReview.test.tsx
@@ -18,6 +18,15 @@ jest.mock('src/identity/verification', () => {
   return { isPhoneVerified: jest.fn(() => true) }
 })
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('InviteReview', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/account/PhotosEducation.test.tsx
+++ b/packages/mobile/src/account/PhotosEducation.test.tsx
@@ -5,6 +5,10 @@ import * as renderer from 'react-test-renderer'
 import PhotosEducation from 'src/account/PhotosEducation'
 import { createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('PhotosEducation', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/account/Profile.test.tsx
+++ b/packages/mobile/src/account/Profile.test.tsx
@@ -9,6 +9,10 @@ import { Screens } from 'src/navigator/Screens'
 import { createMockStore } from 'test/utils'
 import { mockNavigation } from 'test/values'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 function profileFactory() {
   return (
     <Provider store={createMockStore({})}>

--- a/packages/mobile/src/app/App.test.tsx
+++ b/packages/mobile/src/app/App.test.tsx
@@ -25,6 +25,10 @@ jest.mock('src/redux/sagas', () => {
   }
 })
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('App', () => {
   it('renders an ApolloProvider', () => {
     const wrapper = shallow(<App />)

--- a/packages/mobile/src/app/Debug.test.tsx
+++ b/packages/mobile/src/app/Debug.test.tsx
@@ -5,6 +5,10 @@ import * as renderer from 'react-test-renderer'
 import Debug from 'src/app/Debug'
 import { createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Debug', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/app/saga.test.ts
+++ b/packages/mobile/src/app/saga.test.ts
@@ -19,6 +19,15 @@ jest.mock('src/firebase/firebase', () => ({
   getVersionInfo: jest.fn(async () => ({ deprecated: false })),
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const { navigate } = require('src/navigator/NavigationService')
 const { getVersionInfo } = require('src/firebase/firebase')
 

--- a/packages/mobile/src/components/AccountOverview.test.tsx
+++ b/packages/mobile/src/components/AccountOverview.test.tsx
@@ -8,6 +8,10 @@ import { getMockI18nProps } from 'test/utils'
 const SAMPLE_BALANCE = '55.00001'
 const exchangeRatePair: ExchangeRatePair = { goldMaker: '0.11', dollarMaker: '10' }
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 it('renders correctly when ready', () => {
   const tree = renderer.create(
     <AccountOverview

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -53,6 +53,7 @@ export const FIREBASE_ENABLED = stringToBoolean(Config.FIREBASE_ENABLED || 'true
 // react-native-config is undefined.
 export const DEFAULT_TESTNET: Testnets = Config.DEFAULT_TESTNET || 'integration'
 export const BLOCKCHAIN_API_URL = config[DEFAULT_TESTNET].blockchainApiUrl
+export const DEFAULT_INFURA_URL = `https://${DEFAULT_TESTNET}-infura.celo-testnet.org/`
 
 export const SEGMENT_API_KEY = keyOrUndefined(secretsFile, Config.SECRETS_KEY, 'SEGMENT_API_KEY')
 export const FIREBASE_WEB_KEY = keyOrUndefined(secretsFile, Config.SECRETS_KEY, 'FIREBASE_WEB_KEY')

--- a/packages/mobile/src/escrow/EscrowedPaymentLineItem.test.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentLineItem.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import PaymentRequestNotificationInner from 'src/paymentRequest/PaymentRequestNotificationInner'
 import { mockRecipientWithPhoneNumber } from 'test/values'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 it('renders correctly', () => {
   const tree = renderer.create(
     <PaymentRequestNotificationInner

--- a/packages/mobile/src/escrow/ReclaimPaymentConfirmationCard.test.tsx
+++ b/packages/mobile/src/escrow/ReclaimPaymentConfirmationCard.test.tsx
@@ -10,6 +10,10 @@ import { mockE164Number, mockRecipient } from 'test/values'
 
 const store = createMockStore()
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('ReclaimPaymentConfirmationCard', () => {
   it('renders correctly for send payment confirmation', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.test.tsx
+++ b/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.test.tsx
@@ -12,6 +12,15 @@ const TEST_FEE = new BigNumber(10000000000000000)
 
 jest.mock('src/escrow/saga')
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const mockedGetReclaimEscrowFee = getReclaimEscrowFee as jest.Mock
 
 const store = createMockStore()

--- a/packages/mobile/src/exchange/ExchangeTradeScreen.test.tsx
+++ b/packages/mobile/src/exchange/ExchangeTradeScreen.test.tsx
@@ -18,6 +18,10 @@ jest.mock('src/shared/DisconnectBanner', () => ({
   DisconnectBanner: () => null,
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const store = createMockStore({
   exchange: {
     exchangeRatePair,

--- a/packages/mobile/src/exchange/actions.ts
+++ b/packages/mobile/src/exchange/actions.ts
@@ -27,6 +27,7 @@ import { roundDown } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { web3 } from 'src/web3/contracts'
 import { getConnectedAccount, getConnectedUnlockedAccount } from 'src/web3/saga'
+import * as util from 'util'
 
 const TAG = 'exchange/actions'
 const LARGE_DOLLARS_SELL_AMOUNT_IN_WEI = new BigNumber(1000 * 1000000000000000000) // To estimate exchange rate from exchange contract
@@ -233,7 +234,7 @@ export function* exchangeGoldAndStableTokens(action: ExchangeTokensAction) {
       return
     }
     yield call(sendTransaction, approveTx, account, TAG, 'approval')
-    Logger.debug(TAG, `Transaction approved: ${approveTx}`)
+    Logger.debug(TAG, `Transaction approved: ${util.inspect(approveTx.arguments)}`)
 
     const tx = exchangeContract.methods.exchange(
       convertedMakerAmount.toString(),

--- a/packages/mobile/src/fees/saga.test.ts
+++ b/packages/mobile/src/fees/saga.test.ts
@@ -18,6 +18,16 @@ jest.mock('@celo/walletkit', () => ({
   },
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+      toWei: jest.fn((x: any) => x * 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe(estimateFeeSaga, () => {
   beforeAll(() => {
     jest.useRealTimers()

--- a/packages/mobile/src/geth/consts.ts
+++ b/packages/mobile/src/geth/consts.ts
@@ -1,11 +1,17 @@
 export const WEI_PER_CELO = 1000000000000000000.0
 export const UNLOCK_DURATION = 600
 
-// Valid sync mode values can be seen at https://github.com/celo-org/celo-blockchain/blob/8be27f7c044e35dbf63a42500a79805f1bddcfb8/mobile/geth.go#L43-L47
-// Anything invalid will cause Geth to panic and app to crash.
-export const SYNC_MODE_LIGHT = 3
-// Value of 4 corresponds to a deprecated sync mode.
-export const SYNC_MODE_ULTRALIGHT = 5
+export enum GethSyncMode {
+  // Sync mode to imply no local geth node but an infura-like setup.
+  // This mode is internal to Celo wallet app and won't be propagated to
+  // geth node.
+  ZeroSync = -1,
+  // Valid sync mode values can be seen at https://github.com/celo-org/celo-blockchain/blob/8be27f7c044e35dbf63a42500a79805f1bddcfb8/mobile/geth.go#L43-L47
+  // Anything invalid will cause Geth to panic and app to crash.
+  Light = 3,
+  // Value of 4 corresponds to a deprecated sync mode.
+  Ultralight = 5,
+}
 
 // Re-export from utils for convinience since we use these often
 export {

--- a/packages/mobile/src/geth/network-config.ts
+++ b/packages/mobile/src/geth/network-config.ts
@@ -1,30 +1,29 @@
-import { SYNC_MODE_ULTRALIGHT } from 'src/geth/consts'
-import { Testnets } from 'src/web3/testnets'
+import { DEFAULT_SYNC_MODE, Testnets } from 'src/web3/testnets'
 
 export default {
   [Testnets.integration]: {
     nodeDir: `.${Testnets.integration}`,
-    syncMode: SYNC_MODE_ULTRALIGHT,
+    syncMode: DEFAULT_SYNC_MODE,
     blockchainApiUrl: 'https://integration-dot-celo-testnet.appspot.com/',
   },
   [Testnets.alfajoresstaging]: {
     nodeDir: `.${Testnets.alfajoresstaging}`,
-    syncMode: SYNC_MODE_ULTRALIGHT,
+    syncMode: DEFAULT_SYNC_MODE,
     blockchainApiUrl: 'https://alfajoresstaging-dot-celo-testnet.appspot.com/',
   },
   [Testnets.alfajores]: {
     nodeDir: `.${Testnets.alfajores}`,
-    syncMode: SYNC_MODE_ULTRALIGHT,
+    syncMode: DEFAULT_SYNC_MODE,
     blockchainApiUrl: 'https://alfajores-dot-celo-testnet-production.appspot.com/',
   },
   [Testnets.pilot]: {
     nodeDir: `.${Testnets.pilot}`,
-    syncMode: SYNC_MODE_ULTRALIGHT,
+    syncMode: DEFAULT_SYNC_MODE,
     blockchainApiUrl: 'https://pilot-dot-celo-testnet-production.appspot.com/',
   },
   [Testnets.pilotstaging]: {
     nodeDir: `.${Testnets.pilotstaging}`,
-    syncMode: SYNC_MODE_ULTRALIGHT,
+    syncMode: DEFAULT_SYNC_MODE,
     blockchainApiUrl: 'https://pilotstaging-dot-celo-testnet.appspot.com/',
   },
 }

--- a/packages/mobile/src/geth/saga.ts
+++ b/packages/mobile/src/geth/saga.ts
@@ -11,6 +11,7 @@ import { InitializationState, isGethConnectedSelector } from 'src/geth/reducer'
 import { navigateToError } from 'src/navigator/NavigationService'
 import { restartApp } from 'src/utils/AppRestart'
 import Logger from 'src/utils/Logger'
+import { isZeroSyncMode } from 'src/web3/contracts'
 
 const gethEmitter = new NativeEventEmitter(NativeModules.RNGeth)
 
@@ -41,6 +42,9 @@ export function* waitForGethConnectivity() {
 }
 
 function* waitForGethInstance() {
+  if (isZeroSyncMode()) {
+    return GethInitOutcomes.SUCCESS
+  }
   try {
     const gethInstance = yield call(getGeth)
     if (gethInstance == null) {
@@ -128,6 +132,12 @@ function createNewBlockChannel() {
 
 function* monitorGeth() {
   const newBlockChannel = yield createNewBlockChannel()
+
+  if (isZeroSyncMode()) {
+    yield put(setGethConnected(true))
+    yield delay(GETH_MONITOR_DELAY)
+    return
+  }
 
   while (true) {
     try {

--- a/packages/mobile/src/home/CeloDollarsOverview.test.tsx
+++ b/packages/mobile/src/home/CeloDollarsOverview.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import CeloDollarsOverview from 'src/home/CeloDollarsOverview'
 import { createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('CeloDollarsOverview', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/home/NotificationBox.test.tsx
+++ b/packages/mobile/src/home/NotificationBox.test.tsx
@@ -19,6 +19,15 @@ const storeData = {
   },
 }
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('NotificationBox', () => {
   it('Simple test', () => {
     // const store = createMockStore(storeData)

--- a/packages/mobile/src/home/WalletHome.test.tsx
+++ b/packages/mobile/src/home/WalletHome.test.tsx
@@ -20,6 +20,15 @@ const storeData = {
 jest.mock('src/components/AccountOverview')
 jest.mock('src/home/TransactionsList')
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Testnet banner', () => {
   it('Shows testnet banner for 5 seconds', async () => {
     const store = createMockStore({

--- a/packages/mobile/src/home/saga.test.ts
+++ b/packages/mobile/src/home/saga.test.ts
@@ -16,6 +16,10 @@ import { getConnectedAccount } from 'src/web3/saga'
 
 jest.useRealTimers()
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('refreshBalances', () => {
   test('ask for balance when geth and account are ready', () =>
     expectSaga(refreshBalances)

--- a/packages/mobile/src/identity/commentKey.test.ts
+++ b/packages/mobile/src/identity/commentKey.test.ts
@@ -11,6 +11,10 @@ jest.mock('@celo/walletkit', () => ({
   sendTransaction: jest.fn(async () => null),
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Encrypt Comment', () => {
   it('Empty comment', async () => {
     expect(await encryptComment('', 'toAddr', 'fromAddr')).toBe('')

--- a/packages/mobile/src/identity/contactMapping.test.ts
+++ b/packages/mobile/src/identity/contactMapping.test.ts
@@ -33,6 +33,10 @@ const e164NumberRecipients = recipients!.e164NumberToRecipients
 const otherRecipients = recipients!.otherRecipients
 const allRecipients = { ...e164NumberRecipients, ...otherRecipients }
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Import Contacts Saga', () => {
   it('imports contacts and creates contact mappings correctly', async () => {
     const attestationsContract = createMockContract(attestationsStub)

--- a/packages/mobile/src/identity/verification.test.ts
+++ b/packages/mobile/src/identity/verification.test.ts
@@ -50,6 +50,10 @@ jest.mock('@celo/utils', () => ({
   SignatureUtils: { parseSignature: jest.fn(() => ({ r: 'r', s: 's', v: 'v' })) },
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const attestationCode0: AttestationCode = {
   code:
     'ab8049b95ac02e989aae8b61fddc10fe9b3ac3c6aebcd3e68be495570b2d3da15aabc691ab88de69648f988fab653ac943f67404e532cfd1013627f56365f36501',

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -399,7 +399,7 @@ function* revealNeededAttestations(
 ) {
   Logger.debug(TAG + '@revealNeededAttestations', `Revealing ${attestations.length} attestations`)
   yield all(
-    attestations.map((attestation) => {
+    attestations.map((attestation, index) => {
       return call(
         revealAndCompleteAttestation,
         attestationsContract,
@@ -422,6 +422,7 @@ function* revealAndCompleteAttestation(
   Logger.debug(TAG + '@revealAttestation', `Revealing an attestation for issuer: ${issuer}`)
   CeloAnalytics.track(CustomEventNames.verification_reveal_attestation, { issuer })
   const revealTx = yield call(makeRevealTx, attestationsContract, e164Number, issuer)
+  // Crude way to prevent sendTransaction being called in parallel and use the same nonces.
   yield call(sendTransaction, revealTx, account, TAG, `Reveal ${issuer}`)
 
   CeloAnalytics.track(CustomEventNames.verification_revealed_attestation, { issuer })

--- a/packages/mobile/src/import/ImportContacts.test.tsx
+++ b/packages/mobile/src/import/ImportContacts.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import ImportContacts from 'src/import/ImportContacts'
 import { createMockStore, getMockI18nProps } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('ImportContacts Screen', () => {
   it('renders correctly', () => {
     const store = createMockStore()

--- a/packages/mobile/src/import/ImportWallet.test.tsx
+++ b/packages/mobile/src/import/ImportWallet.test.tsx
@@ -17,6 +17,10 @@ jest.mock('src/geth/GethAwareButton', () => {
   return Button
 })
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const SPANISH_MNEMONIC = 'avance colmo poema momia cofre pata res verso secta cinco tubería yacer eterno observar ojo tabaco seta ruina bebé oral miembro gato suelo violín'.normalize(
   'NFD'
 )

--- a/packages/mobile/src/invite/EnterInviteCode.test.tsx
+++ b/packages/mobile/src/invite/EnterInviteCode.test.tsx
@@ -18,6 +18,10 @@ import { createMockStore, getMockI18nProps } from 'test/utils'
 
 SendIntentAndroid.openSMSApp = jest.fn()
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('EnterInviteCode Screen', () => {
   it('renders correctly', () => {
     const store = createMockStore()

--- a/packages/mobile/src/invite/JoinCelo.test.tsx
+++ b/packages/mobile/src/invite/JoinCelo.test.tsx
@@ -8,6 +8,10 @@ import { ErrorMessages } from 'src/app/ErrorMessages'
 import JoinCelo, { JoinCelo as JoinCeloClass } from 'src/invite/JoinCelo'
 import { createMockStore, getMockI18nProps } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('JoinCeloScreen', () => {
   it('renders correctly', () => {
     const store = createMockStore()

--- a/packages/mobile/src/invite/reducer.test.ts
+++ b/packages/mobile/src/invite/reducer.test.ts
@@ -2,6 +2,10 @@ import { storeInviteeData } from 'src/invite/actions'
 import { initialState, inviteReducer as reducer } from 'src/invite/reducer'
 import { mockAccount, mockE164Number } from 'test/values'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('invite/reducer', () => {
   describe(reducer, () => {
     it('returns the default state', () => {

--- a/packages/mobile/src/invite/saga.test.ts
+++ b/packages/mobile/src/invite/saga.test.ts
@@ -50,6 +50,33 @@ jest.mock('src/transactions/send', () => ({
   sendTransaction: async () => true,
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    eth: {
+      accounts: {
+        privateKeyToAccount: () =>
+          '0x1129eb2fbccdc663f4923a6495c35b096249812b589f7c4cd1dba01e1edaf724',
+        wallet: {
+          add: () => null,
+        },
+        create: () => ({
+          address: '0x1129eb2fbccdc663f4923a6495c35b096249812b589f7c4cd1dba01e1edaf724',
+          privateKey: '0x1129eb2fbccdc663f4923a6495c35b096249812b589f7c4cd1dba01e1edaf724',
+        }),
+      },
+      personal: {
+        importRawKey: () => '0x1129eb2fbccdc663f4923a6495c35b096249812b589f7c4cd1dba01e1edaf724',
+        unlockAccount: async () => true,
+      },
+    },
+    utils: {
+      fromWei: (x: any) => x / 1e18,
+      sha3: (x: any) => `a sha3 hash`,
+    },
+  },
+  isZeroSyncMode: () => false,
+}))
+
 SendIntentAndroid.sendSms = jest.fn()
 
 const state = createMockStore({ web3: { account: mockAccount } }).getState()

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -41,7 +41,6 @@ import { dynamicLink } from 'src/utils/dynamicLink'
 import Logger from 'src/utils/Logger'
 import { addLocalAccount, isZeroSyncMode, web3 } from 'src/web3/contracts'
 import { getConnectedUnlockedAccount, getOrCreateAccount } from 'src/web3/saga'
-import Web3 from 'web3'
 
 const TAG = 'invite/saga'
 export const TEMP_PW = 'ce10'
@@ -77,7 +76,7 @@ export function getInvitationVerificationFeeInDollars() {
 }
 
 export function getInvitationVerificationFeeInWei() {
-  return new BigNumber(Web3.utils.toWei(INVITE_FEE))
+  return new BigNumber(web3.utils.toWei(INVITE_FEE))
 }
 
 export async function generateLink(inviteCode: string, recipientName: string) {
@@ -220,24 +219,19 @@ export function* doRedeemInvite(inviteCode: string) {
   try {
     const tempAccount = web3.eth.accounts.privateKeyToAccount(inviteCode).address
     Logger.debug(`TAG@doRedeemInvite`, 'Invite code contains temp account', tempAccount)
-    // TODO(ashishb): check getAccountBalance for zero sync mode - should be fine
     const tempAccountBalanceWei: BigNumber = yield call(getAccountBalance, tempAccount)
     if (tempAccountBalanceWei.isLessThanOrEqualTo(0)) {
       yield put(showError(ErrorMessages.EMPTY_INVITE_CODE))
       return false
     }
 
-    // TODO(ashishb): check getOrCreateAccount for zero sync mode
     const newAccount = yield call(getOrCreateAccount)
     if (!newAccount) {
       throw Error('Unable to create your account')
     }
 
-    // TODO(ashishb): check addTempAccountToWallet for zero sync mode - fixed
     yield call(addTempAccountToWallet, inviteCode)
-    // TODO(ashishb): check withdrawFundsFromTempAccount for zero sync mode - fixed
     yield call(withdrawFundsFromTempAccount, tempAccount, tempAccountBalanceWei, newAccount)
-    // TODO(ashishb): check fetchDollarBalance for zero sync mode - most likely fine?
     yield put(fetchDollarBalance())
     return true
   } catch (e) {

--- a/packages/mobile/src/language/Language.test.tsx
+++ b/packages/mobile/src/language/Language.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import { Language } from 'src/language/Language'
 import { getMockI18nProps } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 it('renders correctly', () => {
   const navigation: any = { getParam: jest.fn() }
   const tree = renderer.create(

--- a/packages/mobile/src/localCurrency/SelectLocalCurrency.test.tsx
+++ b/packages/mobile/src/localCurrency/SelectLocalCurrency.test.tsx
@@ -4,6 +4,10 @@ import { Provider } from 'react-redux'
 import SelectLocalCurrency from 'src/localCurrency/SelectLocalCurrency'
 import { createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('SelectLocalCurrency', () => {
   it('renders correctly', () => {
     const { toJSON } = render(

--- a/packages/mobile/src/missingGlobals.ts
+++ b/packages/mobile/src/missingGlobals.ts
@@ -1,6 +1,7 @@
 // TODO remove, move to celo/utils
 export interface Global {
   btoa: any
+  URL: any
   self: any
 }
 
@@ -9,3 +10,6 @@ if (typeof global.self === 'undefined') {
   global.self = global
 }
 global.btoa = require('Base64').btoa
+// Without this, one will see a confusing error
+// similar to https://imgur.com/a/7rnLIh5
+global.URL = require('whatwg-url').URL

--- a/packages/mobile/src/notifications/EscrowedPaymentReminderNotification.test.tsx
+++ b/packages/mobile/src/notifications/EscrowedPaymentReminderNotification.test.tsx
@@ -8,6 +8,10 @@ import { mockEscrowedPayment } from 'test/values'
 
 const store = createMockStore()
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('EscrowedPaymentReminderNotification', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/notifications/PaymentrequestSummaryNotification.test.tsx
+++ b/packages/mobile/src/notifications/PaymentrequestSummaryNotification.test.tsx
@@ -57,6 +57,10 @@ const fakeRequests = [
 ]
 const store = createMockStore()
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('PaymentRequestSummaryNotification', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.test.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.test.tsx
@@ -15,6 +15,15 @@ const store = createMockStore({
   },
 })
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('PaymentRequestConfirmation', () => {
   it('renders correctly for request payment confirmation', () => {
     const navigation = createMockNavigationProp({

--- a/packages/mobile/src/paymentRequest/PaymentRequestListItem.test.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestListItem.test.tsx
@@ -19,6 +19,10 @@ const commonProps = {
   },
 }
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('PaymentRequestListItem', () => {
   it('renders correctly', () => {
     // @ts-ignore -- kind is not assignable?

--- a/packages/mobile/src/paymentRequest/PaymentRequestListScreen.test.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestListScreen.test.tsx
@@ -29,6 +29,10 @@ const requests = [
   }),
 ]
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 function testStore(paymentRequests: PaymentRequest[]) {
   return createMockStore({
     stableToken: { balance: '120' },

--- a/packages/mobile/src/pincode/PincodeConfirmation.test.tsx
+++ b/packages/mobile/src/pincode/PincodeConfirmation.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import PincodeConfirmation from 'src/pincode/PincodeConfirmation'
 import { createMockNavigationProp, createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('PincodeConfirmation', () => {
   it('renders correctly', () => {
     const navigation = createMockNavigationProp({

--- a/packages/mobile/src/pincode/PincodeSet.test.tsx
+++ b/packages/mobile/src/pincode/PincodeSet.test.tsx
@@ -4,6 +4,10 @@ import { Provider } from 'react-redux'
 import PincodeSet from 'src/pincode/PincodeSet'
 import { createMockStore } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('Pincode', () => {
   it('renders correctly', () => {
     const { toJSON, getByTestId } = render(

--- a/packages/mobile/src/qrcode/QRCode.test.tsx
+++ b/packages/mobile/src/qrcode/QRCode.test.tsx
@@ -14,6 +14,10 @@ const commonProps = {
   ...getMockI18nProps(),
 }
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('QRCode', () => {
   const store = createMockStore({
     account: { name: mockName },

--- a/packages/mobile/src/recipients/RecipientItem.test.tsx
+++ b/packages/mobile/src/recipients/RecipientItem.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import RecipientItem from 'src/recipients/RecipientItem'
 import { mockRecipient } from 'test/values'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe(RecipientItem, () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/recipients/recipient.test.ts
+++ b/packages/mobile/src/recipients/recipient.test.ts
@@ -1,6 +1,10 @@
 import { contactsToRecipients, RecipientKind } from 'src/recipients/recipient'
 import { mockAccount, mockContactList, mockDisplayNumber, mockE164Number } from 'test/values'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('contactsToRecipients', () => {
   it('returns a recipient per phone number', () => {
     const countryCode = '+1'

--- a/packages/mobile/src/redux/sagas.test.ts
+++ b/packages/mobile/src/redux/sagas.test.ts
@@ -2,6 +2,10 @@ import { expectSaga } from 'redux-saga-test-plan'
 import { withTimeout } from 'src/redux/sagas-helpers'
 import { sleep } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('withTimeout Saga', () => {
   test('returns the fn results if no timeout', () =>
     expectSaga(withTimeout(50000, async () => ({ hello: 'world' })))

--- a/packages/mobile/src/send/SendAmount.test.tsx
+++ b/packages/mobile/src/send/SendAmount.test.tsx
@@ -31,6 +31,10 @@ const storeData = {
 const TEXT_PLACEHOLDER = 'groceriesRent'
 const AMOUNT_PLACEHOLDER = 'amount'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('SendAmount', () => {
   beforeAll(() => {
     jest.useRealTimers()

--- a/packages/mobile/src/send/SendConfirmation.test.tsx
+++ b/packages/mobile/src/send/SendConfirmation.test.tsx
@@ -11,6 +11,15 @@ const TEST_FEE = new BigNumber(10000000000000000)
 
 jest.mock('src/send/saga')
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const mockedGetSendFee = getSendFee as jest.Mock
 
 const store = createMockStore({

--- a/packages/mobile/src/send/TransferConfirmationCard.test.tsx
+++ b/packages/mobile/src/send/TransferConfirmationCard.test.tsx
@@ -20,6 +20,10 @@ const store = createMockStore({
   },
 })
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('TransferConfirmationCard', () => {
   it('renders correctly for verification fee drilldown', () => {
     const props = {

--- a/packages/mobile/src/send/TransferReviewCard.test.tsx
+++ b/packages/mobile/src/send/TransferReviewCard.test.tsx
@@ -17,6 +17,15 @@ const store = createMockStore({
   },
 })
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('TransferReviewCard', () => {
   it('renders correctly for send review', () => {
     const props = {

--- a/packages/mobile/src/send/saga.test.ts
+++ b/packages/mobile/src/send/saga.test.ts
@@ -25,6 +25,15 @@ jest.mock('src/navigator/NavigationService', () => ({
   navigate: jest.fn(),
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  web3: {
+    utils: {
+      fromWei: jest.fn((x: any) => x / 1e18),
+    },
+  },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const { navigate } = require('src/navigator/NavigationService')
 
 describe(watchQrCodeDetections, () => {

--- a/packages/mobile/src/shared/BackupPrompt.test.tsx
+++ b/packages/mobile/src/shared/BackupPrompt.test.tsx
@@ -6,6 +6,10 @@ import { getMockI18nProps } from 'test/utils'
 
 const time = 1552353116086
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('BackupPrompt', () => {
   it('renders correctly', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/shared/DisconnectBanner.test.tsx
+++ b/packages/mobile/src/shared/DisconnectBanner.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import DisconnectBanner from 'src/shared/DisconnectBanner'
 import { createMockStore, createMockStoreAppDisconnected } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 it('renders banner when app is disconnected', () => {
   const store = createMockStoreAppDisconnected()
   const tree = renderer.create(

--- a/packages/mobile/src/stableToken/saga.test.ts
+++ b/packages/mobile/src/stableToken/saga.test.ts
@@ -29,6 +29,10 @@ jest.mock('src/web3/actions', () => ({
   unlockAccount: jest.fn(async () => true),
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const { unlockAccount } = require('src/web3/actions')
 
 const state = createMockStore().getState()

--- a/packages/mobile/src/transactions/ExchangeFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/ExchangeFeedItem.test.tsx
@@ -8,6 +8,10 @@ import { ExchangeFeedItem } from 'src/transactions/ExchangeFeedItem'
 import { TransactionStatus, TransactionTypes } from 'src/transactions/reducer'
 import { createMockStore, getMockI18nProps } from 'test/utils'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('ExchangeFeedItem', () => {
   let dateNowSpy: any
   beforeAll(() => {

--- a/packages/mobile/src/transactions/NoActivity.test.tsx
+++ b/packages/mobile/src/transactions/NoActivity.test.tsx
@@ -4,6 +4,10 @@ import * as renderer from 'react-test-renderer'
 import NoActivity from 'src/transactions/NoActivity'
 import { FeedType } from 'src/transactions/TransactionFeed'
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 it('renders loading', () => {
   const tree = renderer.create(<NoActivity loading={true} kind={FeedType.HOME} error={undefined} />)
   expect(tree).toMatchSnapshot()

--- a/packages/mobile/src/transactions/TransactionFeed.test.tsx
+++ b/packages/mobile/src/transactions/TransactionFeed.test.tsx
@@ -14,6 +14,10 @@ import { createMockStore } from 'test/utils'
 
 jest.mock('src/utils/time.ts')
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 const standbyTransactions: StandbyTransaction[] = [
   {
     id: '0110',

--- a/packages/mobile/src/transactions/TransferFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.test.tsx
@@ -26,6 +26,10 @@ const invitee = {
 const encryptedMockComment =
   'BAChYK3v1R/Y1ixIKqhpT6BW9AqigzaHfCl/MTu4Sg6fp1ckDUHR4qMOyxG3UiMe1GrlpJ+Ce66NJh6VemaWkHD7tU3TCbyUHsLHXBwJ0nBwLqt9Lvqrp4MO7unbFYCofqhjZKH+9g3OFBr6TwvSg/JaY7CZiSjq0FPiA+hcmScJBJl12DcGnB+cNl97n7tdCGQZj+LY/ktPdPzH9wUtTNx+UKDjHfF06pWRPd3d7k0rO+ww01cKuh+8aBdS1oMA8HPFUttM2pcigqD1uTWaD/LCnGjYR5nVfSj5luaI/lqinRGHcCPlFzmflqbS3kpaCM/dolP8By7UC8V8leQ3tMI/JsrusWTRFkctBTCEqmk/Pd8/ezPVae8813EisGlsDC7Uxq3VDhkPMTVwrT2NjplqQ6CCLQ4aKvFAdZEo3e/iJWlXa5RKMTiRmpNjb5vhlIC0bWnAkMC17r/5poawS3SjWR+5RLFD+vsj0x/gErZaUCXxOVdiR1CURh1qZ9VyEUTxm1ZnZpC+tg=='
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('transfer feed item renders correctly', () => {
   it('for sent transaction', () => {
     const tree = renderer.create(

--- a/packages/mobile/src/transactions/actions.ts
+++ b/packages/mobile/src/transactions/actions.ts
@@ -5,7 +5,7 @@ import { Screens } from 'src/navigator/Screens'
 import { ConfirmationInput as SendConfirmationCardProps } from 'src/send/SendConfirmation'
 import { OwnProps as TransferConfirmationCardProps } from 'src/send/TransferConfirmationCard'
 import { StandbyTransaction, TransactionTypes } from 'src/transactions/reducer'
-import { web3 } from 'src/web3/contracts'
+import Web3 from 'web3'
 
 export enum Actions {
   ADD_STANDBY_TRANSACTION = 'TRANSACTIONS/ADD_STANDBY_TRANSACTION',
@@ -47,7 +47,7 @@ export type ActionTypes =
   | AddHashToStandbyTransaction
 
 export const generateStandbyTransactionId = (recipientAddress: string) => {
-  return web3.utils.sha3(recipientAddress + String(Date.now()))
+  return Web3.utils.sha3(recipientAddress + String(Date.now()))
 }
 
 export const addStandbyTransaction = (transaction: StandbyTransaction): AddStandbyTransaction => ({

--- a/packages/mobile/src/transactions/actions.ts
+++ b/packages/mobile/src/transactions/actions.ts
@@ -5,7 +5,7 @@ import { Screens } from 'src/navigator/Screens'
 import { ConfirmationInput as SendConfirmationCardProps } from 'src/send/SendConfirmation'
 import { OwnProps as TransferConfirmationCardProps } from 'src/send/TransferConfirmationCard'
 import { StandbyTransaction, TransactionTypes } from 'src/transactions/reducer'
-import Web3 from 'web3'
+import { web3 } from 'src/web3/contracts'
 
 export enum Actions {
   ADD_STANDBY_TRANSACTION = 'TRANSACTIONS/ADD_STANDBY_TRANSACTION',
@@ -47,7 +47,7 @@ export type ActionTypes =
   | AddHashToStandbyTransaction
 
 export const generateStandbyTransactionId = (recipientAddress: string) => {
-  return Web3.utils.sha3(recipientAddress + String(Date.now()))
+  return web3.utils.sha3(recipientAddress + String(Date.now()))
 }
 
 export const addStandbyTransaction = (transaction: StandbyTransaction): AddStandbyTransaction => ({

--- a/packages/mobile/src/transactions/saga.ts
+++ b/packages/mobile/src/transactions/saga.ts
@@ -38,7 +38,7 @@ export function* sendAndMonitorTransaction(
   currency?: CURRENCY_ENUM
 ) {
   try {
-    Logger.debug(TAG + '@sendAndMonitorTransaction', 'Sending transaction with id: ', txId)
+    Logger.debug(TAG + '@sendAndMonitorTransaction', `Sending transaction with id: ${txId}`)
 
     const { transactionHash, confirmation } = yield call(
       sendTransactionPromises,

--- a/packages/mobile/src/transactions/send.ts
+++ b/packages/mobile/src/transactions/send.ts
@@ -2,13 +2,15 @@ import {
   awaitConfirmation,
   getStableTokenContract,
   sendTransactionAsync,
+  sendTransactionAsyncWithWeb3Signing,
   SendTransactionLogEvent,
   SendTransactionLogEventType,
 } from '@celo/walletkit'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
 import { CustomEventNames } from 'src/analytics/constants'
+import { DEFAULT_INFURA_URL } from 'src/config'
 import Logger from 'src/utils/Logger'
-import { web3 } from 'src/web3/contracts'
+import { isZeroSyncMode, web3 } from 'src/web3/contracts'
 import { TransactionObject } from 'web3/eth/types'
 
 // As per https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
@@ -61,8 +63,38 @@ export const sendTransactionPromises = async (
   txId: string,
   staticGas?: number | undefined
 ) => {
+  Logger.debug(
+    'transactions/send@sendTransactionPromises',
+    `Going to send a transaction with id ${txId}`
+  )
   const stableToken = await getStableTokenContract(web3)
-  return sendTransactionAsync(tx, account, stableToken, getLogger(tag, txId), staticGas)
+  // This if-else case is temprary and will disappear once we move from `walletkit` to `contractkit`.
+  if (isZeroSyncMode()) {
+    // In dev mode, verify that we are actually able to connect to the network. This
+    // ensures that we get a more meaningful error if the infura server is down, which
+    // can happen with networks without SLA guarantees like `integration`.
+    if (__DEV__) {
+      await verifyUrlWorksOrThrow(DEFAULT_INFURA_URL)
+    }
+    Logger.debug(
+      'transactions/send@sendTransactionPromises',
+      `Sending transaction with id ${txId} using web3 signing`
+    )
+    return sendTransactionAsyncWithWeb3Signing(
+      web3,
+      tx,
+      account,
+      stableToken,
+      getLogger(tag, txId),
+      staticGas
+    )
+  } else {
+    Logger.debug(
+      'transactions/send@sendTransactionPromises',
+      `Sending transaction with id ${txId} using geth signing`
+    )
+    return sendTransactionAsync(tx, account, stableToken, getLogger(tag, txId), staticGas)
+  }
 }
 
 // Send a transaction and await for its confirmation
@@ -75,4 +107,17 @@ export const sendTransaction = async (
   staticGas?: number | undefined
 ) => {
   return sendTransactionPromises(tx, account, tag, txId, staticGas).then(awaitConfirmation)
+}
+
+async function verifyUrlWorksOrThrow(url: string) {
+  try {
+    await fetch(url)
+  } catch (e) {
+    Logger.error(
+      'contracts@verifyUrlWorksOrThrow',
+      `Failed to perform HEAD request to url: \"${url}\"`,
+      e
+    )
+    throw new Error(`Failed to perform HEAD request to url: \"${url}\", is it working?`)
+  }
 }

--- a/packages/mobile/src/verify/Verify.test.tsx
+++ b/packages/mobile/src/verify/Verify.test.tsx
@@ -11,6 +11,10 @@ import { mockAttestationMessage } from 'test/values'
 
 const store = createMockStore({})
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 it('renders the Education step correctly', () => {
   const tree = renderer.create(
     <Provider store={store}>

--- a/packages/mobile/src/web3/actions.ts
+++ b/packages/mobile/src/web3/actions.ts
@@ -76,11 +76,13 @@ export const updateWeb3SyncProgress = (payload: {
 
 export const checkSyncProgress = () => ({ type: Actions.REQUEST_SYNC_PROGRESS })
 
+// Note: This returns Promise<Block>
 export function getLatestBlock() {
   Logger.debug(TAG, 'Getting latest block')
   return web3.eth.getBlock('latest')
 }
 
+// Note: This returns Promise<Block>
 export function getBlock(blockNumber: number) {
   Logger.debug(TAG, 'Getting block ' + blockNumber)
   return web3.eth.getBlock(blockNumber)

--- a/packages/mobile/src/web3/contracts.ts
+++ b/packages/mobile/src/web3/contracts.ts
@@ -1,14 +1,25 @@
+import { addLocalAccount as web3utilsAddLocalAccount } from '@celo/walletkit'
 import { Platform } from 'react-native'
 import { DocumentDirectoryPath } from 'react-native-fs'
 import * as net from 'react-native-tcp'
+import { DEFAULT_INFURA_URL } from 'src/config'
+import { GethSyncMode } from 'src/geth/consts'
+import config from 'src/geth/network-config'
 import Logger from 'src/utils/Logger'
 import { DEFAULT_TESTNET, Testnets } from 'src/web3/testnets'
 import Web3 from 'web3'
+import { Provider } from 'web3/providers'
 
 // Logging tag
 const tag = 'web3/contracts'
 
-const getWeb3IpcProvider = (testnet: Testnets) => {
+export const web3: Web3 = getWeb3()
+
+export function isZeroSyncMode(): boolean {
+  return config[DEFAULT_TESTNET].syncMode === GethSyncMode.ZeroSync
+}
+
+function getIpcProvider(testnet: Testnets) {
   Logger.debug(tag, 'creating IPCProvider...')
 
   const ipcProvider = new Web3.providers.IpcProvider(
@@ -48,20 +59,54 @@ const getWeb3IpcProvider = (testnet: Testnets) => {
   return ipcProvider
 }
 
-const getWeb3HttpProvider = (testnet: Testnets) => {
-  Logger.debug(tag, 'creating HttpProvider...')
+// Use Http provider on iOS until we add support for local socket on iOS in react-native-tcp
+function getWeb3HttpProviderForIos(): Provider {
+  Logger.debug(tag, 'creating HttpProvider for iOS...')
 
   const httpProvider = new Web3.providers.HttpProvider('http://localhost:8545')
-  Logger.debug(tag, 'created HttpProvider')
+  Logger.debug(tag, 'created HttpProvider for iOS')
 
   return httpProvider
 }
 
-// Use Http provider on iOS until we add support for local socket on iOS in react-native-tcp
-export const getWeb3Provider = Platform.OS === 'ios' ? getWeb3HttpProvider : getWeb3IpcProvider
-
-export const setWeb3Provider = (testnet: Testnets) => {
-  web3.setProvider(getWeb3Provider(testnet))
+function getWebSocketProvider(url: string): Provider {
+  Logger.debug(tag, 'creating HttpProvider...')
+  const provider = new Web3.providers.HttpProvider(url)
+  Logger.debug(tag, 'created HttpProvider')
+  // In the future, we might decide to over-ride the error handler via the following code.
+  // provider.on('error', () => {
+  //   Logger.showError('Error occurred')
+  // })
+  return provider
 }
 
-export let web3 = new Web3(getWeb3Provider(DEFAULT_TESTNET))
+function getWeb3(): Web3 {
+  Logger.info(`Initializing web3, platform: ${Platform.OS}, geth free mode: ${isZeroSyncMode()}`)
+
+  if (isZeroSyncMode() && Platform.OS === 'ios') {
+    throw new Error('Zero sync mode is currently not supported on iOS')
+  } else if (isZeroSyncMode()) {
+    // Geth free mode
+    const url = DEFAULT_INFURA_URL
+    Logger.debug('contracts@getWeb3', `Connecting to url ${url}`)
+    return new Web3(getWebSocketProvider(url))
+  } else if (Platform.OS === 'ios') {
+    // iOS + local geth
+    return new Web3(getWeb3HttpProviderForIos())
+  } else {
+    return new Web3(getIpcProvider(DEFAULT_TESTNET))
+  }
+}
+
+export function addLocalAccount(web3Instance: Web3, privateKey: string) {
+  if (!isZeroSyncMode()) {
+    throw new Error('addLocalAccount can only be called in Zero sync mode')
+  }
+  if (!web3Instance) {
+    throw new Error(`web3 instance is ${web3Instance}`)
+  }
+  if (!privateKey) {
+    throw new Error(`privateKey is ${privateKey}`)
+  }
+  web3utilsAddLocalAccount(web3Instance, privateKey)
+}

--- a/packages/mobile/src/web3/gas.test.ts
+++ b/packages/mobile/src/web3/gas.test.ts
@@ -6,6 +6,10 @@ jest.mock('@celo/walletkit', () => ({
   },
 }))
 
+jest.mock('src/web3/contracts', () => ({
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
+}))
+
 describe('getGasPrice', () => {
   it('refreshes the gas price correctly', async () => {
     const gasPrice = await getGasPrice()

--- a/packages/mobile/src/web3/saga.test.ts
+++ b/packages/mobile/src/web3/saga.test.ts
@@ -34,6 +34,7 @@ jest.mock('src/web3/contracts', () => ({
       getBlock: jest.fn(() => ({ number: LAST_BLOCK_NUMBER })),
     },
   },
+  isZeroSyncMode: jest.fn().mockReturnValueOnce(false),
 }))
 
 const state = createMockStore({ web3: { account: mockAccount } }).getState()

--- a/packages/mobile/src/web3/saga.ts
+++ b/packages/mobile/src/web3/saga.ts
@@ -1,5 +1,7 @@
 import { deriveCEK } from '@celo/utils/src/commentEncryption'
+import { getAccountAddressFromPrivateKey } from '@celo/walletkit'
 import { generateMnemonic, mnemonicToSeedHex } from 'react-native-bip39'
+import * as RNFS from 'react-native-fs'
 import { REHYDRATE } from 'redux-persist/es/constants'
 import { call, delay, put, race, select, take } from 'redux-saga/effects'
 import { setAccountCreationTime } from 'src/account/actions'
@@ -23,7 +25,7 @@ import {
   setPrivateCommentKey,
   updateWeb3SyncProgress,
 } from 'src/web3/actions'
-import { web3 } from 'src/web3/contracts'
+import { addLocalAccount, isZeroSyncMode, web3 } from 'src/web3/contracts'
 import { currentAccountSelector } from 'src/web3/selectors'
 import { Block } from 'web3/eth/types'
 
@@ -37,6 +39,11 @@ const BLOCK_CHAIN_CORRUPTION_ERROR = "Error: CONNECTION ERROR: Couldn't connect 
 
 // checks if web3 claims it is currently syncing and attempts to wait for it to complete
 export function* checkWeb3SyncProgress() {
+  if (isZeroSyncMode()) {
+    // In this mode, the check seems to fail with
+    // web3/saga/checking web3 sync progress: Error: Invalid JSON RPC response: "":
+    return true
+  }
   while (true) {
     try {
       Logger.debug(TAG, 'checkWeb3SyncProgress', 'Checking sync progress')
@@ -134,20 +141,34 @@ export function* assignAccountFromPrivateKey(key: string) {
     }
 
     let account: string
-    try {
-      // @ts-ignore
-      account = yield call(web3.eth.personal.importRawKey, String(key), pincode)
-    } catch (e) {
-      if (e.toString().includes('account already exists')) {
-        account = currentAccount
-        Logger.warn(TAG + '@assignAccountFromPrivateKey', 'Importing same account as current one')
-      } else {
-        Logger.error(TAG + '@assignAccountFromPrivateKey', 'Error importing raw key')
-        throw e
+    if (isZeroSyncMode()) {
+      const privateKey = String(key)
+      Logger.debug(TAG + '@assignAccountFromPrivateKey', 'Init web3 with private key')
+      addLocalAccount(web3, privateKey)
+      // Save the account to a local file on the disk.
+      // This is only required in Geth free mode because if geth is running
+      // it has its own mechanism to save the encrypted key in its keystore.
+      account = getAccountAddressFromPrivateKey(privateKey)
+      yield savePrivateKeyToLocalDisk(account, privateKey, pincode)
+    } else {
+      try {
+        // @ts-ignore
+        account = yield call(web3.eth.personal.importRawKey, String(key), pincode)
+      } catch (e) {
+        if (e.toString().includes('account already exists')) {
+          account = currentAccount
+          Logger.debug(
+            TAG + '@assignAccountFromPrivateKey',
+            'Importing same account as current one'
+          )
+        } else {
+          Logger.error(TAG + '@assignAccountFromPrivateKey', 'Error importing raw key')
+          throw e
+        }
       }
+      yield call(web3.eth.personal.unlockAccount, account, pincode, UNLOCK_DURATION)
     }
 
-    yield call(web3.eth.personal.unlockAccount, account, pincode, UNLOCK_DURATION)
     Logger.debug(
       TAG + '@assignAccountFromPrivateKey',
       `Created account from mnemonic and added to wallet: ${account}`
@@ -157,7 +178,9 @@ export function* assignAccountFromPrivateKey(key: string) {
     yield put(setAccountCreationTime())
     yield call(assignDataKeyFromPrivateKey, key)
 
-    web3.eth.defaultAccount = account
+    if (!isZeroSyncMode()) {
+      web3.eth.defaultAccount = account
+    }
     return account
   } catch (e) {
     Logger.error(
@@ -172,6 +195,43 @@ export function* assignAccountFromPrivateKey(key: string) {
 function* assignDataKeyFromPrivateKey(key: string) {
   const privateCEK = deriveCEK(key).toString('hex')
   yield put(setPrivateCommentKey(privateCEK))
+}
+
+function getPrivateKeyFilePath(account: string): string {
+  return `${RNFS.DocumentDirectoryPath}/private_key_for_${account}.txt`
+}
+
+function ensureAddressAndKeyMatch(address: string, privateKey: string) {
+  const generatedAddress = getAccountAddressFromPrivateKey(privateKey)
+  if (address.toLowerCase() !== generatedAddress.toLowerCase()) {
+    throw new Error(
+      `Address from private key: ${generatedAddress}, ` + `address of sender ${address}`
+    )
+  }
+  console.debug(`signing-utils@ensureCorrectSigner: sender and private key match`)
+}
+
+async function savePrivateKeyToLocalDisk(
+  account: string,
+  privateKey: string,
+  encryptionPassword: string
+) {
+  ensureAddressAndKeyMatch(account, privateKey)
+  const filePath = getPrivateKeyFilePath(account)
+  Logger.debug('savePrivateKeyToLocalDisk', `Writing private key to ${filePath}`)
+  // TODO(ashishb): Store encrypted private key instead
+  await RNFS.writeFile(getPrivateKeyFilePath(account), privateKey)
+}
+
+// Reads and returns unencrypted private key
+export async function readPrivateKeyFromLocalDisk(
+  account: string,
+  encryptionPassword: string
+): Promise<string> {
+  const filePath = getPrivateKeyFilePath(account)
+  Logger.debug('readPrivateKeyFromLocalDisk', `Reading private key from ${filePath}`)
+  // TODO(ashishb): Read and decrypt private key instead
+  return RNFS.readFile(getPrivateKeyFilePath(account))
 }
 
 // Wait for account to exist and then return it
@@ -204,6 +264,8 @@ async function isLocked(address: string) {
   return false
 }
 
+let accountAlreadyAddedInZeroSyncMode = false
+
 export function* unlockAccount(account: string) {
   Logger.debug(TAG + '@unlockAccount', `Unlocking account: ${account}`)
   try {
@@ -213,9 +275,21 @@ export function* unlockAccount(account: string) {
     }
 
     const pincode = yield call(getPincode)
-    yield call(web3.eth.personal.unlockAccount, account, pincode, UNLOCK_DURATION)
-    Logger.debug(TAG + '@unlockAccount', `Account unlocked: ${account}`)
-    return true
+    if (isZeroSyncMode()) {
+      if (accountAlreadyAddedInZeroSyncMode) {
+        Logger.info(TAG + 'unlockAccount', `Account ${account} already added to web3 for signing`)
+      } else {
+        Logger.info(TAG + '@unlockAccount', `unlockDuration is ignored in Geth free mode`)
+        const privateKey: string = yield readPrivateKeyFromLocalDisk(account, pincode)
+        addLocalAccount(web3, privateKey)
+        accountAlreadyAddedInZeroSyncMode = true
+      }
+      return true
+    } else {
+      yield call(web3.eth.personal.unlockAccount, account, pincode, UNLOCK_DURATION)
+      Logger.debug(TAG + '@unlockAccount', `Account unlocked: ${account}`)
+      return true
+    }
   } catch (error) {
     Logger.error(TAG + '@unlockAccount', 'Web3 account unlock failed', error)
     return false

--- a/packages/mobile/src/web3/testnets.ts
+++ b/packages/mobile/src/web3/testnets.ts
@@ -1,3 +1,5 @@
+import { GethSyncMode } from 'src/geth/consts'
+
 import Config from 'react-native-config'
 
 export enum Testnets {
@@ -9,3 +11,4 @@ export enum Testnets {
 }
 
 export const DEFAULT_TESTNET: Testnets = Config.DEFAULT_TESTNET
+export const DEFAULT_SYNC_MODE: GethSyncMode = parseInt(Config.DEFAULT_SYNC_MODE, 10)

--- a/packages/walletkit/index.ts
+++ b/packages/walletkit/index.ts
@@ -64,6 +64,7 @@ export {
   SendTransaction,
   sendTransaction,
   sendTransactionAsync,
+  sendTransactionAsyncWithWeb3Signing,
   SendTransactionLogEvent,
   SendTransactionLogEventType,
   TxLogger,
@@ -96,3 +97,4 @@ export { GoogleStorageUtils }
 export { Logger as WalletKitLogger, LogLevel as WalletKitLogLevel }
 export { StaticNodeUtils }
 export { Web3Utils }
+export { addLocalAccount, getAccountAddressFromPrivateKey } from './src/new-web3-utils'

--- a/packages/walletkit/src/contract-utils.ts
+++ b/packages/walletkit/src/contract-utils.ts
@@ -1,12 +1,17 @@
 import BigNumber from 'bignumber.js'
 import { values } from 'lodash'
+import sleep from 'sleep-promise'
+import * as util from 'util'
 import Web3 from 'web3'
 import Contract from 'web3/eth/contract'
 import { TransactionObject } from 'web3/eth/types'
 import { TransactionReceipt } from 'web3/types'
 import * as ContractList from '../contracts/index'
+import { GasPriceMinimum as GasPriceMinimumType } from '../types/GasPriceMinimum'
 import { GoldToken } from '../types/GoldToken'
 import { StableToken } from '../types/StableToken'
+import { getGasPriceMinimumContract } from './contracts'
+import { getGoldTokenAddress } from './erc20-utils'
 import { Logger } from './logger'
 
 const gasInflateFactor = 1.3
@@ -23,6 +28,11 @@ export function selectContractByAddress(contracts: Contract[], address: string) 
 /**
  * Util function to send a transaction and log it's progression
  * Throws error on tx failure
+ *
+ * TODO(ashishb): This function won't work with locally signed transactions.
+ * I am not fixing it since we are going to move to contractkit soon and
+ * for now, mobile app only uses sendTransactionAsync function which works
+ * with locally signed transactions.
  */
 // tslint:disable:ban-types
 export async function sendTransaction(
@@ -204,7 +214,26 @@ function Exception(error: Error): Exception {
   return { type: SendTransactionLogEventType.Exception, error }
 }
 
-//
+async function getGasPrice(
+  web3: Web3,
+  gasCurrency: string | undefined
+): Promise<string | undefined> {
+  // Gold Token
+  if (gasCurrency === undefined) {
+    return String(await web3.eth.getGasPrice())
+  }
+  const gasPriceMinimum: GasPriceMinimumType = await getGasPriceMinimumContract(web3)
+  const gasPrice: string = await gasPriceMinimum.methods.getGasPriceMinimum(gasCurrency).call()
+  Logger.debug('contract-utils@getGasPrice', `Gas price is ${gasPrice}`)
+  return String(parseInt(gasPrice, 10) * 10)
+}
+
+// Maps account address to current nonce. This ensures that transactions
+// being sent too close to each other do not end up having the
+// same nonce. This does not have to be persisted across app restarts since
+// nonce calculation will be correct over the order of seconds (restart time).
+const currentNonce = new Map<string, number>()
+
 /**
  * sendTransactionAsync mainly abstracts the sending of a transaction in a promise like
  * interface. Use the higher-order sendTransactionFactory as a consumer to configure
@@ -303,6 +332,204 @@ export async function sendTransactionAsync<T>(
         rejectAll(error)
       })
   } catch (error) {
+    logger(Exception(error))
+    rejectAll(error)
+  }
+
+  return {
+    receipt,
+    transactionHash,
+    confirmation,
+  }
+}
+
+/**
+ * sendTransactionAsyncWithWeb3Signing is same as sendTransactionAsync except it fills
+ * in the missing fields and locally signs the transaction. It will fail if the `from`
+ * is not one of the account whose local signing keys are available. This method
+ * should only be used in Zero sync (infura-like) mode where Geth is running
+ * remotely.
+ *
+ * This separate function is temporary and contractkit uses a unified function
+ * for both web3 (local) and remote (geth) siging.
+ *
+ * @param tx The transaction object itself
+ * @param account The address from which the transaction should be sent
+ * @param gasCurrencyContract The contract instance of the Token in which to pay gas for
+ * @param logger An object whose log level functions can be passed a function to pass
+ *               a transaction ID
+ */
+export async function sendTransactionAsyncWithWeb3Signing<T>(
+  web3: Web3,
+  tx: TransactionObject<T>,
+  account: string,
+  gasCurrencyContract: StableToken | GoldToken,
+  logger: TxLogger = emptyTxLogger,
+  estimatedGas?: number | undefined
+): Promise<TxPromises> {
+  const tag = 'contract-utils@sendTransactionAsyncWithWeb3Signing'
+  // @ts-ignore
+  const resolvers: TxPromiseResolvers = {}
+  // @ts-ignore
+  const rejectors: TxPromiseReject = {}
+
+  const receipt: Promise<TransactionReceipt> = new Promise((resolve, reject) => {
+    resolvers.receipt = resolve
+    rejectors.receipt = reject
+  })
+
+  const transactionHash: Promise<string> = new Promise((resolve, reject) => {
+    resolvers.transactionHash = resolve
+    rejectors.transactionHash = reject
+  })
+
+  const confirmation: Promise<boolean> = new Promise((resolve, reject) => {
+    resolvers.confirmation = resolve
+    rejectors.confirmation = reject
+  })
+
+  const rejectAll = (error: Error) => {
+    values(rejectors).map((reject) => {
+      // @ts-ignore
+      reject(error)
+    })
+  }
+
+  try {
+    logger(Started)
+    const txParams: any = {
+      from: account,
+      gasCurrency: gasCurrencyContract._address,
+      gasPrice: '0',
+    }
+
+    if (estimatedGas === undefined) {
+      estimatedGas = Math.round((await tx.estimateGas(txParams)) * gasInflateFactor)
+      logger(EstimatedGas(estimatedGas))
+    }
+    // Ideally, we should fill these fields in CeloProvider but as of now,
+    // we don't have access to web3 inside it, so, in the short-term
+    // fill the fields here.
+    let gasCurrency = gasCurrencyContract._address
+    const gasFeeRecipient = await web3.eth.getCoinbase()
+    Logger.debug(tag, `Gas fee recipient is ${gasFeeRecipient}`)
+    const gasPrice = await getGasPrice(web3, gasCurrency)
+    if (gasCurrency === undefined) {
+      gasCurrency = await getGoldTokenAddress(web3)
+    }
+    Logger.debug(tag, `Gas currency: ${gasCurrency}`)
+
+    let recievedTxHash: string | null = null
+    let alreadyInformedResolversAboutConfirmation = false
+    const informAboutConfirmation = () => {
+      // Don't inform more than once.
+      if (alreadyInformedResolversAboutConfirmation) {
+        Logger.debug(tag, `Already Informed Resolvers About Confirmation`)
+        return
+      }
+      alreadyInformedResolversAboutConfirmation = true
+      logger(Confirmed)
+      if (resolvers.confirmation) {
+        resolvers.confirmation(true)
+      } else {
+        Logger.debug(tag, 'resolver.confirmation is null')
+      }
+    }
+
+    // Use pending transaction count, so that, multiple transactions can be sent without
+    // waiting for the earlier ones to be confirmed.
+    let nonce: number = await web3.eth.getTransactionCount(account, 'pending')
+    if (!currentNonce.has(account)) {
+      Logger.debug(tag, `Initializing current nonce for ${account} to ${nonce}`)
+      currentNonce.set(account, nonce)
+    } else if (nonce <= currentNonce.get(account)!) {
+      const newNonce = currentNonce.get(account)!
+      Logger.debug(
+        'contract-utils@sendTransactionAsync',
+        `nonce is ${nonce} which is less than existing known nonce (${currentNonce.get(
+          account
+        )}), setting it to ${newNonce}`
+      )
+      nonce = newNonce
+    }
+    Logger.debug(tag, `sendTransactionAsync@nonce is ${nonce}`)
+    Logger.debug(tag, `sendTransactionAsync@sending from ${account}`)
+
+    const celoTx = {
+      from: account,
+      nonce,
+      // @ts-ignore
+      gasCurrency,
+      gas: estimatedGas,
+      // Hack to prevent web3 from adding the suggested gold gas price, allowing geth to add
+      // the suggested price in the selected gasCurrency.
+      gasPrice,
+      gasFeeRecipient,
+    }
+    // Increment and store nonce for the next call to sendTransaction.
+    currentNonce.set(account, nonce + 1)
+    try {
+      await tx.send(celoTx)
+    } catch (e) {
+      Logger.debug(tag, `Ignoring error: ${util.inspect(e)}`)
+      Logger.debug(tag, `error message: ${e.message}`)
+      // Ideally, I want to only ignore error whose messsage contains
+      // "Failed to subscribe to new newBlockHeaders" but seems like another wrapped
+      // error (listed below) gets thrown and there is no way to catch that.
+      // "Failed to subscribe to new newBlockHeaders" is thrown when the wallet kit is connected
+      // to a remote node via https.
+      // { [Error: [object Object]]
+      //     line: 352771,
+      //     column: 24,
+      //     sourceURL: 'http://localhost:8081/index.delta?platform=android&dev=true&minify=false' }
+      //     contract-utils@sendTransactionAsync: error: { [Error: Failed to subscribe to new newBlockHeaders to confi
+      //     rm the transaction receipts.
+      //     {
+      //       "line": 352771,
+      //       "column": 24,
+      //       "sourceURL": "http://localhost:8081/index.delta?platform=android&dev=true&minify=false"
+      //     }]
+      //       line: 157373,
+      //       column: 24,
+      //       sourceURL: 'http://localhost:8081/index.delta?platform=android&dev=true&minify=false' }
+      if (e.message.indexOf('Failed to subscribe to new newBlockHeaders') >= 0) {
+        // Ignore this error
+        Logger.warn(tag, `Expected error ignored: ${JSON.stringify(e)}`)
+      } else {
+        Logger.debug(tag, `Unexpected error ignored: ${util.inspect(e)}`)
+      }
+      const signedTxn = await web3.eth.signTransaction(celoTx)
+      recievedTxHash = web3.utils.sha3(signedTxn.raw)
+      Logger.info(tag, `Locally calculated recievedTxHash is ${recievedTxHash}`)
+      logger(TransactionHashReceived(recievedTxHash))
+      if (resolvers.transactionHash) {
+        resolvers.transactionHash(recievedTxHash)
+      }
+    }
+    // This code is required for infura-like setup.
+    // When mobile client directly connects to the remote full node then
+    // it gets `receipt` but not other notifications.
+    let sleepTimeInSecs = 1
+    for (let i = 0; i < 10; i++) {
+      await sleep(sleepTimeInSecs * 1000)
+      // Exponential backoff
+      sleepTimeInSecs *= 2
+      if (recievedTxHash === null) {
+        continue
+      }
+      const txReceipt = await web3.eth.getTransactionReceipt(recievedTxHash)
+      if (txReceipt === null) {
+        continue
+      }
+      const txStatus = txReceipt.status
+      Logger.info(tag, `Transaction status of hash ${recievedTxHash}: ${txStatus}`)
+      if (txStatus === true) {
+        informAboutConfirmation()
+        break
+      }
+    }
+  } catch (error) {
+    Logger.warn(tag, `Transaction failed with error "${util.inspect(error)}"`)
     logger(Exception(error))
     rejectAll(error)
   }

--- a/packages/walletkit/src/new-web3-utils.ts
+++ b/packages/walletkit/src/new-web3-utils.ts
@@ -1,0 +1,161 @@
+import {
+  Callback,
+  ErrorCallback,
+  JSONRPCRequestPayload,
+  Subprovider,
+  Web3ProviderEngine,
+} from '@0x/subproviders'
+import * as util from 'util'
+import Web3 from 'web3'
+import { JsonRPCResponse, Provider } from 'web3/providers'
+import { Logger } from './logger'
+import { CeloProvider } from './transaction-utils'
+
+export function getAccountAddressFromPrivateKey(privateKey: string): string {
+  if (!privateKey.toLowerCase().startsWith('0x')) {
+    privateKey = '0x' + privateKey
+  }
+  return new Web3().eth.accounts.privateKeyToAccount(privateKey).address
+}
+
+// This web3 has signing ability.
+export function addLocalAccount(web3: Web3, privateKey: string) {
+  const celoProvider = new CeloProvider(privateKey)
+  const existingProvider = web3.currentProvider
+  let providerEngine: Web3ProviderEngine
+  if (existingProvider instanceof Web3ProviderEngine) {
+    Logger.debug(
+      'new-web3-utils/addLocalAccount',
+      'Existing provider is already a Web3ProviderEngine'
+    )
+    providerEngine = addLocalAccountToExistingProvider(
+      existingProvider as Web3ProviderEngine,
+      celoProvider
+    )
+  } else {
+    providerEngine = createNewProviderWithLocalAccount(existingProvider, celoProvider)
+    web3.setProvider(providerEngine)
+  }
+
+  providerEngine.start()
+  Logger.debug('new-web3-utils/addLocalAccount', 'Providers configured')
+  providerEngine.stop()
+}
+
+function addLocalAccountToExistingProvider(
+  existingProvider: Web3ProviderEngine,
+  localAccountProvider: CeloProvider
+): Web3ProviderEngine {
+  if (isAccountAlreadyAdded(existingProvider, localAccountProvider)) {
+    return existingProvider
+  }
+
+  // When a private key has already been added, add a new one before
+  // all other providers.
+  // I could not find a better way to do this, so, I had to
+  // access the private `_providers` field of providerEngine
+  // @ts-ignore-next-line
+  existingProvider._providers.splice(0, 0, localAccountProvider)
+  localAccountProvider.setEngine(existingProvider)
+  return existingProvider
+}
+
+function createNewProviderWithLocalAccount(
+  existingProvider: Provider,
+  localAccountProvider: CeloProvider
+): Web3ProviderEngine {
+  // Create a Web3 Provider Engine
+  const providerEngine = new Web3ProviderEngine()
+  // Compose our Providers, order matters
+  // Celo provider provides signing
+  providerEngine.addProvider(localAccountProvider)
+  // Use the existing provider to route all other requests
+  const subprovider = new SubproviderWithLogging(existingProvider)
+  Logger.debug('new-web3-utils/createNewProviderWithLocalAccount', 'Setting up providers...')
+  providerEngine.addProvider(subprovider)
+  return providerEngine
+}
+
+function isAccountAlreadyAdded(
+  existingProvider: Web3ProviderEngine,
+  localAccountProvider: CeloProvider
+): boolean {
+  const alreadyAddedAddresses: string[] = []
+  // @ts-ignore-next-line
+  const providers = existingProvider._providers
+  for (const provider of providers) {
+    if (provider instanceof CeloProvider) {
+      const accounts: string[] = (provider as CeloProvider).getAccounts()
+      alreadyAddedAddresses.push.apply(alreadyAddedAddresses, accounts)
+    }
+  }
+
+  const localAccountAddresses: string[] = localAccountProvider.getAccounts()
+  for (const localAccountAddress of localAccountAddresses) {
+    if (alreadyAddedAddresses.indexOf(localAccountAddress) < 0) {
+      Logger.debug(
+        'new-web3-utils/isAccountAlreadyAdded',
+        `Account ${localAccountAddress} is not already added, ` +
+          `existing accounts are ${alreadyAddedAddresses}`
+      )
+      return false
+    }
+  }
+  Logger.debug(
+    'new-web3-utils/addLocalAccount',
+    `Account ${localAccountAddresses} is already added`
+  )
+  return true
+}
+
+class SubproviderWithLogging extends Subprovider {
+  private _provider: Provider
+
+  constructor(readonly provider: Provider) {
+    super()
+    this._provider = provider
+  }
+  /**
+   * @param payload JSON RPC request payload
+   * @param next A callback to pass the request to the next subprovider in the stack
+   * @param end A callback called once the subprovider is done handling the request
+   */
+  handleRequest(
+    payload: JSONRPCRequestPayload,
+    _next: Callback,
+    end: ErrorCallback
+  ): Promise<void> {
+    Logger.debug(
+      'new-web3-utils/addLocalAccount',
+      `SubproviderWithLogging@handleRequest: ${util.inspect(payload)}`
+    )
+    // Inspired from https://github.com/MetaMask/web3-provider-engine/pull/19/
+    return this._provider.send(payload, (err: null | Error, response?: JsonRPCResponse) => {
+      if (err != null) {
+        Logger.verbose(
+          'new-web3-utils/addLocalAccount',
+          `SubproviderWithLogging@response is error: ${err}`
+        )
+        end(err)
+        return
+      }
+      if (response == null) {
+        end(new Error(`Response is null for ${JSON.stringify(payload)}`))
+        return
+      }
+      if (response.error != null) {
+        Logger.verbose(
+          'new-web3-utils/addLocalAccount',
+          `SubproviderWithLogging@response includes error: ${response}`
+        )
+        end(new Error(response.error))
+        return
+      }
+      Logger.debug(
+        'new-web3-utils/addLocalAccount',
+        `SubproviderWithLogging@response: ${util.inspect(response)}`
+      )
+      end(null, response.result)
+    })
+  }
+}

--- a/packages/walletkit/src/transaction-utils.ts
+++ b/packages/walletkit/src/transaction-utils.ts
@@ -1,8 +1,15 @@
-import { PartialTxParams, PrivateKeyWalletSubprovider } from '@0x/subproviders'
+import {
+  Callback,
+  ErrorCallback,
+  JSONRPCRequestPayload,
+  PartialTxParams,
+  PrivateKeyWalletSubprovider,
+} from '@0x/subproviders'
 import { BigNumber } from 'bignumber.js'
 import Web3 from 'web3'
 import { Tx } from 'web3/eth/types'
 import { Logger } from './logger'
+import { getAccountAddressFromPrivateKey } from './new-web3-utils'
 import { signTransaction } from './signing-utils'
 
 export interface CeloTransaction extends Tx {
@@ -21,6 +28,7 @@ export class CeloProvider extends PrivateKeyWalletSubprovider {
   }
 
   private readonly _celoPrivateKey: string // Always 0x prefixed
+  private readonly accountAddress: string // hex-encoded, lower case alphabets
   private _chainId: number | null = null
 
   constructor(privateKey: string) {
@@ -28,6 +36,42 @@ export class CeloProvider extends PrivateKeyWalletSubprovider {
     super(CeloProvider.getPrivateKeyWithout0xPrefix(privateKey))
     // Prefix 0x here or else the signed transaction produces dramatically different signer!!!
     this._celoPrivateKey = '0x' + CeloProvider.getPrivateKeyWithout0xPrefix(privateKey)
+    this.accountAddress = getAccountAddressFromPrivateKey(this._celoPrivateKey).toLowerCase()
+    Logger.debug('CeloProvider@construct', `CeloProvider Account address: ${this.accountAddress}`)
+  }
+
+  public getAccounts(): string[] {
+    return [this.accountAddress]
+  }
+
+  public async handleRequest(
+    payload: JSONRPCRequestPayload,
+    next: Callback,
+    end: ErrorCallback
+  ): Promise<void> {
+    let signingRequired = false
+    switch (payload.method) {
+      case 'eth_sendTransaction': // fallthrough
+      case 'eth_signTransaction': // fallthrough
+      case 'eth_sign': // fallthrough
+      case 'personal_sign': // fallthrough
+      case 'eth_signTypedData':
+        signingRequired = true
+    }
+    // Either
+    // signing is not required or
+    // signing is required and this class is the correct one to sign
+    const shouldPassToSuperClassForHandling =
+      !signingRequired ||
+      (payload.params[0].from !== undefined &&
+        payload.params[0].from !== null &&
+        payload.params[0].from.toLowerCase() === this.accountAddress)
+    if (shouldPassToSuperClassForHandling) {
+      return super.handleRequest(payload, next, end)
+    } else {
+      // Pass it to the next handler to sign
+      next()
+    }
   }
 
   public async signTransactionAsync(txParams: CeloPartialTxParams): Promise<string> {

--- a/packages/walletkit/test/transaction-utils.test.ts
+++ b/packages/walletkit/test/transaction-utils.test.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'bignumber.js'
+import { getGoldTokenAddress } from '../src/erc20-utils'
 import { Logger, LogLevel } from '../src/logger'
 import { recoverTransaction } from '../src/signing-utils'
 import { getRawTransaction } from '../src/transaction-utils'
@@ -24,6 +25,7 @@ describe('Transaction Utils V2', () => {
       const to = accountAddress
       const amountInWei = new BigNumber(1e18)
       const gasFees = new BigNumber(1000 * 1000)
+      const gasCurrency = await getGoldTokenAddress(web3)
       const nonce = await web3.eth.getTransactionCount(from)
 
       const rawTransaction: string = await getRawTransaction(
@@ -33,7 +35,9 @@ describe('Transaction Utils V2', () => {
         nonce,
         amountInWei,
         gasFees,
-        new BigNumber(gasPrice)
+        new BigNumber(gasPrice),
+        await web3.eth.getCoinbase(),
+        gasCurrency
       )
       const recoveredSigner = recoverTransaction(rawTransaction)
       expect(recoveredSigner).toEqual(from)


### PR DESCRIPTION
### Description

Run mobile app without running a local geth instance. Connect to `{testnet}-infura.celo-testnet.org` for example, https://integration-infura.celo-testnet.org`

### Tested

1. Set `DEFAULT_TESTNET=integration` and `DEFAULT_SYNC_MODE=-1` in `packages/mobile/.env` file. 
2. Run the app with `yarn run dev`.
3. Invite yourself with `celotooljs account invite -e integration --phone <phone number>` to get SMS.
4. Perform the verification, send money, exchange gold, ensure that all of this works.

### Related issues

- Fixes #342 