### PR TITLE
[Wallet] Add timestamp to top banner messages

### DIFF
--- a/packages/mobile/src/alert/AlertBanner.tsx
+++ b/packages/mobile/src/alert/AlertBanner.tsx
@@ -31,6 +31,7 @@ export class AlertBanner extends React.Component<Props> {
 
     return (
       <SmartTopAlert
+        timestamp={Date.now()}
         text={alert && alert.message}
         onPress={hideAlertAction}
         type={alert && alert.type === 'error' ? NotificationTypes.ERROR : NotificationTypes.MESSAGE}

--- a/packages/mobile/src/invite/utils.ts
+++ b/packages/mobile/src/invite/utils.ts
@@ -1,5 +1,6 @@
 import { sanitizeBase64 } from '@celo/walletkit'
 import URLSearchParamsReal from '@ungap/url-search-params'
+import { Platform } from 'react-native'
 import RNInstallReferrer from 'react-native-install-referrer'
 import Logger from 'src/utils/Logger'
 
@@ -53,23 +54,25 @@ interface ReferrerDataError {
 }
 
 export const getValidInviteCodeFromReferrerData = async () => {
-  const referrerData: ReferrerData | ReferrerDataError = await RNInstallReferrer.getReferrer()
-  Logger.info(
-    'invite/utils/getInviteCodeFromReferrerData',
-    'Referrer Data: ' + JSON.stringify(referrerData)
-  )
-  if (referrerData && referrerData.hasOwnProperty('installReferrer')) {
-    const params = new URLSearchParamsReal(
-      decodeURIComponent((referrerData as ReferrerData).installReferrer)
+  if (Platform.OS === 'android') {
+    const referrerData: ReferrerData | ReferrerDataError = await RNInstallReferrer.getReferrer()
+    Logger.info(
+      'invite/utils/getInviteCodeFromReferrerData',
+      'Referrer Data: ' + JSON.stringify(referrerData)
     )
-    const inviteCode = params.get('invite-code')
-    if (inviteCode) {
-      const sanitizedCode = inviteCode.replace(' ', '+')
-      // Accept invite codes which are either base64 encoded or direct hex keys
-      if (isValidPrivateKey(sanitizedCode)) {
-        return sanitizedCode
+    if (referrerData && referrerData.hasOwnProperty('installReferrer')) {
+      const params = new URLSearchParamsReal(
+        decodeURIComponent((referrerData as ReferrerData).installReferrer)
+      )
+      const inviteCode = params.get('invite-code')
+      if (inviteCode) {
+        const sanitizedCode = inviteCode.replace(' ', '+')
+        // Accept invite codes which are either base64 encoded or direct hex keys
+        if (isValidPrivateKey(sanitizedCode)) {
+          return sanitizedCode
+        }
+        return extractValidInviteCode(sanitizedCode)
       }
-      return extractValidInviteCode(sanitizedCode)
     }
   }
   return null

--- a/packages/mobile/src/shared/BackupPrompt.tsx
+++ b/packages/mobile/src/shared/BackupPrompt.tsx
@@ -42,6 +42,7 @@ export class BackupPrompt extends React.Component<Props> {
 
     return (
       <SmartTopAlert
+        timestamp={Date.now()}
         text={isVisible && t('backupPrompt')}
         onPress={this.goToBackup}
         type={NotificationTypes.MESSAGE}

--- a/packages/react-components/components/SmartTopAlert.test.tsx
+++ b/packages/react-components/components/SmartTopAlert.test.tsx
@@ -10,6 +10,7 @@ describe('SmartTopAlert', () => {
   it('renders correctly', async () => {
     const { toJSON } = render(
       <SmartTopAlert
+        timestamp={Date.now()}
         dismissAfter={5}
         title={'Smart Top Alert'}
         text="dont get funny"

--- a/packages/react-components/components/SmartTopAlert.tsx
+++ b/packages/react-components/components/SmartTopAlert.tsx
@@ -12,6 +12,7 @@ export enum NotificationTypes {
 }
 
 interface Props {
+  timestamp: number
   title?: string | null
   text: string | null
   onPress: () => void
@@ -48,7 +49,15 @@ function SmartTopAlert(props: Props) {
         return null
       }
     },
-    [props.type, props.title, props.text, props.buttonMessage, props.dismissAfter, props.onPress]
+    [
+      props.timestamp,
+      props.type,
+      props.title,
+      props.text,
+      props.buttonMessage,
+      props.dismissAfter,
+      props.onPress,
+    ]
   )
 
   function hide() {

--- a/packages/react-components/components/SmartTopAlert.tsx
+++ b/packages/react-components/components/SmartTopAlert.tsx
@@ -11,8 +11,7 @@ export enum NotificationTypes {
   ERROR = 'error',
 }
 
-interface Props {
-  timestamp: number
+interface AlertProps {
   title?: string | null
   text: string | null
   onPress: () => void
@@ -21,9 +20,13 @@ interface Props {
   buttonMessage?: string | null
 }
 
+interface Props extends AlertProps {
+  timestamp: number
+}
+
 // This component needs to be always mounted for the hide animation to be visible
 function SmartTopAlert(props: Props) {
-  const [visibleAlertState, setVisibleAlertState] = useState<Props | null>(null)
+  const [visibleAlertState, setVisibleAlertState] = useState<AlertProps | null>(null)
   const insets = useSafeArea()
   const yOffset = useRef(new Animated.Value(-500))
   const containerRef = useRef<View>()

--- a/packages/verifier/src/components/ErrorBox.tsx
+++ b/packages/verifier/src/components/ErrorBox.tsx
@@ -34,6 +34,7 @@ export class ErrorBox extends React.Component<Props> {
 
     return (
       <SmartTopAlert
+        timestamp={Date.now()}
         text={error && t(error)}
         onPress={clearErrorAction}
         type={NotificationTypes.ERROR}

--- a/packages/verifier/src/components/MessageBanner.tsx
+++ b/packages/verifier/src/components/MessageBanner.tsx
@@ -34,6 +34,7 @@ export class MessageBanner extends React.Component<Props> {
 
     return (
       <SmartTopAlert
+        timestamp={Date.now()}
         text={message}
         title={title}
         onPress={clearMessageAction}


### PR DESCRIPTION


### Description

Add timestamp to top banner messages. This would allow to show the same message again if needed.

### Tested

Ran on iPhone Simulator

### Other changes

Disable `RNInstallReferrer.getReferrer` call for iOS.

### Related issues

- Fixes #1531

### Backwards compatibility

Yes
