### PR TITLE
[circleci] Removed end-to-end-geth-integration-sync-test job in workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,10 +743,6 @@ workflows:
           requires:
             - lint-checks
             - contractkit-test
-      - end-to-end-geth-integration-sync-test:
-          requires:
-            - lint-checks
-            - contractkit-test
       - end-to-end-geth-attestations-test:
           requires:
             - lint-checks


### PR DESCRIPTION
### Description

Quick fix to remove `end-to-end-geth-integration-sync-test` job from circleci workflow.

### Tested

No app code changed.

### Other changes

- No

### Related issues

- Related with PR  #1681

### Backwards compatibility

No problem
