### PR TITLE
Switch to correct cluster when fauceting

### DIFF
--- a/packages/celotool/src/cmds/account/faucet.ts
+++ b/packages/celotool/src/cmds/account/faucet.ts
@@ -1,5 +1,6 @@
 /* tslint:disable no-console */
 import { newKit } from '@celo/contractkit'
+import { switchToClusterFromEnv } from 'src/lib/cluster'
 import { convertToContractDecimals } from 'src/lib/contract-utils'
 import { portForwardAnd } from 'src/lib/port_forward'
 import { validateAccountAddress } from 'src/lib/utils'
@@ -29,6 +30,8 @@ export const builder = (argv: yargs.Argv) => {
 }
 
 export const handler = async (argv: FaucetArgv) => {
+  await switchToClusterFromEnv()
+
   const address = argv.account
 
   const cb = async () => {


### PR DESCRIPTION
### Description

Fixes issues seen when trying to faucet an account without being in the correct cluster/context.

### Tested

Ran it when I was initially in a different context & it worked

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

n/a