### PR TITLE
[ck] Proper promise treatment to avoid UnhandledPromises

### DIFF
--- a/packages/contractkit/src/utils/tx-result.ts
+++ b/packages/contractkit/src/utils/tx-result.ts
@@ -46,11 +46,21 @@ export class TransactionResult {
 
   /** Get (& wait for) transaction hash */
   getHash() {
-    return this.hashFuture.wait()
+    return this.hashFuture.wait().catch((err) => {
+      // if hashFuture fails => receiptFuture also fails
+      // we wait for it here; so not UnhandlePromise error occurrs
+      this.receiptFuture.wait().catch(() => {
+        // ignore
+      })
+      throw err
+    })
   }
 
   /** Get (& wait for) transaction receipt */
-  waitReceipt() {
+  async waitReceipt() {
+    // Make sure `getHash()` promise is consumed
+    await this.getHash()
+
     return this.receiptFuture.wait()
   }
 }


### PR DESCRIPTION
### Description

When a sendTransaction is reject, we need to make sure every rejects promise is handled.

Usually, a user would do:

```ts
const res = await kit.sendTransaction(...)

await res.getHash()
await res.waitReceipt()
```

Others, may directly call `res.waitReceipt()` and don't call `res.getHash()`.

The problem is when `sendTransaction()` fails, and thus both promises (hash & receipt) are rejected. The promises are created when the txResult is created, not when the methods are called. So we need to make sure we `catch` those errors.

This PR address that, by adding `catch` logic in both methods.

### Tested

Manually, when factoring e2e transfer tests

