### PR TITLE
[Wallet] fix missing full name error alert

### DIFF
--- a/packages/mobile/locales/en-US/nuxVerification2.json
+++ b/packages/mobile/locales/en-US/nuxVerification2.json
@@ -13,6 +13,7 @@
   "country": "Country",
   "phoneNumber": "Phone Number",
   "invalidPhone": "Invalid Phone Number",
+  "missingFullName": "Please enter full name",
   "allowSmsPermissions": "Allow Celo Wallet to send and view SMS messages",
   "dontAsk": "Don't ask again",
   "deny": "Deny",

--- a/packages/mobile/locales/es-419/nuxVerification2.json
+++ b/packages/mobile/locales/es-419/nuxVerification2.json
@@ -14,6 +14,7 @@
   "country": "País",
   "phoneNumber": "Número de teléfono",
   "invalidPhone": "Número de teléfono inválido",
+  "missingFullName": "Por favor ingresa tu nombre completo",
   "allowSmsPermissions": "Permitir que el Monedero Celo envíe y vea mensajes de texto (SMS)",
   "dontAsk": "No volver a preguntar",
   "deny": "Denegar",

--- a/packages/mobile/src/app/ErrorMessages.ts
+++ b/packages/mobile/src/app/ErrorMessages.ts
@@ -12,6 +12,7 @@ export enum ErrorMessages {
   IMPORT_BACKUP_FAILED = 'backupKeyFlow6:importBackupFailed',
   BACKUP_QUIZ_FAILED = 'backupKeyFlow6:backupQuizFailed',
   INVALID_PHONE_NUMBER = 'nuxVerification2:invalidPhone',
+  MISSING_FULL_NAME = 'nuxVerification2:missingFullName',
   NOT_READY_FOR_CODE = 'nuxVerification2:notReadyForCode',
   EMPTY_ATTESTATION_CODE = 'nuxVerification2:emptyVerificationCode',
   INVALID_ATTESTATION_CODE = 'nuxVerification2:invalidVerificationCode',

--- a/packages/mobile/src/invite/JoinCelo.test.tsx
+++ b/packages/mobile/src/invite/JoinCelo.test.tsx
@@ -29,6 +29,30 @@ describe('JoinCeloScreen', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  it('show missing full name warning', () => {
+    const showErrorMock = jest.fn()
+    const store = createMockStore()
+    const wrapper = render(
+      <Provider store={store}>
+        <JoinCeloClass
+          showError={showErrorMock}
+          hideAlert={jest.fn()}
+          setPhoneNumber={jest.fn()}
+          setName={jest.fn()}
+          language={'en-us'}
+          cachedName={''}
+          cachedNumber={''}
+          cachedCountryCode={'+1'}
+          pincodeType={PincodeType.Unset}
+          {...getMockI18nProps()}
+        />
+      </Provider>
+    )
+    fireEvent.changeText(wrapper.getByTestId('PhoneNumberField'), '4155556666')
+    fireEvent.press(wrapper.getByTestId('JoinCeloContinueButton'))
+    expect(showErrorMock.mock.calls[0][0]).toBe(ErrorMessages.MISSING_FULL_NAME)
+  })
+
   it('is disabled with no text', () => {
     const wrapper = render(
       <Provider store={createMockStore()}>

--- a/packages/mobile/src/invite/JoinCelo.tsx
+++ b/packages/mobile/src/invite/JoinCelo.tsx
@@ -126,8 +126,13 @@ export class JoinCelo extends React.Component<Props, State> {
       return
     }
 
-    if (!name || !e164Number || !isValidNumber || !countryCode) {
+    if (!e164Number || !isValidNumber || !countryCode) {
       this.props.showError(ErrorMessages.INVALID_PHONE_NUMBER)
+      return
+    }
+
+    if (!name) {
+      this.props.showError(ErrorMessages.MISSING_FULL_NAME)
       return
     }
 


### PR DESCRIPTION
### Description

Fix the message in the alert, when full name is missing at the `Welcome to Celo Wallet` screen and `Continue` button is pressed.

### Tested

Ran on a device for both Spanish and English languages.

### Other changes

Introduced a new i18n key `missingFullName`

### Related issues

- Fixes #1062 

### Backwards compatibility

Yes
