### PR TITLE
[Wallet] Use the country of the phone number for determining the default local currency

### DIFF
--- a/packages/mobile/src/localCurrency/selectors.test.ts
+++ b/packages/mobile/src/localCurrency/selectors.test.ts
@@ -1,0 +1,47 @@
+import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
+
+describe(getLocalCurrencyCode, () => {
+  describe('when no preferred currency is set', () => {
+    it('returns the first supported local currency for the country of the phone number', () => {
+      const state: any = {
+        account: { e164PhoneNumber: '+231881551952' },
+        localCurrency: { preferredCurrencyCode: undefined },
+      }
+      expect(getLocalCurrencyCode(state)).toEqual('LRD')
+    })
+
+    it('returns null for US phone numbers', () => {
+      const state: any = {
+        account: { e164PhoneNumber: '+14155552671' },
+        localCurrency: { preferredCurrencyCode: undefined },
+      }
+      expect(getLocalCurrencyCode(state)).toBeNull()
+    })
+
+    it('returns CAD for CA phone numbers', () => {
+      const state: any = {
+        account: { e164PhoneNumber: '+18192216929' },
+        localCurrency: { preferredCurrencyCode: undefined },
+      }
+      expect(getLocalCurrencyCode(state)).toEqual('CAD')
+    })
+  })
+
+  describe('when a preferred currency is set', () => {
+    it('returns the preferred currency', () => {
+      const state: any = {
+        account: { e164PhoneNumber: '+231881551952' },
+        localCurrency: { preferredCurrencyCode: 'MXN' },
+      }
+      expect(getLocalCurrencyCode(state)).toEqual('MXN')
+    })
+
+    it('returns null when USD is the preferred currency', () => {
+      const state: any = {
+        account: { e164PhoneNumber: '+14155552671' },
+        localCurrency: { preferredCurrencyCode: 'USD' },
+      }
+      expect(getLocalCurrencyCode(state)).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
### Description

We initially tried using the device locale for getting the currencies (`RNLocalize.getCurrencies()`), but the problem is some Android versions don't make it possible to select the correct language/country from the device settings.
So with this PR we now use the country of the phone number to determine the default local currency.

### Tested

Added new tests.

### Other changes

N/A

### Related issues

- Fixes #1683

### Backwards compatibility

Yes
