### PR TITLE
Use better cloud build machine type

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@
 # More details: https://github.com/GoogleContainerTools/kaniko
 
 steps:
-  
+
 - id: "docker:celotool"
   name: gcr.io/kaniko-project/executor:latest
   args: [
@@ -40,5 +40,8 @@ steps:
     "--destination=gcr.io/$PROJECT_ID/celo-monorepo:attestation-service-$COMMIT_SHA"
   ]
   waitFor: ['-']
+
+options:
+  machineType: 'N1_HIGHCPU_8'
 
 timeout: 3000s


### PR DESCRIPTION
### Description

Fixes error code 137 that was thrown during `yarn build` for `transaction-metrics-exporter`

### Tested

Cloud build succeeded

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

This is backwards compatible