### PR TITLE
Clean seed words text area when returns from empty wallet view

### DIFF
--- a/packages/mobile/src/import/ImportWallet.test.tsx
+++ b/packages/mobile/src/import/ImportWallet.test.tsx
@@ -11,6 +11,10 @@ jest.mock('src/geth/GethAwareButton', () => {
   return mockButton
 })
 
+jest.mock('react-navigation', () => ({
+  NavigationEvents: 'NavigationEvents',
+}))
+
 describe('ImportWallet', () => {
   it('renders correctly and is disabled with no text', () => {
     const wrapper = render(

--- a/packages/mobile/src/import/ImportWallet.test.tsx
+++ b/packages/mobile/src/import/ImportWallet.test.tsx
@@ -4,7 +4,7 @@ import 'react-native'
 import { fireEvent, render } from 'react-native-testing-library'
 import { Provider } from 'react-redux'
 import ImportWallet, { ImportWallet as ImportWalletClass } from 'src/import/ImportWallet'
-import { createMockStore, getMockI18nProps } from 'test/utils'
+import { createMockNavigationProp, createMockStore, getMockI18nProps } from 'test/utils'
 import { mockMnemonic } from 'test/values'
 
 jest.mock('src/geth/GethAwareButton', () => {
@@ -32,6 +32,7 @@ describe('ImportWallet', () => {
           importBackupPhrase={importFn}
           hideAlert={jest.fn()}
           isImportingWallet={false}
+          navigation={createMockNavigationProp({})}
           {...getMockI18nProps()}
         />
       </Provider>

--- a/packages/mobile/src/import/ImportWallet.tsx
+++ b/packages/mobile/src/import/ImportWallet.tsx
@@ -8,11 +8,7 @@ import * as React from 'react'
 import { WithNamespaces, withNamespaces } from 'react-i18next'
 import { ActivityIndicator, Image, Keyboard, StyleSheet, Text, View } from 'react-native'
 import SafeAreaView from 'react-native-safe-area-view'
-import {
-  NavigationInjectedProps,
-  withNavigationFocus,
-  NavigationEventSubscription,
-} from 'react-navigation'
+import { NavigationEvents, NavigationInjectedProps } from 'react-navigation'
 import { connect } from 'react-redux'
 import { hideAlert } from 'src/alert/actions'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
@@ -62,25 +58,13 @@ export class ImportWallet extends React.Component<Props, State> {
   state = {
     backupPhrase: '',
   }
-  didFocusSubscription?: NavigationEventSubscription
-
-  componentDidMount() {
-    this.didFocusSubscription = this.props.navigation.addListener('didFocus', () =>
-      this.checkCleanBackupPhrase()
-    )
-  }
-
-  componentWillUnmount() {
-    if (this.didFocusSubscription) {
-      this.didFocusSubscription.remove()
-    }
-  }
 
   checkCleanBackupPhrase() {
     if (this.props.navigation.getParam('clean')) {
       this.setState({
         backupPhrase: '',
       })
+      this.props.navigation.setParams({ clean: false })
     }
   }
 
@@ -114,6 +98,7 @@ export class ImportWallet extends React.Component<Props, State> {
 
     return (
       <SafeAreaView style={styles.container}>
+        <NavigationEvents onDidFocus={this.checkCleanBackupPhrase} />
         <KeyboardAwareScrollView
           contentContainerStyle={styles.scrollContainer}
           keyboardShouldPersistTaps="always"
@@ -190,12 +175,10 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withNavigationFocus(
-  connect<StateProps, DispatchProps, {}, RootState>(
-    mapStateToProps,
-    {
-      importBackupPhrase,
-      hideAlert,
-    }
-  )(withNamespaces(Namespaces.nuxRestoreWallet3)(ImportWallet))
-)
+export default connect<StateProps, DispatchProps, any, RootState>(
+  mapStateToProps,
+  {
+    importBackupPhrase,
+    hideAlert,
+  }
+)(withNamespaces(Namespaces.nuxRestoreWallet3)(ImportWallet))

--- a/packages/mobile/src/import/ImportWalletEmpty.tsx
+++ b/packages/mobile/src/import/ImportWalletEmpty.tsx
@@ -12,7 +12,8 @@ import { Namespaces } from 'src/i18n'
 import { backupIcon } from 'src/images/Images'
 import { importBackupPhrase } from 'src/import/actions'
 import { nuxNavigationOptions } from 'src/navigator/Headers'
-import { navigateBack } from 'src/navigator/NavigationService'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import { RootState } from 'src/redux/reducers'
 import { getMoneyDisplayValue } from 'src/utils/formatting'
 
@@ -48,7 +49,7 @@ export class ImportWalletEmpty extends React.Component<Props> {
   }
 
   onPressTryAnotherKey = () => {
-    navigateBack()
+    navigate(Screens.ImportWallet, { clean: true })
   }
 
   render() {

--- a/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
+++ b/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
@@ -10,6 +10,9 @@ exports[`ImportWallet renders correctly and is disabled with no text 1`] = `
     }
   }
 >
+  <NavigationEvents
+    onDidFocus={[Function]}
+  />
   <RCTScrollView
     contentContainerStyle={
       Object {


### PR DESCRIPTION
### Description

_Clean seed words text area when returns from empty wallet view_

### Tested

_Tested on Android after_

### Related issues

- Fixes #1700 

### Backwards compatibility

_Backward compatible_
