### PR TITLE
[BlockchainApi] Hotfix secrets not present when deploying to App Engine

### DIFF
--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -14,7 +14,8 @@
     "build": "tsc -p .",
     "clean": "rm -rf dist coverage",
     "gcp-build": "npm run build",
-    "deploy": "./deploy.sh"
+    "deploy": "./deploy.sh",
+    "postinstall": "test -f src/secrets.json || echo \"{}\" > src/secrets.json"
   },
   "dependencies": {
     "@celo/contractkit": "0.1.6",

--- a/packages/blockchain-api/src/config.ts
+++ b/packages/blockchain-api/src/config.ts
@@ -1,16 +1,17 @@
 import dotenv from 'dotenv'
+import secrets from './secrets.json'
 
 // Load environment variables from .env file
 dotenv.config()
 
 function getSecrets(deployEnv: string) {
-  try {
-    return require('./secrets.json')[deployEnv]
-  } catch {
-    // Secrets are only available in trusted environments
+  const envSecrets = (secrets as any)[deployEnv]
+  if (!envSecrets) {
+    console.warn(`No secrets found for deploy env ${deployEnv}`)
+    return {}
   }
 
-  return {}
+  return envSecrets
 }
 
 export const DEPLOY_ENV = (process.env.DEPLOY_ENV as string).toLowerCase()


### PR DESCRIPTION
### Description

Hotfix following #1581

Secrets were missing once deployed to App Engine.

This is because dynamically required files don't get copied to the dist folder.
So here we use a static import and create a dummy secrets.json for environments that are not trusted.

### Tested

Ran the tests with and without being able to decrypt `secrets.json.enc`
Ran locally.
Deployed to integration successfully.

### Other changes

N/A

### Backwards compatibility

Yes
