### PR TITLE
[wallet]Store encrypted local signing key

### DIFF
--- a/packages/mobile/src/web3/saga.test.ts
+++ b/packages/mobile/src/web3/saga.test.ts
@@ -5,6 +5,8 @@ import { navigateToError } from 'src/navigator/NavigationService'
 import { setLatestBlockNumber, updateWeb3SyncProgress } from 'src/web3/actions'
 import {
   checkWeb3SyncProgress,
+  getDecryptedData,
+  getEncryptedData,
   getOrCreateAccount,
   SYNC_TIMEOUT,
   waitForWeb3Sync,
@@ -95,5 +97,17 @@ describe(checkWeb3SyncProgress, () => {
       .put(setLatestBlockNumber(LAST_BLOCK_NUMBER)) // finished syncing the second time
       .returns(true)
       .run()
+  })
+})
+
+describe(getEncryptedData, () => {
+  it('encrypts and decrypts correctly', () => {
+    const data = 'testing data'
+    const password = 'a random password'
+    const encryptedBuffer: Buffer = getEncryptedData(data, password)
+    console.debug(`Encrypted data is ${encryptedBuffer.toString('hex')}`)
+    const decryptedData: string = getDecryptedData(encryptedBuffer, password)
+    console.debug(`Decrypted data is \"${decryptedData}\"`)
+    expect(decryptedData).toBe(data)
   })
 })


### PR DESCRIPTION
### Description

Store encrypted local signing key, the encryption password is coming
from the Android Keystore.

### Tested

#### Unit test

`$ node_modules/.bin/jest src/web3/saga.test.ts`

#### Manual test

1. Set `DEFAULT_SYNC_MODE=-1` in `packages/mobile/.env`
2. `packages/mobile $ yarn run dev`. Log in verify that you can send money.
3. Check the contents of the file `/data/data/$APP_ID/files/private_key_for_<address>.txt` are encrypted hex-encoded key `
8672a59c5d55302a5d64288084137303f5cd431abbff3d1edeca4b1c9f8266c41148d712c99d26b52165a6426b048ab1710c6311154c66e75e071386538c7a0091a920d1167d729a8916ad646099adfd`

#### 

### Related issues

- Fixes #1187

### Backwards compatibility

Not backward compatible but this code path was added yesterday (Oct 1) and is still behind a flag. So, it is not an issue.