### PR TITLE
[Wallet] Remove QR debouncing to improve responsiveness

### DIFF
--- a/packages/mobile/src/qrcode/QRScanner.tsx
+++ b/packages/mobile/src/qrcode/QRScanner.tsx
@@ -3,7 +3,6 @@ import QRCode from '@celo/react-components/icons/QRCode'
 import colors from '@celo/react-components/styles/colors'
 import { fontStyles } from '@celo/react-components/styles/fonts'
 import variables from '@celo/react-components/styles/variables'
-import * as _ from 'lodash'
 import * as React from 'react'
 import { WithNamespaces, withNamespaces } from 'react-i18next'
 import { Platform, StyleSheet, Text, View } from 'react-native'
@@ -34,10 +33,10 @@ class QRScanner extends React.Component<Props> {
 
   camera: RNCamera | null = null
 
-  onBardCodeDetected = _.debounce((rawData: any) => {
+  onBardCodeDetected = (rawData: any) => {
     Logger.debug('QRScanner', 'Bar code detected')
     this.props.handleBarcodeDetected(rawData)
-  }, 1000)
+  }
 
   onPressShowYourCode = () => {
     navigate(Screens.QRCode)

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -57,9 +57,8 @@ export async function getSendFee(
 
 export function* watchQrCodeDetections() {
   while (true) {
-    // TODO(Rossy) this gets called taken multiple times before a user can press the send button
-    // Add de-bouncing logic
     const action = yield take(Actions.BARCODE_DETECTED)
+    Logger.debug(TAG, 'Bar bar detected in watcher')
     const addressToE164Number = yield select(addressToE164NumberSelector)
     const recipientCache = yield select(recipientCacheSelector)
     try {


### PR DESCRIPTION
### Description

Remove QR debouncing to improve responsiveness. It seems we no longer need it, possible due to the QR lib upgrade.

### Tested

Scanned QR codes a bunch of times

### Backwards compatibility

Yes
