### PR TITLE
Added hprof to .gitignore and re-aranged it

### DIFF
--- a/packages/mobile/.gitignore
+++ b/packages/mobile/.gitignore
@@ -75,14 +75,4 @@ e2e_run.log
 e2e_pidcat_run.log
 
 # keys
-android/app/google-services.json
-android/app/src/staging/google-services.json
-android/app/src/integration/google-services.json
-android/app/src/alfajores/google-services.json
-android/app/src/debug/google-services.json
-android/app/src/pilot/google-services.json
 secrets.json
-android/sentry.properties
-ios/**/GoogleService-Info*.plist
-ios/sentry.properties
-ios/Pods

--- a/packages/mobile/android/.gitignore
+++ b/packages/mobile/android/.gitignore
@@ -1,0 +1,10 @@
+# keys
+app/google-services.json
+app/src/staging/google-services.json
+app/src/integration/google-services.json
+app/src/alfajores/google-services.json
+app/src/debug/google-services.json
+app/src/pilot/google-services.json
+sentry.properties
+
+*.hprof

--- a/packages/mobile/ios/.gitignore
+++ b/packages/mobile/ios/.gitignore
@@ -1,0 +1,3 @@
+**/GoogleService-Info*.plist
+sentry.properties
+Pods


### PR DESCRIPTION
### Description

Since upgrading to `RN 61`, gradle was generating a `hprof` file of about ~500MB.

### Tested

- 

### Other changes

- split `.gitignore` in `ios` and `android` folders

### Related issues

- 

### Backwards compatibility

-
