### PR TITLE
Reset pincode cache if unlock fails

### DIFF
--- a/packages/mobile/src/pincode/PincodeCache.ts
+++ b/packages/mobile/src/pincode/PincodeCache.ts
@@ -22,7 +22,7 @@ export function getCachedPincode() {
   return null
 }
 
-export function setCachedPincode(pincode: string) {
+export function setCachedPincode(pincode: string | null) {
   pincodeCache.timestamp = Date.now()
   pincodeCache.pincode = pincode
 }

--- a/packages/mobile/src/web3/saga.ts
+++ b/packages/mobile/src/web3/saga.ts
@@ -16,6 +16,7 @@ import { UNLOCK_DURATION } from 'src/geth/consts'
 import { deleteChainData } from 'src/geth/geth'
 import { navigateToError } from 'src/navigator/NavigationService'
 import { waitWeb3LastBlock } from 'src/networkInfo/saga'
+import { setCachedPincode } from 'src/pincode/PincodeCache'
 import { setKey } from 'src/utils/keyStore'
 import Logger from 'src/utils/Logger'
 import {
@@ -323,6 +324,7 @@ export function* unlockAccount(account: string) {
       return true
     }
   } catch (error) {
+    setCachedPincode(null)
     Logger.error(TAG + '@unlockAccount', 'Web3 account unlock failed', error)
     return false
   }


### PR DESCRIPTION
### Description

When a user enters a pincode incorrectly, we set that value in the cache and never reset it. This removes the cache for incorrect values

### Tested

Followed the steps in #1229 and was able to send a payment with correct pincode entry

### Related issues

- Fixes #1229 

### Backwards compatibility

Should have no effect
