### PR TITLE
Reset isRedeemingInvite on rehydrate

### DIFF
--- a/packages/mobile/src/invite/reducer.ts
+++ b/packages/mobile/src/invite/reducer.ts
@@ -30,6 +30,7 @@ export const inviteReducer = (
         ...state,
         ...getRehydratePayload(action, 'invite'),
         isSendingInvite: false,
+        isRedeemingInvite: false,
       }
     }
     case Actions.SEND_INVITE:


### PR DESCRIPTION
### Description

If the app is force quite while redeeming an invite, it will open again with the spinner spinning but no way to paste an invite code.

### Tested

Restarted the app during an invite redeem