### PR TITLE
[Wallet] Limit QR code scanner to 1 code per second

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -491,22 +491,19 @@ DEPENDENCIES:
   - Yoga (from `../../../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  https://github.com/cocoapods/specs.git:
     - Analytics
     - boost-for-react-native
-    - Fabric
-    - Firebase
-    - FirebaseCore
-    - FirebaseInstanceID
-    - GoogleUtilities
-  https://github.com/cocoapods/specs.git:
     - Crashlytics
+    - Fabric
     - Firebase
     - FirebaseAnalytics
     - FirebaseAnalyticsInterop
     - FirebaseAuth
     - FirebaseAuthInterop
+    - FirebaseCore
     - FirebaseDatabase
+    - FirebaseInstanceID
     - FirebaseMessaging
     - FirebaseStorage
     - GoogleAppMeasurement

--- a/packages/mobile/ios/celo/Info.plist
+++ b/packages/mobile/ios/celo/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/packages/mobile/src/qrcode/QRScanner.tsx
+++ b/packages/mobile/src/qrcode/QRScanner.tsx
@@ -23,19 +23,35 @@ interface DispatchProps {
   handleBarcodeDetected: typeof handleBarcodeDetected
 }
 
+interface State {
+  isScanningEnabled: boolean
+}
+
 type Props = DispatchProps & WithNamespaces & NavigationFocusInjectedProps
 
-class QRScanner extends React.Component<Props> {
+class QRScanner extends React.Component<Props, State> {
   static navigationOptions = () => ({
     ...headerWithBackButton,
     headerTitle: i18n.t('sendFlow7:scanCode'),
   })
 
+  state = {
+    isScanningEnabled: true,
+  }
+
   camera: RNCamera | null = null
 
+  // This method would be called multiple times with the same
+  // QR code, so we need to catch only the first one
   onBardCodeDetected = (rawData: any) => {
-    Logger.debug('QRScanner', 'Bar code detected')
-    this.props.handleBarcodeDetected(rawData)
+    if (this.state.isScanningEnabled) {
+      this.setState({ isScanningEnabled: false })
+      Logger.debug('QRScanner', 'Bar code detected')
+      this.props.handleBarcodeDetected(rawData)
+      setTimeout(() => {
+        this.setState({ isScanningEnabled: true })
+      }, 1000)
+    }
   }
 
   onPressShowYourCode = () => {

--- a/packages/mobile/src/qrcode/QRScanner.tsx
+++ b/packages/mobile/src/qrcode/QRScanner.tsx
@@ -35,6 +35,8 @@ class QRScanner extends React.Component<Props, State> {
     headerTitle: i18n.t('sendFlow7:scanCode'),
   })
 
+  timeout: undefined | number = undefined
+
   state = {
     isScanningEnabled: true,
   }
@@ -45,10 +47,11 @@ class QRScanner extends React.Component<Props, State> {
   // QR code, so we need to catch only the first one
   onBardCodeDetected = (rawData: any) => {
     if (this.state.isScanningEnabled) {
-      this.setState({ isScanningEnabled: false })
-      Logger.debug('QRScanner', 'Bar code detected')
-      this.props.handleBarcodeDetected(rawData)
-      setTimeout(() => {
+      this.setState({ isScanningEnabled: false }, () => {
+        Logger.debug('QRScanner', 'Bar code detected')
+        this.props.handleBarcodeDetected(rawData)
+      })
+      this.timeout = setTimeout(() => {
         this.setState({ isScanningEnabled: true })
       }, 1000)
     }
@@ -56,6 +59,12 @@ class QRScanner extends React.Component<Props, State> {
 
   onPressShowYourCode = () => {
     navigate(Screens.QRCode)
+  }
+
+  componentWillUnmount() {
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+    }
   }
 
   render() {


### PR DESCRIPTION
### Description

QR code scanner would emit scanned codes multiple times for the same code. This PR would limit it to scan 1 code per second. So, essentially after the code scanned - 1 second should be enough to leave the QR code scan screen.

### Tested

Ran on iPhone.

### Other changes

Disable Dark Mode in iOS, because it font colors were inverted in it.

### Related issues

- Fixes #1524

### Backwards compatibility
Yes
