### PR TITLE
[Wallet] Add script to build sdk for env before running yarn dev

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -15,6 +15,7 @@
     "build:ts": "tsc --noEmit",
     "build:metro": "echo 'NOT WORKING RIGHT NOW'",
     "build:gen-graphql-types": "gql-gen --schema http://localhost:8080/graphql --template graphql-codegen-typescript-template --out ./typings/ 'src/**/*.tsx'",
+    "predev": "./scripts/pre-dev.sh",
     "dev": "react-native run-android --appIdSuffix \"debug\"",
     "dev:show-menu": "adb devices | grep '\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} adb -s {} shell input keyevent 82",
     "dev:clear-data": "adb shell pm clear org.celo.mobile.debug",

--- a/packages/mobile/scripts/pre-dev.sh
+++ b/packages/mobile/scripts/pre-dev.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ====================================
+# Tasks to run before running yarn dev
+# ====================================
+
+# Detect network from .env and build the sdk for it
+export $(grep -v '^#' .env | xargs)
+echo "Building sdk for testnet $DEFAULT_TESTNET"
+yarn build:sdk $DEFAULT_TESTNET
+echo "Done building sdk"


### PR DESCRIPTION
### Description

Add `predev` yarn script to build sdk for the env stated in `.env. before running `yarn dev`

### Tested

Ran `yarn dev`

### Related issues

- Fixes #608 

### Backwards compatibility

Yes
