### PR TITLE
[Wallet] New camera permission flow

### DIFF
--- a/packages/mobile/locales/en-US/sendFlow7.json
+++ b/packages/mobile/locales/en-US/sendFlow7.json
@@ -55,8 +55,11 @@
   "scanCode": "Scan Code",
   "writeStorageNeededForQrDownload":
     "Storage write permission is needed for downloading the QR code",
-  "ScanCodeByPlacingItInTheBox": "Scan code by placing it in the box",
-  "needCameraPermissionToScan": "App needs camera permission to scan QR codes",
+  "cameraScanInfo": "Scan code by placing it in the box",
+  "cameraNotAuthorizedTitle": "Enable Camera",
+  "cameraNotAuthorizedDescription":
+    "Please enable the Camera in your phone’s Settings. You’ll need it to scan QR codes.",
+  "cameraSettings": "Settings",
   "showYourQRCode": "Show your QR code",
   "toSentOrRequestPayment": "to send or request payment",
   "requestSent": "Request Sent",

--- a/packages/mobile/locales/es-419/sendFlow7.json
+++ b/packages/mobile/locales/es-419/sendFlow7.json
@@ -55,9 +55,11 @@
   "scanCode": "Escanear código",
   "writeStorageNeededForQrDownload":
     "Se necesita permiso de escritura de almacenamiento para descargar el código QR",
-  "ScanCodeByPlacingItInTheBox": "Escanee el código colocándolo en la caja",
-  "needCameraPermissionToScan":
-    "La aplicación necesita permiso de la cámara para escanear códigos QR",
+  "cameraScanInfo": "Escanee el código colocándolo en la caja",
+  "cameraNotAuthorizedTitle": "Habilitar Cámara",
+  "cameraNotAuthorizedDescription":
+    "Habilite la cámara en la configuración de su teléfono. Lo necesitará para escanear códigos QR.",
+  "cameraSettings": "Configuraciones",
   "showYourQRCode": "Muestra tu código QR",
   "toSentOrRequestPayment": "enviar o solicitar pago",
   "requestSent": "Solicitud Enviada",

--- a/packages/mobile/src/qrcode/NotAuthorizedView.test.tsx
+++ b/packages/mobile/src/qrcode/NotAuthorizedView.test.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { render } from 'react-native-testing-library'
+import NotAuthorizedView from 'src/qrcode/NotAuthorizedView'
+
+describe('NotAuthorizedView', () => {
+  it('renders correctly', () => {
+    const { toJSON } = render(<NotAuthorizedView />)
+
+    expect(toJSON()).toMatchSnapshot()
+  })
+})

--- a/packages/mobile/src/qrcode/NotAuthorizedView.tsx
+++ b/packages/mobile/src/qrcode/NotAuthorizedView.tsx
@@ -2,16 +2,17 @@ import Button, { BtnTypes } from '@celo/react-components/components/Button'
 import fontStyles from '@celo/react-components/styles/fonts'
 import React, { useCallback } from 'react'
 import { withNamespaces, WithNamespaces } from 'react-i18next'
-import { Linking, Platform, StyleSheet, Text, View } from 'react-native'
+import { Platform, StyleSheet, Text, View } from 'react-native'
 import * as AndroidOpenSettings from 'react-native-android-open-settings'
 import { Namespaces } from 'src/i18n'
+import { navigateToURI } from 'src/utils/linking'
 
 type Props = WithNamespaces
 
 function NotAuthorizedView({ t }: Props) {
   const onPressSettings = useCallback(async () => {
     if (Platform.OS === 'ios') {
-      await Linking.openURL('app-settings:')
+      navigateToURI('app-settings:')
     } else if (Platform.OS === 'android') {
       AndroidOpenSettings.appDetailsSettings()
     }

--- a/packages/mobile/src/qrcode/NotAuthorizedView.tsx
+++ b/packages/mobile/src/qrcode/NotAuthorizedView.tsx
@@ -1,0 +1,52 @@
+import Button, { BtnTypes } from '@celo/react-components/components/Button'
+import fontStyles from '@celo/react-components/styles/fonts'
+import React, { useCallback } from 'react'
+import { withNamespaces, WithNamespaces } from 'react-i18next'
+import { Linking, Platform, StyleSheet, Text, View } from 'react-native'
+import * as AndroidOpenSettings from 'react-native-android-open-settings'
+import { Namespaces } from 'src/i18n'
+
+type Props = WithNamespaces
+
+function NotAuthorizedView({ t }: Props) {
+  const onPressSettings = useCallback(async () => {
+    if (Platform.OS === 'ios') {
+      await Linking.openURL('app-settings:')
+    } else if (Platform.OS === 'android') {
+      AndroidOpenSettings.appDetailsSettings()
+    }
+  }, [])
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{t('cameraNotAuthorizedTitle')}</Text>
+      <Text style={styles.description}>{t('cameraNotAuthorizedDescription')}</Text>
+      <Button
+        onPress={onPressSettings}
+        text={t('cameraSettings')}
+        standard={false}
+        type={BtnTypes.SECONDARY}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 30,
+  },
+  title: {
+    ...fontStyles.h2,
+    ...fontStyles.bold,
+  },
+  description: {
+    marginTop: 10,
+    ...fontStyles.body,
+    textAlign: 'center',
+  },
+})
+
+export default withNamespaces(Namespaces.sendFlow7)(NotAuthorizedView)

--- a/packages/mobile/src/qrcode/NotAuthorizedView.tsx
+++ b/packages/mobile/src/qrcode/NotAuthorizedView.tsx
@@ -10,7 +10,7 @@ import { navigateToURI } from 'src/utils/linking'
 type Props = WithNamespaces
 
 function NotAuthorizedView({ t }: Props) {
-  const onPressSettings = useCallback(async () => {
+  const onPressSettings = useCallback(() => {
     if (Platform.OS === 'ios') {
       navigateToURI('app-settings:')
     } else if (Platform.OS === 'android') {

--- a/packages/mobile/src/qrcode/QRScanner.tsx
+++ b/packages/mobile/src/qrcode/QRScanner.tsx
@@ -1,11 +1,13 @@
+import Button, { BtnTypes } from '@celo/react-components/components/Button'
 import QRCode from '@celo/react-components/icons/QRCode'
 import colors from '@celo/react-components/styles/colors'
 import { fontStyles } from '@celo/react-components/styles/fonts'
 import variables from '@celo/react-components/styles/variables'
 import * as React from 'react'
 import { WithNamespaces, withNamespaces } from 'react-i18next'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Platform, StyleSheet, Text, View } from 'react-native'
 import { RNCamera } from 'react-native-camera'
+import SafeAreaView from 'react-native-safe-area-view'
 import { NavigationFocusInjectedProps, withNavigationFocus } from 'react-navigation'
 import { connect } from 'react-redux'
 import { componentWithAnalytics } from 'src/analytics/wrapper'
@@ -13,13 +15,8 @@ import i18n, { Namespaces } from 'src/i18n'
 import { headerWithBackButton } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import NotAuthorizedView from 'src/qrcode/NotAuthorizedView'
 import { handleBarcodeDetected } from 'src/send/actions'
-import Logger from 'src/utils/Logger'
-import { requestCameraPermission } from 'src/utils/permissions'
-
-enum BarcodeTypes {
-  QR_CODE = 'QR_CODE',
-}
 
 interface DispatchProps {
   handleBarcodeDetected: typeof handleBarcodeDetected
@@ -40,24 +37,11 @@ class QRScanner extends React.Component<Props> {
   camera: RNCamera | null = null
 
   state = {
-    camera: false,
     qrSubmitted: false,
   }
 
-  async componentDidMount() {
-    const { t } = this.props
-    const cameraPermission = await requestCameraPermission()
-
-    if (!cameraPermission) {
-      Logger.showMessage(t('needCameraPermissionToScan'))
-      navigate(Screens.QRCode)
-      return
-    }
-    this.setState({ camera: true, qrSubmitted: false })
-  }
-
   onBardCodeDetected = (rawData: any) => {
-    if (rawData.type === BarcodeTypes.QR_CODE && !this.state.qrSubmitted) {
+    if (!this.state.qrSubmitted) {
       this.setState({ qrSubmitted: true }, () => {
         this.props.handleBarcodeDetected(rawData)
       })
@@ -67,9 +51,9 @@ class QRScanner extends React.Component<Props> {
   render() {
     const { t } = this.props
     return (
-      <View style={styles.container}>
-        {this.state.camera &&
-          this.props.isFocused && (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.innerContainer}>
+          {(Platform.OS !== 'android' || this.props.isFocused) && (
             <RNCamera
               ref={(ref) => {
                 this.camera = ref
@@ -82,38 +66,50 @@ class QRScanner extends React.Component<Props> {
               flashMode={RNCamera.Constants.FlashMode.auto}
               captureAudio={false}
               autoFocus={RNCamera.Constants.AutoFocus.on}
+              // Passing null here since we want the default system message
+              // @ts-ignore
+              androidCameraPermissionOptions={null}
+              notAuthorizedView={<NotAuthorizedView />}
             >
               <View style={styles.view}>
-                <View style={styles.viewFillVertical} />
-                <View style={styles.viewCameraRow}>
-                  <View style={styles.viewFillHorizontal} />
-                  <View style={styles.viewCameraContainer}>
+                <View style={styles.fillVertical} />
+                <View style={styles.cameraRow}>
+                  <View style={styles.fillHorizontal} />
+                  <View style={styles.cameraContainer}>
                     <View style={styles.camera} />
-                    <Text style={[fontStyles.bodySmall, styles.viewInfoBox]}>
-                      {t('ScanCodeByPlacingItInTheBox')}
-                    </Text>
+                    <View style={styles.infoBox}>
+                      <Text style={styles.infoText}>{t('cameraScanInfo')}</Text>
+                    </View>
                   </View>
-                  <View style={styles.viewFillHorizontal} />
+                  <View style={styles.fillHorizontal} />
                 </View>
-                <View style={styles.viewFillVertical} />
-              </View>
-              <View style={styles.footerContainer}>
-                <View style={styles.footerIcon}>
-                  <QRCode />
-                </View>
-                <TouchableOpacity onPress={goToQrCodeScreen}>
-                  <Text style={styles.footerText}> {t('showYourQRCode')} </Text>
-                </TouchableOpacity>
+                <View style={styles.fillVertical} />
               </View>
             </RNCamera>
           )}
-      </View>
+        </View>
+        <View style={styles.footerContainer}>
+          <Button
+            onPress={goToQrCodeScreen}
+            text={t('showYourQRCode')}
+            standard={false}
+            type={BtnTypes.SECONDARY}
+          >
+            <View style={styles.footerIcon}>
+              <QRCode />
+            </View>
+          </Button>
+        </View>
+      </SafeAreaView>
     )
   }
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+  },
+  innerContainer: {
     flex: 1,
   },
   preview: {
@@ -125,60 +121,49 @@ const styles = StyleSheet.create({
     height: 200,
     width: 200,
     borderRadius: 4,
-    zIndex: 99,
   },
   view: {
     flex: 1,
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  viewFillVertical: {
+  fillVertical: {
     backgroundColor: 'rgba(46, 51, 56, 0.3)',
     width: variables.width,
     flex: 1,
   },
-  viewFillHorizontal: {
+  fillHorizontal: {
     backgroundColor: 'rgba(46, 51, 56, 0.3)',
     flex: 1,
   },
-  viewCameraRow: {
+  cameraRow: {
     display: 'flex',
     flexDirection: 'row',
   },
-  viewCameraContainer: {
+  cameraContainer: {
     height: 200,
   },
-  viewInfoBox: {
+  infoBox: {
     paddingVertical: 9,
     paddingHorizontal: 5,
     backgroundColor: colors.dark,
     opacity: 1,
     marginTop: 15,
+    borderRadius: 3,
+  },
+  infoText: {
+    ...fontStyles.bodySmall,
+    lineHeight: undefined,
     color: colors.white,
-    zIndex: 99,
   },
   footerContainer: {
-    height: 50,
-    width: variables.width,
-    backgroundColor: 'white',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    textAlign: 'center',
+    backgroundColor: colors.background,
   },
   footerIcon: {
     borderWidth: 1,
     borderRadius: 15,
     borderColor: colors.celoGreen,
     padding: 4,
-  },
-  footerText: {
-    color: colors.celoGreen,
   },
 })
 

--- a/packages/mobile/src/qrcode/__snapshots__/NotAuthorizedView.test.tsx.snap
+++ b/packages/mobile/src/qrcode/__snapshots__/NotAuthorizedView.test.tsx.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotAuthorizedView renders correctly 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+      "paddingHorizontal": 30,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "color": "#2E3338",
+        "fontFamily": "Hind-Bold",
+        "fontSize": 18,
+        "textAlign": "center",
+      }
+    }
+  >
+    cameraNotAuthorizedTitle
+  </Text>
+  <Text
+    style={
+      Object {
+        "color": "#2E3338",
+        "fontFamily": "Hind-Regular",
+        "fontSize": 16,
+        "lineHeight": 24,
+        "marginTop": 10,
+        "textAlign": "center",
+      }
+    }
+  >
+    cameraNotAuthorizedDescription
+  </Text>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderRadius": 3,
+          "flexDirection": "row",
+        },
+        null,
+        null,
+        undefined,
+        Object {
+          "backgroundColor": "transparent",
+        },
+      ]
+    }
+  >
+    <View
+      accessible={true}
+      isTVSelectable={true}
+      nativeBackgroundAndroid={
+        Object {
+          "attribute": "selectableItemBackground",
+          "type": "ThemeAttrAndroid",
+        }
+      }
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "justifyContent": "center",
+          },
+          Object {
+            "backgroundColor": "transparent",
+          },
+          Object {
+            "height": 50,
+          },
+          Object {
+            "borderWidth": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "fontFamily": "Hind-SemiBold",
+                "fontSize": 16,
+              },
+              Object {
+                "color": "#42D689",
+              },
+              Object {
+                "paddingLeft": 5,
+                "paddingRight": 5,
+              },
+            ]
+          }
+        >
+          cameraSettings
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/packages/mobile/src/utils/permissions.android.ts
+++ b/packages/mobile/src/utils/permissions.android.ts
@@ -21,16 +21,8 @@ export async function requestContactsPermission() {
   )
 }
 
-export async function requestCameraPermission() {
-  return requestPermission(PermissionsAndroid.PERMISSIONS.CAMERA)
-}
-
 export async function checkContactsPermission() {
   return PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_CONTACTS)
-}
-
-export async function checkCameraPermission() {
-  return PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.CAMERA)
 }
 
 async function requestPermission(permission: Permission, title?: string, message?: string) {

--- a/packages/mobile/src/utils/permissions.ios.ts
+++ b/packages/mobile/src/utils/permissions.ios.ts
@@ -17,11 +17,6 @@ export async function requestContactsPermission(): Promise<boolean> {
   })
 }
 
-export async function requestCameraPermission() {
-  throw new Error('Unimplemented method')
-  return false
-}
-
 export async function checkContactsPermission(): Promise<boolean> {
   return new Promise((resolve, reject) => {
     Contacts.checkPermission((err, permission) => {
@@ -32,9 +27,4 @@ export async function checkContactsPermission(): Promise<boolean> {
       }
     })
   })
-}
-
-export async function checkCameraPermission() {
-  throw new Error('Unimplemented method')
-  return false
 }


### PR DESCRIPTION
### Description

![camera_permissioning](https://user-images.githubusercontent.com/57791/67089541-2fc8cf80-f1a8-11e9-9089-224d01561429.png)

Highlights:
- react-native-camera now handles the details of asking for permissions
- a custom view is displayed when the permission has been denied so the
user can navigate to the settings and allow the permission

### Tested

Tested the flow on both iOS and Android.
- go to qr scanner > deny permission > it shows the message instructing to go to the settings to allow permission > tap 'Settings' > Settings open
- go to qr scanner > accept permission > it can successfully scan

**iOS**
![IMG_2740](https://user-images.githubusercontent.com/57791/67088746-38200b00-f1a6-11e9-996b-9644cda01e45.PNG)
![IMG_2737](https://user-images.githubusercontent.com/57791/67088765-3eae8280-f1a6-11e9-8144-2dd04ec64141.PNG)
![IMG_2735](https://user-images.githubusercontent.com/57791/67088769-41a97300-f1a6-11e9-9e6d-94aae4b3ebca.PNG)

**Android**
![iTerm2 NCkoL3](https://user-images.githubusercontent.com/57791/67089191-5c301c00-f1a7-11e9-80f9-f9e6a9f4c96e.png)
![iTerm2 Yn4EU2](https://user-images.githubusercontent.com/57791/67089205-618d6680-f1a7-11e9-99b1-d3986b93e289.png)
![iTerm2 uPNfeQ](https://user-images.githubusercontent.com/57791/67089208-6520ed80-f1a7-11e9-8108-7689ac02f56a.png)

### Other changes

- You can now tap the QR icon next to "Show your QR code" to trigger the action ;) Previously only tapping the text would trigger it.

### Related issues

- Fixes #1397

### Backwards compatibility

Yes
