### PR TITLE
Prettify Solidity files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "install-pkg": "yarn install --link-duplicates",
     "lint": "yarn lerna run lint",
-    "prettify": "yarn run prettier --config .prettierrc.js --write '**/*.+(ts|tsx|js|jsx)'",
-    "prettify:diff": "yarn run prettier --config .prettierrc.js --list-different '**/*.+(ts|tsx|js|jsx)'",
+    "prettify": "yarn run prettier --config .prettierrc.js --write '**/*.+(ts|tsx|js|jsx|sol)'",
+    "prettify:diff": "yarn run prettier --config .prettierrc.js --list-different '**/*.+(ts|tsx|js|jsx|sol)'",
     "reset": "yarn reset-modules && yarn reset-cache",
     "reset-cache": "yarn reset-yarn && yarn reset-rn",
     "reset-modules": "rm -rf node_modules/ packages/*/node_modules",
@@ -51,6 +51,7 @@
     "lerna": "^3.16.0",
     "patch-package": "^5.1.1",
     "prettier": "1.13.5",
+    "prettier-plugin-solidity": "1.0.0-alpha.34",
     "pretty-quick": "^1.11.1",
     "solc": "0.5.8",
     "tslint": "^5.20.0",
@@ -76,4 +77,4 @@
     "**/extend": "^3.0.2",
     "sha3": "1.2.3"
   }
-} 
+}

--- a/packages/protocol/contracts/Migrations.sol
+++ b/packages/protocol/contracts/Migrations.sol
@@ -1,10 +1,8 @@
 pragma solidity ^0.5.3;
 
-
 contract Migrations {
-
   address public owner;
-  uint public last_completed_migration; // solhint-disable var-name-mixedcase
+  uint256 public last_completed_migration; // solhint-disable var-name-mixedcase
 
   modifier restricted() {
     if (msg.sender == owner) _;
@@ -14,7 +12,7 @@ contract Migrations {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) external restricted {
+  function setCompleted(uint256 completed) external restricted {
     last_completed_migration = completed; // solhint-disable var-name-mixedcase
   }
 

--- a/packages/protocol/contracts/baklava/Freezable.sol
+++ b/packages/protocol/contracts/baklava/Freezable.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 contract Freezable {
   bool public frozen;
   address public freezer;

--- a/packages/protocol/contracts/baklava/test/FreezableTest.sol
+++ b/packages/protocol/contracts/baklava/test/FreezableTest.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../Freezable.sol";
-
+import '../Freezable.sol';
 
 contract FreezableTest is Freezable {
   event FunctionCalled();

--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -1,29 +1,26 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import 'openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
-import "./interfaces/IAccounts.sol";
+import './interfaces/IAccounts.sol';
 
-import "../common/Initializable.sol";
-import "../common/Signatures.sol";
-import "../common/UsingRegistry.sol";
+import '../common/Initializable.sol';
+import '../common/Signatures.sol';
+import '../common/UsingRegistry.sol';
 
 contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
-
   using SafeMath for uint256;
 
   struct Signers {
     //The address that is authorized to vote in governance and validator elections on behalf of the
     // account. The account can vote as well, whether or not an vote signing key has been specified.
     address voting;
-
     // The address that is authorized to manage a validator or validator group and sign consensus
     // messages on behalf of the account. The account can manage the validator, whether or not an
     // validation signing key has been specified. However if an validation signing key has been
     // specified, only that key may actually participate in consensus.
     address validating;
-
     // The address of the key with which this account wants to sign attestations on the Attestations
     // contract
     address attesting;
@@ -35,17 +32,13 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
     // These keys may not be keys of other accounts, and may not be authorized by any other
     // account for any purpose.
     Signers signers;
-
     // The address at which the account expects to receive transfers. If it's empty/0x0, the
     // account indicates that an address exchange should be initiated with the dataEncryptionKey
     address walletAddress;
-
     // An optional human readable identifier for the account
     string name;
-
     // The ECDSA public key used to encrypt and decrypt data for this account
     bytes dataEncryptionKey;
-
     // The URL under which an account adds metadata and claims
     string metadataURL;
   }
@@ -53,7 +46,6 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
   mapping(address => Account) private accounts;
   // Maps voting and validating keys to the account that provided the authorization.
   mapping(address => address) public authorizedBy;
-
 
   event AttestationSignerAuthorized(address indexed account, address signer);
   event VoteSignerAuthorized(address indexed account, address signer);
@@ -70,14 +62,10 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
    * @param dataEncryptionKey secp256k1 public key for data encryption. Preferably compressed.
    * @param walletAddress The wallet address to set for the account
    */
-  function setAccount(
-    string calldata name,
-    bytes calldata dataEncryptionKey,
-    address walletAddress
-  )
+  function setAccount(string calldata name, bytes calldata dataEncryptionKey, address walletAddress)
     external
   {
-    if(!isAccount(msg.sender)) {
+    if (!isAccount(msg.sender)) {
       createAccount();
     }
     setName(name);
@@ -103,15 +91,7 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
    * @param s Output value s of the ECDSA signature.
    * @dev v, r, s constitute `voter`'s signature on `msg.sender`.
    */
-  function authorizeVoteSigner(
-    address voter,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  )
-    external
-    nonReentrant
-  {
+  function authorizeVoteSigner(address voter, uint8 v, bytes32 r, bytes32 s) external nonReentrant {
     Account storage account = accounts[msg.sender];
     authorize(voter, account.signers.voting, v, r, s);
     account.signers.voting = voter;
@@ -126,12 +106,7 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
    * @param s Output value s of the ECDSA signature.
    * @dev v, r, s constitute `validator`'s signature on `msg.sender`.
    */
-  function authorizeValidationSigner(
-    address validator,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  )
+  function authorizeValidationSigner(address validator, uint8 v, bytes32 r, bytes32 s)
     external
     nonReentrant
   {
@@ -179,11 +154,7 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
    * @dev Fails if the `accountOrVoteSigner` is not an account or active authorized vote signer.
    * @return The associated account.
    */
-  function activeVoteSignerToAccount(address accountOrVoteSigner)
-    external
-    view
-    returns (address)
-  {
+  function activeVoteSignerToAccount(address accountOrVoteSigner) external view returns (address) {
     address authorizingAccount = authorizedBy[accountOrVoteSigner];
     if (authorizingAccount != address(0)) {
       require(accounts[authorizingAccount].signers.voting == accountOrVoteSigner);
@@ -228,7 +199,7 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
     return accounts[account].metadataURL;
   }
 
-    /**
+  /**
    * @notice Getter for the data encryption key and version.
    * @param account The address of the account to get the key for
    * @return dataEncryptionKey secp256k1 public key for data encryption. Preferably compressed.
@@ -283,7 +254,7 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
    * @param dataEncryptionKey secp256k1 public key for data encryption. Preferably compressed.
    */
   function setAccountDataEncryptionKey(bytes memory dataEncryptionKey) public {
-    require(dataEncryptionKey.length >= 33, "data encryption key length <= 32");
+    require(dataEncryptionKey.length >= 33, 'data encryption key length <= 32');
     accounts[msg.sender].dataEncryptionKey = dataEncryptionKey;
     emit AccountDataEncryptionKeySet(msg.sender, dataEncryptionKey);
   }
@@ -296,14 +267,7 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
    * @param s Output value s of the ECDSA signature.
    * @dev v, r, s constitute `attestor`'s signature on `msg.sender`.
    */
-  function authorizeAttestationSigner(
-    address attestor,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  )
-    public
-  {
+  function authorizeAttestationSigner(address attestor, uint8 v, bytes32 r, bytes32 s) public {
     Account storage account = accounts[msg.sender];
     authorize(attestor, account.signers.attesting, v, r, s);
     account.signers.attesting = attestor;
@@ -444,15 +408,7 @@ contract Accounts is IAccounts, ReentrancyGuard, Initializable, UsingRegistry {
    * @dev Fails if the address is already authorized or is an account.
    * @dev v, r, s constitute `current`'s signature on `msg.sender`.
    */
-  function authorize(
-    address current,
-    address previous,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  )
-    private
-  {
+  function authorize(address current, address previous, uint8 v, bytes32 r, bytes32 s) private {
     require(isAccount(msg.sender) && isNotAccount(current) && isNotAuthorized(current));
 
     address signer = Signatures.getSignerOfAddress(msg.sender, v, r, s);

--- a/packages/protocol/contracts/common/ExtractFunctionSignature.sol
+++ b/packages/protocol/contracts/common/ExtractFunctionSignature.sol
@@ -7,7 +7,9 @@ library ExtractFunctionSignature {
    * @return The first four bytes of `input`.
    */
   function extractFunctionSignature(bytes memory input) internal pure returns (bytes4) {
-    return (bytes4(input[0]) | bytes4(input[1])>>8 | bytes4(input[2])>>16 | bytes4(input[3])>>24);
+    return (bytes4(input[0]) |
+      (bytes4(input[1]) >> 8) |
+      (bytes4(input[2]) >> 16) |
+      (bytes4(input[3]) >> 24));
   }
 }
-

--- a/packages/protocol/contracts/common/FixidityLib.sol
+++ b/packages/protocol/contracts/common/FixidityLib.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.0;
 
-
 /**
  * @title FixidityLib
  * @author Gadi Guy, Alberto Cuesta Canada
@@ -16,7 +15,6 @@ pragma solidity ^0.5.0;
  * overflow.
  */
 library FixidityLib {
-
   struct Fraction {
     uint256 value;
   }
@@ -120,11 +118,7 @@ library FixidityLib {
    * Test newFixed(maxNewFixed()) returns maxNewFixed() * fixed1()
    * Test newFixed(maxNewFixed()+1) fails
    */
-  function newFixed(uint256 x)
-    internal
-    pure
-    returns (Fraction memory)
-  {
+  function newFixed(uint256 x) internal pure returns (Fraction memory) {
     require(x <= maxNewFixed());
     return Fraction(x * FIXED1_UINT);
   }
@@ -133,11 +127,7 @@ library FixidityLib {
    * @notice Converts a uint256 in the fixed point representation of this
    * library to a non decimal. All decimal digits will be truncated.
    */
-  function fromFixed(Fraction memory x)
-    internal
-    pure
-    returns (uint256)
-  {
+  function fromFixed(Fraction memory x) internal pure returns (uint256) {
     return x.value / FIXED1_UINT;
   }
 
@@ -153,10 +143,7 @@ library FixidityLib {
    * Test newFixedFraction(maxFixedDividend(),1) returns maxFixedDividend()*fixed1()
    * Test newFixedFraction(1,fixed1()) returns 1
    */
-  function newFixedFraction(
-    uint256 numerator,
-    uint256 denominator
-  )
+  function newFixedFraction(uint256 numerator, uint256 denominator)
     internal
     pure
     returns (Fraction memory)
@@ -278,7 +265,7 @@ library FixidityLib {
    */
   function reciprocal(Fraction memory x) internal pure returns (Fraction memory) {
     require(x.value != 0);
-    return Fraction((FIXED1_UINT*FIXED1_UINT) / x.value); // Can't overflow
+    return Fraction((FIXED1_UINT * FIXED1_UINT) / x.value); // Can't overflow
   }
 
   /**

--- a/packages/protocol/contracts/common/FractionUtil.sol
+++ b/packages/protocol/contracts/common/FractionUtil.sol
@@ -1,11 +1,9 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 // TODO(asa): Move to uint128 if gas savings are significant enough.
 library FractionUtil {
-
   using SafeMath for uint256;
   using FractionUtil for Fraction;
 
@@ -40,14 +38,7 @@ library FractionUtil {
    * @param y A Fraction struct.
    * @return x == y
    */
-  function equals(
-    Fraction memory x,
-    Fraction memory y
-  )
-    internal
-    pure
-    returns (bool)
-  {
+  function equals(Fraction memory x, Fraction memory y) internal pure returns (bool) {
     return x.numerator.mul(y.denominator) == y.numerator.mul(x.denominator);
   }
 
@@ -57,18 +48,13 @@ library FractionUtil {
    * @param y A Fraction struct.
    * @return x + y
    */
-  function add(
-    Fraction memory x,
-    Fraction memory y
-  )
-    internal
-    pure
-    returns (Fraction memory)
-  {
-    return Fraction(
-      x.numerator.mul(y.denominator).add(y.numerator.mul(x.denominator)),
-      x.denominator.mul(y.denominator)
-    ).reduce();
+  function add(Fraction memory x, Fraction memory y) internal pure returns (Fraction memory) {
+    return
+      Fraction(
+        x.numerator.mul(y.denominator).add(y.numerator.mul(x.denominator)),
+        x.denominator.mul(y.denominator)
+      )
+        .reduce();
   }
 
   /**
@@ -77,19 +63,14 @@ library FractionUtil {
    * @param y A Fraction struct.
    * @return x - y
    */
-  function sub(
-    Fraction memory x,
-    Fraction memory y
-  )
-    internal
-    pure
-    returns (Fraction memory)
-  {
+  function sub(Fraction memory x, Fraction memory y) internal pure returns (Fraction memory) {
     require(isGreaterThanOrEqualTo(x, y));
-    return Fraction(
-      x.numerator.mul(y.denominator).sub(y.numerator.mul(x.denominator)),
-      x.denominator.mul(y.denominator)
-    ).reduce();
+    return
+      Fraction(
+        x.numerator.mul(y.denominator).sub(y.numerator.mul(x.denominator)),
+        x.denominator.mul(y.denominator)
+      )
+        .reduce();
   }
 
   /**
@@ -117,18 +98,9 @@ library FractionUtil {
    * @param x A Fraction struct.
    * @return 1 / x
    */
-  function inverse(
-    Fraction memory x
-  )
-    internal
-    pure
-    returns (Fraction memory)
-  {
+  function inverse(Fraction memory x) internal pure returns (Fraction memory) {
     require(x.numerator != 0);
-    return Fraction(
-      x.denominator,
-      x.numerator
-    );
+    return Fraction(x.denominator, x.numerator);
   }
 
   /**
@@ -148,14 +120,7 @@ library FractionUtil {
    * @param y A Fraction struct.
    * @return x > y
    */
-  function isGreaterThan(
-    Fraction memory x,
-    Fraction memory y
-  )
-    internal
-    pure
-    returns (bool)
-  {
+  function isGreaterThan(Fraction memory x, Fraction memory y) internal pure returns (bool) {
     return x.numerator.mul(y.denominator) > y.numerator.mul(x.denominator);
   }
 
@@ -165,10 +130,7 @@ library FractionUtil {
    * @param y A Fraction struct.
    * @return x >= y
    */
-  function isGreaterThanOrEqualTo(
-    Fraction memory x,
-    Fraction memory y
-  )
+  function isGreaterThanOrEqualTo(Fraction memory x, Fraction memory y)
     internal
     pure
     returns (bool)
@@ -182,14 +144,7 @@ library FractionUtil {
    * @param y A Fraction struct.
    * @return x < y
    */
-  function isLessThan(
-    Fraction memory x,
-    Fraction memory y
-  )
-    internal
-    pure
-    returns (bool)
-  {
+  function isLessThan(Fraction memory x, Fraction memory y) internal pure returns (bool) {
     return x.numerator.mul(y.denominator) < y.numerator.mul(x.denominator);
   }
 
@@ -199,14 +154,7 @@ library FractionUtil {
    * @param y A Fraction struct.
    * @return x <= y
    */
-  function isLessThanOrEqualTo(
-    Fraction memory x,
-    Fraction memory y
-  )
-    internal
-    pure
-    returns (bool)
-  {
+  function isLessThanOrEqualTo(Fraction memory x, Fraction memory y) internal pure returns (bool) {
     return x.numerator.mul(y.denominator) <= y.numerator.mul(x.denominator);
   }
 
@@ -217,11 +165,7 @@ library FractionUtil {
    * @param y A Fraction struct representing a rate higher than "x".
    * @return x <= z <= y
    */
-  function isBetween(
-    Fraction memory z,
-    Fraction memory x,
-    Fraction memory y
-  )
+  function isBetween(Fraction memory z, Fraction memory x, Fraction memory y)
     internal
     pure
     returns (bool)

--- a/packages/protocol/contracts/common/GasCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/GasCurrencyWhitelist.sol
@@ -1,17 +1,15 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
-import "./interfaces/IGasCurrencyWhitelist.sol";
+import './interfaces/IGasCurrencyWhitelist.sol';
 
-import "../common/Initializable.sol";
-
+import '../common/Initializable.sol';
 
 /**
  * @title Holds a whitelist of the ERC20+ tokens that can be used to pay for gas
  */
 contract GasCurrencyWhitelist is IGasCurrencyWhitelist, Ownable, Initializable {
-
   address[] public whitelist;
 
   function initialize() external initializer {

--- a/packages/protocol/contracts/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts/common/GasPriceMinimum.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "./Initializable.sol";
-import "./UsingRegistry.sol";
-import "./FixidityLib.sol";
-import "../stability/interfaces/ISortedOracles.sol";
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import './Initializable.sol';
+import './UsingRegistry.sol';
+import './FixidityLib.sol';
+import '../stability/interfaces/ISortedOracles.sol';
 
 /**
  * @title Stores and provides gas price minimum for various currencies.
@@ -14,17 +14,11 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
   using FixidityLib for FixidityLib.Fraction;
   using SafeMath for uint256;
 
-  event TargetDensitySet(
-    uint256 targetDensity
-  );
+  event TargetDensitySet(uint256 targetDensity);
 
-  event AdjustmentSpeedSet(
-    uint256 adjustmentSpeed
-  );
+  event AdjustmentSpeedSet(uint256 adjustmentSpeed);
 
-  event ProposerFractionSet(
-    uint256 proposerFraction
-  );
+  event ProposerFractionSet(uint256 proposerFraction);
 
   uint256 public gasPriceMinimum;
 
@@ -52,10 +46,7 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
     uint256 _targetDensity,
     uint256 _adjustmentSpeed,
     uint256 _proposerFraction
-  )
-    external
-    initializer
-  {
+  ) external initializer {
     _transferOwnership(msg.sender);
     setRegistry(_registryAddress);
     gasPriceMinimum = initialGas;
@@ -107,7 +98,6 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
     ) {
       return gasPriceMinimum;
     } else {
-
       ISortedOracles sortedOracles = ISortedOracles(
         registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID)
       );
@@ -125,10 +115,7 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
    * @param blockGasLimit The maxBlockGasLimit of the past block.
    * @return result of the calculation (new gas price minimum)
    */
-  function updateGasPriceMinimum(
-    uint256 blockGasTotal,
-    uint256 blockGasLimit
-  )
+  function updateGasPriceMinimum(uint256 blockGasTotal, uint256 blockGasLimit)
     external
     onlyVm
     returns (uint256)
@@ -146,28 +133,27 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
    * @dev Calculate using the following formula:
    * oldGasPriceMinimum * (1 + (adjustmentSpeed * (blockDensity - targetDensity))) + 1.
    */
-  function getUpdatedGasPriceMinimum(
-    uint256 blockGasTotal,
-    uint256 blockGasLimit
-  )
+  function getUpdatedGasPriceMinimum(uint256 blockGasTotal, uint256 blockGasLimit)
     public
     view
     returns (uint256)
   {
     FixidityLib.Fraction memory blockDensity = FixidityLib.newFixedFraction(
-      blockGasTotal, blockGasLimit
+      blockGasTotal,
+      blockGasLimit
     );
     bool densityGreaterThanTarget = blockDensity.gt(targetDensity);
-    FixidityLib.Fraction memory densityDelta = densityGreaterThanTarget ?
-      blockDensity.subtract(targetDensity) :
-      targetDensity.subtract(blockDensity);
-    FixidityLib.Fraction memory adjustment = densityGreaterThanTarget ?
-      FixidityLib.fixed1().add(adjustmentSpeed.multiply(densityDelta)) :
-      FixidityLib.fixed1().subtract(adjustmentSpeed.multiply(densityDelta));
+    FixidityLib.Fraction memory densityDelta = densityGreaterThanTarget
+      ? blockDensity.subtract(targetDensity)
+      : targetDensity.subtract(blockDensity);
+    FixidityLib.Fraction memory adjustment = densityGreaterThanTarget
+      ? FixidityLib.fixed1().add(adjustmentSpeed.multiply(densityDelta))
+      : FixidityLib.fixed1().subtract(adjustmentSpeed.multiply(densityDelta));
 
-    return adjustment
-      .multiply(FixidityLib.newFixed(gasPriceMinimum))
-      .add(FixidityLib.fixed1())
-      .fromFixed();
+    return
+      adjustment
+        .multiply(FixidityLib.newFixed(gasPriceMinimum))
+        .add(FixidityLib.fixed1())
+        .fromFixed();
   }
 }

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -1,49 +1,37 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
-import "./Initializable.sol";
-import "./interfaces/IERC20Token.sol";
-import "./interfaces/ICeloToken.sol";
-
+import './Initializable.sol';
+import './interfaces/IERC20Token.sol';
+import './interfaces/ICeloToken.sol';
 
 contract GoldToken is Initializable, IERC20Token, ICeloToken {
-
   using SafeMath for uint256;
 
   // Address of the TRANSFER precompiled contract.
   // solhint-disable state-visibility
   address constant TRANSFER = address(0xfd);
-  string constant NAME = "Celo Gold";
-  string constant SYMBOL = "cGLD";
+  string constant NAME = 'Celo Gold';
+  string constant SYMBOL = 'cGLD';
   uint8 constant DECIMALS = 18;
   uint256 internal totalSupply_;
   // solhint-enable state-visibility
 
-  mapping (address => mapping (address => uint256)) internal allowed;
+  mapping(address => mapping(address => uint256)) internal allowed;
 
-  event Transfer(
-    address indexed from,
-    address indexed to,
-    uint256 value
-  );
+  event Transfer(address indexed from, address indexed to, uint256 value);
 
-  event TransferComment(
-    string comment
-  );
+  event TransferComment(string comment);
 
-  event Approval(
-    address indexed owner,
-    address indexed spender,
-    uint256 value
-  );
+  event Approval(address indexed owner, address indexed spender, uint256 value);
 
   /**
    * Only VM would be able to set the caller address to 0x0 unless someone
    * really has the private key for 0x0
    */
   modifier onlyVm() {
-    require(msg.sender == address(0), "sender was not vm (reserved 0x0 addr)");
+    require(msg.sender == address(0), 'sender was not vm (reserved 0x0 addr)');
     _;
   }
 
@@ -73,11 +61,7 @@ contract GoldToken is Initializable, IERC20Token, ICeloToken {
    * @param comment The transfer comment
    * @return True if the transaction succeeds.
    */
-  function transferWithComment(
-    address to,
-    uint256 value,
-    string calldata comment
-  )
+  function transferWithComment(address to, uint256 value, string calldata comment)
     external
     returns (bool)
   {
@@ -104,10 +88,7 @@ contract GoldToken is Initializable, IERC20Token, ICeloToken {
    * @param value The increment of the amount of Celo Gold approved to the spender.
    * @return True if the transaction succeeds.
    */
-  function increaseAllowance(address spender, uint256 value)
-    external
-    returns (bool)
-  {
+  function increaseAllowance(address spender, uint256 value) external returns (bool) {
     uint256 oldValue = allowed[msg.sender][spender];
     uint256 newValue = oldValue.add(value);
     allowed[msg.sender][spender] = newValue;
@@ -121,13 +102,7 @@ contract GoldToken is Initializable, IERC20Token, ICeloToken {
    * @param value The decrement of the amount of Celo Gold approved to the spender.
    * @return True if the transaction succeeds.
    */
-  function decreaseAllowance(
-    address spender,
-    uint256 value
-  )
-    external
-    returns (bool)
-  {
+  function decreaseAllowance(address spender, uint256 value) external returns (bool) {
     uint256 oldValue = allowed[msg.sender][spender];
     uint256 newValue = oldValue.sub(value);
     allowed[msg.sender][spender] = newValue;
@@ -143,16 +118,16 @@ contract GoldToken is Initializable, IERC20Token, ICeloToken {
    * @return True if the transaction succeeds.
    */
   function transferFrom(address from, address to, uint256 value) external returns (bool) {
-    require(to != address(0), "transfer attempted to reserved address 0x0");
-    require(value <= balanceOf(from), "transfer value exceeded balance of sender");
+    require(to != address(0), 'transfer attempted to reserved address 0x0');
+    require(value <= balanceOf(from), 'transfer value exceeded balance of sender');
     require(
       value <= allowed[from][msg.sender],
       "transfer value exceeded sender's allowance for recipient"
     );
 
     bool success;
-    (success,) = TRANSFER.call.value(0).gas(gasleft())(abi.encode(from, to, value));
-    require(success, "Celo Gold transfer failed");
+    (success, ) = TRANSFER.call.value(0).gas(gasleft())(abi.encode(from, to, value));
+    require(success, 'Celo Gold transfer failed');
 
     allowed[from][msg.sender] = allowed[from][msg.sender].sub(value);
     emit Transfer(from, to, value);
@@ -221,13 +196,12 @@ contract GoldToken is Initializable, IERC20Token, ICeloToken {
    * @return True if the transaction succeeds.
    */
   function _transfer(address to, uint256 value) internal returns (bool) {
-    require(to != address(0), "transfer attempted to reserved address 0x0");
-    require(value <= balanceOf(msg.sender), "transfer value exceeded balance of sender");
-
+    require(to != address(0), 'transfer attempted to reserved address 0x0');
+    require(value <= balanceOf(msg.sender), 'transfer value exceeded balance of sender');
 
     bool success;
-    (success,) = TRANSFER.call.value(0).gas(gasleft())(abi.encode(msg.sender, to, value));
-    require(success, "Celo Gold transfer failed");
+    (success, ) = TRANSFER.call.value(0).gas(gasleft())(abi.encode(msg.sender, to, value));
+    require(success, 'Celo Gold transfer failed');
     emit Transfer(msg.sender, to, value);
     return true;
   }

--- a/packages/protocol/contracts/common/Initializable.sol
+++ b/packages/protocol/contracts/common/Initializable.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 contract Initializable {
   bool public initialized;
 

--- a/packages/protocol/contracts/common/MultiSig.sol
+++ b/packages/protocol/contracts/common/MultiSig.sol
@@ -1,46 +1,44 @@
 pragma solidity ^0.5.3;
 /* solhint-disable no-inline-assembly, avoid-low-level-calls, func-name-mixedcase, func-order */
 
-import "./Initializable.sol";
-import "./libraries/AddressesHelper.sol";
-
+import './Initializable.sol';
+import './libraries/AddressesHelper.sol';
 
 /// @title Multisignature wallet - Allows multiple parties to agree on transactions before
 /// execution.
 /// @author Stefan George - <stefan.george@consensys.net>
 contract MultiSig is Initializable {
-
   /*
    *  Events
    */
-  event Confirmation(address indexed sender, uint indexed transactionId);
-  event Revocation(address indexed sender, uint indexed transactionId);
-  event Submission(uint indexed transactionId);
-  event Execution(uint indexed transactionId);
-  event ExecutionFailure(uint indexed transactionId);
-  event Deposit(address indexed sender, uint value);
+  event Confirmation(address indexed sender, uint256 indexed transactionId);
+  event Revocation(address indexed sender, uint256 indexed transactionId);
+  event Submission(uint256 indexed transactionId);
+  event Execution(uint256 indexed transactionId);
+  event ExecutionFailure(uint256 indexed transactionId);
+  event Deposit(address indexed sender, uint256 value);
   event OwnerAddition(address indexed owner);
   event OwnerRemoval(address indexed owner);
-  event RequirementChange(uint required);
+  event RequirementChange(uint256 required);
 
   /*
    *  Constants
    */
-  uint constant public MAX_OWNER_COUNT = 50;
+  uint256 public constant MAX_OWNER_COUNT = 50;
 
   /*
    *  Storage
    */
-  mapping (uint => Transaction) public transactions;
-  mapping (uint => mapping (address => bool)) public confirmations;
-  mapping (address => bool) public isOwner;
+  mapping(uint256 => Transaction) public transactions;
+  mapping(uint256 => mapping(address => bool)) public confirmations;
+  mapping(address => bool) public isOwner;
   address[] public owners;
-  uint public required;
-  uint public transactionCount;
+  uint256 public required;
+  uint256 public transactionCount;
 
   struct Transaction {
     address destination;
-    uint value;
+    uint256 value;
     bytes data;
     bool executed;
   }
@@ -49,57 +47,55 @@ contract MultiSig is Initializable {
    *  Modifiers
    */
   modifier onlyWallet() {
-    require(msg.sender == address(this), "msg.sender was not multisig wallet");
+    require(msg.sender == address(this), 'msg.sender was not multisig wallet');
     _;
   }
 
   modifier ownerDoesNotExist(address owner) {
-    require(!isOwner[owner], "owner already existed");
+    require(!isOwner[owner], 'owner already existed');
     _;
   }
 
   modifier ownerExists(address owner) {
-    require(isOwner[owner], "owner does not exist");
+    require(isOwner[owner], 'owner does not exist');
     _;
   }
 
-  modifier transactionExists(uint transactionId) {
-    require(transactions[transactionId].destination != address(0), "transaction does not exist");
+  modifier transactionExists(uint256 transactionId) {
+    require(transactions[transactionId].destination != address(0), 'transaction does not exist');
     _;
   }
 
-  modifier confirmed(uint transactionId, address owner) {
-    require(confirmations[transactionId][owner], "transaction was not confirmed for owner");
+  modifier confirmed(uint256 transactionId, address owner) {
+    require(confirmations[transactionId][owner], 'transaction was not confirmed for owner');
     _;
   }
 
-  modifier notConfirmed(uint transactionId, address owner) {
-    require(!confirmations[transactionId][owner], "transaction was already confirmed for owner");
+  modifier notConfirmed(uint256 transactionId, address owner) {
+    require(!confirmations[transactionId][owner], 'transaction was already confirmed for owner');
     _;
   }
 
-  modifier notExecuted(uint transactionId) {
-    require(!transactions[transactionId].executed, "transaction was executed already");
+  modifier notExecuted(uint256 transactionId) {
+    require(!transactions[transactionId].executed, 'transaction was executed already');
     _;
   }
 
   modifier notNull(address _address) {
-    require(_address != address(0), "address was null");
+    require(_address != address(0), 'address was null');
     _;
   }
 
-  modifier validRequirement(uint ownerCount, uint _required) {
-    require(ownerCount <= MAX_OWNER_COUNT
-      && _required <= ownerCount
-      && _required != 0
-      && ownerCount != 0);
+  modifier validRequirement(uint256 ownerCount, uint256 _required) {
+    require(
+      ownerCount <= MAX_OWNER_COUNT && _required <= ownerCount && _required != 0 && ownerCount != 0
+    );
     _;
   }
 
   /// @dev Fallback function allows to deposit ether.
   function() external payable {
-    if (msg.value > 0)
-      emit Deposit(msg.sender, msg.value);
+    if (msg.value > 0) emit Deposit(msg.sender, msg.value);
   }
 
   /*
@@ -108,18 +104,15 @@ contract MultiSig is Initializable {
   /// @dev Contract constructor sets initial owners and required number of confirmations.
   /// @param _owners List of initial owners.
   /// @param _required Number of required confirmations.
-  function initialize(
-    address[] calldata _owners,
-    uint256 _required
-  )
+  function initialize(address[] calldata _owners, uint256 _required)
     external
     initializer
     validRequirement(_owners.length, _required)
   {
-    for (uint256 i=0; i < _owners.length; i++) {
+    for (uint256 i = 0; i < _owners.length; i++) {
       require(
         !isOwner[_owners[i]] && _owners[i] != address(0),
-        "owner was null or already given owner status"
+        'owner was null or already given owner status'
       );
       isOwner[_owners[i]] = true;
     }
@@ -143,20 +136,15 @@ contract MultiSig is Initializable {
 
   /// @dev Allows to remove an owner. Transaction has to be sent by wallet.
   /// @param owner Address of owner.
-  function removeOwner(address owner)
-    external
-    onlyWallet
-    ownerExists(owner)
-  {
+  function removeOwner(address owner) external onlyWallet ownerExists(owner) {
     isOwner[owner] = false;
-    for (uint i=0; i < owners.length - 1; i++)
+    for (uint256 i = 0; i < owners.length - 1; i++)
       if (owners[i] == owner) {
         owners[i] = owners[owners.length - 1];
         break;
       }
     owners.length -= 1;
-    if (required > owners.length)
-      changeRequirement(owners.length);
+    if (required > owners.length) changeRequirement(owners.length);
     emit OwnerRemoval(owner);
   }
 
@@ -169,7 +157,7 @@ contract MultiSig is Initializable {
     ownerExists(owner)
     ownerDoesNotExist(newOwner)
   {
-    for (uint i=0; i < owners.length - 1; i++)
+    for (uint256 i = 0; i < owners.length - 1; i++)
       if (owners[i] == owner) {
         owners[i] = newOwner;
         break;
@@ -183,7 +171,7 @@ contract MultiSig is Initializable {
   /// @dev Allows to change the number of required confirmations. Transaction has to be sent by
   /// wallet.
   /// @param _required Number of required confirmations.
-  function changeRequirement(uint _required)
+  function changeRequirement(uint256 _required)
     public
     onlyWallet
     validRequirement(owners.length, _required)
@@ -197,9 +185,9 @@ contract MultiSig is Initializable {
   /// @param value Transaction ether value.
   /// @param data Transaction data payload.
   /// @return Returns transaction ID.
-  function submitTransaction(address destination, uint value, bytes calldata data)
+  function submitTransaction(address destination, uint256 value, bytes calldata data)
     external
-    returns (uint transactionId)
+    returns (uint256 transactionId)
   {
     transactionId = addTransaction(destination, value, data);
     confirmTransaction(transactionId);
@@ -207,7 +195,7 @@ contract MultiSig is Initializable {
 
   /// @dev Allows an owner to confirm a transaction.
   /// @param transactionId Transaction ID.
-  function confirmTransaction(uint transactionId)
+  function confirmTransaction(uint256 transactionId)
     public
     ownerExists(msg.sender)
     transactionExists(transactionId)
@@ -220,7 +208,7 @@ contract MultiSig is Initializable {
 
   /// @dev Allows an owner to revoke a confirmation for a transaction.
   /// @param transactionId Transaction ID.
-  function revokeConfirmation(uint transactionId)
+  function revokeConfirmation(uint256 transactionId)
     external
     ownerExists(msg.sender)
     confirmed(transactionId, msg.sender)
@@ -232,7 +220,7 @@ contract MultiSig is Initializable {
 
   /// @dev Allows anyone to execute a confirmed transaction.
   /// @param transactionId Transaction ID.
-  function executeTransaction(uint transactionId)
+  function executeTransaction(uint256 transactionId)
     public
     ownerExists(msg.sender)
     confirmed(transactionId, msg.sender)
@@ -252,34 +240,29 @@ contract MultiSig is Initializable {
 
   // call has been separated into its own function in order to take advantage
   // of the Solidity's code generator to produce a loop that copies tx.data into memory.
-  function external_call(
-    address destination,
-    uint value,
-    uint dataLength,
-    bytes memory data
-  )
+  function external_call(address destination, uint256 value, uint256 dataLength, bytes memory data)
     private
     returns (bool)
   {
     bool result;
 
     if (dataLength > 0)
-      require(AddressesHelper.isContract(destination), "Invalid contract address");
+      require(AddressesHelper.isContract(destination), 'Invalid contract address');
 
     /* solhint-disable max-line-length */
     assembly {
-      let x := mload(0x40)   // "Allocate" memory for output (0x40 is where "free memory" pointer is stored by convention)
+      let x := mload(0x40) // "Allocate" memory for output (0x40 is where "free memory" pointer is stored by convention)
       let d := add(data, 32) // First 32 bytes are the padded length of data, so exclude that
       result := call(
-        sub(gas, 34710),   // 34710 is the value that solidity is currently emitting
-                           // It includes callGas (700) + callVeryLow (3, to pay for SUB) + callValueTransferGas (9000) +
-                           // callNewAccountGas (25000, in case the destination address does not exist and needs creating)
+        sub(gas, 34710), // 34710 is the value that solidity is currently emitting
+        // It includes callGas (700) + callVeryLow (3, to pay for SUB) + callValueTransferGas (9000) +
+        // callNewAccountGas (25000, in case the destination address does not exist and needs creating)
         destination,
         value,
         d,
-        dataLength,        // Size of the input (in bytes) - this is what fixes the padding problem
+        dataLength, // Size of the input (in bytes) - this is what fixes the padding problem
         x,
-        0                  // Output is ignored, therefore the output size is zero
+        0 // Output is ignored, therefore the output size is zero
       )
     }
     /* solhint-enable max-line-length */
@@ -289,17 +272,11 @@ contract MultiSig is Initializable {
   /// @dev Returns the confirmation status of a transaction.
   /// @param transactionId Transaction ID.
   /// @return Confirmation status.
-  function isConfirmed(uint transactionId)
-    public
-    view
-    returns (bool)
-  {
-    uint count = 0;
-    for (uint i = 0; i < owners.length; i++) {
-      if (confirmations[transactionId][owners[i]])
-        count += 1;
-      if (count == required)
-        return true;
+  function isConfirmed(uint256 transactionId) public view returns (bool) {
+    uint256 count = 0;
+    for (uint256 i = 0; i < owners.length; i++) {
+      if (confirmations[transactionId][owners[i]]) count += 1;
+      if (count == required) return true;
     }
   }
 
@@ -311,10 +288,10 @@ contract MultiSig is Initializable {
   /// @param value Transaction ether value.
   /// @param data Transaction data payload.
   /// @return Returns transaction ID.
-  function addTransaction(address destination, uint value, bytes memory data)
+  function addTransaction(address destination, uint256 value, bytes memory data)
     internal
     notNull(destination)
-    returns (uint transactionId)
+    returns (uint256 transactionId)
   {
     transactionId = transactionCount;
     transactions[transactionId] = Transaction({
@@ -333,60 +310,45 @@ contract MultiSig is Initializable {
   /// @dev Returns number of confirmations of a transaction.
   /// @param transactionId Transaction ID.
   /// @return Number of confirmations.
-  function getConfirmationCount(uint transactionId)
-    external
-    view
-    returns (uint count)
-  {
-    for (uint i = 0; i < owners.length; i++)
-      if (confirmations[transactionId][owners[i]])
-        count += 1;
+  function getConfirmationCount(uint256 transactionId) external view returns (uint256 count) {
+    for (uint256 i = 0; i < owners.length; i++)
+      if (confirmations[transactionId][owners[i]]) count += 1;
   }
 
   /// @dev Returns total number of transactions after filers are applied.
   /// @param pending Include pending transactions.
   /// @param executed Include executed transactions.
   /// @return Total number of transactions after filters are applied.
-  function getTransactionCount(bool pending, bool executed)
-    external
-    view
-    returns (uint count)
-  {
-    for (uint i = 0; i < transactionCount; i++)
-      if (pending && !transactions[i].executed
-        || executed && transactions[i].executed)
+  function getTransactionCount(bool pending, bool executed) external view returns (uint256 count) {
+    for (uint256 i = 0; i < transactionCount; i++)
+      if ((pending && !transactions[i].executed) || (executed && transactions[i].executed))
         count += 1;
   }
 
   /// @dev Returns list of owners.
   /// @return List of owner addresses.
-  function getOwners()
-    external
-    view
-    returns (address[] memory)
-  {
+  function getOwners() external view returns (address[] memory) {
     return owners;
   }
 
   /// @dev Returns array with owner addresses, which confirmed transaction.
   /// @param transactionId Transaction ID.
   /// @return Returns array of owner addresses.
-  function getConfirmations(uint transactionId)
+  function getConfirmations(uint256 transactionId)
     external
     view
     returns (address[] memory _confirmations)
   {
     address[] memory confirmationsTemp = new address[](owners.length);
-    uint count = 0;
-    uint i;
+    uint256 count = 0;
+    uint256 i;
     for (i = 0; i < owners.length; i++)
       if (confirmations[transactionId][owners[i]]) {
         confirmationsTemp[count] = owners[i];
         count += 1;
       }
     _confirmations = new address[](count);
-    for (i = 0; i < count; i++)
-      _confirmations[i] = confirmationsTemp[i];
+    for (i = 0; i < count; i++) _confirmations[i] = confirmationsTemp[i];
   }
 
   /// @dev Returns list of transaction IDs in defined range.
@@ -395,21 +357,20 @@ contract MultiSig is Initializable {
   /// @param pending Include pending transactions.
   /// @param executed Include executed transactions.
   /// @return Returns array of transaction IDs.
-  function getTransactionIds(uint from, uint to, bool pending, bool executed)
+  function getTransactionIds(uint256 from, uint256 to, bool pending, bool executed)
     external
     view
-    returns (uint[] memory _transactionIds)
+    returns (uint256[] memory _transactionIds)
   {
-    uint[] memory transactionIdsTemp = new uint[](transactionCount);
-    uint count = 0;
-    uint i;
+    uint256[] memory transactionIdsTemp = new uint256[](transactionCount);
+    uint256 count = 0;
+    uint256 i;
     for (i = 0; i < transactionCount; i++)
-      if (pending && !transactions[i].executed || executed && transactions[i].executed) {
+      if ((pending && !transactions[i].executed) || (executed && transactions[i].executed)) {
         transactionIdsTemp[count] = i;
         count += 1;
       }
-    _transactionIds = new uint[](to - from);
-    for (i = from; i < to; i++)
-      _transactionIds[i - from] = transactionIdsTemp[i];
+    _transactionIds = new uint256[](to - from);
+    for (i = from; i < to; i++) _transactionIds[i - from] = transactionIdsTemp[i];
   }
 }

--- a/packages/protocol/contracts/common/Proxy.sol
+++ b/packages/protocol/contracts/common/Proxy.sol
@@ -1,16 +1,16 @@
 pragma solidity ^0.5.3;
 /* solhint-disable no-inline-assembly, no-complex-fallback, avoid-low-level-calls */
 
-import "./libraries/AddressesHelper.sol";
+import './libraries/AddressesHelper.sol';
 
 /**
  * @title A Proxy utilizing the Unstructured Storage pattern.
  */
 contract Proxy {
   // Used to store the address of the owner.
-  bytes32 constant private OWNER_POSITION = keccak256("org.celo.owner");
+  bytes32 private constant OWNER_POSITION = keccak256('org.celo.owner');
   // Used to store the address of the implementation contract.
-  bytes32 constant private IMPLEMENTATION_POSITION = keccak256("org.celo.implementation");
+  bytes32 private constant IMPLEMENTATION_POSITION = keccak256('org.celo.implementation');
 
   event OwnerSet(address indexed owner);
   event ImplementationSet(address indexed implementation);
@@ -23,14 +23,14 @@ contract Proxy {
    * @notice Throws if called by any account other than the owner.
    */
   modifier onlyOwner() {
-    require(msg.sender == _getOwner(), "sender was not owner");
+    require(msg.sender == _getOwner(), 'sender was not owner');
     _;
   }
 
   /**
    * @notice Delegates calls to the implementation contract.
    */
-  function () external payable {
+  function() external payable {
     bytes32 implementationPosition = IMPLEMENTATION_POSITION;
 
     address implementationAddress;
@@ -39,11 +39,11 @@ contract Proxy {
       implementationAddress := sload(implementationPosition)
     }
 
-    // Avoid checking if address is a contract or executing delegated call when 
+    // Avoid checking if address is a contract or executing delegated call when
     // implementation address is 0x0
     if (implementationAddress == address(0)) return;
-    
-    require(AddressesHelper.isContract(implementationAddress), "Invalid contract address");
+
+    require(AddressesHelper.isContract(implementationAddress), 'Invalid contract address');
 
     assembly {
       let newCallDataPosition := mload(0x40)
@@ -66,12 +66,12 @@ contract Proxy {
       returndatacopy(returnDataPosition, 0, returnDataSize)
 
       switch delegatecallSuccess
-      case 0 {
-        revert(returnDataPosition, returnDataSize)
-      }
-      default {
-        return(returnDataPosition, returnDataSize)
-      }
+        case 0 {
+          revert(returnDataPosition, returnDataSize)
+        }
+        default {
+          return(returnDataPosition, returnDataSize)
+        }
     }
   }
 
@@ -92,10 +92,7 @@ contract Proxy {
    * @dev If the target contract does not need initialization, use
    * setImplementation instead.
    */
-  function _setAndInitializeImplementation(
-    address implementation,
-    bytes calldata callbackData
-  )
+  function _setAndInitializeImplementation(address implementation, bytes calldata callbackData)
     external
     payable
     onlyOwner
@@ -104,7 +101,7 @@ contract Proxy {
     bool success;
     bytes memory returnValue;
     (success, returnValue) = implementation.delegatecall(callbackData);
-    require(success, "initialization callback failed");
+    require(success, 'initialization callback failed');
   }
 
   /**
@@ -126,7 +123,7 @@ contract Proxy {
   function _setImplementation(address implementation) public onlyOwner {
     bytes32 implementationPosition = IMPLEMENTATION_POSITION;
 
-    require(AddressesHelper.isContract(implementation), "Invalid contract address");
+    require(AddressesHelper.isContract(implementation), 'Invalid contract address');
 
     assembly {
       sstore(implementationPosition, implementation)

--- a/packages/protocol/contracts/common/Registry.sol
+++ b/packages/protocol/contracts/common/Registry.sol
@@ -1,23 +1,17 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
-import "./interfaces/IRegistry.sol";
-import "./Initializable.sol";
-
+import './interfaces/IRegistry.sol';
+import './Initializable.sol';
 
 /**
  * @title Routes identifiers to addresses.
  */
 contract Registry is IRegistry, Ownable, Initializable {
+  mapping(bytes32 => address) public registry;
 
-  mapping (bytes32 => address) public registry;
-
-  event RegistryUpdated(
-    string identifier,
-    bytes32 indexed identifierHash,
-    address addr
-  );
+  event RegistryUpdated(string identifier, bytes32 indexed identifierHash, address addr);
 
   function initialize() external initializer {
     _transferOwnership(msg.sender);
@@ -40,7 +34,7 @@ contract Registry is IRegistry, Ownable, Initializable {
    * @dev Throws if address not set.
    */
   function getAddressForOrDie(bytes32 identifierHash) external view returns (address) {
-    require(registry[identifierHash] != address(0), "identifier has no registry entry");
+    require(registry[identifierHash] != address(0), 'identifier has no registry entry');
     return registry[identifierHash];
   }
 
@@ -59,7 +53,7 @@ contract Registry is IRegistry, Ownable, Initializable {
    */
   function getAddressForStringOrDie(string calldata identifier) external view returns (address) {
     bytes32 identifierHash = keccak256(abi.encodePacked(identifier));
-    require(registry[identifierHash] != address(0), "identifier has no registry entry");
+    require(registry[identifierHash] != address(0), 'identifier has no registry entry');
     return registry[identifierHash];
   }
 

--- a/packages/protocol/contracts/common/SafeCast.sol
+++ b/packages/protocol/contracts/common/SafeCast.sol
@@ -15,7 +15,6 @@ pragma solidity ^0.5.0;
  * class of bugs, so it's recommended to use it always.
  */
 library SafeCast {
-
   /**
     * @dev Returns the downcasted uint128 from uint256, reverting on
     * overflow (when the input is greater than largest uint128).
@@ -26,7 +25,7 @@ library SafeCast {
     * - input must fit into 128 bits
     */
   function toUint128(uint256 value) internal pure returns (uint128) {
-    require(value < 2**128, "SafeCast: value doesn\'t fit in 128 bits");
+    require(value < 2**128, "SafeCast: value doesn't fit in 128 bits");
     return uint128(value);
   }
 
@@ -40,7 +39,7 @@ library SafeCast {
     * - input must fit into 64 bits
     */
   function toUint64(uint256 value) internal pure returns (uint64) {
-    require(value < 2**64, "SafeCast: value doesn\'t fit in 64 bits");
+    require(value < 2**64, "SafeCast: value doesn't fit in 64 bits");
     return uint64(value);
   }
 
@@ -54,7 +53,7 @@ library SafeCast {
     * - input must fit into 32 bits
     */
   function toUint32(uint256 value) internal pure returns (uint32) {
-    require(value < 2**32, "SafeCast: value doesn\'t fit in 32 bits");
+    require(value < 2**32, "SafeCast: value doesn't fit in 32 bits");
     return uint32(value);
   }
 
@@ -68,7 +67,7 @@ library SafeCast {
     * - input must fit into 16 bits
     */
   function toUint16(uint256 value) internal pure returns (uint16) {
-    require(value < 2**16, "SafeCast: value doesn\'t fit in 16 bits");
+    require(value < 2**16, "SafeCast: value doesn't fit in 16 bits");
     return uint16(value);
   }
 
@@ -82,7 +81,7 @@ library SafeCast {
     * - input must fit into 8 bits.
     */
   function toUint8(uint256 value) internal pure returns (uint8) {
-    require(value < 2**8, "SafeCast: value doesn\'t fit in 8 bits");
+    require(value < 2**8, "SafeCast: value doesn't fit in 8 bits");
     return uint8(value);
   }
 }

--- a/packages/protocol/contracts/common/SafeCastTest.sol
+++ b/packages/protocol/contracts/common/SafeCastTest.sol
@@ -1,30 +1,29 @@
-
 pragma solidity ^0.5.0;
 // TODO: Remove this and use upstream when
 // https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1926/files gets merged
 
-import "./SafeCast.sol";
+import './SafeCast.sol';
 
 contract SafeCastTest {
-  using SafeCast for uint;
+  using SafeCast for uint256;
 
-  function toUint128(uint a) public pure returns (uint128) {
+  function toUint128(uint256 a) public pure returns (uint128) {
     return a.toUint128();
   }
 
-  function toUint64(uint a) public pure returns (uint64) {
+  function toUint64(uint256 a) public pure returns (uint64) {
     return a.toUint64();
   }
 
-  function toUint32(uint a) public pure returns (uint32) {
+  function toUint32(uint256 a) public pure returns (uint32) {
     return a.toUint32();
   }
 
-  function toUint16(uint a) public pure returns (uint16) {
+  function toUint16(uint256 a) public pure returns (uint16) {
     return a.toUint16();
   }
 
-  function toUint8(uint a) public pure returns (uint8) {
+  function toUint8(uint256 a) public pure returns (uint8) {
     return a.toUint8();
   }
 }

--- a/packages/protocol/contracts/common/Signatures.sol
+++ b/packages/protocol/contracts/common/Signatures.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 library Signatures {
   /**
   * @notice Given a signed address, returns the signer of the address.
@@ -9,12 +8,7 @@ library Signatures {
   * @param r Output value r of the ECDSA signature.
   * @param s Output value s of the ECDSA signature.
   */
-  function getSignerOfAddress(
-    address message,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  )
+  function getSignerOfAddress(address message, uint8 v, bytes32 r, bytes32 s)
     public
     pure
     returns (address)
@@ -30,17 +24,12 @@ library Signatures {
   * @param r Output value r of the ECDSA signature.
   * @param s Output value s of the ECDSA signature.
   */
-  function getSignerOfMessageHash(
-    bytes32 messageHash,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  )
+  function getSignerOfMessageHash(bytes32 messageHash, uint8 v, bytes32 r, bytes32 s)
     public
     pure
     returns (address)
   {
-    bytes memory prefix = "\x19Ethereum Signed Message:\n32";
+    bytes memory prefix = '\x19Ethereum Signed Message:\n32';
     bytes32 prefixedHash = keccak256(abi.encodePacked(prefix, messageHash));
     return ecrecover(prefixedHash, v, r, s);
   }

--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -21,11 +21,7 @@ contract UsingPrecompiles {
     uint256 bDenominator,
     uint256 exponent,
     uint256 _decimals
-  )
-    public
-    view
-    returns (uint256, uint256)
-  {
+  ) public view returns (uint256, uint256) {
     require(aDenominator != 0 && bDenominator != 0);
     uint256 returnNumerator;
     uint256 returnDenominator;
@@ -40,10 +36,10 @@ contract UsingPrecompiles {
       mstore(add(newCallDataPosition, 128), exponent)
       mstore(add(newCallDataPosition, 160), _decimals)
       let success := staticcall(
-        1050,                 // estimated gas cost for this function
+        1050, // estimated gas cost for this function
         0xfc,
         newCallDataPosition,
-        0xc4,                 // input size, 6 * 32 = 192 bytes
+        0xc4, // input size, 6 * 32 = 192 bytes
         0,
         0
       )
@@ -54,13 +50,13 @@ contract UsingPrecompiles {
       returndatacopy(returnDataPosition, 0, returnDataSize)
 
       switch success
-      case 0 {
-        revert(returnDataPosition, returnDataSize)
-      }
-      default {
-        returnNumerator := mload(returnDataPosition)
-        returnDenominator := mload(add(returnDataPosition, 32))
-      }
+        case 0 {
+          revert(returnDataPosition, returnDataSize)
+        }
+        default {
+          returnNumerator := mload(returnDataPosition)
+          returnDenominator := mload(add(returnDataPosition, 32))
+        }
     }
     return (returnNumerator, returnDenominator);
   }
@@ -130,18 +126,14 @@ contract UsingPrecompiles {
    * @param proofOfPossessionBytes The public key and signature of the proof of possession.
    * @return True upon success.
    */
-  function checkProofOfPossession(
-    address sender,
-    bytes memory proofOfPossessionBytes
-  )
+  function checkProofOfPossession(address sender, bytes memory proofOfPossessionBytes)
     public
     returns (bool)
   {
     bool success;
-    (success, ) = PROOF_OF_POSSESSION
-      .call
-      .value(0)
-      .gas(gasleft())(abi.encodePacked(sender, proofOfPossessionBytes));
+    (success, ) = PROOF_OF_POSSESSION.call.value(0).gas(gasleft())(
+      abi.encodePacked(sender, proofOfPossessionBytes)
+    );
     return success;
   }
 }

--- a/packages/protocol/contracts/common/UsingRegistry.sol
+++ b/packages/protocol/contracts/common/UsingRegistry.sol
@@ -1,20 +1,19 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
-import "./interfaces/IERC20Token.sol";
-import "./interfaces/IRegistry.sol";
-import "./interfaces/IAccounts.sol";
+import './interfaces/IERC20Token.sol';
+import './interfaces/IRegistry.sol';
+import './interfaces/IAccounts.sol';
 
+import '../governance/interfaces/IElection.sol';
+import '../governance/interfaces/IGovernance.sol';
+import '../governance/interfaces/ILockedGold.sol';
+import '../governance/interfaces/IValidators.sol';
 
-import "../governance/interfaces/IElection.sol";
-import "../governance/interfaces/IGovernance.sol";
-import "../governance/interfaces/ILockedGold.sol";
-import "../governance/interfaces/IValidators.sol";
+import '../identity/interfaces/IRandom.sol';
 
-import "../identity/interfaces/IRandom.sol";
-
-import "../stability/interfaces/IStableToken.sol";
+import '../stability/interfaces/IStableToken.sol';
 
 // Ideally, UsingRegistry should inherit from Initializable and implement initialize() which calls
 // setRegistry(). TypeChain currently has problems resolving overloaded functions, so this is not
@@ -22,31 +21,30 @@ import "../stability/interfaces/IStableToken.sol";
 // TODO(amy): Fix this when the TypeChain issue resolves.
 
 contract UsingRegistry is Ownable {
-
   event RegistrySet(address indexed registryAddress);
 
   // solhint-disable state-visibility
-  bytes32 constant ACCOUNTS_REGISTRY_ID = keccak256(abi.encodePacked("Accounts"));
-  bytes32 constant ATTESTATIONS_REGISTRY_ID = keccak256(abi.encodePacked("Attestations"));
-  bytes32 constant ELECTION_REGISTRY_ID = keccak256(abi.encodePacked("Election"));
-  bytes32 constant EXCHANGE_REGISTRY_ID = keccak256(abi.encodePacked("Exchange"));
+  bytes32 constant ACCOUNTS_REGISTRY_ID = keccak256(abi.encodePacked('Accounts'));
+  bytes32 constant ATTESTATIONS_REGISTRY_ID = keccak256(abi.encodePacked('Attestations'));
+  bytes32 constant ELECTION_REGISTRY_ID = keccak256(abi.encodePacked('Election'));
+  bytes32 constant EXCHANGE_REGISTRY_ID = keccak256(abi.encodePacked('Exchange'));
   bytes32 constant GAS_CURRENCY_WHITELIST_REGISTRY_ID = keccak256(
-    abi.encodePacked("GasCurrencyWhitelist")
+    abi.encodePacked('GasCurrencyWhitelist')
   );
-  bytes32 constant GOLD_TOKEN_REGISTRY_ID = keccak256(abi.encodePacked("GoldToken"));
-  bytes32 constant GOVERNANCE_REGISTRY_ID = keccak256(abi.encodePacked("Governance"));
-  bytes32 constant LOCKED_GOLD_REGISTRY_ID = keccak256(abi.encodePacked("LockedGold"));
-  bytes32 constant RESERVE_REGISTRY_ID = keccak256(abi.encodePacked("Reserve"));
-  bytes32 constant RANDOM_REGISTRY_ID = keccak256(abi.encodePacked("Random"));
-  bytes32 constant SORTED_ORACLES_REGISTRY_ID = keccak256(abi.encodePacked("SortedOracles"));
-  bytes32 constant STABLE_TOKEN_REGISTRY_ID = keccak256(abi.encodePacked("StableToken"));
-  bytes32 constant VALIDATORS_REGISTRY_ID = keccak256(abi.encodePacked("Validators"));
+  bytes32 constant GOLD_TOKEN_REGISTRY_ID = keccak256(abi.encodePacked('GoldToken'));
+  bytes32 constant GOVERNANCE_REGISTRY_ID = keccak256(abi.encodePacked('Governance'));
+  bytes32 constant LOCKED_GOLD_REGISTRY_ID = keccak256(abi.encodePacked('LockedGold'));
+  bytes32 constant RESERVE_REGISTRY_ID = keccak256(abi.encodePacked('Reserve'));
+  bytes32 constant RANDOM_REGISTRY_ID = keccak256(abi.encodePacked('Random'));
+  bytes32 constant SORTED_ORACLES_REGISTRY_ID = keccak256(abi.encodePacked('SortedOracles'));
+  bytes32 constant STABLE_TOKEN_REGISTRY_ID = keccak256(abi.encodePacked('StableToken'));
+  bytes32 constant VALIDATORS_REGISTRY_ID = keccak256(abi.encodePacked('Validators'));
   // solhint-enable state-visibility
 
   IRegistry public registry;
 
   modifier onlyRegisteredContract(bytes32 identifierHash) {
-    require(registry.getAddressForOrDie(identifierHash) == msg.sender, "only registered contract");
+    require(registry.getAddressForOrDie(identifierHash) == msg.sender, 'only registered contract');
     _;
   }
 

--- a/packages/protocol/contracts/common/interfaces/IAccounts.sol
+++ b/packages/protocol/contracts/common/interfaces/IAccounts.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 interface IAccounts {
   function isAccount(address) external view returns (bool);
   function activeVoteSignerToAccount(address) external view returns (address);

--- a/packages/protocol/contracts/common/interfaces/ICeloToken.sol
+++ b/packages/protocol/contracts/common/interfaces/ICeloToken.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 /**
  * @title This interface describes the non- ERC20 shared interface for all Celo Tokens, and
  * in the absence of interface inheritance is intended as a companion to IERC20.sol.

--- a/packages/protocol/contracts/common/interfaces/IERC20Token.sol
+++ b/packages/protocol/contracts/common/interfaces/IERC20Token.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 /**
  * @title This interface describes the ERC20 functions shared by all Celo Tokens.
  */

--- a/packages/protocol/contracts/common/interfaces/IGasCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/interfaces/IGasCurrencyWhitelist.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-
 interface IGasCurrencyWhitelist {
-
   function initialize() external;
   function addToken(address) external;
   function getWhitelist() external view returns (address[] memory);

--- a/packages/protocol/contracts/common/interfaces/IRegistry.sol
+++ b/packages/protocol/contracts/common/interfaces/IRegistry.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-
 interface IRegistry {
-
   function initialize() external;
   function setAddressFor(string calldata, address) external;
   function getAddressForOrDie(bytes32) external view returns (address);

--- a/packages/protocol/contracts/common/interfaces/IValidators.sol
+++ b/packages/protocol/contracts/common/interfaces/IValidators.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-
 interface IValidators {
-
   function initialize() external;
   function addValidator(address) external;
   function removeValidator(address, uint256) external;

--- a/packages/protocol/contracts/common/libraries/AddressesHelper.sol
+++ b/packages/protocol/contracts/common/libraries/AddressesHelper.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.5.3;
  * @title Library with support functions to deal with addresses
  */
 library AddressesHelper {
-
   /**
    * @dev isContract detect whether the address is 
    *      a contract address or externally owned account (EOA)
@@ -15,7 +14,9 @@ library AddressesHelper {
   function isContract(address addr) internal view returns (bool) {
     uint256 size;
     /* solium-disable-next-line security/no-inline-assembly */
-    assembly { size := extcodesize(addr) }
+    assembly {
+      size := extcodesize(addr)
+    }
     return size > 0;
   }
 }

--- a/packages/protocol/contracts/common/linkedlists/AddressLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressLinkedList.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
-import "./LinkedList.sol";
+import './LinkedList.sol';
 
 /**
  * @title Maintains a doubly linked list keyed by address.
@@ -25,12 +25,7 @@ library AddressLinkedList {
    * @param previousKey The key of the element that comes before the element to insert.
    * @param nextKey The key of the element that comes after the element to insert.
    */
-  function insert(
-    LinkedList.List storage list,
-    address key,
-    address previousKey,
-    address nextKey
-  )
+  function insert(LinkedList.List storage list, address key, address previousKey, address nextKey)
     public
   {
     list.insert(toBytes(key), toBytes(previousKey), toBytes(nextKey));
@@ -58,12 +53,7 @@ library AddressLinkedList {
    * @param previousKey The key of the element that comes before the updated element.
    * @param nextKey The key of the element that comes after the updated element.
    */
-  function update(
-    LinkedList.List storage list,
-    address key,
-    address previousKey,
-    address nextKey
-  )
+  function update(LinkedList.List storage list, address key, address previousKey, address nextKey)
     public
   {
     list.update(toBytes(key), toBytes(previousKey), toBytes(nextKey));

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
@@ -1,16 +1,14 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/Math.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "./AddressLinkedList.sol";
-import "./SortedLinkedList.sol";
-
+import 'openzeppelin-solidity/contracts/math/Math.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import './AddressLinkedList.sol';
+import './SortedLinkedList.sol';
 
 /**
  * @title Maintains a sorted list of unsigned ints keyed by address.
  */
 library AddressSortedLinkedList {
-
   using SortedLinkedList for SortedLinkedList.List;
 
   function toBytes(address a) public pure returns (bytes32) {
@@ -34,9 +32,7 @@ library AddressSortedLinkedList {
     uint256 value,
     address lesserKey,
     address greaterKey
-  )
-    public
-  {
+  ) public {
     list.insert(toBytes(key), value, toBytes(lesserKey), toBytes(greaterKey));
   }
 
@@ -62,9 +58,7 @@ library AddressSortedLinkedList {
     uint256 value,
     address lesserKey,
     address greaterKey
-  )
-    public
-  {
+  ) public {
     list.update(toBytes(key), value, toBytes(lesserKey), toBytes(greaterKey));
   }
 
@@ -90,9 +84,7 @@ library AddressSortedLinkedList {
    * @notice Gets all elements from the doubly linked list.
    * @return An unpacked list of elements from largest to smallest.
    */
-  function getElements(
-    SortedLinkedList.List storage list
-  )
+  function getElements(SortedLinkedList.List storage list)
     public
     view
     returns (address[] memory, uint256[] memory)
@@ -117,11 +109,7 @@ library AddressSortedLinkedList {
     SortedLinkedList.List storage list,
     uint256 threshold,
     uint256 max
-  )
-    public
-    view
-    returns (uint256)
-  {
+  ) public view returns (uint256) {
     uint256 revisedMax = Math.min(max, list.list.numElements);
     bytes32 key = list.list.head;
     for (uint256 i = 0; i < revisedMax; i++) {
@@ -138,10 +126,7 @@ library AddressSortedLinkedList {
    * @param n The number of elements to return.
    * @return The keys of the greatest elements.
    */
-  function headN(
-    SortedLinkedList.List storage list,
-    uint256 n
-  )
+  function headN(SortedLinkedList.List storage list, uint256 n)
     public
     view
     returns (address[] memory)

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
@@ -1,15 +1,13 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "./AddressLinkedList.sol";
-import "./SortedLinkedListWithMedian.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import './AddressLinkedList.sol';
+import './SortedLinkedListWithMedian.sol';
 
 /**
  * @title Maintains a sorted list of unsigned ints keyed by address.
  */
 library AddressSortedLinkedListWithMedian {
-
   using SortedLinkedListWithMedian for SortedLinkedListWithMedian.List;
 
   function toBytes(address a) public pure returns (bytes32) {
@@ -33,9 +31,7 @@ library AddressSortedLinkedListWithMedian {
     uint256 value,
     address lesserKey,
     address greaterKey
-  )
-    public
-  {
+  ) public {
     list.insert(toBytes(key), value, toBytes(lesserKey), toBytes(greaterKey));
   }
 
@@ -61,9 +57,7 @@ library AddressSortedLinkedListWithMedian {
     uint256 value,
     address lesserKey,
     address greaterKey
-  )
-    public
-  {
+  ) public {
     list.update(toBytes(key), value, toBytes(lesserKey), toBytes(greaterKey));
   }
 
@@ -72,10 +66,7 @@ library AddressSortedLinkedListWithMedian {
    * @param key The element key.
    * @return Whether or not the key is in the sorted list.
    */
-  function contains(
-    SortedLinkedListWithMedian.List storage list,
-    address key
-  )
+  function contains(SortedLinkedListWithMedian.List storage list, address key)
     public
     view
     returns (bool)
@@ -88,10 +79,7 @@ library AddressSortedLinkedListWithMedian {
    * @param key The element key.
    * @return The element value.
    */
-  function getValue(
-    SortedLinkedListWithMedian.List storage list,
-    address key
-  )
+  function getValue(SortedLinkedListWithMedian.List storage list, address key)
     public
     view
     returns (uint256)
@@ -103,9 +91,7 @@ library AddressSortedLinkedListWithMedian {
    * @notice Returns the median value of the sorted list.
    * @return The median value.
    */
-  function getMedianValue(
-    SortedLinkedListWithMedian.List storage list
-  )
+  function getMedianValue(SortedLinkedListWithMedian.List storage list)
     public
     view
     returns (uint256)
@@ -141,9 +127,7 @@ library AddressSortedLinkedListWithMedian {
    * @notice Returns the number of elements in the list.
    * @return The number of elements in the list.
    */
-  function getNumElements(
-    SortedLinkedListWithMedian.List storage list
-  )
+  function getNumElements(SortedLinkedListWithMedian.List storage list)
     external
     view
     returns (uint256)
@@ -155,9 +139,7 @@ library AddressSortedLinkedListWithMedian {
    * @notice Gets all elements from the doubly linked list.
    * @return An unpacked list of elements from largest to smallest.
    */
-  function getElements(
-    SortedLinkedListWithMedian.List storage list
-  )
+  function getElements(SortedLinkedListWithMedian.List storage list)
     public
     view
     returns (address[] memory, uint256[] memory, SortedLinkedListWithMedian.MedianRelation[] memory)
@@ -165,6 +147,7 @@ library AddressSortedLinkedListWithMedian {
     bytes32[] memory byteKeys = list.getKeys();
     address[] memory keys = new address[](byteKeys.length);
     uint256[] memory values = new uint256[](byteKeys.length);
+    // prettier-ignore
     SortedLinkedListWithMedian.MedianRelation[] memory relations =
       new SortedLinkedListWithMedian.MedianRelation[](keys.length);
     for (uint256 i = 0; i < byteKeys.length; i++) {

--- a/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
@@ -1,15 +1,13 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "./LinkedList.sol";
-import "./SortedLinkedList.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import './LinkedList.sol';
+import './SortedLinkedList.sol';
 
 /**
  * @title Maintains a sorted list of unsigned ints keyed by uint256.
  */
 library IntegerSortedLinkedList {
-
   using SortedLinkedList for SortedLinkedList.List;
 
   /**
@@ -25,9 +23,7 @@ library IntegerSortedLinkedList {
     uint256 value,
     uint256 lesserKey,
     uint256 greaterKey
-  )
-    public
-  {
+  ) public {
     list.insert(bytes32(key), value, bytes32(lesserKey), bytes32(greaterKey));
   }
 
@@ -53,9 +49,7 @@ library IntegerSortedLinkedList {
     uint256 value,
     uint256 lesserKey,
     uint256 greaterKey
-  )
-    public
-  {
+  ) public {
     list.update(bytes32(key), value, bytes32(lesserKey), bytes32(greaterKey));
   }
 
@@ -103,9 +97,7 @@ library IntegerSortedLinkedList {
    * @notice Gets all elements from the doubly linked list.
    * @return An unpacked list of elements from largest to smallest.
    */
-  function getElements(
-    SortedLinkedList.List storage list
-  )
+  function getElements(SortedLinkedList.List storage list)
     public
     view
     returns (uint256[] memory, uint256[] memory)

--- a/packages/protocol/contracts/common/linkedlists/LinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/LinkedList.sol
@@ -1,14 +1,12 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 /**
  * @title Maintains a doubly linked list keyed by bytes32.
  * @dev Following the `next` pointers will lead you to the head, rather than the tail.
  */
 library LinkedList {
-
   using SafeMath for uint256;
 
   struct Element {
@@ -30,19 +28,12 @@ library LinkedList {
    * @param previousKey The key of the element that comes before the element to insert.
    * @param nextKey The key of the element that comes after the element to insert.
    */
-  function insert(
-    List storage list,
-    bytes32 key,
-    bytes32 previousKey,
-    bytes32 nextKey
-  )
-    public
-  {
-    require(key != bytes32(0), "Key must be defined");
+  function insert(List storage list, bytes32 key, bytes32 previousKey, bytes32 nextKey) public {
+    require(key != bytes32(0), 'Key must be defined');
     require(!contains(list, key), "Can't insert an existing element");
     require(
       previousKey != key && nextKey != key,
-      "Key cannot be the same as previousKey or nextKey"
+      'Key cannot be the same as previousKey or nextKey'
     );
 
     Element storage element = list.elements[key];
@@ -54,7 +45,7 @@ library LinkedList {
     } else {
       require(
         previousKey != bytes32(0) || nextKey != bytes32(0),
-        "Either previousKey or nextKey must be defined"
+        'Either previousKey or nextKey must be defined'
       );
 
       element.previousKey = previousKey;
@@ -63,22 +54,19 @@ library LinkedList {
       if (previousKey != bytes32(0)) {
         require(
           contains(list, previousKey),
-          "If previousKey is defined, it must exist in the list"
+          'If previousKey is defined, it must exist in the list'
         );
         Element storage previousElement = list.elements[previousKey];
-        require(
-          previousElement.nextKey == nextKey,
-          "previousKey must be adjacent to nextKey"
-        );
+        require(previousElement.nextKey == nextKey, 'previousKey must be adjacent to nextKey');
         previousElement.nextKey = key;
       } else {
         list.tail = key;
       }
 
       if (nextKey != bytes32(0)) {
-        require(contains(list, nextKey), "If nextKey is defined, it must exist in the list");
+        require(contains(list, nextKey), 'If nextKey is defined, it must exist in the list');
         Element storage nextElement = list.elements[nextKey];
-        require(nextElement.previousKey == previousKey, "previousKey must be adjacent to nextKey");
+        require(nextElement.previousKey == previousKey, 'previousKey must be adjacent to nextKey');
         nextElement.previousKey = key;
       } else {
         list.head = key;
@@ -127,14 +115,7 @@ library LinkedList {
    * @param previousKey The key of the element that comes before the updated element.
    * @param nextKey The key of the element that comes after the updated element.
    */
-  function update(
-    List storage list,
-    bytes32 key,
-    bytes32 previousKey,
-    bytes32 nextKey
-  )
-    public
-  {
+  function update(List storage list, bytes32 key, bytes32 previousKey, bytes32 nextKey) public {
     require(key != bytes32(0) && key != previousKey && key != nextKey && contains(list, key));
     remove(list, key);
     insert(list, key, previousKey, nextKey);

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
@@ -1,14 +1,12 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "./LinkedList.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import './LinkedList.sol';
 
 /**
  * @title Maintains a sorted list of unsigned ints keyed by bytes32.
  */
 library SortedLinkedList {
-
   using SafeMath for uint256;
   using LinkedList for LinkedList.List;
 
@@ -30,9 +28,7 @@ library SortedLinkedList {
     uint256 value,
     bytes32 lesserKey,
     bytes32 greaterKey
-  )
-    public
-  {
+  ) public {
     require(key != bytes32(0) && key != lesserKey && key != greaterKey && !contains(list, key));
     require((lesserKey != bytes32(0) || greaterKey != bytes32(0)) || list.list.numElements == 0);
     require(contains(list, lesserKey) || lesserKey == bytes32(0));
@@ -65,9 +61,7 @@ library SortedLinkedList {
     uint256 value,
     bytes32 lesserKey,
     bytes32 greaterKey
-  )
-    public
-  {
+  ) public {
     // TODO(asa): Optimize by not making any changes other than value if lesserKey and greaterKey
     // don't change.
     // TODO(asa): Optimize by not updating lesserKey/greaterKey for key
@@ -121,13 +115,7 @@ library SortedLinkedList {
    * @notice Gets all elements from the doubly linked list.
    * @return An unpacked list of elements from largest to smallest.
    */
-  function getElements(
-    List storage list
-  )
-    public
-    view
-    returns (bytes32[] memory, uint256[] memory)
-  {
+  function getElements(List storage list) public view returns (bytes32[] memory, uint256[] memory) {
     bytes32[] memory keys = getKeys(list);
     uint256[] memory values = new uint256[](keys.length);
     for (uint256 i = 0; i < keys.length; i = i.add(1)) {
@@ -154,7 +142,6 @@ library SortedLinkedList {
     return list.list.headN(n);
   }
 
-
   // TODO(asa): Gas optimizations by passing in elements to isValueBetween
   /**
    * @notice Returns the keys of the elements greaterKey than and less than the provided value.
@@ -168,11 +155,7 @@ library SortedLinkedList {
     uint256 value,
     bytes32 lesserKey,
     bytes32 greaterKey
-  )
-    private
-    view
-    returns (bytes32, bytes32)
-  {
+  ) private view returns (bytes32, bytes32) {
     // Check for one of the following conditions and fail if none are met:
     //   1. The value is less than the current lowest value
     //   2. The value is greater than the current greatest value
@@ -186,8 +169,8 @@ library SortedLinkedList {
       return (list.list.head, greaterKey);
     } else if (
       lesserKey != bytes32(0) &&
-      isValueBetween(list, value, lesserKey, list.list.elements[lesserKey].nextKey))
-    {
+      isValueBetween(list, value, lesserKey, list.list.elements[lesserKey].nextKey)
+    ) {
       return (lesserKey, list.list.elements[lesserKey].nextKey);
     } else if (
       greaterKey != bytes32(0) &&
@@ -206,12 +189,7 @@ library SortedLinkedList {
    * @param greaterKey The key of the element whose value should be greaterKey.
    * @return True if the given element is between the two other elements.
    */
-  function isValueBetween(
-    List storage list,
-    uint256 value,
-    bytes32 lesserKey,
-    bytes32 greaterKey
-  )
+  function isValueBetween(List storage list, uint256 value, bytes32 lesserKey, bytes32 greaterKey)
     private
     view
     returns (bool)

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
@@ -1,30 +1,19 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "./LinkedList.sol";
-import "./SortedLinkedList.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import './LinkedList.sol';
+import './SortedLinkedList.sol';
 
 /**
  * @title Maintains a sorted list of unsigned ints keyed by bytes32.
  */
 library SortedLinkedListWithMedian {
-
   using SafeMath for uint256;
   using SortedLinkedList for SortedLinkedList.List;
 
-  enum MedianAction {
-    None,
-    Lesser,
-    Greater
-  }
+  enum MedianAction { None, Lesser, Greater }
 
-  enum MedianRelation {
-    Undefined,
-    Lesser,
-    Greater,
-    Equal
-  }
+  enum MedianRelation { Undefined, Lesser, Greater, Equal }
 
   struct List {
     SortedLinkedList.List list;
@@ -45,9 +34,7 @@ library SortedLinkedListWithMedian {
     uint256 value,
     bytes32 lesserKey,
     bytes32 greaterKey
-  )
-    public
-  {
+  ) public {
     list.list.insert(key, value, lesserKey, greaterKey);
     LinkedList.Element storage element = list.list.list.elements[key];
 
@@ -73,8 +60,7 @@ library SortedLinkedListWithMedian {
       // the previous median, we need to slide the median up one element, since we always select
       // the greater of the two middle elements.
       if (
-        element.nextKey == bytes32(0) ||
-        list.relation[element.nextKey] == MedianRelation.Greater
+        element.nextKey == bytes32(0) || list.relation[element.nextKey] == MedianRelation.Greater
       ) {
         action = MedianAction.Greater;
         list.relation[key] = MedianRelation.Greater;
@@ -98,8 +84,7 @@ library SortedLinkedListWithMedian {
       // Thus, if the element we're removing is greaterKey than or equal to the median we need to
       // slide the median left by one.
       if (
-        list.relation[key] == MedianRelation.Greater ||
-        list.relation[key] == MedianRelation.Equal
+        list.relation[key] == MedianRelation.Greater || list.relation[key] == MedianRelation.Equal
       ) {
         action = MedianAction.Lesser;
       }
@@ -108,8 +93,7 @@ library SortedLinkedListWithMedian {
       // Thus, if the element we're removing is less than or equal to the median, we need to slide
       // median right by one.
       if (
-        list.relation[key] == MedianRelation.Lesser ||
-        list.relation[key] == MedianRelation.Equal
+        list.relation[key] == MedianRelation.Lesser || list.relation[key] == MedianRelation.Equal
       ) {
         action = MedianAction.Greater;
       }
@@ -133,9 +117,7 @@ library SortedLinkedListWithMedian {
     uint256 value,
     bytes32 lesserKey,
     bytes32 greaterKey
-  )
-    public
-  {
+  ) public {
     // TODO(asa): Optimize by not making any changes other than value if lesserKey and greaterKey
     // don't change.
     // TODO(asa): Optimize by not updating lesserKey/greaterKey for key
@@ -229,9 +211,7 @@ library SortedLinkedListWithMedian {
    * @notice Gets all elements from the doubly linked list.
    * @return An unpacked list of elements from largest to smallest.
    */
-  function getElements(
-    List storage list
-  )
+  function getElements(List storage list)
     public
     view
     returns (bytes32[] memory, uint256[] memory, MedianRelation[] memory)
@@ -262,7 +242,7 @@ library SortedLinkedListWithMedian {
     LinkedList.Element storage previousMedian = list.list.list.elements[list.median];
     if (action == MedianAction.Lesser) {
       list.relation[list.median] = MedianRelation.Greater;
-      list.median  = previousMedian.previousKey;
+      list.median = previousMedian.previousKey;
     } else if (action == MedianAction.Greater) {
       list.relation[list.median] = MedianRelation.Lesser;
       list.median = previousMedian.nextKey;

--- a/packages/protocol/contracts/common/proxies/AccountsProxy.sol
+++ b/packages/protocol/contracts/common/proxies/AccountsProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Proxy.sol";
-
+import '../Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract AccountsProxy is Proxy {
-}
+contract AccountsProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/GasCurrencyWhitelistProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GasCurrencyWhitelistProxy.sol
@@ -1,9 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Proxy.sol";
-
+import '../Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract GasCurrencyWhitelistProxy is Proxy {
-}
-
+contract GasCurrencyWhitelistProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/GasPriceMinimumProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GasPriceMinimumProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Proxy.sol";
-
+import '../Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract GasPriceMinimumProxy is Proxy {
-}
+contract GasPriceMinimumProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/GoldTokenProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GoldTokenProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Proxy.sol";
-
+import '../Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract GoldTokenProxy is Proxy {
-}
+contract GoldTokenProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/MultiSigProxy.sol
+++ b/packages/protocol/contracts/common/proxies/MultiSigProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Proxy.sol";
-
+import '../Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract MultiSigProxy is Proxy {
-}
+contract MultiSigProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/RegistryProxy.sol
+++ b/packages/protocol/contracts/common/proxies/RegistryProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Proxy.sol";
-
+import '../Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract RegistryProxy is Proxy {
-}
+contract RegistryProxy is Proxy {}

--- a/packages/protocol/contracts/common/test/AddressSortedLinkedListWithMedianTest.sol
+++ b/packages/protocol/contracts/common/test/AddressSortedLinkedListWithMedianTest.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.5.3;
 
-import "../linkedlists/AddressSortedLinkedListWithMedian.sol";
-import "../linkedlists/SortedLinkedListWithMedian.sol";
-
+import '../linkedlists/AddressSortedLinkedListWithMedian.sol';
+import '../linkedlists/SortedLinkedListWithMedian.sol';
 
 contract AddressSortedLinkedListWithMedianTest {
   using AddressSortedLinkedListWithMedian for SortedLinkedListWithMedian.List;
@@ -32,11 +31,7 @@ contract AddressSortedLinkedListWithMedianTest {
   function getElements()
     external
     view
-    returns (
-        address[] memory,
-        uint256[] memory,
-        SortedLinkedListWithMedian.MedianRelation[] memory
-    )
+    returns (address[] memory, uint256[] memory, SortedLinkedListWithMedian.MedianRelation[] memory)
   {
     return list.getElements();
   }

--- a/packages/protocol/contracts/common/test/ExtractFunctionSignatureTest.sol
+++ b/packages/protocol/contracts/common/test/ExtractFunctionSignatureTest.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../ExtractFunctionSignature.sol";
+import '../ExtractFunctionSignature.sol';
 
 contract ExtractFunctionSignatureTest {
   // using ExtractFunctionSignature;

--- a/packages/protocol/contracts/common/test/FixidityTest.sol
+++ b/packages/protocol/contracts/common/test/FixidityTest.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../FixidityLib.sol";
-
+import '../FixidityLib.sol';
 
 contract FixidityTest {
   using FixidityLib for FixidityLib.Fraction;

--- a/packages/protocol/contracts/common/test/FractionUtilTest.sol
+++ b/packages/protocol/contracts/common/test/FractionUtilTest.sol
@@ -1,11 +1,9 @@
 pragma solidity ^0.5.3;
 
-import "../FractionUtil.sol";
-
+import '../FractionUtil.sol';
 
 // TODO(asa) Actually test this
 contract FractionUtilTest {
-
   using FractionUtil for FractionUtil.Fraction;
 
   function reduce(uint256 numerator, uint256 denominator) external pure returns (uint256, uint256) {
@@ -19,22 +17,13 @@ contract FractionUtilTest {
     uint256 denominatorA,
     uint256 numeratorB,
     uint256 denominatorB
-  )
-    external
-    pure
-    returns (bool)
-  {
+  ) external pure returns (bool) {
     FractionUtil.Fraction memory fractionA = FractionUtil.Fraction(numeratorA, denominatorA);
     FractionUtil.Fraction memory fractionB = FractionUtil.Fraction(numeratorB, denominatorB);
     return fractionA.equals(fractionB);
   }
 
-  function add(
-    uint256 numeratorA,
-    uint256 denominatorA,
-    uint256 numeratorB,
-    uint256 denominatorB
-  )
+  function add(uint256 numeratorA, uint256 denominatorA, uint256 numeratorB, uint256 denominatorB)
     external
     pure
     returns (uint256, uint256)
@@ -45,12 +34,7 @@ contract FractionUtilTest {
     return (fraction.numerator, fraction.denominator);
   }
 
-  function sub(
-    uint256 numeratorA,
-    uint256 denominatorA,
-    uint256 numeratorB,
-    uint256 denominatorB
-  )
+  function sub(uint256 numeratorA, uint256 denominatorA, uint256 numeratorB, uint256 denominatorB)
     external
     pure
     returns (uint256, uint256)
@@ -71,11 +55,7 @@ contract FractionUtilTest {
     uint256 denominatorA,
     uint256 numeratorB,
     uint256 denominatorB
-  )
-    external
-    pure
-    returns (bool)
-  {
+  ) external pure returns (bool) {
     FractionUtil.Fraction memory fractionA = FractionUtil.Fraction(numeratorA, denominatorA);
     FractionUtil.Fraction memory fractionB = FractionUtil.Fraction(numeratorB, denominatorB);
     return fractionA.isGreaterThan(fractionB);
@@ -86,11 +66,7 @@ contract FractionUtilTest {
     uint256 denominatorA,
     uint256 numeratorB,
     uint256 denominatorB
-  )
-    external
-    pure
-    returns (bool)
-  {
+  ) external pure returns (bool) {
     FractionUtil.Fraction memory fractionA = FractionUtil.Fraction(numeratorA, denominatorA);
     FractionUtil.Fraction memory fractionB = FractionUtil.Fraction(numeratorB, denominatorB);
     return fractionA.isGreaterThanOrEqualTo(fractionB);
@@ -101,11 +77,7 @@ contract FractionUtilTest {
     uint256 denominatorA,
     uint256 numeratorB,
     uint256 denominatorB
-  )
-    external
-    pure
-    returns (bool)
-  {
+  ) external pure returns (bool) {
     FractionUtil.Fraction memory fractionA = FractionUtil.Fraction(numeratorA, denominatorA);
     FractionUtil.Fraction memory fractionB = FractionUtil.Fraction(numeratorB, denominatorB);
     return fractionA.isLessThan(fractionB);
@@ -116,11 +88,7 @@ contract FractionUtilTest {
     uint256 denominatorA,
     uint256 numeratorB,
     uint256 denominatorB
-  )
-    external
-    pure
-    returns (bool)
-  {
+  ) external pure returns (bool) {
     FractionUtil.Fraction memory fractionA = FractionUtil.Fraction(numeratorA, denominatorA);
     FractionUtil.Fraction memory fractionB = FractionUtil.Fraction(numeratorB, denominatorB);
     return fractionA.isLessThanOrEqualTo(fractionB);

--- a/packages/protocol/contracts/common/test/GetSetV0.sol
+++ b/packages/protocol/contracts/common/test/GetSetV0.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 contract GetSetV0 {
   uint256 public x;
 

--- a/packages/protocol/contracts/common/test/GetSetV1.sol
+++ b/packages/protocol/contracts/common/test/GetSetV1.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 contract GetSetV1 {
   uint256 public x;
   string public y;

--- a/packages/protocol/contracts/common/test/HasInitializer.sol
+++ b/packages/protocol/contracts/common/test/HasInitializer.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Initializable.sol";
-
+import '../Initializable.sol';
 
 contract HasInitializer is Initializable {
   uint256 public x;

--- a/packages/protocol/contracts/common/test/IntegerSortedLinkedListTest.sol
+++ b/packages/protocol/contracts/common/test/IntegerSortedLinkedListTest.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../linkedlists/IntegerSortedLinkedList.sol";
-
+import '../linkedlists/IntegerSortedLinkedList.sol';
 
 contract IntegerSortedLinkedListTest {
   using IntegerSortedLinkedList for SortedLinkedList.List;

--- a/packages/protocol/contracts/common/test/LinkedListTest.sol
+++ b/packages/protocol/contracts/common/test/LinkedListTest.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.8;
 
-import "../linkedlists/LinkedList.sol";
+import '../linkedlists/LinkedList.sol';
 
 contract LinkedListTest {
   using LinkedList for LinkedList.List;
@@ -27,13 +27,7 @@ contract LinkedListTest {
     return list.numElements;
   }
 
-  function getKeys()
-    external
-    view
-    returns (
-        bytes32[] memory
-    )
-  {
+  function getKeys() external view returns (bytes32[] memory) {
     return list.getKeys();
   }
 

--- a/packages/protocol/contracts/common/test/MsgSenderCheck.sol
+++ b/packages/protocol/contracts/common/test/MsgSenderCheck.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.5.3;
 
-
 contract MsgSenderCheck {
   function checkMsgSender(address addr) external view {
-    require(addr == msg.sender, "address was not msg.sender");
+    require(addr == msg.sender, 'address was not msg.sender');
   }
 }

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -1,13 +1,12 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "../common/Initializable.sol";
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import '../common/Initializable.sol';
 
 /**
  * @title Contract for storing blockchain parameters that can be set by governance.
  */
 contract BlockchainParameters is Ownable, Initializable {
-
   struct ClientVersion {
     uint256 major;
     uint256 minor;
@@ -19,7 +18,7 @@ contract BlockchainParameters is Ownable, Initializable {
   uint256 public intrinsicGasForAlternativeGasCurrency;
 
   event MinimumClientVersionSet(uint256 major, uint256 minor, uint256 patch);
-  event IntrinsicGasForAlternativeGasCurrencySet(uint gas);
+  event IntrinsicGasForAlternativeGasCurrencySet(uint256 gas);
 
   /**
    * @notice Initializes critical variables.
@@ -30,12 +29,9 @@ contract BlockchainParameters is Ownable, Initializable {
    * @param patch Minimum client version that can be used in the chain,
    * patch level.
    */
-  function initialize(
-    uint256 major,
-    uint256 minor,
-    uint256 patch,
-    uint256 _gasForNonGoldCurrencies
-  ) external initializer
+  function initialize(uint256 major, uint256 minor, uint256 patch, uint256 _gasForNonGoldCurrencies)
+    external
+    initializer
   {
     _transferOwnership(msg.sender);
     setMinimumClientVersion(major, minor, patch);

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -1,21 +1,25 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/Math.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
+import 'openzeppelin-solidity/contracts/math/Math.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol';
 
-import "./interfaces/IElection.sol";
-import "../common/Initializable.sol";
-import "../common/FixidityLib.sol";
-import "../common/linkedlists/AddressSortedLinkedList.sol";
-import "../common/UsingPrecompiles.sol";
-import "../common/UsingRegistry.sol";
-
+import './interfaces/IElection.sol';
+import '../common/Initializable.sol';
+import '../common/FixidityLib.sol';
+import '../common/linkedlists/AddressSortedLinkedList.sol';
+import '../common/UsingPrecompiles.sol';
+import '../common/UsingRegistry.sol';
 
 contract Election is
-  IElection, Ownable, ReentrancyGuard, Initializable, UsingRegistry, UsingPrecompiles {
-
+  IElection,
+  Ownable,
+  ReentrancyGuard,
+  Initializable,
+  UsingRegistry,
+  UsingPrecompiles
+{
   using AddressSortedLinkedList for SortedLinkedList.List;
   using FixidityLib for FixidityLib.Fraction;
   using SafeMath for uint256;
@@ -90,44 +94,21 @@ contract Election is
   // elections.
   FixidityLib.Fraction public electabilityThreshold;
 
-  event ElectableValidatorsSet(
-    uint256 min,
-    uint256 max
-  );
+  event ElectableValidatorsSet(uint256 min, uint256 max);
 
-  event MaxNumGroupsVotedForSet(
-    uint256 maxNumGroupsVotedFor
-  );
+  event MaxNumGroupsVotedForSet(uint256 maxNumGroupsVotedFor);
 
-  event ElectabilityThresholdSet(
-    uint256 electabilityThreshold
-  );
+  event ElectabilityThresholdSet(uint256 electabilityThreshold);
 
-  event ValidatorGroupMarkedEligible(
-    address group
-  );
+  event ValidatorGroupMarkedEligible(address group);
 
-  event ValidatorGroupMarkedIneligible(
-    address group
-  );
+  event ValidatorGroupMarkedIneligible(address group);
 
-  event ValidatorGroupVoteCast(
-    address indexed account,
-    address indexed group,
-    uint256 value
-  );
+  event ValidatorGroupVoteCast(address indexed account, address indexed group, uint256 value);
 
-  event ValidatorGroupVoteActivated(
-    address indexed account,
-    address indexed group,
-    uint256 value
-  );
+  event ValidatorGroupVoteActivated(address indexed account, address indexed group, uint256 value);
 
-  event ValidatorGroupVoteRevoked(
-    address indexed account,
-    address indexed group,
-    uint256 value
-  );
+  event ValidatorGroupVoteRevoked(address indexed account, address indexed group, uint256 value);
 
   /**
    * @notice Initializes critical variables.
@@ -144,10 +125,7 @@ contract Election is
     uint256 maxElectableValidators,
     uint256 _maxNumGroupsVotedFor,
     uint256 _electabilityThreshold
-  )
-    external
-    initializer
-  {
+  ) external initializer {
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
     setElectableValidators(minElectableValidators, maxElectableValidators);
@@ -182,13 +160,7 @@ contract Election is
    * @param _maxNumGroupsVotedFor The maximum number of groups an account can vote for.
    * @return True upon success.
    */
-  function setMaxNumGroupsVotedFor(
-    uint256 _maxNumGroupsVotedFor
-  )
-    public
-    onlyOwner
-    returns (bool)
-  {
+  function setMaxNumGroupsVotedFor(uint256 _maxNumGroupsVotedFor) public onlyOwner returns (bool) {
     require(_maxNumGroupsVotedFor != maxNumGroupsVotedFor);
     maxNumGroupsVotedFor = _maxNumGroupsVotedFor;
     emit MaxNumGroupsVotedForSet(_maxNumGroupsVotedFor);
@@ -204,7 +176,7 @@ contract Election is
     electabilityThreshold = FixidityLib.wrap(threshold);
     require(
       electabilityThreshold.lt(FixidityLib.fixed1()),
-      "Electability threshold must be lower than 100%"
+      'Electability threshold must be lower than 100%'
     );
     emit ElectabilityThresholdSet(threshold);
     return true;
@@ -229,12 +201,7 @@ contract Election is
    * @return True upon success.
    * @dev Fails if `group` is empty or not a validator group.
    */
-  function vote(
-    address group,
-    uint256 value,
-    address lesser,
-    address greater
-  )
+  function vote(address group, uint256 value, address lesser, address greater)
     external
     nonReentrant
     returns (bool)
@@ -294,11 +261,7 @@ contract Election is
     address lesser,
     address greater,
     uint256 index
-  )
-    external
-    nonReentrant
-    returns (bool)
-  {
+  ) external nonReentrant returns (bool) {
     require(group != address(0));
     address account = getAccounts().activeVoteSignerToAccount(msg.sender);
     require(0 < value && value <= getPendingVotesForGroupByAccount(group, account));
@@ -330,11 +293,7 @@ contract Election is
     address lesser,
     address greater,
     uint256 index
-  )
-    external
-    nonReentrant
-    returns (bool)
-  {
+  ) external nonReentrant returns (bool) {
     // TODO(asa): Dedup with revokePending.
     require(group != address(0));
     address account = getAccounts().activeVoteSignerToAccount(msg.sender);
@@ -369,10 +328,7 @@ contract Election is
    * @param account The address of the voting account.
    * @return The pending votes for `group` made by `account`.
    */
-  function getPendingVotesForGroupByAccount(
-    address group,
-    address account
-  )
+  function getPendingVotesForGroupByAccount(address group, address account)
     public
     view
     returns (uint256)
@@ -386,10 +342,7 @@ contract Election is
    * @param account The address of the voting account.
    * @return The active votes for `group` made by `account`.
    */
-  function getActiveVotesForGroupByAccount(
-    address group,
-    address account
-  )
+  function getActiveVotesForGroupByAccount(address group, address account)
     public
     view
     returns (uint256)
@@ -409,10 +362,7 @@ contract Election is
    * @param account The address of the voting account.
    * @return The total votes for `group` made by `account`.
    */
-  function getTotalVotesForGroupByAccount(
-    address group,
-    address account
-  )
+  function getTotalVotesForGroupByAccount(address group, address account)
     public
     view
     returns (uint256)
@@ -447,10 +397,7 @@ contract Election is
    * @return The amount of rewards that voters for `group` are due at the end of an epoch.
    * @dev Eligible groups that have received their maximum number of votes cannot receive more.
    */
-  function getGroupEpochRewards(
-    address group,
-    uint256 totalEpochRewards
-  )
+  function getGroupEpochRewards(address group, uint256 totalEpochRewards)
     external
     view
     returns (uint256)
@@ -472,12 +419,7 @@ contract Election is
    * @param greater The group receiving more votes than `group` after the rewards are added.
    * @dev Can only be called directly by the protocol.
    */
-  function distributeEpochRewards(
-    address group,
-    uint256 value,
-    address lesser,
-    address greater
-  )
+  function distributeEpochRewards(address group, uint256 value, address lesser, address greater)
     external
   {
     require(msg.sender == address(0));
@@ -491,12 +433,7 @@ contract Election is
    * @param lesser The group receiving fewer votes than `group` after the rewards are added.
    * @param greater The group receiving more votes than `group` after the rewards are added.
    */
-  function _distributeEpochRewards(
-    address group,
-    uint256 value,
-    address lesser,
-    address greater
-  )
+  function _distributeEpochRewards(address group, uint256 value, address lesser, address greater)
     internal
   {
     if (votes.total.eligible.contains(group)) {
@@ -517,12 +454,7 @@ contract Election is
    * @param greater The group receiving more votes than the group for which the vote was cast,
    *   or 0 if that group has the most votes of any validator group.
    */
-  function incrementTotalVotes(
-    address group,
-    uint256 value,
-    address lesser,
-    address greater
-  )
+  function incrementTotalVotes(address group, uint256 value, address lesser, address greater)
     private
   {
     uint256 newVoteTotal = votes.total.eligible.getValue(group).add(value);
@@ -538,12 +470,7 @@ contract Election is
    * @param greater The group receiving more votes than the group for which the vote was revoked,
    *   or 0 if that group has the most votes of any validator group.
    */
-  function decrementTotalVotes(
-    address group,
-    uint256 value,
-    address lesser,
-    address greater
-  )
+  function decrementTotalVotes(address group, uint256 value, address lesser, address greater)
     private
   {
     if (votes.total.eligible.contains(group)) {
@@ -557,9 +484,7 @@ contract Election is
    * @param group The address of the validator group.
    * @dev Can only be called by the registered "Validators" contract.
    */
-  function markGroupIneligible(
-    address group
-  )
+  function markGroupIneligible(address group)
     external
     onlyRegisteredContract(VALIDATORS_REGISTRY_ID)
   {
@@ -573,11 +498,7 @@ contract Election is
    * @param lesser The address of the group that has received fewer votes than this group.
    * @param greater The address of the group that has received more votes than this group.
    */
-  function markGroupEligible(
-    address group,
-    address lesser,
-    address greater
-  )
+  function markGroupEligible(address group, address lesser, address greater)
     external
     onlyRegisteredContract(VALIDATORS_REGISTRY_ID)
   {
@@ -600,7 +521,7 @@ contract Election is
     groupPending.total = groupPending.total.add(value);
 
     PendingVote storage pendingVote = groupPending.byAccount[account];
-    pendingVote.value  = pendingVote.value.add(value);
+    pendingVote.value = pendingVote.value.add(value);
     pendingVote.epoch = getEpochNumber();
   }
 
@@ -673,9 +594,8 @@ contract Election is
     if (votes.active.forGroup[group].total == 0) {
       return value;
     } else {
-      return value.mul(votes.active.forGroup[group].totalUnits).div(
-        votes.active.forGroup[group].total
-      );
+      return
+        value.mul(votes.active.forGroup[group].totalUnits).div(votes.active.forGroup[group].total);
     }
   }
 
@@ -716,10 +636,7 @@ contract Election is
   function canReceiveVotes(address group, uint256 value) public view returns (bool) {
     uint256 totalVotesForGroup = getTotalVotesForGroup(group).add(value);
     uint256 left = totalVotesForGroup.mul(
-      Math.min(
-        electableValidators.max,
-        getValidators().getNumRegisteredValidators()
-      )
+      Math.min(electableValidators.max, getValidators().getNumRegisteredValidators())
     );
     uint256 right = getValidators().getGroupNumMembers(group).add(1).mul(
       getLockedGold().getTotalLockedGold()
@@ -784,9 +701,9 @@ contract Election is
   function electValidators() external view returns (address[] memory) {
     // Groups must have at least `electabilityThreshold` proportion of the total votes to be
     // considered for the election.
-    uint256 requiredVotes = electabilityThreshold.multiply(
-      FixidityLib.newFixed(getTotalVotes())
-    ).fromFixed();
+    uint256 requiredVotes = electabilityThreshold
+      .multiply(FixidityLib.newFixed(getTotalVotes()))
+      .fromFixed();
     // Only consider groups with at least `requiredVotes` but do not consider more groups than the
     // max number of electable validators.
     uint256 numElectionGroups = votes.total.eligible.numElementsGreaterThan(
@@ -842,11 +759,7 @@ contract Election is
     address[] memory electionGroups,
     uint256[] memory numMembers,
     uint256[] memory numMembersElected
-  )
-    private
-    view
-    returns (uint256, bool)
-  {
+  ) private view returns (uint256, bool) {
     bool memberElected = false;
     uint256 groupIndex = 0;
     FixidityLib.Fraction memory maxN = FixidityLib.wrap(0);
@@ -854,11 +767,9 @@ contract Election is
       address group = electionGroups[i];
       // Only consider groups with members left to be elected.
       if (numMembers[i] > numMembersElected[i]) {
-        FixidityLib.Fraction memory n = FixidityLib.newFixed(
-          votes.total.eligible.getValue(group)
-        ).divide(
-          FixidityLib.newFixed(numMembersElected[i].add(1))
-        );
+        FixidityLib.Fraction memory n = FixidityLib
+          .newFixed(votes.total.eligible.getValue(group))
+          .divide(FixidityLib.newFixed(numMembersElected[i].add(1)));
         if (n.gt(maxN)) {
           maxN = n;
           groupIndex = i;

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -1,18 +1,18 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "openzeppelin-solidity/contracts/math/Math.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import 'openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/math/Math.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
-import "./interfaces/IGovernance.sol";
-import "./Proposals.sol";
-import "../common/ExtractFunctionSignature.sol";
-import "../common/Initializable.sol";
-import "../common/FixidityLib.sol";
-import "../common/linkedlists/IntegerSortedLinkedList.sol";
-import "../common/UsingRegistry.sol";
-import "../common/UsingPrecompiles.sol";
+import './interfaces/IGovernance.sol';
+import './Proposals.sol';
+import '../common/ExtractFunctionSignature.sol';
+import '../common/Initializable.sol';
+import '../common/FixidityLib.sol';
+import '../common/linkedlists/IntegerSortedLinkedList.sol';
+import '../common/UsingRegistry.sol';
+import '../common/UsingPrecompiles.sol';
 
 // TODO(asa): Hardcode minimum times for queueExpiry, etc.
 /**
@@ -32,24 +32,12 @@ contract Governance is
   using IntegerSortedLinkedList for SortedLinkedList.List;
   using BytesLib for bytes;
 
-  uint256 constant private FIXED_HALF = 500000000000000000000000;
+  uint256 private constant FIXED_HALF = 500000000000000000000000;
 
   // TODO(asa): Consider a delay stage.
-  enum ProposalStage {
-    None,
-    Queued,
-    Approval,
-    Referendum,
-    Execution,
-    Expiration
-  }
+  enum ProposalStage { None, Queued, Approval, Referendum, Execution, Expiration }
 
-  enum VoteValue {
-    None,
-    Abstain,
-    No,
-    Yes
-  }
+  enum VoteValue { None, Abstain, No, Yes }
 
   struct UpvoteRecord {
     uint256 proposalId;
@@ -114,43 +102,23 @@ contract Governance is
   uint256[] public emptyIndices;
   ParticipationParameters private participationParameters;
 
-  event ApproverSet(
-    address approver
-  );
+  event ApproverSet(address approver);
 
-  event ConcurrentProposalsSet(
-    uint256 concurrentProposals
-  );
+  event ConcurrentProposalsSet(uint256 concurrentProposals);
 
-  event MinDepositSet(
-    uint256 minDeposit
-  );
+  event MinDepositSet(uint256 minDeposit);
 
-  event QueueExpirySet(
-    uint256 queueExpiry
-  );
+  event QueueExpirySet(uint256 queueExpiry);
 
-  event DequeueFrequencySet(
-    uint256 dequeueFrequency
-  );
+  event DequeueFrequencySet(uint256 dequeueFrequency);
 
-  event ApprovalStageDurationSet(
-    uint256 approvalStageDuration
-  );
+  event ApprovalStageDurationSet(uint256 approvalStageDuration);
 
-  event ReferendumStageDurationSet(
-    uint256 referendumStageDuration
-  );
+  event ReferendumStageDurationSet(uint256 referendumStageDuration);
 
-  event ExecutionStageDurationSet(
-    uint256 executionStageDuration
-  );
+  event ExecutionStageDurationSet(uint256 executionStageDuration);
 
-  event ConstitutionSet(
-    address indexed destination,
-    bytes4 indexed functionId,
-    uint256 threshold
-  );
+  event ConstitutionSet(address indexed destination, bytes4 indexed functionId, uint256 threshold);
 
   event ProposalQueued(
     uint256 indexed proposalId,
@@ -160,11 +128,7 @@ contract Governance is
     uint256 timestamp
   );
 
-  event ProposalUpvoted(
-    uint256 indexed proposalId,
-    address indexed account,
-    uint256 upvotes
-  );
+  event ProposalUpvoted(uint256 indexed proposalId, address indexed account, uint256 upvotes);
 
   event ProposalUpvoteRevoked(
     uint256 indexed proposalId,
@@ -172,14 +136,9 @@ contract Governance is
     uint256 revokedUpvotes
   );
 
-  event ProposalDequeued(
-    uint256 indexed proposalId,
-    uint256 timestamp
-  );
+  event ProposalDequeued(uint256 indexed proposalId, uint256 timestamp);
 
-  event ProposalApproved(
-    uint256 indexed proposalId
-  );
+  event ProposalApproved(uint256 indexed proposalId);
 
   event ProposalVoted(
     uint256 indexed proposalId,
@@ -188,47 +147,25 @@ contract Governance is
     uint256 weight
   );
 
-  event ProposalExecuted(
-    uint256 indexed proposalId
-  );
+  event ProposalExecuted(uint256 indexed proposalId);
 
-  event ProposalExpired(
-    uint256 proposalId
-  );
+  event ProposalExpired(uint256 proposalId);
 
-  event ParticipationBaselineUpdated(
-    uint256 participationBaseline
-  );
+  event ParticipationBaselineUpdated(uint256 participationBaseline);
 
-  event ParticipationFloorSet(
-    uint256 participationFloor
-  );
+  event ParticipationFloorSet(uint256 participationFloor);
 
-  event ParticipationBaselineUpdateFactorSet(
-    uint256 baselineUpdateFactor
-  );
+  event ParticipationBaselineUpdateFactorSet(uint256 baselineUpdateFactor);
 
-  event ParticipationBaselineQuorumFactorSet(
-    uint256 baselineQuorumFactor
-  );
+  event ParticipationBaselineQuorumFactorSet(uint256 baselineQuorumFactor);
 
-  event HotfixWhitelisted(
-    bytes32 indexed hash,
-    address whitelister
-  );
+  event HotfixWhitelisted(bytes32 indexed hash, address whitelister);
 
-  event HotfixApproved(
-    bytes32 indexed hash
-  );
+  event HotfixApproved(bytes32 indexed hash);
 
-  event HotfixPrepared(
-    bytes32 indexed hash,
-    uint256 indexed epoch
-  );
+  event HotfixPrepared(bytes32 indexed hash, uint256 indexed epoch);
 
-  event HotfixExecuted(
-    bytes32 indexed hash
-  );
+  event HotfixExecuted(bytes32 indexed hash);
 
   function() external payable {} // solhint-disable no-empty-blocks
 
@@ -267,19 +204,16 @@ contract Governance is
     uint256 participationFloor,
     uint256 baselineUpdateFactor,
     uint256 baselineQuorumFactor
-  )
-    external
-    initializer
-  {
+  ) external initializer {
     require(
       _approver != address(0) &&
-      _concurrentProposals != 0 &&
-      _minDeposit != 0 &&
-      _queueExpiry != 0 &&
-      _dequeueFrequency != 0 &&
-      approvalStageDuration != 0 &&
-      referendumStageDuration != 0 &&
-      executionStageDuration != 0
+        _concurrentProposals != 0 &&
+        _minDeposit != 0 &&
+        _queueExpiry != 0 &&
+        _dequeueFrequency != 0 &&
+        approvalStageDuration != 0 &&
+        referendumStageDuration != 0 &&
+        executionStageDuration != 0
     );
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
@@ -389,7 +323,7 @@ contract Governance is
     FixidityLib.Fraction memory participationBaselineFrac = FixidityLib.wrap(participationBaseline);
     require(
       FixidityLib.isProperFraction(participationBaselineFrac) &&
-      !participationBaselineFrac.equals(participationParameters.baseline)
+        !participationBaselineFrac.equals(participationParameters.baseline)
     );
     participationParameters.baseline = participationBaselineFrac;
     emit ParticipationBaselineUpdated(participationBaseline);
@@ -403,7 +337,7 @@ contract Governance is
     FixidityLib.Fraction memory participationFloorFrac = FixidityLib.wrap(participationFloor);
     require(
       FixidityLib.isProperFraction(participationFloorFrac) &&
-      !participationFloorFrac.equals(participationParameters.baselineFloor)
+        !participationFloorFrac.equals(participationParameters.baselineFloor)
     );
     participationParameters.baselineFloor = participationFloorFrac;
     emit ParticipationFloorSet(participationFloor);
@@ -417,7 +351,7 @@ contract Governance is
     FixidityLib.Fraction memory baselineUpdateFactorFrac = FixidityLib.wrap(baselineUpdateFactor);
     require(
       FixidityLib.isProperFraction(baselineUpdateFactorFrac) &&
-      !baselineUpdateFactorFrac.equals(participationParameters.baselineUpdateFactor)
+        !baselineUpdateFactorFrac.equals(participationParameters.baselineUpdateFactor)
     );
     participationParameters.baselineUpdateFactor = baselineUpdateFactorFrac;
     emit ParticipationBaselineUpdateFactorSet(baselineUpdateFactor);
@@ -431,7 +365,7 @@ contract Governance is
     FixidityLib.Fraction memory baselineQuorumFactorFrac = FixidityLib.wrap(baselineQuorumFactor);
     require(
       FixidityLib.isProperFraction(baselineQuorumFactorFrac) &&
-      !baselineQuorumFactorFrac.equals(participationParameters.baselineQuorumFactor)
+        !baselineQuorumFactorFrac.equals(participationParameters.baselineQuorumFactor)
     );
     participationParameters.baselineQuorumFactor = baselineQuorumFactorFrac;
     emit ParticipationBaselineQuorumFactorSet(baselineQuorumFactor);
@@ -445,11 +379,7 @@ contract Governance is
    * @param threshold The threshold.
    * @dev If no constitution is explicitly set the default is a simple majority, i.e. 1:2.
    */
-  function setConstitution(
-    address destination,
-    bytes4 functionId,
-    uint256 threshold
-  )
+  function setConstitution(address destination, bytes4 functionId, uint256 threshold)
     external
     onlyOwner
   {
@@ -460,8 +390,7 @@ contract Governance is
     if (functionId == 0) {
       constitution[destination].defaultThreshold = FixidityLib.wrap(threshold);
     } else {
-      constitution[destination].functionThresholds[functionId] =
-        FixidityLib.wrap(threshold);
+      constitution[destination].functionThresholds[functionId] = FixidityLib.wrap(threshold);
     }
     emit ConstitutionSet(destination, functionId, threshold);
   }
@@ -481,11 +410,7 @@ contract Governance is
     address[] calldata destinations,
     bytes calldata data,
     uint256[] calldata dataLengths
-  )
-    external
-    payable
-    returns (uint256)
-  {
+  ) external payable returns (uint256) {
     dequeueProposalsIfReady();
     require(msg.value >= minDeposit);
 
@@ -507,11 +432,7 @@ contract Governance is
    * @dev Provide 0 for `lesser`/`greater` when the proposal will be at the tail/head of the queue.
    * @dev Reverts if the account has already upvoted a proposal in the queue.
    */
-  function upvote(
-    uint256 proposalId,
-    uint256 lesser,
-    uint256 greater
-  )
+  function upvote(uint256 proposalId, uint256 lesser, uint256 greater)
     external
     nonReentrant
     returns (bool)
@@ -539,11 +460,11 @@ contract Governance is
     }
     // We can upvote a proposal in the queue if we're not already upvoting a proposal in the queue.
     uint256 weight = getLockedGold().getAccountTotalLockedGold(account);
-    require(weight > 0, "cannot upvote without locking gold");
-    require(isQueued(proposalId), "cannot upvote a proposal not in the queue");
+    require(weight > 0, 'cannot upvote without locking gold');
+    require(isQueued(proposalId), 'cannot upvote a proposal not in the queue');
     require(
       voter.upvote.proposalId == 0 || !queue.contains(voter.upvote.proposalId),
-      "cannot upvote more than one queued proposal"
+      'cannot upvote more than one queued proposal'
     );
     uint256 upvotes = queue.getValue(proposalId).add(weight);
     queue.update(proposalId, upvotes, lesser, greater);
@@ -561,14 +482,7 @@ contract Governance is
    * @return Whether or not the upvote was revoked successfully.
    * @dev Provide 0 for `lesser`/`greater` when the proposal will be at the tail/head of the queue.
    */
-  function revokeUpvote(
-    uint256 lesser,
-    uint256 greater
-  )
-    external
-    nonReentrant
-    returns (bool)
-  {
+  function revokeUpvote(uint256 lesser, uint256 greater) external nonReentrant returns (bool) {
     dequeueProposalsIfReady();
     address account = getAccounts().activeVoteSignerToAccount(msg.sender);
     Voter storage voter = voters[account];
@@ -629,11 +543,7 @@ contract Governance is
    * @return Whether or not the vote was cast successfully.
    */
   /* solhint-disable code-complexity */
-  function vote(
-    uint256 proposalId,
-    uint256 index,
-    Proposals.VoteValue value
-  )
+  function vote(uint256 proposalId, uint256 index, Proposals.VoteValue value)
     external
     nonReentrant
     returns (bool)
@@ -651,9 +561,9 @@ contract Governance is
     uint256 weight = getLockedGold().getAccountTotalLockedGold(account);
     require(
       proposal.isApproved() &&
-      stage == Proposals.Stage.Referendum &&
-      value != Proposals.VoteValue.None &&
-      weight > 0
+        stage == Proposals.Stage.Referendum &&
+        value != Proposals.VoteValue.None &&
+        weight > 0
     );
     VoteRecord storage voteRecord = voter.referendumVotes[index];
     proposal.updateVote(
@@ -720,9 +630,9 @@ contract Governance is
    * @param hash The hash of the hotfix to be prepared.
    */
   function prepareHotfix(bytes32 hash) external {
-    require(isHotfixPassing(hash), "hotfix not whitelisted by 2f+1 validators");
+    require(isHotfixPassing(hash), 'hotfix not whitelisted by 2f+1 validators');
     uint256 epoch = getEpochNumber();
-    require(hotfixes[hash].preparedEpoch < epoch, "hotfix already prepared for this epoch");
+    require(hotfixes[hash].preparedEpoch < epoch, 'hotfix already prepared for this epoch');
     hotfixes[hash].preparedEpoch = epoch;
     emit HotfixPrepared(hash, epoch);
   }
@@ -740,24 +650,15 @@ contract Governance is
     address[] calldata destinations,
     bytes calldata data,
     uint256[] calldata dataLengths
-  )
-    external
-  {
+  ) external {
     bytes32 hash = keccak256(abi.encode(values, destinations, data, dataLengths));
 
     (bool approved, bool executed, uint256 preparedEpoch) = getHotfixRecord(hash);
-    require(!executed, "hotfix already executed");
-    require(approved, "hotfix not approved");
-    require(preparedEpoch == getEpochNumber(), "hotfix must be prepared for this epoch");
+    require(!executed, 'hotfix already executed');
+    require(approved, 'hotfix not approved');
+    require(preparedEpoch == getEpochNumber(), 'hotfix must be prepared for this epoch');
 
-    Proposals.makeMem(
-      values,
-      destinations,
-      data,
-      dataLengths,
-      msg.sender,
-      0
-    ).executeMem();
+    Proposals.makeMem(values, destinations, data, dataLengths, msg.sender, 0).executeMem();
 
     hotfixes[hash].executed = true;
     emit HotfixExecuted(hash);
@@ -785,9 +686,8 @@ contract Governance is
     uint256 upvotedProposal = voter.upvote.proposalId;
     bool isVotingQueue = upvotedProposal != 0 && isQueued(upvotedProposal);
     Proposals.Proposal storage proposal = proposals[voter.mostRecentReferendumProposal];
-    bool isVotingReferendum = (
-      proposal.getDequeuedStage(stageDurations) == Proposals.Stage.Referendum
-    );
+    bool isVotingReferendum = (proposal.getDequeuedStage(stageDurations) ==
+      Proposals.Stage.Referendum);
     return isVotingQueue || isVotingReferendum;
   }
 
@@ -842,9 +742,7 @@ contract Governance is
    * @param proposalId The ID of the proposal to unpack.
    * @return The unpacked proposal with its transaction count.
    */
-  function getProposal(
-    uint256 proposalId
-  )
+  function getProposal(uint256 proposalId)
     external
     view
     returns (address, uint256, uint256, uint256)
@@ -858,10 +756,7 @@ contract Governance is
    * @param index The index of the specified transaction in the proposal's transaction list.
    * @return The specified transaction.
    */
-  function getProposalTransaction(
-    uint256 proposalId,
-    uint256 index
-  )
+  function getProposalTransaction(uint256 proposalId, uint256 index)
     external
     view
     returns (uint256, address, bytes memory)
@@ -984,11 +879,7 @@ contract Governance is
    * @return Hotfix tuple of (approved, executed, preparedEpoch)
    */
   function getHotfixRecord(bytes32 hash) public view returns (bool, bool, uint256) {
-    return (
-      hotfixes[hash].approved,
-      hotfixes[hash].executed,
-      hotfixes[hash].preparedEpoch
-    );
+    return (hotfixes[hash].approved, hotfixes[hash].executed, hotfixes[hash].preparedEpoch);
   }
 
   /**
@@ -1086,11 +977,7 @@ contract Governance is
     Proposals.Proposal storage proposal,
     uint256 proposalId,
     uint256 index
-  )
-    private
-    view
-    returns (bool)
-  {
+  ) private view returns (bool) {
     return proposal.exists() && dequeued[index] == proposalId;
   }
 
@@ -1099,10 +986,7 @@ contract Governance is
    * @param proposal The proposal struct.
    * @return Whether or not the dequeued proposal has expired.
    */
-  function isDequeuedProposalExpired(
-    Proposals.Proposal storage proposal,
-    Proposals.Stage stage
-  )
+  function isDequeuedProposalExpired(Proposals.Proposal storage proposal, Proposals.Stage stage)
     private
     view
     returns (bool)
@@ -1111,11 +995,9 @@ contract Governance is
     //   1. Past the approval stage and not approved.
     //   2. Past the referendum stage and not passing.
     //   3. Past the execution stage.
-    return (
-      (stage > Proposals.Stage.Execution) ||
+    return ((stage > Proposals.Stage.Execution) ||
       (stage > Proposals.Stage.Referendum && !_isProposalPassing(proposal)) ||
-      (stage > Proposals.Stage.Approval && !proposal.isApproved())
-    );
+      (stage > Proposals.Stage.Approval && !proposal.isApproved()));
   }
 
   /**
@@ -1128,9 +1010,7 @@ contract Governance is
     Proposals.Proposal storage proposal,
     uint256 proposalId,
     uint256 index
-  )
-    private
-  {
+  ) private {
     if (proposal.isApproved() && proposal.networkWeight > 0) {
       updateParticipationBaseline(proposal);
     }
@@ -1159,14 +1039,7 @@ contract Governance is
     emit ParticipationBaselineUpdated(participationParameters.baseline.unwrap());
   }
 
-  function getConstitution(
-    address destination,
-    bytes4 functionId
-  )
-    external
-    view
-    returns (uint256)
-  {
+  function getConstitution(address destination, bytes4 functionId) external view returns (uint256) {
     return _getConstitution(destination, functionId).unwrap();
   }
 
@@ -1177,10 +1050,7 @@ contract Governance is
    *   default.
    * @return The ratio of yes:no votes needed to exceed in order to pass the proposal.
    */
-  function _getConstitution(
-    address destination,
-    bytes4 functionId
-  )
+  function _getConstitution(address destination, bytes4 functionId)
     internal
     view
     returns (FixidityLib.Fraction memory)

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -1,17 +1,16 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import 'openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
-import "./interfaces/ILockedGold.sol";
+import './interfaces/ILockedGold.sol';
 
-import "../common/Initializable.sol";
-import "../common/Signatures.sol";
-import "../common/UsingRegistry.sol";
+import '../common/Initializable.sol';
+import '../common/Signatures.sol';
+import '../common/UsingRegistry.sol';
 
 contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistry {
-
   using SafeMath for uint256;
 
   struct Authorizations {
@@ -83,8 +82,8 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
    * @notice Locks gold to be used for voting.
    */
   function lock() external payable nonReentrant {
-    require(getAccounts().isAccount(msg.sender), "not account");
-    require(msg.value > 0, "no value");
+    require(getAccounts().isAccount(msg.sender), 'not account');
+    require(msg.value > 0, 'no value');
     _incrementNonvotingAccountBalance(msg.sender, msg.value);
     emit GoldLocked(msg.sender, msg.value);
   }
@@ -95,10 +94,7 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
    * @param value The amount by which to increment.
    * @dev Can only be called by the registered Election smart contract.
    */
-  function incrementNonvotingAccountBalance(
-    address account,
-    uint256 value
-  )
+  function incrementNonvotingAccountBalance(address account, uint256 value)
     external
     onlyRegisteredContract(ELECTION_REGISTRY_ID)
   {
@@ -111,10 +107,7 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
    * @param value The amount by which to decrement.
    * @dev Can only be called by the registered "Election" smart contract.
    */
-  function decrementNonvotingAccountBalance(
-    address account,
-    uint256 value
-  )
+  function decrementNonvotingAccountBalance(address account, uint256 value)
     external
     onlyRegisteredContract(ELECTION_REGISTRY_ID)
   {
@@ -154,7 +147,7 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
     uint256 balanceRequirement = getValidators().getAccountLockedGoldRequirement(msg.sender);
     require(
       balanceRequirement == 0 ||
-      balanceRequirement <= getAccountTotalLockedGold(msg.sender).sub(value)
+        balanceRequirement <= getAccountTotalLockedGold(msg.sender).sub(value)
     );
     _decrementNonvotingAccountBalance(msg.sender, value);
     uint256 available = now.add(unlockingPeriod);
@@ -234,9 +227,7 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
    * @param account The address of the account.
    * @return The value and timestamp for each pending withdrawal.
    */
-  function getPendingWithdrawals(
-    address account
-  )
+  function getPendingWithdrawals(address account)
     external
     view
     returns (uint256[] memory, uint256[] memory)

--- a/packages/protocol/contracts/governance/Proposals.sol
+++ b/packages/protocol/contracts/governance/Proposals.sol
@@ -1,35 +1,22 @@
 pragma solidity ^0.5.8;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "solidity-bytes-utils/contracts/BytesLib.sol";
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'solidity-bytes-utils/contracts/BytesLib.sol';
 
-import "../common/FixidityLib.sol";
-import "../common/libraries/AddressesHelper.sol";
+import '../common/FixidityLib.sol';
+import '../common/libraries/AddressesHelper.sol';
 
 /**
  * @title A library operating on Celo Governance proposals.
  */
 library Proposals {
-
   using FixidityLib for FixidityLib.Fraction;
   using SafeMath for uint256;
   using BytesLib for bytes;
 
-  enum Stage {
-    None,
-    Queued,
-    Approval,
-    Referendum,
-    Execution,
-    Expiration
-  }
+  enum Stage { None, Queued, Approval, Referendum, Execution, Expiration }
 
-  enum VoteValue {
-    None,
-    Abstain,
-    No,
-    Yes
-  }
+  enum VoteValue { None, Abstain, No, Yes }
 
   struct StageDurations {
     uint256 approval;
@@ -78,9 +65,7 @@ library Proposals {
     uint256[] memory dataLengths,
     address proposer,
     uint256 deposit
-  )
-    public
-  {
+  ) public {
     require(values.length == destinations.length && destinations.length == dataLengths.length);
     uint256 transactionCount = values.length;
 
@@ -92,16 +77,14 @@ library Proposals {
     uint256 dataPosition = 0;
     delete proposal.transactions;
     for (uint256 i = 0; i < transactionCount; i = i.add(1)) {
-      proposal.transactions.push(Transaction(
-        values[i],
-        destinations[i],
-        data.slice(dataPosition, dataLengths[i])
-      ));
+      proposal.transactions.push(
+        Transaction(values[i], destinations[i], data.slice(dataPosition, dataLengths[i]))
+      );
       dataPosition = dataPosition.add(dataLengths[i]);
     }
   }
 
-    /**
+  /**
    * @notice Constructs a proposal for use in memory.
    * @param values The values of Celo Gold to be sent in the proposed transactions.
    * @param destinations The destination addresses of the proposed transactions.
@@ -117,13 +100,11 @@ library Proposals {
     uint256[] memory dataLengths,
     address proposer,
     uint256 deposit
-  )
-    internal view returns (Proposal memory)
-  {
+  ) internal view returns (Proposal memory) {
     require(values.length == destinations.length && destinations.length == dataLengths.length);
     uint256 transactionCount = values.length;
 
-    Proposal memory proposal; 
+    Proposal memory proposal;
     proposal.proposer = proposer;
     proposal.deposit = deposit;
     // solhint-disable-next-line not-rely-on-time
@@ -156,9 +137,7 @@ library Proposals {
     uint256 currentWeight,
     VoteValue previousVote,
     VoteValue currentVote
-  )
-    public
-  {
+  ) public {
     // Subtract previous vote.
     if (previousVote == VoteValue.Abstain) {
       proposal.votes.abstain = proposal.votes.abstain.sub(previousWeight);
@@ -221,20 +200,16 @@ library Proposals {
   function getSupportWithQuorumPadding(
     Proposal storage proposal,
     FixidityLib.Fraction memory quorum
-  )
-    internal
-    view
-    returns (FixidityLib.Fraction memory)
-  {
+  ) internal view returns (FixidityLib.Fraction memory) {
     uint256 yesVotes = proposal.votes.yes;
     if (yesVotes == 0) {
       return FixidityLib.newFixed(0);
     }
     uint256 noVotes = proposal.votes.no;
     uint256 totalVotes = yesVotes.add(noVotes).add(proposal.votes.abstain);
-    uint256 requiredVotes = quorum.multiply(
-        FixidityLib.newFixed(proposal.networkWeight)
-    ).fromFixed();
+    uint256 requiredVotes = quorum
+      .multiply(FixidityLib.newFixed(proposal.networkWeight))
+      .fromFixed();
     if (requiredVotes > totalVotes) {
       noVotes = noVotes.add(requiredVotes.sub(totalVotes));
     }
@@ -248,17 +223,16 @@ library Proposals {
    * @return The stage of the dequeued proposal.
    * @dev Must be called on a dequeued proposal.
    */
-  function getDequeuedStage(
-    Proposal storage proposal,
-    StageDurations storage stageDurations
-  )
+  function getDequeuedStage(Proposal storage proposal, StageDurations storage stageDurations)
     internal
     view
     returns (Stage)
   {
-    uint256 stageStartTime = proposal.timestamp.add(stageDurations.approval).add(
-      stageDurations.referendum
-    ).add(stageDurations.execution);
+    uint256 stageStartTime = proposal
+      .timestamp
+      .add(stageDurations.approval)
+      .add(stageDurations.referendum)
+      .add(stageDurations.execution);
     // solhint-disable-next-line not-rely-on-time
     if (now >= stageStartTime) {
       return Stage.Expiration;
@@ -282,12 +256,10 @@ library Proposals {
    * @param proposal The proposal struct.
    * @return The participation of the proposal.
    */
-  function getParticipation(
-    Proposal storage proposal
-  ) 
-    internal 
-    view 
-    returns (FixidityLib.Fraction memory) 
+  function getParticipation(Proposal storage proposal)
+    internal
+    view
+    returns (FixidityLib.Fraction memory)
   {
     uint256 totalVotes = proposal.votes.yes.add(proposal.votes.no).add(proposal.votes.abstain);
     return FixidityLib.newFixedFraction(totalVotes, proposal.networkWeight);
@@ -299,10 +271,7 @@ library Proposals {
    * @param index The index of the specified transaction in the proposal's transaction list.
    * @return The specified transaction.
    */
-  function getTransaction(
-    Proposal storage proposal,
-    uint256 index
-  )
+  function getTransaction(Proposal storage proposal, uint256 index)
     public
     view
     returns (uint256, address, bytes memory)
@@ -317,19 +286,12 @@ library Proposals {
    * @param proposal The proposal struct.
    * @return The unpacked proposal with its transaction count.
    */
-  function unpack(
-    Proposal storage proposal
-  )
+  function unpack(Proposal storage proposal)
     internal
     view
     returns (address, uint256, uint256, uint256)
   {
-    return (
-      proposal.proposer,
-      proposal.deposit,
-      proposal.timestamp,
-      proposal.transactions.length
-    );
+    return (proposal.proposer, proposal.deposit, proposal.timestamp, proposal.transactions.length);
   }
 
   /**
@@ -337,9 +299,7 @@ library Proposals {
    * @param proposal The proposal struct.
    * @return The yes, no, and abstain vote totals.
    */
-  function getVoteTotals(
-    Proposal storage proposal
-  )
+  function getVoteTotals(Proposal storage proposal)
     internal
     view
     returns (uint256, uint256, uint256)
@@ -374,35 +334,30 @@ library Proposals {
    * @param dataLength The length of the data to be included in the function call.
    * @param data The data to be included in the function call.
    */
-  function externalCall(
-    address destination,
-    uint value,
-    uint dataLength,
-    bytes memory data
-  )
+  function externalCall(address destination, uint256 value, uint256 dataLength, bytes memory data)
     private
     returns (bool)
   {
     bool result;
 
     if (dataLength > 0)
-      require(AddressesHelper.isContract(destination), "Invalid contract address");
+      require(AddressesHelper.isContract(destination), 'Invalid contract address');
 
     /* solhint-disable no-inline-assembly */
     assembly {
       /* solhint-disable max-line-length */
-      let x := mload(0x40)   // "Allocate" memory for output (0x40 is where "free memory" pointer is stored by convention)
+      let x := mload(0x40) // "Allocate" memory for output (0x40 is where "free memory" pointer is stored by convention)
       let d := add(data, 32) // First 32 bytes are the padded length of data, so exclude that
       result := call(
-        sub(gas, 34710),   // 34710 is the value that solidity is currently emitting
-                           // It includes callGas (700) + callVeryLow (3, to pay for SUB) + callValueTransferGas (9000) +
-                           // callNewAccountGas (25000, in case the destination address does not exist and needs creating)
+        sub(gas, 34710), // 34710 is the value that solidity is currently emitting
+        // It includes callGas (700) + callVeryLow (3, to pay for SUB) + callValueTransferGas (9000) +
+        // callNewAccountGas (25000, in case the destination address does not exist and needs creating)
         destination,
         value,
         d,
-        dataLength,        // Size of the input (in bytes) - this is what fixes the padding problem
+        dataLength, // Size of the input (in bytes) - this is what fixes the padding problem
         x,
-        0                  // Output is ignored, therefore the output size is zero
+        0 // Output is ignored, therefore the output size is zero
       )
       /* solhint-enable max-line-length */
     }

--- a/packages/protocol/contracts/governance/interfaces/IElection.sol
+++ b/packages/protocol/contracts/governance/interfaces/IElection.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.5.3;
 
-
 interface IElection {
   function getTotalVotes() external view returns (uint256);
   function getTotalVotesByAccount(address) external view returns (uint256);
   function markGroupIneligible(address) external;
-  function markGroupEligible(address,address,address) external;
+  function markGroupEligible(address, address, address) external;
   function electValidators() external view returns (address[] memory);
 }

--- a/packages/protocol/contracts/governance/interfaces/IGovernance.sol
+++ b/packages/protocol/contracts/governance/interfaces/IGovernance.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 interface IGovernance {
   function isVoting(address) external view returns (bool);
 }

--- a/packages/protocol/contracts/governance/interfaces/ILockedGold.sol
+++ b/packages/protocol/contracts/governance/interfaces/ILockedGold.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 interface ILockedGold {
   function incrementNonvotingAccountBalance(address, uint256) external;
   function decrementNonvotingAccountBalance(address, uint256) external;

--- a/packages/protocol/contracts/governance/interfaces/IValidators.sol
+++ b/packages/protocol/contracts/governance/interfaces/IValidators.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 interface IValidators {
   function getAccountLockedGoldRequirement(address) external view returns (uint256);
   function meetsAccountLockedGoldRequirements(address) external view returns (bool);

--- a/packages/protocol/contracts/governance/proxies/BlockchainParametersProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/BlockchainParametersProxy.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract BlockchainParametersProxy is Proxy {
-}
+contract BlockchainParametersProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/ElectionProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ElectionProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract ElectionProxy is Proxy {
-}
+contract ElectionProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/GovernanceProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/GovernanceProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract GovernanceProxy is Proxy {
-}
+contract GovernanceProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/LockedGoldProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/LockedGoldProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract LockedGoldProxy is Proxy {
-}
+contract LockedGoldProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/ValidatorsProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ValidatorsProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract ValidatorsProxy is Proxy {
-}
+contract ValidatorsProxy is Proxy {}

--- a/packages/protocol/contracts/governance/test/ElectionTest.sol
+++ b/packages/protocol/contracts/governance/test/ElectionTest.sol
@@ -1,19 +1,13 @@
 pragma solidity ^0.5.8;
 
-import "../Election.sol";
-import "../../common/FixidityLib.sol";
+import '../Election.sol';
+import '../../common/FixidityLib.sol';
 
 /**
  * @title A wrapper around Election that exposes onlyVm functions for testing.
  */
 contract ElectionTest is Election {
-
-  function distributeEpochRewards(
-    address group,
-    uint256 value,
-    address lesser,
-    address greater
-  )
+  function distributeEpochRewards(address group, uint256 value, address lesser, address greater)
     external
   {
     return _distributeEpochRewards(group, value, lesser, greater);

--- a/packages/protocol/contracts/governance/test/GovernanceTest.sol
+++ b/packages/protocol/contracts/governance/test/GovernanceTest.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Governance.sol";
+import '../Governance.sol';
 
 contract GovernanceTest is Governance {
   address[] validatorSet;

--- a/packages/protocol/contracts/governance/test/MockElection.sol
+++ b/packages/protocol/contracts/governance/test/MockElection.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.5.3;
 
-import "../interfaces/IElection.sol";
+import '../interfaces/IElection.sol';
 
 /**
  * @title Holds a list of addresses of validators
  */
 contract MockElection is IElection {
-
   mapping(address => bool) public isIneligible;
   mapping(address => bool) public isEligible;
   address[] public electedValidators;

--- a/packages/protocol/contracts/governance/test/MockGovernance.sol
+++ b/packages/protocol/contracts/governance/test/MockGovernance.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../interfaces/IGovernance.sol";
+import '../interfaces/IGovernance.sol';
 
 /**
  * @title A mock Governance for testing.

--- a/packages/protocol/contracts/governance/test/MockLockedGold.sol
+++ b/packages/protocol/contracts/governance/test/MockLockedGold.sol
@@ -1,15 +1,13 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
-import "../interfaces/ILockedGold.sol";
+import '../interfaces/ILockedGold.sol';
 
-
- /**
+/**
  * @title A mock LockedGold for testing.
  */
 contract MockLockedGold is ILockedGold {
-
   using SafeMath for uint256;
 
   struct Authorizations {

--- a/packages/protocol/contracts/governance/test/MockValidators.sol
+++ b/packages/protocol/contracts/governance/test/MockValidators.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.5.3;
 
-import "../interfaces/IValidators.sol";
+import '../interfaces/IValidators.sol';
 
 /**
  * @title Holds a list of addresses of validators
  */
 contract MockValidators is IValidators {
-
   mapping(address => bool) private _isValidating;
   mapping(address => bool) private _isVoting;
   mapping(address => uint256) private numGroupMembers;
@@ -63,10 +62,7 @@ contract MockValidators is IValidators {
     return lockedGoldRequirements[account];
   }
 
-  function getTopGroupValidators(
-    address group,
-    uint256 n
-  )
+  function getTopGroupValidators(address group, uint256 n)
     external
     view
     returns (address[] memory)

--- a/packages/protocol/contracts/governance/test/ProposalsTest.sol
+++ b/packages/protocol/contracts/governance/test/ProposalsTest.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.8;
 
-import "../Proposals.sol";
-import "../../common/FixidityLib.sol";
+import '../Proposals.sol';
+import '../../common/FixidityLib.sol';
 
 contract ProposalsTest {
   using Proposals for Proposals.Proposal;
@@ -19,8 +19,7 @@ contract ProposalsTest {
   }
 
   function getSupportWithQuorumPadding(uint256 criticalBaseline) external view returns (uint256) {
-    return FixidityLib.unwrap(
-        proposal.getSupportWithQuorumPadding(FixidityLib.wrap(criticalBaseline))
-    );
+    return
+      FixidityLib.unwrap(proposal.getSupportWithQuorumPadding(FixidityLib.wrap(criticalBaseline)));
   }
 }

--- a/packages/protocol/contracts/governance/test/TestTransactions.sol
+++ b/packages/protocol/contracts/governance/test/TestTransactions.sol
@@ -1,11 +1,9 @@
 pragma solidity ^0.5.3;
 
-
 /**
  * @title A contract for transaction testing.
  */
 contract TestTransactions {
-
   mapping(uint256 => uint256) public values;
 
   function getValue(uint256 key) external view returns (uint256) {

--- a/packages/protocol/contracts/governance/test/ValidatorsTest.sol
+++ b/packages/protocol/contracts/governance/test/ValidatorsTest.sol
@@ -1,13 +1,12 @@
 pragma solidity ^0.5.8;
 
-import "../Validators.sol";
-import "../../common/FixidityLib.sol";
+import '../Validators.sol';
+import '../../common/FixidityLib.sol';
 
 /**
  * @title A wrapper around Validators that exposes onlyVm functions for testing.
  */
 contract ValidatorsTest is Validators {
-
   function updateValidatorScore(address validator, uint256 uptime) external {
     return _updateValidatorScore(validator, uptime);
   }

--- a/packages/protocol/contracts/identity/Escrow.sol
+++ b/packages/protocol/contracts/identity/Escrow.sol
@@ -1,18 +1,17 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import 'openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
-import "./interfaces/IAttestations.sol";
-import "./interfaces/IEscrow.sol";
-import "../common/Initializable.sol";
-import "../common/UsingRegistry.sol";
-import "../common/Signatures.sol";
+import './interfaces/IAttestations.sol';
+import './interfaces/IEscrow.sol';
+import '../common/Initializable.sol';
+import '../common/UsingRegistry.sol';
+import '../common/Signatures.sol';
 
 contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegistry {
-
   using SafeMath for uint256;
 
   event Transfer(
@@ -67,7 +66,7 @@ contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegist
     setRegistry(registryAddress);
   }
 
-/**
+  /**
   * @notice Transfer tokens to a specific user. Supports both identity with privacy (an empty
   *         identifier and 0 minAttestations) and without (with identifier and minAttestations).
   * @param identifier The hashed identifier of a user to transfer to.
@@ -89,12 +88,8 @@ contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegist
     uint256 expirySeconds,
     address paymentId,
     uint256 minAttestations
-  )
-    external
-    nonReentrant
-    returns (bool)
-  {
-    require(token != address(0) && value > 0 && expirySeconds > 0, "Invalid transfer inputs.");
+  ) external nonReentrant returns (bool) {
+    require(token != address(0) && value > 0 && expirySeconds > 0, 'Invalid transfer inputs.');
     require(
       !(identifier.length <= 0 && !(minAttestations == 0)),
       "Invalid privacy inputs: Can't require attestations if no identifier"
@@ -115,12 +110,12 @@ contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegist
     newPayment.expirySeconds = expirySeconds;
     newPayment.minAttestations = minAttestations;
 
-    require(ERC20(token).transferFrom(msg.sender, address(this), value), "Transfer unsuccessful.");
+    require(ERC20(token).transferFrom(msg.sender, address(this), value), 'Transfer unsuccessful.');
     emit Transfer(msg.sender, identifier, token, value, paymentId, minAttestations);
     return true;
   }
 
-/**
+  /**
   * @notice Withdraws tokens for a verified user.
   * @param paymentId The ID for the EscrowedPayment struct that contains all relevant information.
   * @param v The recovery id of the incoming ECDSA signature.
@@ -129,40 +124,31 @@ contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegist
   * @dev Throws if 'token' or 'value' is 0.
   * @dev Throws if msg.sender does not prove ownership of the withdraw key.
   */
-  function withdraw (
-    address paymentId,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  )
+  function withdraw(address paymentId, uint8 v, bytes32 r, bytes32 s)
     external
     nonReentrant
     returns (bool)
   {
     address signer = Signatures.getSignerOfAddress(msg.sender, v, r, s);
-    require(
-      signer == paymentId,
-      "Failed to prove ownership of the withdraw key"
-    );
+    require(signer == paymentId, 'Failed to prove ownership of the withdraw key');
     EscrowedPayment memory payment = escrowedPayments[paymentId];
-    require(payment.token != address(0) && payment.value > 0, "Invalid withdraw value.");
+    require(payment.token != address(0) && payment.value > 0, 'Invalid withdraw value.');
 
     if (payment.recipientIdentifier.length > 0) {
-      IAttestations attestations = IAttestations(
-        registry.getAddressFor(ATTESTATIONS_REGISTRY_ID)
-      );
+      IAttestations attestations = IAttestations(registry.getAddressFor(ATTESTATIONS_REGISTRY_ID));
       (uint64 completedAttestations, ) = attestations.getAttestationStats(
-        payment.recipientIdentifier, msg.sender
+        payment.recipientIdentifier,
+        msg.sender
       );
       require(
         uint256(completedAttestations) >= payment.minAttestations,
-        "This account does not have enough attestations to withdraw this payment."
+        'This account does not have enough attestations to withdraw this payment.'
       );
     }
 
     deletePayment(paymentId);
 
-    require(ERC20(payment.token).transfer(msg.sender, payment.value), "Transfer not successful.");
+    require(ERC20(payment.token).transfer(msg.sender, payment.value), 'Transfer not successful.');
 
     emit Withdrawal(
       payment.recipientIdentifier,
@@ -182,24 +168,18 @@ contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegist
   * @dev Throws if msg.sender is not the sender of payment.
   * @dev Throws if redeem time hasn't been reached yet.
   */
-  function revoke(
-    address paymentId
-  )
-    external
-    nonReentrant
-    returns (bool)
-  {
+  function revoke(address paymentId) external nonReentrant returns (bool) {
     EscrowedPayment memory payment = escrowedPayments[paymentId];
-    require(payment.sender == msg.sender, "Only sender of payment can attempt to revoke payment.");
+    require(payment.sender == msg.sender, 'Only sender of payment can attempt to revoke payment.');
     require(
       // solhint-disable-next-line not-rely-on-time
       now >= (payment.timestamp + payment.expirySeconds),
-      "Transaction not redeemable for sender yet."
+      'Transaction not redeemable for sender yet.'
     );
 
     deletePayment(paymentId);
 
-    require(ERC20(payment.token).transfer(msg.sender, payment.value), "Transfer not successful.");
+    require(ERC20(payment.token).transfer(msg.sender, payment.value), 'Transfer not successful.');
 
     emit Revocation(
       payment.recipientIdentifier,
@@ -213,7 +193,7 @@ contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegist
 
   }
 
-/**
+  /**
   * @notice Gets array of all Escrowed Payments received by identifier.
   * @param identifier The hash of an identifier of the receiver of the escrowed payment.
   * @return An array containing all the IDs of the Escrowed Payments that were received
@@ -223,7 +203,7 @@ contract Escrow is IEscrow, ReentrancyGuard, Ownable, Initializable, UsingRegist
     return receivedPaymentIds[identifier];
   }
 
-/**
+  /**
   * @notice Gets array of all Escrowed Payment IDs sent by sender.
   * @param sender The address of the sender of the escrowed payments.
   * @return An array containing all the IDs of the Escrowed Payments that were sent by the

--- a/packages/protocol/contracts/identity/Random.sol
+++ b/packages/protocol/contracts/identity/Random.sol
@@ -1,16 +1,15 @@
 pragma solidity ^0.5.3;
 
-import "./interfaces/IRandom.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import './interfaces/IRandom.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
-import "../common/Initializable.sol";
+import '../common/Initializable.sol';
 
 /**
  * @title Provides randomness for verifier selection
  */
 contract Random is IRandom, Ownable, Initializable {
-
   using SafeMath for uint256;
 
   /* Stores most recent commitment per address */
@@ -18,7 +17,7 @@ contract Random is IRandom, Ownable, Initializable {
 
   uint256 public randomnessBlockRetentionWindow = 256;
 
-  mapping (uint256 => bytes32) private history;
+  mapping(uint256 => bytes32) private history;
   uint256 private historyFirst;
   uint256 private historySize;
 
@@ -39,7 +38,7 @@ contract Random is IRandom, Ownable, Initializable {
    * @param value Number of old random blocks whose randomness values can be queried.
    */
   function setRandomnessBlockRetentionWindow(uint256 value) public onlyOwner {
-    require(value > 0, "randomnessBlockRetetionWindow cannot be zero");
+    require(value > 0, 'randomnessBlockRetetionWindow cannot be zero');
     randomnessBlockRetentionWindow = value;
     emit RandomnessBlockRetentionWindowSet(value);
   }
@@ -54,12 +53,8 @@ contract Random is IRandom, Ownable, Initializable {
    * `randomness` and `newCommitment`. Before running regular transactions, this function should be
    * called.
    */
-  function revealAndCommit(
-    bytes32 randomness,
-    bytes32 newCommitment,
-    address proposer
-  ) external {
-    require(msg.sender == address(0), "only VM can call");
+  function revealAndCommit(bytes32 randomness, bytes32 newCommitment, address proposer) external {
+    require(msg.sender == address(0), 'only VM can call');
     _revealAndCommit(randomness, newCommitment, proposer);
   }
 
@@ -69,21 +64,17 @@ contract Random is IRandom, Ownable, Initializable {
    * @param newCommitment The hash of randomness that will be revealed in the future.
    * @param proposer Address of the block proposer.
    */
-  function _revealAndCommit(
-    bytes32 randomness,
-    bytes32 newCommitment,
-    address proposer
-  ) internal {
+  function _revealAndCommit(bytes32 randomness, bytes32 newCommitment, address proposer) internal {
     // ensure revealed randomness matches previous commitment
     if (commitments[proposer] != 0) {
-      require(randomness != 0, "randomness cannot be zero if there is a previous commitment");
+      require(randomness != 0, 'randomness cannot be zero if there is a previous commitment');
       bytes32 expectedCommitment = computeCommitment(randomness);
       require(
         expectedCommitment == commitments[proposer],
         "commitment didn't match the posted randomness"
       );
     } else {
-      require(randomness == 0, "randomness should be zero if there is no previous commitment");
+      require(randomness == 0, 'randomness should be zero if there is no previous commitment');
     }
 
     // add entropy
@@ -107,13 +98,14 @@ contract Random is IRandom, Ownable, Initializable {
       historySize = 1;
     } else if (historySize > randomnessBlockRetentionWindow) {
       delete history[historyFirst];
-      delete history[historyFirst+1];
+      delete history[historyFirst + 1];
       historyFirst += 2;
       historySize--;
     } else if (historySize == randomnessBlockRetentionWindow) {
       delete history[historyFirst];
       historyFirst++;
-    } else /* historySize < randomnessBlockRetentionWindow */ {
+    } else {
+      // historySize < randomnessBlockRetentionWindow
       historySize++;
     }
   }
@@ -151,12 +143,13 @@ contract Random is IRandom, Ownable, Initializable {
    * @return The associated randomness value.
    */
   function _getBlockRandomness(uint256 blockNumber, uint256 cur) internal view returns (bytes32) {
-    require(blockNumber <= cur, "Cannot query randomness of future blocks");
+    require(blockNumber <= cur, 'Cannot query randomness of future blocks');
     require(
       blockNumber > cur.sub(historySize) &&
-      (randomnessBlockRetentionWindow >= cur ||
-      blockNumber > cur.sub(randomnessBlockRetentionWindow)),
-      "Cannot query randomness older than the stored history");
+        (randomnessBlockRetentionWindow >= cur ||
+          blockNumber > cur.sub(randomnessBlockRetentionWindow)),
+      'Cannot query randomness older than the stored history'
+    );
     return history[blockNumber];
   }
 }

--- a/packages/protocol/contracts/identity/interfaces/IAttestations.sol
+++ b/packages/protocol/contracts/identity/interfaces/IAttestations.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-
 interface IAttestations {
-
   function initialize(address, uint256, uint256, address[] calldata, uint256[] calldata) external;
 
   function setAttestationRequestFee(address, uint256) external;
@@ -15,26 +13,14 @@ interface IAttestations {
 
   function setAttestationExpiryBlocks(uint256) external;
 
-
-
   function getUnselectedRequest(bytes32, address) external view returns (uint32, uint32, address);
   function getAttestationRequestFee(address) external view returns (uint256);
 
   function lookupAccountsForIdentifier(bytes32) external view returns (address[] memory);
 
-  function getAttestationStats(
-    bytes32,
-    address
-  )
-    external
-    view
-    returns (uint32, uint32);
+  function getAttestationStats(bytes32, address) external view returns (uint32, uint32);
 
-  function getAttestationState(
-    bytes32,
-    address,
-    address
-  )
+  function getAttestationState(bytes32, address, address)
     external
     view
     returns (uint8, uint32, address);

--- a/packages/protocol/contracts/identity/interfaces/IEscrow.sol
+++ b/packages/protocol/contracts/identity/interfaces/IEscrow.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 interface IEscrow {
   function initialize(address registryAddress) external;
 
@@ -11,22 +10,11 @@ interface IEscrow {
     uint256 expirySeconds,
     address paymentId,
     uint256 minAttestations
-  )
-    external
-    returns (bool);
-
-  function withdraw (
-    address paymentID,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
   ) external returns (bool);
 
-  function revoke(
-    address paymentID
-  )
-    external
-    returns (bool);
+  function withdraw(address paymentID, uint8 v, bytes32 r, bytes32 s) external returns (bool);
+
+  function revoke(address paymentID) external returns (bool);
 
   function getReceivedPaymentIds(bytes32 identifier) external view returns (address[] memory);
 

--- a/packages/protocol/contracts/identity/interfaces/IRandom.sol
+++ b/packages/protocol/contracts/identity/interfaces/IRandom.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-
 interface IRandom {
-
   function revealAndCommit(bytes32, bytes32, address) external;
   function random() external view returns (bytes32);
   function getBlockRandomness(uint256) external view returns (bytes32);

--- a/packages/protocol/contracts/identity/proxies/AttestationsProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/AttestationsProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract AttestationsProxy is Proxy {
-}
+contract AttestationsProxy is Proxy {}

--- a/packages/protocol/contracts/identity/proxies/EscrowProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/EscrowProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract EscrowProxy is Proxy {
-}
+contract EscrowProxy is Proxy {}

--- a/packages/protocol/contracts/identity/proxies/RandomProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/RandomProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract RandomProxy is Proxy {
-}
+contract RandomProxy is Proxy {}

--- a/packages/protocol/contracts/identity/test/MockAttestations.sol
+++ b/packages/protocol/contracts/identity/test/MockAttestations.sol
@@ -1,17 +1,12 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 /**
  * @title A mock Attestations for testing.
  */
 contract MockAttestations {
-
-  enum AttestationStatus {
-    None,
-    Incomplete,
-    Complete
-  }
+  enum AttestationStatus { None, Incomplete, Complete }
 
   struct Attestation {
     AttestationStatus status;
@@ -35,10 +30,7 @@ contract MockAttestations {
     identifiers[identifier].attestations[msg.sender].completed++;
   }
 
-  function getAttestationStats(
-    bytes32 identifier,
-    address account
-  )
+  function getAttestationStats(bytes32 identifier, address account)
     external
     view
     returns (uint64, uint64)

--- a/packages/protocol/contracts/identity/test/MockERC20Token.sol
+++ b/packages/protocol/contracts/identity/test/MockERC20Token.sol
@@ -1,10 +1,8 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 contract MockERC20Token {
-
   using SafeMath for uint256;
 
   mapping(address => uint256) private balances;

--- a/packages/protocol/contracts/identity/test/MockRandom.sol
+++ b/packages/protocol/contracts/identity/test/MockRandom.sol
@@ -1,15 +1,15 @@
 pragma solidity ^0.5.3;
 
-import "../Random.sol";
+import '../Random.sol';
 
 contract MockRandom is Random {
-  mapping (uint256 => bytes32) private history;
+  mapping(uint256 => bytes32) private history;
 
   function addTestRandomness(uint256 blockNumber, bytes32 randomness) external {
     history[blockNumber] = randomness;
   }
   function getBlockRandomness(uint256 blockNumber) external view returns (bytes32) {
-    require(history[blockNumber] != 0x0, "No randomness found");
+    require(history[blockNumber] != 0x0, 'No randomness found');
     return history[blockNumber];
   }
 }

--- a/packages/protocol/contracts/identity/test/TestAttestations.sol
+++ b/packages/protocol/contracts/identity/test/TestAttestations.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Attestations.sol";
-
+import '../Attestations.sol';
 
 /*
  * We need a test contract that behaves like the actual Attestations contract,

--- a/packages/protocol/contracts/identity/test/TestRandom.sol
+++ b/packages/protocol/contracts/identity/test/TestRandom.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../Random.sol";
+import '../Random.sol';
 
 contract TestRandom is Random {
   function addTestRandomness(uint256 blockNumber, bytes32 randomness) external {
@@ -10,4 +10,3 @@ contract TestRandom is Random {
     return _getBlockRandomness(blockNumber, cur);
   }
 }
-

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -1,22 +1,20 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import 'openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
-import "./interfaces/IReserve.sol";
-import "./interfaces/ISortedOracles.sol";
-import "./interfaces/IStableToken.sol";
+import './interfaces/IReserve.sol';
+import './interfaces/ISortedOracles.sol';
+import './interfaces/IStableToken.sol';
 
-import "../common/Initializable.sol";
-import "../common/UsingRegistry.sol";
-
+import '../common/Initializable.sol';
+import '../common/UsingRegistry.sol';
 
 /**
  * @title Ensures price stability of StableTokens with respect to their pegs
  */
 contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyGuard {
-
   using SafeMath for uint256;
 
   struct TobinTaxCache {
@@ -38,16 +36,13 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
   event SpenderRemoved(address spender);
 
   modifier isStableToken(address token) {
-    require(isToken[token], "token addr was never registered");
+    require(isToken[token], 'token addr was never registered');
     _;
   }
 
   function() external payable {} // solhint-disable no-empty-blocks
 
-  function initialize(
-    address registryAddress,
-    uint256 _tobinTaxStalenessThreshold
-  )
+  function initialize(address registryAddress, uint256 _tobinTaxStalenessThreshold)
     external
     initializer
   {
@@ -61,7 +56,7 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
    * @param value The number of seconds to cache the tobin tax value for.
    */
   function setTobinTaxStalenessThreshold(uint256 value) external onlyOwner {
-    require(value > 0, "value was zero");
+    require(value > 0, 'value was zero');
     tobinTaxStalenessThreshold = value;
     emit TobinTaxStalenessThresholdSet(value);
   }
@@ -71,14 +66,14 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
    * @param token The address of the token being stabilized.
    */
   function addToken(address token) external onlyOwner nonReentrant returns (bool) {
-    require(!isToken[token], "token addr already registered");
+    require(!isToken[token], 'token addr already registered');
     // Require an exchange rate between the new token and Gold exists.
     address sortedOraclesAddress = registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID);
     ISortedOracles sortedOracles = ISortedOracles(sortedOraclesAddress);
     uint256 tokenAmount;
     uint256 goldAmount;
     (tokenAmount, goldAmount) = sortedOracles.medianRate(token);
-    require(goldAmount > 0, "median rate returned 0 gold");
+    require(goldAmount > 0, 'median rate returned 0 gold');
     isToken[token] = true;
     _tokens.push(token);
     emit TokenAdded(token);
@@ -90,10 +85,7 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
    * @param token The address of the token no longer being stabilized.
    * @param index The index of the token in _tokens.
    */
-  function removeToken(
-    address token,
-    uint256 index
-  )
+  function removeToken(address token, uint256 index)
     external
     onlyOwner
     isStableToken(token)
@@ -101,16 +93,15 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
   {
     require(
       index < _tokens.length && _tokens[index] == token,
-      "index into tokens list not mapped to token"
+      'index into tokens list not mapped to token'
     );
     isToken[token] = false;
-    address lastItem = _tokens[_tokens.length-1];
+    address lastItem = _tokens[_tokens.length - 1];
     _tokens[index] = lastItem;
     _tokens.length--;
     emit TokenRemoved(token, index);
     return true;
   }
-
 
   /**
    * @notice Gives an address permission to spend Reserve funds.
@@ -135,15 +126,9 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
    * @param to The address that will receive the gold.
    * @param value The amount of gold to transfer.
    */
-  function transferGold(
-    address to,
-    uint256 value
-  )
-    external
-    returns (bool)
-  {
-    require(isSpender[msg.sender], "sender not allowed to transfer Reserve funds");
-    require(getGoldToken().transfer(to, value), "transfer of gold token failed");
+  function transferGold(address to, uint256 value) external returns (bool) {
+    require(isSpender[msg.sender], 'sender not allowed to transfer Reserve funds');
+    require(getGoldToken().transfer(to, value), 'transfer of gold token failed');
     return true;
   }
 
@@ -202,11 +187,7 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
    * @param token The address of the token to mint.
    * @param value The amount of tokens to mint.
    */
-  function mintToken(
-    address to,
-    address token,
-    uint256 value
-  )
+  function mintToken(address to, address token, uint256 value)
     private
     isStableToken(token)
     returns (bool)

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "./interfaces/ISortedOracles.sol";
-import "../common/Initializable.sol";
-import "../common/linkedlists/AddressSortedLinkedListWithMedian.sol";
-import "../common/linkedlists/SortedLinkedListWithMedian.sol";
-
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import './interfaces/ISortedOracles.sol';
+import '../common/Initializable.sol';
+import '../common/linkedlists/AddressSortedLinkedListWithMedian.sol';
+import '../common/linkedlists/SortedLinkedListWithMedian.sol';
 
 // TODO: don't treat timestamps as Fixidity values
 /**
@@ -27,15 +26,9 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
 
   uint256 public reportExpirySeconds;
 
-  event OracleAdded(
-    address indexed token,
-    address indexed oracleAddress
-  );
+  event OracleAdded(address indexed token, address indexed oracleAddress);
 
-  event OracleRemoved(
-    address indexed token,
-    address indexed oracleAddress
-  );
+  event OracleRemoved(address indexed token, address indexed oracleAddress);
 
   event OracleReported(
     address token,
@@ -45,23 +38,14 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
     uint256 denominator
   );
 
-  event OracleReportRemoved(
-    address indexed token,
-    address indexed oracle
-  );
+  event OracleReportRemoved(address indexed token, address indexed oracle);
 
-  event MedianUpdated(
-    address token,
-    uint256 numerator,
-    uint256 denominator
-  );
+  event MedianUpdated(address token, uint256 numerator, uint256 denominator);
 
-  event ReportExpirySet(
-    uint256 reportExpiry
-  );
+  event ReportExpirySet(uint256 reportExpiry);
 
   modifier onlyOracle(address token) {
-    require(isOracle[token][msg.sender], "sender was not an oracle for token addr");
+    require(isOracle[token][msg.sender], 'sender was not an oracle for token addr');
     _;
   }
 
@@ -87,7 +71,7 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
   function addOracle(address token, address oracleAddress) external onlyOwner {
     require(
       token != address(0) && oracleAddress != address(0) && !isOracle[token][oracleAddress],
-      "token addr was null or oracle addr was null or oracle addr is not an oracle for token addr"
+      'token addr was null or oracle addr was null or oracle addr is not an oracle for token addr'
     );
     isOracle[token][oracleAddress] = true;
     oracles[token].push(oracleAddress);
@@ -101,10 +85,10 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
   function removeOracle(address token, address oracleAddress, uint256 index) external onlyOwner {
     require(
       token != address(0) &&
-      oracleAddress != address(0) &&
-      oracles[token].length > index &&
-      oracles[token][index] == oracleAddress,
-      "token addr null or oracle addr null or index of token oracle not mapped to oracle addr"
+        oracleAddress != address(0) &&
+        oracles[token].length > index &&
+        oracles[token][index] == oracleAddress,
+      'token addr null or oracle addr null or index of token oracle not mapped to oracle addr'
     );
     isOracle[token][oracleAddress] = false;
     oracles[token][index] = oracles[token][oracles[token].length.sub(1)];
@@ -148,10 +132,7 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
     uint256 denominator,
     address lesserKey,
     address greaterKey
-  )
-    external
-    onlyOracle(token)
-  {
+  ) external onlyOracle(token) {
     uint256 originalMedian = rates[token].getMedianValue();
     uint256 value = numerator.mul(DENOMINATOR).div(denominator);
     if (rates[token].contains(msg.sender)) {
@@ -208,16 +189,10 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
    * @param token The address of the token for which the Celo Gold exchange rate is being reported.
    * @return An unpacked list of elements from largest to smallest.
    */
-  function getRates(
-    address token
-  )
+  function getRates(address token)
     external
     view
-    returns (
-        address[] memory,
-        uint256[] memory,
-        SortedLinkedListWithMedian.MedianRelation[] memory
-    )
+    returns (address[] memory, uint256[] memory, SortedLinkedListWithMedian.MedianRelation[] memory)
   {
     return rates[token].getElements();
   }
@@ -245,16 +220,10 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
    * @param token The address of the token for which the Celo Gold exchange rate is being reported.
    * @return An unpacked list of elements from largest to smallest.
    */
-  function getTimestamps(
-    address token
-  )
+  function getTimestamps(address token)
     external
     view
-    returns (
-        address[] memory,
-        uint256[] memory,
-        SortedLinkedListWithMedian.MedianRelation[] memory
-    )
+    returns (address[] memory, uint256[] memory, SortedLinkedListWithMedian.MedianRelation[] memory)
   {
     return timestamps[token].getElements();
   }

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -1,47 +1,39 @@
 pragma solidity ^0.5.3;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
-
-import "./interfaces/IStableToken.sol";
-import "../common/interfaces/IERC20Token.sol";
-import "../common/interfaces/ICeloToken.sol";
-import "../common/Initializable.sol";
-import "../common/FixidityLib.sol";
-import "../common/UsingRegistry.sol";
-import "../common/UsingPrecompiles.sol";
-
+import './interfaces/IStableToken.sol';
+import '../common/interfaces/IERC20Token.sol';
+import '../common/interfaces/ICeloToken.sol';
+import '../common/Initializable.sol';
+import '../common/FixidityLib.sol';
+import '../common/UsingRegistry.sol';
+import '../common/UsingPrecompiles.sol';
 
 /**
  * @title An ERC20 compliant token with adjustable supply.
  */
 // solhint-disable-next-line max-line-length
-contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
-  Initializable, UsingRegistry, UsingPrecompiles {
+contract StableToken is
+  IStableToken,
+  IERC20Token,
+  ICeloToken,
+  Ownable,
+  Initializable,
+  UsingRegistry,
+  UsingPrecompiles
+{
   using FixidityLib for FixidityLib.Fraction;
   using SafeMath for uint256;
 
-  event InflationFactorUpdated(
-    uint256 factor,
-    uint256 lastUpdated
-  );
+  event InflationFactorUpdated(uint256 factor, uint256 lastUpdated);
 
-  event InflationParametersUpdated(
-    uint256 rate,
-    uint256 updatePeriod,
-    uint256 lastUpdated
-  );
+  event InflationParametersUpdated(uint256 rate, uint256 updatePeriod, uint256 lastUpdated);
 
-  event Transfer(
-    address indexed from,
-    address indexed to,
-    uint256 value
-  );
+  event Transfer(address indexed from, address indexed to, uint256 value);
 
-  event TransferComment(
-    string comment
-  );
+  event TransferComment(string comment);
 
   string internal name_;
   string internal symbol_;
@@ -52,7 +44,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
   uint256 internal totalSupply_;
 
   // Stored as values. Units can be found using valueToUnits().
-  mapping(address => mapping (address => uint256)) internal allowed;
+  mapping(address => mapping(address => uint256)) internal allowed;
 
   // STABILITY FEE PARAMETERS
 
@@ -74,7 +66,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * really has the private key for 0x0
    */
   modifier onlyVm() {
-    require(msg.sender == address(0), "sender was not vm (reserved 0x0 addr)");
+    require(msg.sender == address(0), 'sender was not vm (reserved 0x0 addr)');
     _;
   }
 
@@ -91,10 +83,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
     if (lastUpdated != inflationState.factorLastUpdated) {
       inflationState.factor = updatedInflationFactor;
       inflationState.factorLastUpdated = lastUpdated;
-      emit InflationFactorUpdated(
-        inflationState.factor.unwrap(),
-        inflationState.factorLastUpdated
-      );
+      emit InflationFactorUpdated(inflationState.factor.unwrap(), inflationState.factorLastUpdated);
     }
     _;
   }
@@ -116,11 +105,8 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
     uint256 inflationFactorUpdatePeriod,
     address[] calldata initialBalanceAddresses,
     uint256[] calldata initialBalanceValues
-  )
-    external
-    initializer
-  {
-    require(inflationRate != 0, "Must provide a non-zero inflation rate.");
+  ) external initializer {
+    require(inflationRate != 0, 'Must provide a non-zero inflation rate.');
 
     _transferOwnership(msg.sender);
     totalSupply_ = 0;
@@ -146,15 +132,12 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param rate new rate.
    * @param updatePeriod how often inflationFactor is updated.
    */
-  function setInflationParameters(
-    uint256 rate,
-    uint256 updatePeriod
-  )
+  function setInflationParameters(uint256 rate, uint256 updatePeriod)
     external
     onlyOwner
     updateInflationFactor
   {
-    require(rate != 0, "Must provide a non-zero inflation rate.");
+    require(rate != 0, 'Must provide a non-zero inflation rate.');
     inflationState.rate = FixidityLib.wrap(rate);
     inflationState.updatePeriod = updatePeriod;
 
@@ -172,10 +155,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param value The increment of the amount of StableToken approved to the spender.
    * @return True if the transaction succeeds.
    */
-  function increaseAllowance(
-    address spender,
-    uint256 value
-  )
+  function increaseAllowance(address spender, uint256 value)
     external
     updateInflationFactor
     returns (bool)
@@ -193,10 +173,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param value The decrement of the amount of StableToken approved to the spender.
    * @return True if the transaction succeeds.
    */
-  function decreaseAllowance(
-    address spender,
-    uint256 value
-  )
+  function decreaseAllowance(address spender, uint256 value)
     external
     updateInflationFactor
     returns (bool)
@@ -214,14 +191,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param value The amount of StableToken approved to the spender.
    * @return True if the transaction succeeds.
    */
-  function approve(
-    address spender,
-    uint256 value
-  )
-    external
-    updateInflationFactor
-    returns (bool)
-  {
+  function approve(address spender, uint256 value) external updateInflationFactor returns (bool) {
     allowed[msg.sender][spender] = value;
     emit Approval(msg.sender, spender, value);
     return true;
@@ -232,18 +202,11 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param to The account for which to mint tokens.
    * @param value The amount of StableToken to mint.
    */
-  function mint(
-    address to,
-    uint256 value
-  )
-    external
-    updateInflationFactor
-    returns (bool)
-  {
+  function mint(address to, uint256 value) external updateInflationFactor returns (bool) {
     // Only the Exchange and Validators contracts are authorized to mint.
     require(
       msg.sender == registry.getAddressFor(EXCHANGE_REGISTRY_ID) ||
-      msg.sender == registry.getAddressFor(VALIDATORS_REGISTRY_ID)
+        msg.sender == registry.getAddressFor(VALIDATORS_REGISTRY_ID)
     );
     return _mint(to, value);
   }
@@ -253,14 +216,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param to The account for which to mint tokens.
    * @param value The amount of StableToken to mint.
    */
-  function _mint(
-    address to,
-    uint256 value
-  )
-    private
-    updateInflationFactor
-    returns (bool)
-  {
+  function _mint(address to, uint256 value) private updateInflationFactor returns (bool) {
     uint256 units = _valueToUnits(inflationState.factor, value);
     totalSupply_ = totalSupply_.add(units);
     balances[to] = balances[to].add(units);
@@ -275,11 +231,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param comment The transfer comment.
    * @return True if the transaction succeeds.
    */
-  function transferWithComment(
-    address to,
-    uint256 value,
-    string calldata comment
-  )
+  function transferWithComment(address to, uint256 value, string calldata comment)
     external
     updateInflationFactor
     returns (bool)
@@ -293,16 +245,14 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @notice Burns StableToken from the balance of msg.sender.
    * @param value The amount of StableToken to burn.
    */
-  function burn(
-    uint256 value
-  )
+  function burn(uint256 value)
     external
     onlyRegisteredContract(EXCHANGE_REGISTRY_ID)
     updateInflationFactor
     returns (bool)
   {
     uint256 units = _valueToUnits(inflationState.factor, value);
-    require(units <= balances[msg.sender], "value exceeded balance of sender");
+    require(units <= balances[msg.sender], 'value exceeded balance of sender');
     totalSupply_ = totalSupply_.sub(units);
     balances[msg.sender] = balances[msg.sender].sub(units);
     return true;
@@ -315,18 +265,14 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param value The amount of StableToken to transfer.
    * @return True if the transaction succeeds.
    */
-  function transferFrom(
-    address from,
-    address to,
-    uint256 value
-  )
+  function transferFrom(address from, address to, uint256 value)
     external
     updateInflationFactor
     returns (bool)
   {
     uint256 units = _valueToUnits(inflationState.factor, value);
-    require(to != address(0), "transfer attempted to reserved address 0x0");
-    require(units <= balances[from], "transfer value exceeded balance of sender");
+    require(to != address(0), 'transfer attempted to reserved address 0x0');
+    require(units <= balances[from], 'transfer value exceeded balance of sender');
     require(
       value <= allowed[from][msg.sender],
       "transfer value exceeded sender's allowance for recipient"
@@ -394,11 +340,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @return updatePeriod
    * @return factorLastUpdated
    */
-  function getInflationParameters()
-    external
-    view
-    returns (uint256, uint256, uint256, uint256)
-  {
+  function getInflationParameters() external view returns (uint256, uint256, uint256, uint256) {
     return (
       inflationState.rate.unwrap(),
       inflationState.factor.unwrap(),
@@ -446,10 +388,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @return The units corresponding to `value` given the current inflation factor.
    * @dev we assume any function calling this will have updated the inflation factor.
    */
-  function _valueToUnits(
-    FixidityLib.Fraction memory inflationFactor,
-    uint256 value
-  )
+  function _valueToUnits(FixidityLib.Fraction memory inflationFactor, uint256 value)
     private
     pure
     returns (uint256)
@@ -462,11 +401,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @return current inflation factor.
    * @return lastUpdated time when the returned inflation factor went into effect.
    */
-  function getUpdatedInflationFactor()
-    private
-    view
-    returns (FixidityLib.Fraction memory, uint256)
-  {
+  function getUpdatedInflationFactor() private view returns (FixidityLib.Fraction memory, uint256) {
     /* solhint-disable not-rely-on-time */
     if (now < inflationState.factorLastUpdated.add(inflationState.updatePeriod)) {
       return (inflationState.factor, inflationState.factorLastUpdated);
@@ -496,8 +431,9 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
       return (inflationState.factor, inflationState.factorLastUpdated);
     }
 
-    FixidityLib.Fraction memory currentInflationFactor =
-      FixidityLib.wrap(numerator).divide(FixidityLib.wrap(denominator));
+    FixidityLib.Fraction memory currentInflationFactor = FixidityLib.wrap(numerator).divide(
+      FixidityLib.wrap(denominator)
+    );
     uint256 lastUpdated = inflationState.factorLastUpdated.add(
       inflationState.updatePeriod.mul(timesToApplyInflation)
     );
@@ -511,7 +447,7 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param to The address to transfer to.
    * @param value The amount to be transferred.
    */
-   // solhint-disable-next-line no-simple-event-func-name
+  // solhint-disable-next-line no-simple-event-func-name
   function transfer(address to, uint256 value) public updateInflationFactor returns (bool) {
     return _transfer(to, value);
   }
@@ -546,9 +482,9 @@ contract StableToken is IStableToken, IERC20Token, ICeloToken, Ownable,
    * @param value The amount of StableToken to be transferred.
    */
   function _transfer(address to, uint256 value) internal returns (bool) {
-    require(to != address(0), "transfer attempted to reserved address 0x0");
+    require(to != address(0), 'transfer attempted to reserved address 0x0');
     uint256 units = _valueToUnits(inflationState.factor, value);
-    require(balances[msg.sender] >= units, "transfer value exceeded balance of sender");
+    require(balances[msg.sender] >= units, 'transfer value exceeded balance of sender');
     balances[msg.sender] = balances[msg.sender].sub(units);
     balances[to] = balances[to].add(units);
     emit Transfer(msg.sender, to, value);

--- a/packages/protocol/contracts/stability/interfaces/IExchange.sol
+++ b/packages/protocol/contracts/stability/interfaces/IExchange.sol
@@ -1,17 +1,7 @@
 pragma solidity ^0.5.3;
 
-
 interface IExchange {
-
-  function initialize(
-    address,
-    address,
-    address,
-    uint256,
-    uint256,
-    uint256,
-    uint256
-  ) external;
+  function initialize(address, address, address, uint256, uint256, uint256, uint256) external;
 
   function exchange(uint256, uint256, bool) external returns (uint256);
   function setUpdateFrequency(uint256) external;

--- a/packages/protocol/contracts/stability/interfaces/IReserve.sol
+++ b/packages/protocol/contracts/stability/interfaces/IReserve.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-
 interface IReserve {
-
   function initialize(address, uint256) external;
   function setTobinTaxStalenessThreshold(uint256) external;
   function addToken(address) external returns (bool);

--- a/packages/protocol/contracts/stability/interfaces/ISortedOracles.sol
+++ b/packages/protocol/contracts/stability/interfaces/ISortedOracles.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-
 interface ISortedOracles {
-
   function addOracle(address, address) external;
   function removeOracle(address, address, uint256) external;
   function report(address, uint256, uint256, address, address) external;

--- a/packages/protocol/contracts/stability/interfaces/IStableToken.sol
+++ b/packages/protocol/contracts/stability/interfaces/IStableToken.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.3;
 
-
 /**
  * @title This interface describes the functions specific to Celo Stable Tokens, and in the
  * absence of interface inheritance is intended as a companion to IERC20.sol and ICeloToken.sol.
@@ -12,24 +11,14 @@ interface IStableToken {
   function creditTo(address, uint256) external;
   function setInflationParameters(uint256, uint256) external;
 
-  function fractionMulExp(
-    uint256,
-    uint256,
-    uint256,
-    uint256,
-    uint256,
-    uint256
-  )
+  function fractionMulExp(uint256, uint256, uint256, uint256, uint256, uint256)
     external
     view
     returns (uint256, uint256);
 
   function valueToUnits(uint256) external view returns (uint256);
   function unitsToValue(uint256) external view returns (uint256);
-  function getInflationParameters()
-    external
-    view
-    returns (uint256, uint256, uint256, uint256);
+  function getInflationParameters() external view returns (uint256, uint256, uint256, uint256);
 
   // NOTE: duplicated with IERC20.sol, remove once interface inheritance is supported.
   function balanceOf(address) external view returns (uint256);

--- a/packages/protocol/contracts/stability/proxies/ExchangeProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ExchangeProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract ExchangeProxy is Proxy {
-}
+contract ExchangeProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/ReserveProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ReserveProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract ReserveProxy is Proxy {
-}
+contract ReserveProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/SortedOraclesProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/SortedOraclesProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract SortedOraclesProxy is Proxy {
-}
+contract SortedOraclesProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/StableTokenProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/StableTokenProxy.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.3;
 
-import "../../common/Proxy.sol";
-
+import '../../common/Proxy.sol';
 
 /* solhint-disable no-empty-blocks */
-contract StableTokenProxy is Proxy {
-}
+contract StableTokenProxy is Proxy {}

--- a/packages/protocol/contracts/stability/test/MockGoldToken.sol
+++ b/packages/protocol/contracts/stability/test/MockGoldToken.sol
@@ -1,12 +1,10 @@
 pragma solidity ^0.5.3;
 // solhint-disable no-unused-vars
 
-
 /**
  * @title A mock GoldToken for testing.
  */
 contract MockGoldToken {
-
   uint8 public constant decimals = 18;
 
   function transfer(address, uint256) external pure returns (bool) {

--- a/packages/protocol/contracts/stability/test/MockReserve.sol
+++ b/packages/protocol/contracts/stability/test/MockReserve.sol
@@ -1,27 +1,25 @@
 pragma solidity ^0.5.3;
 // solhint-disable no-unused-vars
 
-import "../../common/interfaces/IERC20Token.sol";
-
+import '../../common/interfaces/IERC20Token.sol';
 
 /**
  * @title A mock Reserve for testing.
  */
 contract MockReserve {
-
   mapping(address => bool) public tokens;
 
   IERC20Token public goldToken;
 
   // solhint-disable-next-line no-empty-blocks
-  function () external payable {}
+  function() external payable {}
 
   function setGoldToken(address goldTokenAddress) external {
     goldToken = IERC20Token(goldTokenAddress);
   }
 
   function transferGold(address to, uint256 value) external returns (bool) {
-    require(goldToken.transfer(to, value), "gold token transfer failed");
+    require(goldToken.transfer(to, value), 'gold token transfer failed');
     return true;
   }
 

--- a/packages/protocol/contracts/stability/test/MockSortedOracles.sol
+++ b/packages/protocol/contracts/stability/test/MockSortedOracles.sol
@@ -1,21 +1,15 @@
 pragma solidity ^0.5.3;
 
-
 /**
  * @title A mock SortedOracles for testing.
  */
 contract MockSortedOracles {
-
   mapping(address => uint128) public numerators;
   mapping(address => uint128) public denominators;
   mapping(address => uint128) public medianTimestamp;
   mapping(address => uint128) public numRates;
 
-  function setMedianRate(
-    address token,
-    uint128 numerator,
-    uint128 denominator
-  )
+  function setMedianRate(address token, uint128 numerator, uint128 denominator)
     external
     returns (bool)
   {

--- a/packages/protocol/contracts/stability/test/MockStableToken.sol
+++ b/packages/protocol/contracts/stability/test/MockStableToken.sol
@@ -1,17 +1,15 @@
 pragma solidity ^0.5.3;
 // solhint-disable no-unused-vars
 
-
 /**
  * @title A mock StableToken for testing.
  */
 contract MockStableToken {
-
   uint8 public constant decimals = 18;
   bool public _needsRebase;
   uint256 public _totalSupply;
   uint256 public _targetTotalSupply;
-  mapping (address => uint256) public balanceOf;
+  mapping(address => uint256) public balanceOf;
 
   function setNeedsRebase() external {
     _needsRebase = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12176,6 +12176,11 @@ dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
+dir-to-object@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-to-object/-/dir-to-object-2.0.0.tgz#29723e9bd1c3e58e4f307bd04ff634c0370c8f8a"
+  integrity sha512-sXs0JKIhymON7T1UZuO2Ud6VTNAx/VTBXIl4+3mjb2RgfOpt+hectX0x04YqPOPdkeOAKoJuKqwqnXXURNPNEA==
+
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
@@ -12632,6 +12637,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -12997,7 +13007,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@2.0.0:
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
@@ -13190,6 +13200,13 @@ espree@^5.0.1:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
+
+esprima-extract-comments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz#0dacab567a5900240de6d344cf18c33617becbc9"
+  integrity sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==
+  dependencies:
+    esprima "^4.0.0"
 
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
@@ -14355,6 +14372,14 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extract-comments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/extract-comments/-/extract-comments-1.1.0.tgz#b90bca033a056bd69b8ba1c6b6b120fc2ee95c18"
+  integrity sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==
+  dependencies:
+    esprima-extract-comments "^1.1.0"
+    parse-code-context "^1.0.0"
 
 extract-stack@^1.0.0:
   version "1.0.0"
@@ -18486,6 +18511,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-function@^1.0.1, is-function@~1.0.0:
   version "1.0.1"
@@ -24659,6 +24689,11 @@ parse-cache-control@^1.0.1:
   resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
   integrity sha1-juqz5U+laSD+Fro493+iGqzC104=
 
+parse-code-context@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-code-context/-/parse-code-context-1.0.0.tgz#718c295c593d0d19a37f898473268cc75e98de1e"
+  integrity sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==
+
 parse-filepath@^0.6.1:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-0.6.3.tgz#38e17a73e5e4e6776bae9506fc3ccb14bc3a2b80"
@@ -25483,6 +25518,20 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier-plugin-solidity@1.0.0-alpha.34:
+  version "1.0.0-alpha.34"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.34.tgz#9a2584fb1773569e2b22c0edba36cd4b80aa3905"
+  integrity sha512-cg/HrnS4P6m7rdnazZt3QdN7TwuW+TO5quLpTLzvN2BTsbyNFjBjTBUFIJwlFVhjUjw8mQ2uxKfk3b7pSvXJyw==
+  dependencies:
+    dir-to-object "^2.0.0"
+    emoji-regex "^8.0.0"
+    escape-string-regexp "^2.0.0"
+    extract-comments "^1.1.0"
+    prettier "^1.15.3"
+    semver "^6.3.0"
+    solidity-parser-antlr "^0.4.11"
+    string-width "^4.1.0"
+
 prettier@1.13.5:
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
@@ -25502,6 +25551,11 @@ prettier@^1.14.3:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
   integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+
+prettier@^1.15.3:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-bytes@^1.0.2:
   version "1.0.4"
@@ -26795,6 +26849,11 @@ react-native-share@^2.0.0:
   resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-2.0.0.tgz#4543a746013e0d8fa9f765fb8937007cfbcffcf7"
   integrity sha512-J8Xl3mq0L9KDFtSYtKsQDAnZWw/niZIpAD1PRiNfZFHo44Rc+oS2bEIhskNnoQXKEgBNdPzCl/DenMXYAHXRYg==
 
+react-native-sms@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-sms/-/react-native-sms-1.9.0.tgz#362d94f75664d45144433d820155d9da66adf053"
+  integrity sha512-qq5v5rClCSMwTZL5TAK3P89SOQFrBwa6LyqCQV1Md0p78cS+DQWTX/wnb1H8gH32gDzr7barKTEXZPN7lZ5fCA==
+
 react-native-snap-carousel@^3.8.4:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/react-native-snap-carousel/-/react-native-snap-carousel-3.8.4.tgz#4c749c6a714d46ed82de527233850cb5da41bc62"
@@ -26802,11 +26861,6 @@ react-native-snap-carousel@^3.8.4:
   dependencies:
     prop-types "^15.6.1"
     react-addons-shallow-compare "15.6.2"
-    
-react-native-sms@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/react-native-sms/-/react-native-sms-1.9.0.tgz#362d94f75664d45144433d820155d9da66adf053"
-  integrity sha512-qq5v5rClCSMwTZL5TAK3P89SOQFrBwa6LyqCQV1Md0p78cS+DQWTX/wnb1H8gH32gDzr7barKTEXZPN7lZ5fCA==
 
 react-native-splash-screen@^3.2.0:
   version "3.2.0"
@@ -28720,7 +28774,7 @@ semver@^6.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
   integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
 
-semver@^6.1.0, semver@^6.1.1, semver@^6.1.2:
+semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -29671,7 +29725,7 @@ solidity-bytes-utils@0.0.7:
   dependencies:
     truffle-hdwallet-provider "0.0.3"
 
-solidity-parser-antlr@^0.4.2:
+solidity-parser-antlr@^0.4.11, solidity-parser-antlr@^0.4.2:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz#af43e1f13b3b88309a875455f5d6e565b05ee5f1"
   integrity sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg==
@@ -30153,6 +30207,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
+  integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^5.2.0"
 
 string.prototype.trim@^1.1.2, string.prototype.trim@~1.1.2:
   version "1.1.2"
@@ -34082,6 +34145,7 @@ websocket@^1.0.28:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
+    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
### Description

As a constant violator of the Solidity Style Guide (@asaj can attest to this fact), I told myself: "No more!". Hence this PR adds `prettier-solidity` which will prettify our `.sol` files so that future generations shall no longer need to live in fear of style guide violations!

It was actually incredibly easy, there was only 1 place where I needed to add a `// prettier-ignore`

### Tested

- CI

### Backwards compatibility

- I believe they should be
