### PR TITLE
New Version for contractkit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ reference:
     environment:
       TERM: dumb
       _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
-      GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true'
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true"
 
 defaults: &defaults
   working_directory: ~/app
@@ -29,7 +29,7 @@ android-defaults: &android-defaults
     - image: circleci/android:api-28-node
   environment:
     _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
-    GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true'
+    GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true"
 
 e2e-defaults: &e2e-defaults
   <<: *defaults
@@ -240,7 +240,7 @@ jobs:
       - run:
           name: Start pidcat logging
           command: pidcat -t "GoLog" -t "Go" # React logs are on metro step since RN 61
-          background: true 
+          background: true
       - run:
           name: Run yarn dev
           command: cd ~/src/packages/mobile && ENVFILE=".env.test" yarn dev
@@ -249,7 +249,7 @@ jobs:
           command: adb kill-server && adb start-server
       - run:
           name: Run test itself
-          
+
           command: |
             cd ~/src/packages/mobile 
             # detox sometimes without releasing the terminal and thus making the CI timout
@@ -450,7 +450,7 @@ jobs:
       - run:
           name: Generate DevChain
           command: |
-            (cd packages/cli && yarn test:reset)          
+            (cd packages/cli && yarn test:reset)
       - run:
           name: Run Tests
           command: yarn --cwd=packages/cli test
@@ -468,15 +468,16 @@ jobs:
           command: |
             yarn --cwd=packages/cli run celocli account:new
 
-      - run:
-          name: Install and test the npm package
-          command: |
-            set -euo pipefail
-            cd packages/cli
-            yarn pack
-            cd /tmp
-            npm install ~/app/packages/cli/celo-celocli-*.tgz
-            ./node_modules/.bin/celocli account:new # Small test
+      # Won't work when cli uses git dependencies!
+      # - run:
+      #     name: Install and test the npm package
+      #     command: |
+      #       set -euo pipefail
+      #       cd packages/cli
+      #       yarn pack
+      #       cd /tmp
+      #       npm install ~/app/packages/cli/celo-celocli-*.tgz
+      #       ./node_modules/.bin/celocli account:new # Small test
 
   typescript-test:
     <<: *defaults

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "**/codecov/**/js-yaml": "^3.13.1",
     "**/deep-extend": "^0.5.1",
     "**/extend": "^3.0.2",
+    "**/cross-fetch": "^3.0.2",
     "sha3": "1.2.3"
   }
 }

--- a/packages/attestation-service/package.json
+++ b/packages/attestation-service/package.json
@@ -27,7 +27,7 @@
     "lint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
-    "@celo/contractkit": "0.1.6",
+    "@celo/contractkit": "0.2.1-dev",
     "@celo/utils": "^0.1.0",
     "bignumber.js": "^7.2.0",
     "body-parser": "1.19.0",

--- a/packages/blockchain-api/jest.config.js
+++ b/packages/blockchain-api/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   setupFiles: ['./setupJest.ts'],
   testMatch: ['**/?(*.)(spec|test).ts?(x)'],
-  testResultsProcessor: 'jest-junit',
+  // testResultsProcessor: 'jest-junit',
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -36,5 +36,8 @@
     "jest-fetch-mock": "^2.1.2",
     "tsc-watch": "^1.0.31",
     "typescript": "^3.5.3"
+  },
+  "resolutions": {
+    "**/cross-fetch": "3.0.4"
   }
 }

--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -17,7 +17,7 @@
     "deploy": "./deploy.sh"
   },
   "dependencies": {
-    "@celo/contractkit": "0.1.6",
+    "@celo/contractkit": "0.2.0",
     "apollo-datasource-rest": "^0.3.1",
     "apollo-server-express": "^2.4.2",
     "bignumber.js": "^7.2.0",

--- a/packages/celotool/package.json
+++ b/packages/celotool/package.json
@@ -9,7 +9,7 @@
     "@celo/verification-pool-api": "^1.0.0",
     "@celo/utils": "^0.1.0",
     "@celo/walletkit": "^0.0.14",
-    "@celo/contractkit": "0.1.6",
+    "@celo/contractkit": "0.2.1-dev",
     "@google-cloud/monitoring": "0.7.1",
     "@google-cloud/pubsub": "^0.28.1",
     "@google-cloud/storage": "^2.4.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "test": "TZ=UTC jest --runInBand"
   },
   "dependencies": {
-    "@celo/contractkit": "0.1.6",
+    "@celo/contractkit": "0.2.1-dev",
     "@celo/utils": "^0.1.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/contractkit",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Celo's ContractKit to interact with Celo network",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -31,13 +31,13 @@
     "bignumber.js": "^7.2.0",
     "cross-fetch": "3.0.4",
     "debug": "^4.1.1",
-    "fp-ts": "2.1.1",
     "eth-lib": "^0.2.8",
+    "fp-ts": "2.1.1",
     "io-ts": "2.0.1",
     "web3": "1.0.0-beta.37",
     "web3-core-helpers": "1.0.0-beta.37",
-    "web3-utils": "1.0.0-beta.37",
-    "web3-eth-abi": "1.0.0-beta.37"
+    "web3-eth-abi": "1.0.0-beta.37",
+    "web3-utils": "1.0.0-beta.37"
   },
   "devDependencies": {
     "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#9d77e02",

--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/contractkit",
-  "version": "0.2.0",
+  "version": "0.2.1-dev",
   "description": "Celo's ContractKit to interact with Celo network",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@celo/client": "9575a01",
-    "@celo/contractkit": "^0.1.6",
+    "@celo/contractkit": "0.2.1-dev",
     "@celo/react-components": "1.0.0",
     "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#b88e502",
     "@celo/utils": "^0.1.1",

--- a/packages/transaction-metrics-exporter/package.json
+++ b/packages/transaction-metrics-exporter/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@celo/contractkit": "^0.1.1",
+    "@celo/contractkit": "0.1.6",
     "@celo/utils": "^0.1.0",    
     "express": "4.16.4",
     "prom-client": "11.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,7 +2193,26 @@
     web3-eth-abi "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
-"@celo/contractkit@0.1.6", "@celo/contractkit@^0.1.1", "@celo/contractkit@^0.1.5":
+"@celo/contractkit@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-0.2.0.tgz#6db7479c786f36ac0a1c4ffe7cb23a5f98690f83"
+  integrity sha512-UGI6dvoL46H2pa8kbfG9CTNF1o2Pg1slhyVfAM1gK9Ohr7Agm+mNivdx5DESIjEZ8NX1PWcOOd4PMJWinBnWRg==
+  dependencies:
+    "@0x/subproviders" "^5.0.0"
+    "@celo/utils" "^0.1.0"
+    "@types/debug" "^4.1.5"
+    bignumber.js "^7.2.0"
+    cross-fetch "3.0.4"
+    debug "^4.1.1"
+    eth-lib "^0.2.8"
+    fp-ts "2.1.1"
+    io-ts "2.0.1"
+    web3 "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-eth-abi "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
+
+"@celo/contractkit@^0.1.1", "@celo/contractkit@^0.1.5":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-0.1.6.tgz#c4f6d5003694cc28853f7331b5c0597a208a389d"
   integrity sha512-3mEmfOVaqOjyAT5mHWAESYdcKTvZPDDCkkh7GVDDpq7sPhnZ5dGX5oT26XzMLhe8TfdTQMzp6B22EDaPjOLx8A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,6 +2193,25 @@
     web3-eth-abi "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
+"@celo/contractkit@0.1.6", "@celo/contractkit@^0.1.5":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-0.1.6.tgz#c4f6d5003694cc28853f7331b5c0597a208a389d"
+  integrity sha512-3mEmfOVaqOjyAT5mHWAESYdcKTvZPDDCkkh7GVDDpq7sPhnZ5dGX5oT26XzMLhe8TfdTQMzp6B22EDaPjOLx8A==
+  dependencies:
+    "@0x/subproviders" "^5.0.0"
+    "@celo/utils" "^0.1.0"
+    "@types/debug" "^4.1.5"
+    bignumber.js "^7.2.0"
+    cross-fetch "3.0.4"
+    debug "^4.1.1"
+    eth-lib "^0.2.8"
+    fp-ts "2.0.5"
+    io-ts "2.0.1"
+    web3 "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-eth-abi "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
+
 "@celo/contractkit@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-0.2.0.tgz#6db7479c786f36ac0a1c4ffe7cb23a5f98690f83"
@@ -2206,25 +2225,6 @@
     debug "^4.1.1"
     eth-lib "^0.2.8"
     fp-ts "2.1.1"
-    io-ts "2.0.1"
-    web3 "1.0.0-beta.37"
-    web3-core-helpers "1.0.0-beta.37"
-    web3-eth-abi "1.0.0-beta.37"
-    web3-utils "1.0.0-beta.37"
-
-"@celo/contractkit@^0.1.1", "@celo/contractkit@^0.1.5":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-0.1.6.tgz#c4f6d5003694cc28853f7331b5c0597a208a389d"
-  integrity sha512-3mEmfOVaqOjyAT5mHWAESYdcKTvZPDDCkkh7GVDDpq7sPhnZ5dGX5oT26XzMLhe8TfdTQMzp6B22EDaPjOLx8A==
-  dependencies:
-    "@0x/subproviders" "^5.0.0"
-    "@celo/utils" "^0.1.0"
-    "@types/debug" "^4.1.5"
-    bignumber.js "^7.2.0"
-    cross-fetch "3.0.4"
-    debug "^4.1.1"
-    eth-lib "^0.2.8"
-    fp-ts "2.0.5"
     io-ts "2.0.1"
     web3 "1.0.0-beta.37"
     web3-core-helpers "1.0.0-beta.37"
@@ -11165,31 +11165,7 @@ cross-env@^5.1.3, cross-env@^5.1.6:
     cross-spawn "^5.1.0"
     is-windows "^1.0.0"
 
-cross-fetch@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
-  integrity sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=
-  dependencies:
-    node-fetch "2.1.2"
-    whatwg-fetch "2.0.4"
-
-cross-fetch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
-  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
-  dependencies:
-    node-fetch "2.6.0"
-    whatwg-fetch "3.0.0"
-
-cross-fetch@^2.1.0, cross-fetch@^2.1.1, cross-fetch@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.3.tgz#e8a0b3c54598136e037f8650f8e823ccdfac198e"
-  integrity sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==
-  dependencies:
-    node-fetch "2.1.2"
-    whatwg-fetch "2.0.4"
-
-cross-fetch@^3.0.2:
+cross-fetch@2.2.2, cross-fetch@3.0.4, cross-fetch@^2.1.0, cross-fetch@^2.1.1, cross-fetch@^2.2.2, cross-fetch@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.2.tgz#b7136491967031949c7f86b15903aef4fa3f1768"
   integrity sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==
@@ -22840,20 +22816,10 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
-
 node-fetch@2.3.0, node-fetch@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
-
-node-fetch@2.6.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-fetch@^1.0.1, node-fetch@~1.7.1:
   version "1.7.3"
@@ -22867,6 +22833,11 @@ node-fetch@^2.0.0-alpha.8, node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
   integrity sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==
+
+node-fetch@^2.5.0, node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-forge@0.7.4:
   version "0.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,6 +2193,25 @@
     web3-eth-abi "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
+"@celo/contractkit@0.1.6", "@celo/contractkit@^0.1.1", "@celo/contractkit@^0.1.5":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-0.1.6.tgz#c4f6d5003694cc28853f7331b5c0597a208a389d"
+  integrity sha512-3mEmfOVaqOjyAT5mHWAESYdcKTvZPDDCkkh7GVDDpq7sPhnZ5dGX5oT26XzMLhe8TfdTQMzp6B22EDaPjOLx8A==
+  dependencies:
+    "@0x/subproviders" "^5.0.0"
+    "@celo/utils" "^0.1.0"
+    "@types/debug" "^4.1.5"
+    bignumber.js "^7.2.0"
+    cross-fetch "3.0.4"
+    debug "^4.1.1"
+    eth-lib "^0.2.8"
+    fp-ts "2.0.5"
+    io-ts "2.0.1"
+    web3 "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-eth-abi "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
+
 "@celo/dev-cli@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@celo/dev-cli/-/dev-cli-2.0.3.tgz#67f61dfee373ad8b412925e386cf122aabada5f5"
@@ -15069,6 +15088,11 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+
+fp-ts@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.0.5.tgz#9560d8a6a4f53cbda9f9b31ed8d1458e41939e07"
+  integrity sha512-opI5r+rVlpZE7Rhk0YtqsrmxGkbIw0dRNqGca8FEAMMnjomXotG+R9QkLQg20onx7R8qhepAn4CCOP8usma/Xw==
 
 fp-ts@2.1.1:
   version "2.1.1"
@@ -33965,7 +33989,6 @@ websocket@^1.0.28:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
### Description

Freezes all last changes on ContractKit on a new Version 0.2.

For all packages that depended on the "git version", they now depend on the "0.2.1-dev" which signal the git unpublished version.

The rest of the packages were not updated, since they depended on the 0.1.6 npm version from a few months ago. Probably an alfajores one

@asaj It would be nice if we avoid squashing the commits here. Since first commits represents the npm new version (and should be tagged) and the second commit is the start of the next dev cycle.

### Tested

CI / Build

