### PR TITLE
Try CircleCI memory+ class to fix build step (6GB instead of 4GB of memory)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,8 @@ general:
 jobs:
   install_dependencies:
     <<: *defaults
+    # Source: https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    resource_class: medium+
     steps:
       - restore_cache:
           keys:


### PR DESCRIPTION
### Description

Though https://github.com/celo-org/celo-monorepo/pull/1549 built fine, merging it caused the initial install step to run out of memory:

https://app.circleci.com/jobs/github/celo-org/celo-monorepo/66762
<img width="968" alt="Screenshot 2019-11-19 at 15 11 03" src="https://user-images.githubusercontent.com/57791/69154788-efc77600-0ae0-11ea-86d4-5f94427164c6.png">

This PR makes CircleCI run the failing step with a VM with more memory (6GB instead of the default 4GB).