### PR TITLE
Fixed react-native-gesture-handler path

### DIFF
--- a/packages/mobile/android/settings.gradle
+++ b/packages/mobile/android/settings.gradle
@@ -10,7 +10,7 @@ project(':@react-native-community_netinfo').projectDir = new File(rootProject.pr
 include ':react-native-screens'
 project(':react-native-screens').projectDir = new File(rootProject.projectDir, '../../../node_modules/react-native-screens/android')
 include ':react-native-gesture-handler'
-project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../../../node_modules/react-native-gesture-handler/android')
 include ':@segment_analytics-react-native-firebase'
 project(':@segment_analytics-react-native-firebase').projectDir = new File(rootProject.projectDir, '../../../node_modules/@segment/analytics-react-native-firebase/android')
 include ':@segment_analytics-react-native'

--- a/packages/verifier/android/settings.gradle
+++ b/packages/verifier/android/settings.gradle
@@ -2,7 +2,7 @@ rootProject.name = 'verifier'
 include ':@react-native-community_netinfo'
 project(':@react-native-community_netinfo').projectDir = new File(rootProject.projectDir, '../../../node_modules/@react-native-community/netinfo/android')
 include ':react-native-gesture-handler'
-project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../../../node_modules/react-native-gesture-handler/android')
 include ':@segment_analytics-react-native-firebase'
 project(':@segment_analytics-react-native-firebase').projectDir = new File(rootProject.projectDir, '../../../node_modules/@segment/analytics-react-native-firebase/android')
 include ':@segment_analytics-react-native'


### PR DESCRIPTION
### Description

The paths in the `settings.gradle` files for the app and the verifier were wrong. Somehow it works locally but while experimenting with travis CI they fail.

### Tested

See CI

### Other changes

-

### Related issues

- 

### Backwards compatibility

_No
