### PR TITLE
[Wallet] Fix disable conditions for butons on Enter Invite screen

### DIFF
--- a/packages/mobile/src/invite/EnterInviteCode.tsx
+++ b/packages/mobile/src/invite/EnterInviteCode.tsx
@@ -218,7 +218,7 @@ export class EnterInviteCode extends React.Component<Props, State> {
           </Text>
           <Button
             onPress={this.onPressContinue}
-            disabled={!redeemComplete && !account}
+            disabled={isRedeemingInvite || !redeemComplete || !account}
             text={t('continue')}
             standard={false}
             style={styles.continueButton}
@@ -227,7 +227,7 @@ export class EnterInviteCode extends React.Component<Props, State> {
           />
           <Button
             onPress={this.onPressImportClick}
-            disabled={redeemComplete || !!account}
+            disabled={isRedeemingInvite || !!account}
             text={t('importIt')}
             standard={false}
             style={styles.continueButton}

--- a/packages/mobile/src/invite/__snapshots__/EnterInviteCode.test.tsx.snap
+++ b/packages/mobile/src/invite/__snapshots__/EnterInviteCode.test.tsx.snap
@@ -311,7 +311,7 @@ exports[`EnterInviteCode Screen renders correctly 1`] = `
             "width": "100%",
           },
           Object {
-            "backgroundColor": "#42D689",
+            "backgroundColor": "#A3EBC6",
           },
         ]
       }
@@ -339,7 +339,7 @@ exports[`EnterInviteCode Screen renders correctly 1`] = `
               "justifyContent": "center",
             },
             Object {
-              "backgroundColor": "#42D689",
+              "backgroundColor": "#A3EBC6",
             },
             Object {
               "height": 50,
@@ -784,7 +784,7 @@ exports[`EnterInviteCode Screen renders with an error 1`] = `
             "width": "100%",
           },
           Object {
-            "backgroundColor": "#42D689",
+            "backgroundColor": "#A3EBC6",
           },
         ]
       }
@@ -812,7 +812,7 @@ exports[`EnterInviteCode Screen renders with an error 1`] = `
               "justifyContent": "center",
             },
             Object {
-              "backgroundColor": "#42D689",
+              "backgroundColor": "#A3EBC6",
             },
             Object {
               "height": 50,

--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -8,7 +8,7 @@ const { CoverageSubprovider } = require('@0x/sol-coverage')
 const argv = require('minimist')(process.argv.slice(2), { string: ['truffle_override', 'network'] })
 
 const SOLC_VERSION = '0.5.8'
-const ALFAJORES_NETWORKID = 44782
+const ALFAJORES_NETWORKID = 44784
 
 const OG_FROM = '0xfeE1a22F43BeeCB912B5a4912ba87527682ef0fC'
 const DEVELOPMENT_FROM = '0x5409ed021d9299bf6814279a6a1411a7e866a631'


### PR DESCRIPTION
### Description

Fixes when the Continue and Import Wallet buttons enable on the invite screen

### Tested

Did invite flow, buttons look all good
Used back button to return after it's finished, confirmed I can still move forward again

### Related issues

- Fixes #1212
