### PR TITLE
[Wallet] Enable push notifications on iOS

### DIFF
--- a/packages/mobile/ios/celo.xcodeproj/project.pbxproj
+++ b/packages/mobile/ios/celo.xcodeproj/project.pbxproj
@@ -313,6 +313,9 @@
 						DevelopmentTeam = HDPUB8C3KG;
 						LastSwiftMigration = 1020;
 						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
 							com.apple.Push = {
 								enabled = 1;
 							};

--- a/packages/mobile/ios/celo/AppDelegate.m
+++ b/packages/mobile/ios/celo/AppDelegate.m
@@ -20,12 +20,15 @@
 #endif
 
 @import Firebase;
+#import "RNFirebaseNotifications.h"
+#import "RNFirebaseMessaging.h"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   [FIRApp configure];
+  [RNFirebaseNotifications configure];
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"celo"
@@ -50,6 +53,19 @@
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification {
+  [[RNFirebaseNotifications instance] didReceiveLocalNotification:notification];
+}
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo
+fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler{
+  [[RNFirebaseNotifications instance] didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+}
+
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
+  [[RNFirebaseMessaging instance] didRegisterUserNotificationSettings:notificationSettings];
 }
 
 @end

--- a/packages/mobile/ios/celo/Info.plist
+++ b/packages/mobile/ios/celo/Info.plist
@@ -51,6 +51,10 @@
 		<string>Hind-Regular.ttf</string>
 		<string>Hind-SemiBold.ttf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
### Description

This PR enables push notifications on iOS.

I've also generated the APNs key and added it to the iOS apps on firebase.

### Tested

Manually sent a push notification through firebase cloud messaging UI.
I haven't been able to do an end-to-end test with a payment as there's currently a problem with the notification service on integration. I'm debugging that as well and will open another issue/PR to track it.

![IMG_2734](https://user-images.githubusercontent.com/57791/67025985-3bb08500-f107-11e9-8fa8-fd336f3c06f1.jpg)

### Other changes

N/A

### Related issues

- Fixes #1160

### Backwards compatibility

Yes.
