### PR TITLE
Rename hosted node references to forno

### DIFF
--- a/packages/attestation-service/config/.env.development
+++ b/packages/attestation-service/config/.env.development
@@ -1,5 +1,5 @@
 DB_URL=sqlite://db/dev.db
-CELO_PROVIDER=https://integration-infura.celo-testnet.org
+CELO_PROVIDER=https://integration-forno.celo-testnet.org
 ACCOUNT_ADDRESS=0xE6e53b5fc2e18F51781f14a3ce5E7FD468247a15
 ATTESTATION_KEY=x
 APP_SIGNATURE=x

--- a/packages/blockchain-api/.env
+++ b/packages/blockchain-api/.env
@@ -2,4 +2,4 @@ EXCHANGE_RATES_API=https://api.exchangeratesapi.io
 BLOCKSCOUT_API=https://integration-blockscout.celo-testnet.org/api
 FAUCET_ADDRESS=0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
 VERIFICATION_REWARDS_ADDRESS=0xb4fdaf5f3cd313654aa357299ada901b1d2dd3b5
-WEB3_PROVIDER_URL=https://integration-infura.celo-testnet.org/
+WEB3_PROVIDER_URL=https://integration-forno.celo-testnet.org/

--- a/packages/blockchain-api/app.alfajores.yaml
+++ b/packages/blockchain-api/app.alfajores.yaml
@@ -8,4 +8,4 @@ env_variables:
   # TODO Pull addresses from the build artifacts of the network in protocol/build
   FAUCET_ADDRESS: "0xCEa3eF8e187490A9d85A1849D98412E5D27D1Bb3"
   VERIFICATION_REWARDS_ADDRESS: "0xb4fdaf5f3cd313654aa357299ada901b1d2dd3b5"
-  WEB3_PROVIDER_URL: "https://alfajores-infura.celo-testnet.org/"
+  WEB3_PROVIDER_URL: "https://alfajores-forno.celo-testnet.org/"

--- a/packages/blockchain-api/app.alfajoresstaging.yaml
+++ b/packages/blockchain-api/app.alfajoresstaging.yaml
@@ -8,4 +8,4 @@ env_variables:
   # TODO Pull addresses from the build artifacts of the network in protocol/build
   FAUCET_ADDRESS: "0xF4314cb9046bECe6AA54bb9533155434d0c76909"
   VERIFICATION_REWARDS_ADDRESS: "0xb4fdaf5f3cd313654aa357299ada901b1d2dd3b5"
-  WEB3_PROVIDER_URL: "https://alfajoresstaging-infura.celo-testnet.org/"
+  WEB3_PROVIDER_URL: "https://alfajoresstaging-forno.celo-testnet.org/"

--- a/packages/blockchain-api/app.integration.yaml
+++ b/packages/blockchain-api/app.integration.yaml
@@ -8,4 +8,4 @@ env_variables:
   # TODO Pull addresses from the build artifacts of the network in protocol/build
   FAUCET_ADDRESS: "0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95"
   VERIFICATION_REWARDS_ADDRESS: "0xb4fdaf5f3cd313654aa357299ada901b1d2dd3b5"
-  WEB3_PROVIDER_URL: "https://integration-infura.celo-testnet.org/"
+  WEB3_PROVIDER_URL: "https://integration-forno.celo-testnet.org/"

--- a/packages/blockchain-api/app.pilot.yaml
+++ b/packages/blockchain-api/app.pilot.yaml
@@ -8,4 +8,4 @@ env_variables:
   # TODO Pull addresses from the build artifacts of the network in protocol/build
   FAUCET_ADDRESS: "0x387bCb16Bfcd37AccEcF5c9eB2938E30d3aB8BF2"
   VERIFICATION_REWARDS_ADDRESS: "0xb4fdaf5f3cd313654aa357299ada901b1d2dd3b5"
-  WEB3_PROVIDER_URL: "https://pilot-infura.celo-testnet.org/"
+  WEB3_PROVIDER_URL: "https://pilot-forno.celo-testnet.org/"

--- a/packages/blockchain-api/app.pilotstaging.yaml
+++ b/packages/blockchain-api/app.pilotstaging.yaml
@@ -8,4 +8,4 @@ env_variables:
   # TODO Pull addresses from the build artifacts of the network in protocol/build
   FAUCET_ADDRESS: "0x545DEBe3030B570731EDab192640804AC8Cf65CA"
   VERIFICATION_REWARDS_ADDRESS: "0xb4fdaf5f3cd313654aa357299ada901b1d2dd3b5"
-  WEB3_PROVIDER_URL: "https://pilotstaging-infura.celo-testnet.org/"
+  WEB3_PROVIDER_URL: "https://pilotstaging-forno.celo-testnet.org/"

--- a/packages/contractkit/README.md
+++ b/packages/contractkit/README.md
@@ -30,7 +30,7 @@ To start working with contractkit you need a `kit` instance:
 ```ts
 import { newKit } from '@celo/contractkit'
 
-const kit = newKit('https://alfajores-infura.celo-testnet.org:8545')
+const kit = newKit('https://alfajores-forno.celo-testnet.org:8545')
 ```
 
 To access web3:
@@ -47,7 +47,7 @@ await kit.web3.eth.getBalance(someAddress)
 import { newKit, CeloContract } from '@celo/contractkit'
 
 async function getKit(myAddress: string) {
-  const kit = newKit('https://alfajores-infura.celo-testnet.org:8545')
+  const kit = newKit('https://alfajores-forno.celo-testnet.org:8545')
 
   // default from
   kit.defaultAccount = myAddress

--- a/packages/dappkit/README.md
+++ b/packages/dappkit/README.md
@@ -55,7 +55,7 @@ Once you have the account address, you can make calls against your own smart con
   const address = dappkitResponse.address
   this.setState({ address, phoneNumber: dappkitResponse.phoneNumber, isLoadingBalance: true })
 
-  const kit = newKit('https://alfajores-infura.celo-testnet.org')
+  const kit = newKit('https://alfajores-forno.celo-testnet.org')
   kit.defaultAccount = address
 
   const stableToken = await kit.contracts.getStableToken()

--- a/packages/docs/developer-resources/contractkit/setup.md
+++ b/packages/docs/developer-resources/contractkit/setup.md
@@ -19,7 +19,7 @@ To start working with contractkit you need a `kit` instance:
 ```ts
 import { newKit } from '@celo/contractkit'
 
-const kit = newKit('https://alfajores-infura.celo-testnet.org')
+const kit = newKit('https://alfajores-forno.celo-testnet.org')
 ```
 
 To access web3:

--- a/packages/docs/developer-resources/dappkit/usage.md
+++ b/packages/docs/developer-resources/dappkit/usage.md
@@ -43,7 +43,7 @@ Once you have the account address, you can make calls against your own smart con
   const address = dappkitResponse.address
   this.setState({ address, phoneNumber: dappkitResponse.phoneNumber, isLoadingBalance: true })
 
-  const kit = newKit('https://alfajores-infura.celo-testnet.org')
+  const kit = newKit('https://alfajores-forno.celo-testnet.org')
   kit.defaultAccount = address
 
   const stableToken = await kit.contracts.getStableToken()

--- a/packages/helm-charts/attestation-service/templates/attestation.statefulset.yaml
+++ b/packages/helm-charts/attestation-service/templates/attestation.statefulset.yaml
@@ -67,7 +67,7 @@ spec:
         - name: DB_URL
           value: sqlite://db/dev.db
         - name: CELO_PROVIDER
-          value: https://{{ .Release.Namespace }}-infura.{{ .Values.domain.name }}.org
+          value: https://{{ .Release.Namespace }}-forno.{{ .Values.domain.name }}.org
         - name: APP_SIGNATURE
           value: {{ .Values.attestation_service.sms_retriever_hash_code }}}
         - name: NEXMO_KEY

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -216,7 +216,7 @@ Relevant code references:
 
 There are two major differencs in ZeroSync mode:
 
-1.  Geth won't run at all. The web3 would instead connect to <testnet>-infura.celo-testnet.org using an https provider, for example, [https://integration-infura.celo-testnet.org](https://integration-infura.celo-testnet.org).
+1.  Geth won't run at all. The web3 would instead connect to <testnet>-forno.celo-testnet.org using an https provider, for example, [https://integration-forno.celo-testnet.org](https://integration-forno.celo-testnet.org).
 2.  Changes to [sendTransactionAsyncWithWeb3Signing](https://github.com/celo-org/celo-monorepo/blob/8689634a1d10d74ba6d4f3b36b2484db60a95bdb/packages/walletkit/src/contract-utils.ts#L362) in walletkit to poll after sending a transaction for the transaction to succeed. This is needed because http provider, unliked web sockets and IPC provider, does not support subscriptions.
 
 #### Why http(s) provider?

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -51,7 +51,7 @@ export const FIREBASE_ENABLED = stringToBoolean(Config.FIREBASE_ENABLED || 'true
 // We need to fallback to `integration` for testing under jest where
 // react-native-config is undefined.
 export const DEFAULT_TESTNET = Config.DEFAULT_TESTNET || 'integration'
-export const DEFAULT_INFURA_URL = `https://${DEFAULT_TESTNET}-infura.celo-testnet.org/`
+export const DEFAULT_FORNO_URL = `https://${DEFAULT_TESTNET}-forno.celo-testnet.org/`
 
 export const SEGMENT_API_KEY = keyOrUndefined(secretsFile, Config.SECRETS_KEY, 'SEGMENT_API_KEY')
 export const FIREBASE_WEB_KEY = keyOrUndefined(secretsFile, Config.SECRETS_KEY, 'FIREBASE_WEB_KEY')

--- a/packages/mobile/src/transactions/send.ts
+++ b/packages/mobile/src/transactions/send.ts
@@ -9,7 +9,7 @@ import {
 import { call, select } from 'redux-saga/effects'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
 import { CustomEventNames } from 'src/analytics/constants'
-import { DEFAULT_INFURA_URL } from 'src/config'
+import { DEFAULT_FORNO_URL } from 'src/config'
 import Logger from 'src/utils/Logger'
 import { web3 } from 'src/web3/contracts'
 import { zeroSyncSelector } from 'src/web3/selectors'
@@ -73,10 +73,10 @@ export function* sendTransactionPromises(
   const zeroSyncMode = yield select(zeroSyncSelector)
   if (zeroSyncMode) {
     // In dev mode, verify that we are actually able to connect to the network. This
-    // ensures that we get a more meaningful error if the infura server is down, which
+    // ensures that we get a more meaningful error if the forno server is down, which
     // can happen with networks without SLA guarantees like `integration`.
     if (__DEV__) {
-      yield call(verifyUrlWorksOrThrow, DEFAULT_INFURA_URL)
+      yield call(verifyUrlWorksOrThrow, DEFAULT_FORNO_URL)
     }
     Logger.debug(
       `${TAG}@sendTransactionPromises`,

--- a/packages/mobile/src/web3/contracts.ts
+++ b/packages/mobile/src/web3/contracts.ts
@@ -2,7 +2,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { addLocalAccount as web3utilsAddLocalAccount } from '@celo/walletkit'
 import { Platform } from 'react-native'
 import * as net from 'react-native-tcp'
-import { DEFAULT_INFURA_URL, DEFAULT_TESTNET } from 'src/config'
+import { DEFAULT_FORNO_URL, DEFAULT_TESTNET } from 'src/config'
 import { IPC_PATH } from 'src/geth/geth'
 import networkConfig, { Testnets } from 'src/geth/networkConfig'
 import Logger from 'src/utils/Logger'
@@ -76,7 +76,7 @@ function getWeb3(): Web3 {
     throw new Error('Zero sync mode is currently not supported on iOS')
   } else if (isInitiallyZeroSyncMode()) {
     // Geth free mode
-    const url = DEFAULT_INFURA_URL
+    const url = DEFAULT_FORNO_URL
     Logger.debug('contracts@getWeb3', `Connecting to url ${url}`)
     return new Web3(getWebSocketProvider(url))
   } else {
@@ -87,8 +87,8 @@ function getWeb3(): Web3 {
 // Mutates web3 with new provider
 export function switchWeb3ProviderForSyncMode(zeroSync: boolean) {
   if (zeroSync) {
-    web3.setProvider(getWebSocketProvider(DEFAULT_INFURA_URL))
-    Logger.info(`${tag}@switchWeb3ProviderForSyncMode`, `Set provider to ${DEFAULT_INFURA_URL}`)
+    web3.setProvider(getWebSocketProvider(DEFAULT_FORNO_URL))
+    Logger.info(`${tag}@switchWeb3ProviderForSyncMode`, `Set provider to ${DEFAULT_FORNO_URL}`)
   } else {
     web3.setProvider(getIpcProvider(DEFAULT_TESTNET))
     Logger.info(`${tag}@switchWeb3ProviderForSyncMode`, `Set provider to IPC provider`)

--- a/packages/notification-service/config/config.integration.env
+++ b/packages/notification-service/config/config.integration.env
@@ -7,4 +7,4 @@ DEFAULT_LOCALE=en
 NOTIFICATION_TTL_MS=604800000
 POLLING_INTERVAL=1000
 EXCHANGE_POLLING_INTERVAL=1800000
-WEB3_PROVIDER_URL=https://integration-infura.celo-testnet.org/
+WEB3_PROVIDER_URL=https://integration-forno.celo-testnet.org/

--- a/packages/notification-service/config/config.local.env
+++ b/packages/notification-service/config/config.local.env
@@ -8,4 +8,4 @@ GOOGLE_APPLICATION_CREDENTIALS="./config/serviceAccountKey.json"
 NOTIFICATION_TTL_MS=604800000
 POLLING_INTERVAL=5000
 EXCHANGE_POLLING_INTERVAL=1800000
-WEB3_PROVIDER_URL=https://integration-infura.celo-testnet.org/
+WEB3_PROVIDER_URL=https://integration-forno.celo-testnet.org/

--- a/packages/notification-service/config/config.test.env
+++ b/packages/notification-service/config/config.test.env
@@ -8,4 +8,4 @@ GOOGLE_APPLICATION_CREDENTIALS="./config/serviceAccountKey.json"
 NOTIFICATION_TTL_MS=604800000
 POLLING_INTERVAL=5000
 EXCHANGE_POLLING_INTERVAL=1800000
-WEB3_PROVIDER_URL=https://integration-infura.celo-testnet.org/
+WEB3_PROVIDER_URL=https://integration-forno.celo-testnet.org/

--- a/packages/verification-pool-api/src/config.ts
+++ b/packages/verification-pool-api/src/config.ts
@@ -22,7 +22,7 @@ export const smsAckTimeout = functionConfig[CELO_ENV]['sms-ack-timeout'] || 5000
 console.debug(`Config settings: app-signture:${appSignature}, networkId:${networkid}`)
 
 // @ts-ignore
-export const web3 = new Web3(`https://${CELO_ENV}-infura.celo-testnet.org`)
+export const web3 = new Web3(`https://${CELO_ENV}-forno.celo-testnet.org`)
 
 let twilioClient: any
 let nexmoClient: any

--- a/packages/walletkit/src/contract-utils.ts
+++ b/packages/walletkit/src/contract-utils.ts
@@ -347,8 +347,7 @@ export async function sendTransactionAsync<T>(
  * sendTransactionAsyncWithWeb3Signing is same as sendTransactionAsync except it fills
  * in the missing fields and locally signs the transaction. It will fail if the `from`
  * is not one of the account whose local signing keys are available. This method
- * should only be used in Zero sync (infura-like) mode where Geth is running
- * remotely.
+ * should only be used in forno mode where Geth is running remotely.
  *
  * This separate function is temporary and contractkit uses a unified function
  * for both web3 (local) and remote (geth) siging.
@@ -506,7 +505,7 @@ export async function sendTransactionAsyncWithWeb3Signing<T>(
         resolvers.transactionHash(recievedTxHash)
       }
     }
-    // This code is required for infura-like setup.
+    // This code is required for forno setup.
     // When mobile client directly connects to the remote full node then
     // it gets `receipt` but not other notifications.
     let sleepTimeInSecs = 1


### PR DESCRIPTION
### Description

Update references to our hosted node / infura-like set up to "forno". PR #1507 updates these ingresses, which are already up. 

### Tested

Ensured a stackdriver uptime check is running for production networks (alfajores, pilot)

### Related issues

- Fixes clabs issue: https://github.com/celo-org/celo-labs/issues/160

### Backwards compatibility

Yes, assuming that forno hosted node is up
