### PR TITLE
[celotool]Add fast mode to celotool invite

### DIFF
--- a/packages/celotool/src/cmds/account/invite.ts
+++ b/packages/celotool/src/cmds/account/invite.ts
@@ -12,24 +12,39 @@ export const describe = 'command for sending an invite code to a phone number'
 
 interface InviteArgv extends AccountArgv {
   phone: string
+  fast: boolean
 }
 
 export const builder = (yargs: Argv) => {
-  return yargs.option('phone', {
-    type: 'string',
-    description: 'Phone number to send invite code,',
-    demand: 'Please specify phone number to send invite code',
-  })
+  return yargs
+    .option('phone', {
+      type: 'string',
+      description: 'Phone number to send invite code,',
+      demand: 'Please specify phone number to send invite code',
+    })
+    .option('fast', {
+      type: 'boolean',
+      default: false,
+      description: "Don't download artifacts, use this for repeated invocations",
+      demand: 'Please specify phone number to send invite code',
+    })
 }
 
 export const handler = async (argv: InviteArgv) => {
-  await switchToClusterFromEnv(false)
   console.log(`Sending invitation code to ${argv.phone}`)
   const cb = async () => {
-    await execCmd(`yarn --cwd ../protocol run invite -n ${argv.celoEnv} -p ${argv.phone}`)
+    await execCmd(
+      `yarn --cwd ../protocol run invite -n ${argv.celoEnv} -p ${argv.phone} -f ${argv.fast}`
+    )
   }
   try {
-    await downloadArtifacts(argv.celoEnv)
+    if (argv.fast) {
+      console.log(`Fast mode is on, cluster won't be switched, artifacts won't be downloaded`)
+    } else {
+      console.log(`Fast mode is off, artifacts will be downloaded`)
+      await switchToClusterFromEnv(false)
+      await downloadArtifacts(argv.celoEnv)
+    }
     await portForwardAnd(argv.celoEnv, cb)
   } catch (error) {
     console.error(`Unable to send invitation code to ${argv.phone}`)


### PR DESCRIPTION
### Description

`celotool account invite` performs the following tasks

1. downloads the latest protocol artifacts
2. compiles the protocol scripts
3. changes Google cloud project
4. fetches the Twilio config
5. Sends the invite.

I added a new `fast` mode which assumes that step 1-4 have already been done in a previous invocation. This makes repeated invocations faster. This saves about 30 seconds. To avoid any confusions, the default path is still thorough and slow.

Also, in `invite.ts` script, the contracts were being fetched serially, fetching then in parallel saved about another 10 seconds. This is fixed for both fast and non-fast mode.

Overall, the thorough and slow invite time is down from ~80 seconds to ~70 seconds and repeated invite time is down from ~80 seconds to ~40 seconds.

### Tested

`time celotooljs account invite -e alfajoresstaging --phone +1650555555 --verbose`
`time celotooljs account invite -e alfajoresstaging --phone +16505555555 --verbose --fast`