### PR TITLE
[Wallet] Hotfix local currency

### DIFF
--- a/packages/mobile/src/exchange/ExchangeConfirmationCard.tsx
+++ b/packages/mobile/src/exchange/ExchangeConfirmationCard.tsx
@@ -10,7 +10,11 @@ import ExchangeRate from 'src/exchange/ExchangeRate'
 import FeeExchangeIcon from 'src/exchange/FeeExchangeIcon'
 import { CURRENCY_ENUM } from 'src/geth/consts'
 import { Namespaces } from 'src/i18n'
-import { useLocalCurrencySymbol } from 'src/localCurrency/hooks'
+import {
+  useDollarsToLocalAmount,
+  useLocalCurrencyCode,
+  useLocalCurrencySymbol,
+} from 'src/localCurrency/hooks'
 import FeeIcon from 'src/send/FeeIcon'
 import RoundedArrow from 'src/shared/RoundedArrow'
 import { getMoneyDisplayValue } from 'src/utils/formatting'
@@ -84,13 +88,22 @@ export function ExchangeConfirmationCard(props: Props) {
     fee,
   } = props
 
+  const localCurrencyCode = useLocalCurrencyCode()
   const localCurrencySymbol = useLocalCurrencySymbol()
+  const localMakerAmount = useDollarsToLocalAmount(props.makerAmount)
+  const localTakerAmount = useDollarsToLocalAmount(props.takerAmount)
+
+  const takerToken = getTakerToken(props)
 
   return (
     <View style={styles.container}>
       <View style={styles.exchange}>
         <CurrencyDisplay
-          amount={makerAmount}
+          amount={
+            props.makerToken === CURRENCY_ENUM.DOLLAR && localCurrencyCode
+              ? new BigNumber(localMakerAmount || 0)
+              : makerAmount
+          }
           size={36}
           type={props.makerToken}
           currencySymbol={localCurrencySymbol}
@@ -99,9 +112,13 @@ export function ExchangeConfirmationCard(props: Props) {
           <RoundedArrow />
         </View>
         <CurrencyDisplay
-          amount={takerAmount}
+          amount={
+            takerToken === CURRENCY_ENUM.DOLLAR && localCurrencyCode
+              ? new BigNumber(localTakerAmount || 0)
+              : takerAmount
+          }
           size={36}
-          type={getTakerToken(props)}
+          type={takerToken}
           currencySymbol={localCurrencySymbol}
         />
       </View>
@@ -112,13 +129,13 @@ export function ExchangeConfirmationCard(props: Props) {
 
       <View style={styles.feeContainer}>
         <LineItemRow
-          currencySymbol={getTakerToken(props)}
+          currencySymbol={takerToken}
           amount={fee}
           title={t('securityFee')}
           titleIcon={<FeeIcon />}
         />
         <LineItemRow
-          currencySymbol={getTakerToken(props)}
+          currencySymbol={takerToken}
           amount={'0.01'}
           title={t('exchangeFee')}
           titleIcon={<FeeExchangeIcon />}

--- a/packages/mobile/src/exchange/__snapshots__/ExchangeConfirmationCard.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/ExchangeConfirmationCard.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`renders correctly with giant numbers 1`] = `
           ]
         }
       >
-        24,000,000.00
+        31,920,000.00
       </Text>
     </View>
     <View
@@ -665,7 +665,7 @@ exports[`renders correctly with no exchange rate 1`] = `
           ]
         }
       >
-        1.99
+        2.64
       </Text>
     </View>
   </View>

--- a/packages/mobile/src/localCurrency/SelectLocalCurrency.tsx
+++ b/packages/mobile/src/localCurrency/SelectLocalCurrency.tsx
@@ -14,6 +14,7 @@ const DEFAULT_CURRENCY_CODE = LocalCurrencyCode.USD
 const keyExtractor = (item: LocalCurrencyCode) => item
 
 function SelectLocalCurrency() {
+  // tslint:disable-next-line: react-hooks-nesting
   const selectedCurrencyCode = useLocalCurrencyCode() || DEFAULT_CURRENCY_CODE
   const dispatch = useDispatch()
 

--- a/packages/mobile/src/send/TransferConfirmationCard.tsx
+++ b/packages/mobile/src/send/TransferConfirmationCard.tsx
@@ -72,7 +72,9 @@ const renderAmountSection = (props: Props) => {
   const localCurrencySymbol = useLocalCurrencySymbol()
   const localValue = useDollarsToLocalAmount(value) || 0
   // tslint:enable react-hooks-nesting
-  const transactionValue = getMoneyDisplayValue(localCurrencyCode ? localValue : value)
+  const transactionValue = getMoneyDisplayValue(
+    currency === CURRENCY_ENUM.DOLLAR && localCurrencyCode ? localValue : value
+  )
 
   switch (type) {
     case TransactionTypes.INVITE_SENT: // fallthrough
@@ -88,7 +90,10 @@ const renderAmountSection = (props: Props) => {
     default:
       return (
         <MoneyAmount
-          symbol={localCurrencySymbol || CURRENCIES[currency].symbol}
+          symbol={
+            (currency === CURRENCY_ENUM.DOLLAR && localCurrencySymbol) ||
+            CURRENCIES[currency].symbol
+          }
           amount={transactionValue}
         />
       )

--- a/packages/mobile/src/send/TransferConfirmationCard.tsx
+++ b/packages/mobile/src/send/TransferConfirmationCard.tsx
@@ -67,11 +67,12 @@ const renderTopSection = (props: Props) => {
 const renderAmountSection = (props: Props) => {
   const { currency, type, value } = props
 
+  // tslint:disable react-hooks-nesting
   const localCurrencyCode = useLocalCurrencyCode()
   const localCurrencySymbol = useLocalCurrencySymbol()
-  const transactionValue = getMoneyDisplayValue(
-    localCurrencyCode ? useDollarsToLocalAmount(value) || 0 : value
-  )
+  const localValue = useDollarsToLocalAmount(value) || 0
+  // tslint:enable react-hooks-nesting
+  const transactionValue = getMoneyDisplayValue(localCurrencyCode ? localValue : value)
 
   switch (type) {
     case TransactionTypes.INVITE_SENT: // fallthrough

--- a/packages/mobile/src/transactions/ExchangeFeedItem.tsx
+++ b/packages/mobile/src/transactions/ExchangeFeedItem.tsx
@@ -10,8 +10,10 @@ import { Image, StyleSheet, Text, View } from 'react-native'
 import { HomeExchangeFragment } from 'src/apollo/types'
 import { CURRENCY_ENUM, resolveCurrency } from 'src/geth/consts'
 import { Namespaces } from 'src/i18n'
+import { LocalCurrencyCode, LocalCurrencySymbol } from 'src/localCurrency/consts'
+import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
 import {
-  useDollarsToLocalAmount,
+  useExchangeRate,
   useLocalCurrencyCode,
   useLocalCurrencySymbol,
 } from 'src/localCurrency/hooks'
@@ -26,83 +28,131 @@ type Props = (HomeExchangeFragment | ExchangeStandby) &
     showGoldAmount: boolean
   }
 
-type ExchangeProps = ReturnType<typeof getDollarExchangeProps>
+type ExchangeInputProps = Props & {
+  localCurrencyCode: LocalCurrencyCode | null
+  localCurrencySymbol: LocalCurrencySymbol | null
+  localExchangeRate: number | null | undefined
+}
+type ExchangeProps =
+  | ReturnType<typeof getDollarExchangeProps>
+  | ReturnType<typeof getGoldExchangeProps>
 
-function getDollarExchangeProps({ inValue, outValue }: Props) {
+function getLocalAmount(
+  dollarAmount: BigNumber.Value,
+  localExchangeRate: number | null | undefined
+) {
+  const localAmount = convertDollarsToLocalAmount(dollarAmount, localExchangeRate)
+  if (!localAmount) {
+    return null
+  }
+
+  return localAmount.toString()
+}
+
+function getDollarExchangeProps({
+  inValue: dollarAmount,
+  outValue: goldAmount,
+  localCurrencyCode,
+  localCurrencySymbol,
+  localExchangeRate,
+}: ExchangeInputProps) {
+  const localAmount = getLocalAmount(dollarAmount, localExchangeRate)
   return {
     icon: require('src/transactions/ExchangeGreenGold.png'),
-    dollarAmount: inValue,
+    dollarAmount,
     dollarDirection: '-',
-    goldAmount: outValue,
+    localCurrencyCode,
+    localCurrencySymbol,
+    localAmount,
+    goldAmount,
     goldDirection: '',
+    inValue: localCurrencyCode ? localAmount : dollarAmount,
     inColor: colors.celoGreen,
+    outValue: goldAmount,
     outColor: colors.celoGold,
   }
 }
 
-function getGoldExchangeProps({ inValue, outValue }: Props) {
+function getGoldExchangeProps({
+  inValue: goldAmount,
+  outValue: dollarAmount,
+  localCurrencyCode,
+  localCurrencySymbol,
+  localExchangeRate,
+}: ExchangeInputProps) {
+  const localAmount = getLocalAmount(dollarAmount, localExchangeRate)
   return {
     icon: require('src/transactions/ExchangeGoldGreen.png'),
-    dollarAmount: outValue,
+    dollarAmount,
     dollarDirection: '',
-    goldAmount: inValue,
+    localCurrencyCode,
+    localCurrencySymbol,
+    localAmount,
+    goldAmount,
     goldDirection: '-',
+    inValue: goldAmount,
     inColor: colors.celoGold,
+    outValue: localCurrencyCode ? localAmount : dollarAmount,
     outColor: colors.celoGreen,
   }
 }
 
-function getGoldAmountProps({ goldAmount, goldDirection }: ExchangeProps) {
+function getGoldAmountProps({ goldAmount: amount, goldDirection: amountDirection }: ExchangeProps) {
   return {
-    amount: goldAmount,
-    amountDirection: goldDirection,
+    amount,
+    amountDirection,
     amountColor: colors.celoGold,
+    displayAmount: `${amountDirection}${getMoneyDisplayValue(amount)}`,
   }
 }
 
-function getDollarAmountProps({ dollarAmount, dollarDirection }: ExchangeProps) {
+function getDollarAmountProps({
+  dollarAmount,
+  dollarDirection: amountDirection,
+  localCurrencyCode,
+  localCurrencySymbol,
+  localAmount,
+}: ExchangeProps) {
+  const amount = localCurrencyCode ? localAmount : dollarAmount
   return {
-    amount: dollarAmount,
-    amountDirection: dollarDirection,
+    amount,
+    amountDirection,
     amountColor: colors.celoGreen,
+    displayAmount: amount
+      ? `${amountDirection}${localCurrencySymbol +
+          getMoneyDisplayValue(amount) +
+          (localCurrencyCode || '')}`
+      : '-',
   }
 }
 
 export function ExchangeFeedItem(props: Props) {
   const { showGoldAmount, inSymbol, status, timestamp, t, i18n } = props
-  let { inValue, outValue } = props
+
+  const localCurrencyCode = useLocalCurrencyCode()
+  const localCurrencySymbol = useLocalCurrencySymbol()
+  const localExchangeRate = useExchangeRate()
 
   const onPress = () => {
     navigateToExchangeReview(timestamp, {
       makerToken: resolveCurrency(inSymbol),
-      makerAmount: new BigNumber(inValue),
-      takerAmount: new BigNumber(outValue),
+      makerAmount: new BigNumber(props.inValue),
+      takerAmount: new BigNumber(props.outValue),
     })
   }
 
   const inCurrency = resolveCurrency(inSymbol)
+  const exchangeInputProps = { ...props, localCurrencyCode, localCurrencySymbol, localExchangeRate }
   const exchangeProps =
     inCurrency === CURRENCY_ENUM.DOLLAR
-      ? getDollarExchangeProps(props)
-      : getGoldExchangeProps(props)
+      ? getDollarExchangeProps(exchangeInputProps)
+      : getGoldExchangeProps(exchangeInputProps)
   const amountProps = showGoldAmount
     ? getGoldAmountProps(exchangeProps)
     : getDollarAmountProps(exchangeProps)
 
-  const { amountDirection, amountColor } = amountProps
-  let { amount } = amountProps
-
-  const localCurrencyCode = useLocalCurrencyCode()
-  const localCurrencySymbol = useLocalCurrencySymbol()
-
-  if (!showGoldAmount) {
-    amount = !localCurrencyCode ? amount : useDollarsToLocalAmount(amount) || 0
-  }
-  if (inCurrency === CURRENCY_ENUM.DOLLAR) {
-    inValue = !localCurrencyCode ? inValue : useDollarsToLocalAmount(inValue) || 0
-  } else {
-    outValue = !localCurrencyCode ? outValue : useDollarsToLocalAmount(outValue) || 0
-  }
+  const { inValue, outValue } = exchangeProps
+  const { displayAmount, amountDirection, amountColor } = amountProps
 
   const timeFormatted = formatFeedTime(timestamp, i18n)
   const dateTimeFormatted = getDatetimeDisplayString(timestamp, t, i18n)
@@ -132,21 +182,18 @@ export function ExchangeFeedItem(props: Props) {
                 styles.amount,
               ]}
             >
-              {amountDirection}
-              {showGoldAmount
-                ? getMoneyDisplayValue(amount)
-                : localCurrencySymbol + getMoneyDisplayValue(amount) + (localCurrencyCode || '')}
+              {displayAmount}
             </Text>
           </View>
           <View style={styles.exchangeContainer}>
             <Text style={[fontStyles.activityCurrency, inStyle]}>
-              {getMoneyDisplayValue(inValue)}
+              {inValue ? getMoneyDisplayValue(inValue) : '-'}
             </Text>
             <View style={styles.arrow}>
               <ExchangeArrow />
             </View>
             <Text style={[fontStyles.activityCurrency, outStyle]}>
-              {getMoneyDisplayValue(outValue)}
+              {outValue ? getMoneyDisplayValue(outValue) : '-'}
             </Text>
           </View>
           <View style={styles.statusContainer}>

--- a/packages/mobile/src/transactions/TransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.tsx
@@ -140,6 +140,7 @@ export function TransferFeedItem(props: Props) {
     invitees,
     addressToE164Number,
     recipientCache,
+    showLocalCurrency,
   } = props
 
   const localCurrencyCode = useLocalCurrencyCode()
@@ -153,7 +154,7 @@ export function TransferFeedItem(props: Props) {
   const transactionValue =
     type === TransactionTypes.NETWORK_FEE
       ? getNetworkFeeDisplayValue(props.value)
-      : localCurrencyCode
+      : showLocalCurrency && localCurrencyCode
         ? getMoneyDisplayValue(localValue || 0)
         : getMoneyDisplayValue(props.value)
 
@@ -189,9 +190,9 @@ export function TransferFeedItem(props: Props) {
               ]}
             >
               {currencyStyle.direction}
-              {localCurrencySymbol}
+              {showLocalCurrency && localCurrencySymbol}
               {transactionValue}
-              {localCurrencyCode}
+              {showLocalCurrency && localCurrencyCode}
             </Text>
           </View>
           {!!info && <Text style={styles.info}>{info}</Text>}

--- a/packages/mobile/src/transactions/__snapshots__/ExchangeFeedItem.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/ExchangeFeedItem.test.tsx.snap
@@ -96,7 +96,6 @@ exports[`ExchangeFeedItem renders correctly 1`] = `
             ]
           }
         >
-          
           10.00
         </Text>
       </View>

--- a/packages/mobile/src/transactions/__snapshots__/TransactionFeed.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/TransactionFeed.test.tsx.snap
@@ -486,8 +486,7 @@ exports[`renders for gold to dollar exchange properly 1`] = `
                   ]
                 }
               >
-                -
-                $26.60MXN
+                -$26.60MXN
               </Text>
             </View>
             <View
@@ -896,8 +895,7 @@ exports[`renders for gold to dollar exchange properly 1`] = `
                   ]
                 }
               >
-                -
-                $39.90MXN
+                -$39.90MXN
               </Text>
             </View>
             <View
@@ -1371,8 +1369,7 @@ exports[`renders for loading 1`] = `
                   ]
                 }
               >
-                -
-                $26.60MXN
+                -$26.60MXN
               </Text>
             </View>
             <View
@@ -2046,8 +2043,7 @@ exports[`renders for no transactions 1`] = `
                   ]
                 }
               >
-                -
-                $26.60MXN
+                -$26.60MXN
               </Text>
             </View>
             <View
@@ -2721,8 +2717,7 @@ exports[`renders for standbyTransactions 1`] = `
                   ]
                 }
               >
-                -
-                $26.60MXN
+                -$26.60MXN
               </Text>
             </View>
             <View

--- a/packages/mobile/tslint.json
+++ b/packages/mobile/tslint.json
@@ -6,6 +6,7 @@
   "rules": {
     "no-relative-imports": true,
     "max-classes-per-file": [true, 2],
-    "no-global-arrow-functions": false
+    "no-global-arrow-functions": false,
+    "react-hooks-nesting": "error"
   }
 }

--- a/packages/react-components/tslint.json
+++ b/packages/react-components/tslint.json
@@ -6,6 +6,7 @@
   "rules": {
     "no-relative-imports": true,
     "max-classes-per-file": [true, 2],
-    "no-global-arrow-functions": false
+    "no-global-arrow-functions": false,
+    "react-hooks-nesting": "error"
   }
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -13,6 +13,7 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "tslint-react": "^4.1.0"
+    "tslint-react": "^4.1.0",
+    "tslint-react-hooks": "^2.2.1"
   }
 }

--- a/packages/typescript/tslint.json
+++ b/packages/typescript/tslint.json
@@ -29,7 +29,6 @@
     "void-zero": false,
     "no-global-arrow-functions": true,
     "no-floating-promises": true,
-    "no-promise-as-boolean": true,
-    "react-hooks-nesting": "error"
+    "no-promise-as-boolean": true
   }
 }

--- a/packages/typescript/tslint.json
+++ b/packages/typescript/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["tslint:latest", "tslint-react", "tslint-config-prettier"],
+  "extends": ["tslint:latest", "tslint-react", "tslint-react-hooks", "tslint-config-prettier"],
   "rulesDirectory": [
     "../../../node_modules/tslint-eslint-rules/dist/rules",
     "../../../node_modules/tslint-microsoft-contrib",
@@ -29,6 +29,7 @@
     "void-zero": false,
     "no-global-arrow-functions": true,
     "no-floating-promises": true,
-    "no-promise-as-boolean": true
+    "no-promise-as-boolean": true,
+    "react-hooks-nesting": "error"
   }
 }

--- a/packages/verifier/tslint.json
+++ b/packages/verifier/tslint.json
@@ -6,6 +6,7 @@
   "rules": {
     "no-relative-imports": true,
     "max-classes-per-file": [true, 2],
-    "no-global-arrow-functions": false
+    "no-global-arrow-functions": false,
+    "react-hooks-nesting": "error"
   }
 }

--- a/packages/web/tslint.json
+++ b/packages/web/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "max-classes-per-file": [true, 2],
     "no-global-arrow-functions": false,
-    "no-floating-promises": true
+    "no-floating-promises": true,
+    "react-hooks-nesting": "error"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31087,6 +31087,11 @@ tslint-microsoft-contrib@^6.2.0:
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 
+tslint-react-hooks@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tslint-react-hooks/-/tslint-react-hooks-2.2.1.tgz#c52c7df65ee1517b2d6c92bc716e9ef72ccdf208"
+  integrity sha512-bqIg2uZe+quJMfSOGc4OOZ4awo6TP1ejGDGS6IKg2WIrS0XnWfhUJ99i3B8rUpnZhuD4vRSvyYIbXPUmEqQxxQ==
+
 tslint-react@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-4.1.0.tgz#7153b724a8cfbea52423d0ffa469e8eba3bcc834"


### PR DESCRIPTION
### Description

Fixed some regressions introduced by #1325
- crash when changing the local currency from the settings (caused by incorrect usage of react hooks)
- incorrect exchange rate values displayed for exchanges
- gold received from faucet showing as local currency

This will probably need further refactoring, the logic is easy to break given the different use cases.

### Tested

![image](https://user-images.githubusercontent.com/57791/67570849-b21a3c00-f732-11e9-94fc-7e97a89b7c5b.png)
![image](https://user-images.githubusercontent.com/57791/67570859-b9414a00-f732-11e9-8cab-31354420bd62.png)
![image](https://user-images.githubusercontent.com/57791/67570867-bcd4d100-f732-11e9-95e9-c40649e1df5d.png)
![image](https://user-images.githubusercontent.com/57791/67570872-bfcfc180-f732-11e9-84b1-f0e04ab07ffc.png)
![image](https://user-images.githubusercontent.com/57791/67570882-c3634880-f732-11e9-9523-d6a83e05cceb.png)
![image](https://user-images.githubusercontent.com/57791/67570889-c6f6cf80-f732-11e9-999d-1da49d60010b.png)

### Other changes

N/A

### Related issues

- Fixes #1461

### Backwards compatibility

Yes
