### PR TITLE
[Wallet] Fix yarn dev command for running android

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -101,7 +101,6 @@ Execute the following (and make sure the lines are in your `~/.bash_profile`):
 ```bash
 export ANDROID_HOME=/usr/local/share/android-sdk
 export ANDROID_NDK=/usr/local/share/android-ndk
-# Optional to speedup java builds
 export GRADLE_OPTS='-Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.jvmargs="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError"'
 ```
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -16,7 +16,7 @@
     "build:metro": "echo 'NOT WORKING RIGHT NOW'",
     "build:gen-graphql-types": "gql-gen --schema http://localhost:8080/graphql --template graphql-codegen-typescript-template --out ./typings/ 'src/**/*.tsx'",
     "predev": "./scripts/pre-dev.sh",
-    "dev": "react-native run-android --appIdSuffix \"debug\"",
+    "dev": "react-native run-android --appIdSuffix \"debug\" --no-packager && react-native start",
     "dev:show-menu": "adb devices | grep '\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} adb -s {} shell input keyevent 82",
     "dev:clear-data": "adb shell pm clear org.celo.mobile.debug",
     "dev:clean-android": "cd android && ./gradlew clean",

--- a/packages/mobile/scripts/unlock.sh
+++ b/packages/mobile/scripts/unlock.sh
@@ -19,7 +19,7 @@ adb wait-for-device shell \
   'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'
 
 
-echo "locksettings set-pin 123456" | adb shell
+echo "locksettings set-pin 123456" | adb shell || true
 
 sleep 1
 echo "Device is done booting"


### PR DESCRIPTION
### Description

`yarn dev` is broken since the RN upgrade to 0.61
This is basically because `react-native run-android` runs the bundler from the monorepo root instead of the mobile project. This is a simple workaround for now.
