### PR TITLE
CI: brings back to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,7 @@ jobs:
           command: |
             set -e
             cd packages/celotool
-            ./ci_test_transfers.sh checkout kobigurk/proof_of_possesion_zexe_upgrade
+            ./ci_test_transfers.sh checkout master
 
   end-to-end-geth-exit-test:
     <<: *e2e-defaults
@@ -518,7 +518,7 @@ jobs:
           command: |
             set -e
             cd packages/celotool
-            ./ci_test_exit.sh checkout kobigurk/proof_of_possesion_zexe_upgrade
+            ./ci_test_exit.sh checkout master
 
   end-to-end-geth-governance-test:
     <<: *e2e-defaults
@@ -538,7 +538,7 @@ jobs:
           command: |
             set -e
             cd packages/celotool
-            ./ci_test_governance.sh checkout kobigurk/proof_of_possesion_zexe_upgrade
+            ./ci_test_governance.sh checkout master
 
   end-to-end-geth-sync-test:
     <<: *e2e-defaults
@@ -557,7 +557,7 @@ jobs:
           command: |
             set -e
             cd packages/celotool
-            ./ci_test_sync.sh checkout kobigurk/proof_of_possesion_zexe_upgrade
+            ./ci_test_sync.sh checkout master
 
   end-to-end-geth-integration-sync-test:
     <<: *e2e-defaults
@@ -592,7 +592,7 @@ jobs:
           command: |
             set -e
             cd packages/celotool
-            ./ci_test_attestations.sh checkout kobigurk/proof_of_possesion_zexe_upgrade
+            ./ci_test_attestations.sh checkout master
 
   end-to-end-geth-validator-order-test:
     <<: *e2e-defaults


### PR DESCRIPTION
### Description

CI was moved to a specific branch in https://github.com/celo-org/celo-monorepo/pull/1494. This brings it back.