### PR TITLE
Fix gateway fee encoding to ensure value is passed correctly

### DIFF
--- a/packages/contractkit/src/providers/celo-private-keys-subprovider.ts
+++ b/packages/contractkit/src/providers/celo-private-keys-subprovider.ts
@@ -124,7 +124,7 @@ export class CeloPrivateKeysWalletProvider extends PrivateKeyWalletSubprovider {
       txParams.gatewayFeeRecipient = await this.getCoinbase()
     }
     if (!isEmpty(txParams.gatewayFeeRecipient) && isEmpty(txParams.gatewayFee)) {
-      txParams.gatewayFee = DefaultGatewayFee.toString()
+      txParams.gatewayFee = DefaultGatewayFee.toString(16)
     }
     debug(
       'Gateway fee for the transaction is %s paid to %s',

--- a/packages/contractkit/src/utils/signing-utils.ts
+++ b/packages/contractkit/src/utils/signing-utils.ts
@@ -22,6 +22,9 @@ function trimLeadingZero(hex: string) {
 }
 
 function makeEven(hex: string) {
+  if (hex && !hex.startsWith('0x')) {
+    throw new Error('input string is not hex')
+  }
   if (hex.length % 2 === 1) {
     hex = hex.replace('0x', '0x0')
   }
@@ -59,16 +62,16 @@ export async function signTransaction(txn: any, privateKey: string) {
       // This order should match the order in Geth.
       // https://github.com/celo-org/celo-blockchain/blob/027dba2e4584936cc5a8e8993e4e27d28d5247b8/core/types/transaction.go#L65
       const rlpEncoded = RLP.encode([
-        Bytes.fromNat(transaction.nonce),
-        Bytes.fromNat(transaction.gasPrice),
-        Bytes.fromNat(transaction.gas),
+        makeEven(transaction.nonce),
+        makeEven(transaction.gasPrice),
+        makeEven(transaction.gas),
         transaction.feeCurrency.toLowerCase(),
         transaction.gatewayFeeRecipient.toLowerCase(),
-        Bytes.fromNat(transaction.gatewayFee),
+        makeEven(transaction.gatewayFee),
         transaction.to.toLowerCase(),
-        Bytes.fromNat(transaction.value),
+        makeEven(transaction.value),
         transaction.data,
-        Bytes.fromNat(transaction.chainId || '0x1'),
+        makeEven(transaction.chainId || '0x1'),
         '0x',
         '0x',
       ])

--- a/packages/faucet/src/protocol/signing-utils.ts
+++ b/packages/faucet/src/protocol/signing-utils.ts
@@ -1,7 +1,7 @@
 // Originally taken from https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth-accounts/src/index.js
 
 // @ts-ignore
-import { bytes, hash, nat, RLP } from 'eth-lib'
+import { hash, nat, RLP } from 'eth-lib'
 // @ts-ignore
 import * as helpers from 'web3-core-helpers'
 // @ts-ignore
@@ -21,6 +21,9 @@ function trimLeadingZero(hex: string) {
 }
 
 function makeEven(hex: string) {
+  if (hex && !hex.startsWith('0x')) {
+    throw new Error('input string is not hex')
+  }
   if (hex.length % 2 === 1) {
     hex = hex.replace('0x', '0x0')
   }
@@ -56,16 +59,16 @@ export async function signTransaction(web3: Web3, txn: any, privateKey: string) 
       transaction.gatewayFee = tx.gatewayFee || '0x'
 
       const rlpEncoded = RLP.encode([
-        bytes.fromNat(transaction.nonce),
-        bytes.fromNat(transaction.gasPrice),
-        bytes.fromNat(transaction.gas),
+        makeEven(transaction.nonce),
+        makeEven(transaction.gasPrice),
+        makeEven(transaction.gas),
         transaction.feeCurrency.toLowerCase(),
         transaction.gatewayFeeRecipient.toLowerCase(),
-        bytes.fromNat(transaction.gatewayFee),
+        makeEven(transaction.gatewayFee),
         transaction.to.toLowerCase(),
-        bytes.fromNat(transaction.value),
+        makeEven(transaction.value),
         transaction.data,
-        bytes.fromNat(transaction.chainId || '0x1'),
+        makeEven(transaction.chainId || '0x1'),
         '0x',
         '0x',
       ])

--- a/packages/protocol/lib/signing-utils.ts
+++ b/packages/protocol/lib/signing-utils.ts
@@ -1,7 +1,7 @@
 // Originally taken from https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth-accounts/src/index.js
 
 import { parseSignature } from "@celo/utils/lib/signatureUtils"
-import { bytes, hash, nat, RLP } from 'eth-lib'
+import { hash, nat, RLP } from 'eth-lib'
 import * as _ from 'underscore'
 import * as helpers from 'web3-core-helpers'
 import * as Account from 'web3-eth-accounts/node_modules/eth-lib/lib/account'
@@ -21,6 +21,9 @@ function trimLeadingZero(hex: string) {
 }
 
 function makeEven(hex: string) {
+  if (hex && !hex.startsWith('0x')) {
+      throw new Error('input string is not hex')
+  }
   if (hex.length % 2 === 1) {
     hex = hex.replace('0x', '0x0')
   }
@@ -62,16 +65,16 @@ export async function signTransaction(web3: Web3, txn: any, privateKey: string) 
       transaction.gatewayFee = tx.gatewayFee || '0x'
 
       const rlpEncoded = RLP.encode([
-        bytes.fromNat(transaction.nonce),
-        bytes.fromNat(transaction.gasPrice),
-        bytes.fromNat(transaction.gas),
+        makeEven(transaction.nonce),
+        makeEven(transaction.gasPrice),
+        makeEven(transaction.gas),
         transaction.feeCurrency.toLowerCase(),
         transaction.gatewayFeeRecipient.toLowerCase(),
-        bytes.fromNat(transaction.gatewayFee),
+        makeEven(transaction.gatewayFee),
         transaction.to.toLowerCase(),
-        bytes.fromNat(transaction.value),
+        makeEven(transaction.value),
         transaction.data,
-        bytes.fromNat(transaction.chainId || '0x1'),
+        makeEven(transaction.chainId || '0x1'),
         '0x',
         '0x',
       ])

--- a/packages/verification-pool-api/src/signing-utils.ts
+++ b/packages/verification-pool-api/src/signing-utils.ts
@@ -19,6 +19,9 @@ function trimLeadingZero(hex: string) {
 }
 
 function makeEven(hex: string) {
+  if (hex && !hex.startsWith('0x')) {
+    throw new Error('input string is not hex')
+  }
   if (hex.length % 2 === 1) {
     hex = hex.replace('0x', '0x0')
   }
@@ -54,16 +57,16 @@ export async function signTransaction(web3: Web3, txn: any, privateKey: string) 
       transaction.gatewayFee = tx.gatewayFee || '0x'
 
       const rlpEncoded = RLP.encode([
-        Bytes.fromNat(transaction.nonce),
-        Bytes.fromNat(transaction.gasPrice),
-        Bytes.fromNat(transaction.gas),
+        makeEven(transaction.nonce),
+        makeEven(transaction.gasPrice),
+        makeEven(transaction.gas),
         transaction.feeCurrency.toLowerCase(),
         transaction.gatewayFeeRecipient.toLowerCase(),
-        Bytes.fromNat(transaction.gatewayFee),
+        makeEven(transaction.gatewayFee),
         transaction.to.toLowerCase(),
-        Bytes.fromNat(transaction.value),
+        makeEven(transaction.value),
         transaction.data,
-        Bytes.fromNat(transaction.chainId || '0x1'),
+        makeEven(transaction.chainId || '0x1'),
         '0x',
         '0x',
       ])

--- a/packages/verification-pool-api/src/signing-utils.ts
+++ b/packages/verification-pool-api/src/signing-utils.ts
@@ -1,6 +1,6 @@
 // Originally taken from https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth-accounts/src/index.js
 
-import { account as Account, bytes as Bytes, hash as Hash, nat as Nat, RLP } from 'eth-lib'
+import { account as Account, hash as Hash, nat as Nat, RLP } from 'eth-lib'
 import * as _ from 'lodash'
 import * as helpers from 'web3-core-helpers'
 import * as utils from 'web3-utils'

--- a/packages/walletkit/src/contract-utils.ts
+++ b/packages/walletkit/src/contract-utils.ts
@@ -16,7 +16,7 @@ import { Logger } from './logger'
 const gasInflateFactor = 1.3
 
 // TODO(nategraf): Allow this paramter to be fetched from the full-node peer.
-const defaultGatewayFee = new BigNumber(10000)
+const defaultGatewayFee = '0x2710' // 10000
 
 export function selectContractByAddress(contracts: Contract[], address: string) {
   const addresses = contracts.map((contract) => contract.options.address)
@@ -413,7 +413,7 @@ export async function sendTransactionAsyncWithWeb3Signing<T>(
     // fill the fields here.
     let feeCurrency = feeCurrencyContract._address
     const gatewayFeeRecipient = await web3.eth.getCoinbase()
-    const gatewayFee = defaultGatewayFee.toString()
+    const gatewayFee = defaultGatewayFee
     Logger.debug(tag, `Gateway fee is ${gatewayFee} paid to ${gatewayFeeRecipient}`)
     const gasPrice = await getGasPrice(web3, feeCurrency)
     if (feeCurrency === undefined) {

--- a/packages/walletkit/src/signing-utils.ts
+++ b/packages/walletkit/src/signing-utils.ts
@@ -26,6 +26,9 @@ function trimLeadingZero(hex: string) {
 }
 
 function makeEven(hex: string) {
+  if (hex && !hex.startsWith('0x')) {
+    throw new Error('input string is not hex')
+  }
   if (hex.length % 2 === 1) {
     hex = hex.replace('0x', '0x0')
   }
@@ -104,16 +107,16 @@ export async function signTransaction(txn: CeloPartialTxParams, privateKey: stri
       transaction.chainId = utils.numberToHex(tx.chainId)
 
       const rlpEncoded = RLP.encode([
-        Bytes.fromNat(transaction.nonce),
-        Bytes.fromNat(transaction.gasPrice),
-        Bytes.fromNat(transaction.gas),
+        makeEven(transaction.nonce),
+        makeEven(transaction.gasPrice),
+        makeEven(transaction.gas),
         transaction.feeCurrency.toLowerCase(),
         transaction.gatewayFeeRecipient.toLowerCase(),
-        Bytes.fromNat(transaction.gatewayFee),
+        makeEven(transaction.gatewayFee),
         transaction.to.toLowerCase(),
-        Bytes.fromNat(transaction.value),
+        makeEven(transaction.value),
         transaction.data,
-        Bytes.fromNat(transaction.chainId || '0x1'),
+        makeEven(transaction.chainId || '0x1'),
         '0x',
         '0x',
       ])


### PR DESCRIPTION
### Description

As discovered by Nam, the gateway fee is not guaranteed to be encoded correctly when local signing is used. https://github.com/celo-org/celo-monorepo/pull/1848 fixes an instance of this issue and this PR aims to fix the issue elsewhere and ensure it is covered in tests.

### Tested

Added check to unit tests