### PR TITLE
[Wallet] Fix unable to backup key on iOS

### DIFF
--- a/packages/mobile/src/backup/BackupPhrase.tsx
+++ b/packages/mobile/src/backup/BackupPhrase.tsx
@@ -6,7 +6,7 @@ import { fontStyles } from '@celo/react-components/styles/fonts'
 import { componentStyles } from '@celo/react-components/styles/styles'
 import * as React from 'react'
 import { WithNamespaces, withNamespaces } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { Platform, StyleSheet, Text, View } from 'react-native'
 import FlagSecure from 'react-native-flag-secure-android'
 import SafeAreaView from 'react-native-safe-area-view'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
@@ -34,11 +34,15 @@ class BackupPhrase extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    FlagSecure.activate()
+    if (Platform.OS === 'android') {
+      FlagSecure.activate()
+    }
   }
 
   componentWillUnmount() {
-    FlagSecure.deactivate()
+    if (Platform.OS === 'android') {
+      FlagSecure.deactivate()
+    }
   }
 
   onSelectAnswer = (word: string) => this.setState({ selectedAnswer: word })


### PR DESCRIPTION
### Description

This PR fixes the crash on iOS when trying to go through the backup flow.
`react-native-flag-secure-android` can't be used on iOS ;)

Preventing screenshots is harder on iOS, a quick search revealed https://screenshieldkit.com/
If we want to have this feature on iOS, we could try that one.

### Tested

Went through the backup flow successfully on iOS.

### Other changes

N/A

### Related issues

- Fixes #1384

### Backwards compatibility

Yes.
