### PR TITLE
Serialize to hex string

### DIFF
--- a/packages/contractkit/src/providers/celo-private-keys-subprovider.ts
+++ b/packages/contractkit/src/providers/celo-private-keys-subprovider.ts
@@ -124,7 +124,7 @@ export class CeloPrivateKeysWalletProvider extends PrivateKeyWalletSubprovider {
       txParams.gatewayFeeRecipient = await this.getCoinbase()
     }
     if (!isEmpty(txParams.gatewayFeeRecipient) && isEmpty(txParams.gatewayFee)) {
-      txParams.gatewayFee = DefaultGatewayFee.toString()
+      txParams.gatewayFee = DefaultGatewayFee.toString(16)
     }
     debug(
       'Gateway fee for the transaction is %s paid to %s',


### PR DESCRIPTION
### Description

The default gateway fee was not properly encoded

```
> lib.bytes.fromNat(new BN(10000).toString())
'0x0000'
```

### Tested

- Deployed attestation service to integration
