### PR TITLE
Remove ContractKit/Protocol building from Transaction Metrics Exporter Docker Image

### DIFF
--- a/dockerfiles/transaction-metrics-exporter/Dockerfile
+++ b/dockerfiles/transaction-metrics-exporter/Dockerfile
@@ -18,8 +18,6 @@ COPY scripts/ scripts/
 # Copy only pkg.json
 COPY packages/typescript/package.json packages/typescript/
 COPY packages/utils/package.json packages/utils/
-COPY packages/protocol/package.json packages/protocol/
-COPY packages/contractkit/package.json packages/contractkit/
 COPY packages/transaction-metrics-exporter/package.json packages/transaction-metrics-exporter/
 
 RUN yarn install --network-timeout 100000 --frozen-lockfile && yarn cache clean
@@ -27,8 +25,6 @@ RUN yarn install --network-timeout 100000 --frozen-lockfile && yarn cache clean
 # Copy the rest
 COPY packages/typescript packages/typescript/
 COPY packages/utils packages/utils/
-COPY packages/protocol/ packages/protocol/
-COPY packages/contractkit packages/contractkit/
 COPY packages/transaction-metrics-exporter packages/transaction-metrics-exporter/
 
 # build all


### PR DESCRIPTION
### Description

Building protocol and contractkit in the docker image for whatever reason lead to OOMs, so for now, we'll just rely on using the public npm package for it. Note that this means that any changes to CK for TME would require an update to the npm package.

### Tested

- Cloud build builds

