### PR TITLE
Remove end-to-end attestations test from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,24 +583,6 @@ jobs:
             cd packages/celotool
             ./ci_test_sync.sh checkout master
 
-  end-to-end-geth-attestations-test:
-    <<: *e2e-defaults
-    resource_class: medium+
-    steps:
-      - attach_workspace:
-          at: ~/app
-      - run:
-          name: Check if the test should run
-          command: |
-            FILES_TO_CHECK="${PWD}/packages/celotool,${PWD}/packages/protocol,${PWD}/.circleci/config.yml"
-            ./scripts/ci_check_if_test_should_run_v2.sh ${FILES_TO_CHECK}
-      - run:
-          name: Run test
-          command: |
-            set -e
-            cd packages/celotool
-            ./ci_test_attestations.sh checkout master
-
   end-to-end-geth-validator-order-test:
     <<: *e2e-defaults
     resource_class: large
@@ -740,10 +722,6 @@ workflows:
             - lint-checks
             - contractkit-test
       - end-to-end-geth-sync-test:
-          requires:
-            - lint-checks
-            - contractkit-test
-      - end-to-end-geth-attestations-test:
           requires:
             - lint-checks
             - contractkit-test


### PR DESCRIPTION
### Description

This test is broken and never passes, removing it so that we don't become desensitized to broken builds.

### Tested

Not tested.

### Other changes

None.

