### PR TITLE
[Wallet] Show splash screen until JS is ready on iOS

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -137,7 +137,7 @@ PODS:
     - React
   - react-native-safe-area-context (0.3.6):
     - React
-  - react-native-splash-screen (3.1.1):
+  - react-native-splash-screen (3.2.0):
     - React
   - react-native-tcp (3.3.0):
     - React
@@ -428,7 +428,7 @@ SPEC CHECKSUMS:
   react-native-mail: 021d8ee60e374609f5689ef354dc8e36839a9ba6
   react-native-netinfo: 1ea4efa22c02519ac8043ac3f000062a4e320795
   react-native-safe-area-context: e380a6f783ccaec848e2f3cc8eb205a62362950d
-  react-native-splash-screen: 353334c5ae82d8c74501ea7cbb916cb7cb20c8bf
+  react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-tcp: e1a8c3ac010774cd71811989805ff3eaebb62f17
   react-native-udp: 54a1aa9bf5c0824f930b1ba6dbfb3fd3e733bba9
   react-native-version-check: 901616b6d258b385628120441bd0b285b24c7be1

--- a/packages/mobile/ios/celo/AppDelegate.m
+++ b/packages/mobile/ios/celo/AppDelegate.m
@@ -22,6 +22,7 @@
 @import Firebase;
 #import "RNFirebaseNotifications.h"
 #import "RNFirebaseMessaging.h"
+#import "RNSplashScreen.h"
 
 // Use same key as react-native-secure-key-store
 // so we don't reset already working installs
@@ -42,6 +43,7 @@ static NSString * const kHasRunBeforeKey = @"RnSksIsAppInstalled";
                                                    moduleName:@"celo"
                                             initialProperties:nil];
 
+  [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
   [RNSentry installWithRootView:rootView];
 
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -114,7 +114,7 @@
     "react-native-sentry": "^0.43.2",
     "react-native-shadow": "^1.2.2",
     "react-native-share": "^1.1.3",
-    "react-native-splash-screen": "^3.1.1",
+    "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^9.8.4",
     "react-native-swiper": "^1.5.13",
     "react-native-tcp": "https://github.com/cmcewen/react-native-tcp#408b674",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -48,7 +48,7 @@
     "react-native-languages": "^3.0.1",
     "react-native-modal-dropdown": "^0.6.2",
     "react-native-restart-android": "^0.0.7",
-    "react-native-splash-screen": "^3.1.1",
+    "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^9.8.4",
     "react-navigation": "^3.9.0",
     "react-redux": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26370,10 +26370,10 @@ react-native-share@^1.1.3:
   resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-1.1.3.tgz#513ea61075e2bb945d33cfda120e12592916299e"
   integrity sha512-vKAJqgkEt7HjsF0HUwgom+E0FbmFNVZNncHwby1+O8/mXlKugh+Ym6rvv+A2ASHmD5TXKohJMYT2+jYofzPORA==
 
-react-native-splash-screen@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.1.1.tgz#1a4e46c9fdce53ff52af2a2cb4181788c4e30b30"
-  integrity sha512-PU2YocOSGbLjL9Vgcq/cwMNuHHKNjjuPpa1IPMuWo+6EB/fSZ5VOmxSa7+eucQe3631s3NhGuk3eHKahU03a4Q==
+react-native-splash-screen@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
+  integrity sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==
 
 react-native-svg-mock@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description

Splash screen on iOS  was displayed when the app was launched (system behavior) but there was a small gap with a blank screen while the JS bundle was loading.

This makes it display the splash screen until JS is ready.

### Tested

Launched the app -> app hides splash screen when JS is ready, i.e. no blank screen while JS is loading.

### Other changes

N/A

### Related issues

- Fixes #1159

### Backwards compatibility

Yes
