### PR TITLE
Set IN_MEMORY_DISCOVERY_TABLE=true for integration

### DIFF
--- a/.env.integration
+++ b/.env.integration
@@ -53,7 +53,7 @@ TX_NODES=2
 STATIC_IPS_FOR_GETH_NODES=false
 # Whether tx_nodes/validators stateful set should use ssd persistent disks
 GETH_NODES_SSD_DISKS=true
-IN_MEMORY_DISCOVERY_TABLE=false
+IN_MEMORY_DISCOVERY_TABLE=true
 
 # Testnet vars
 GETH_NODES_BACKUP_CRONJOB_ENABLED=true


### PR DESCRIPTION
### Description

Fixes the peering issues on `integration`

### Tested

`celotooljs deploy upgrade testnet -e integration` & nodes began peering again

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

Yes
