### PR TITLE
[wallet] If an action is in the blacklist, now only logs the name (but not the payload)

### DIFF
--- a/packages/mobile/src/redux/sagas.ts
+++ b/packages/mobile/src/redux/sagas.ts
@@ -43,6 +43,9 @@ function* loggerSaga() {
 
   yield takeEvery('*', (action: AnyAction) => {
     if (action && action.type && loggerBlacklist.includes(action.type)) {
+      // Log only action type, but not the payload as it can have
+      // sensitive information.
+      Logger.debug('redux/saga@logger', `${action.type} (payload not logged)`)
       return
     }
     try {


### PR DESCRIPTION
### Description

If an action is in the blacklist, then it was not logged at all. This can cause confuse developers as they might be lead to thing their action was not triggered at all.

Also helps debugging, as the logs are now completed.

### Tested

- They don't show up in the logs

### Other changes

-

### Related issues

- 

### Backwards compatibility

-
