### PR TITLE
Use cert manager instead of lego for k8s SSL certificates

### DIFF
--- a/packages/celotool/src/lib/cluster.ts
+++ b/packages/celotool/src/lib/cluster.ts
@@ -16,7 +16,6 @@ import { networkName } from './vm-testnet-utils'
 const SYSTEM_HELM_RELEASES = [
   'nginx-ingress-release',
   'kube-lego-release',
-  'cert-manager',
   'cert-manager-cluster-issuers',
 ]
 const HELM_RELEASE_REGEX = new RegExp(/(.*)-\d+\.\d+\.\d+$/)

--- a/packages/celotool/src/lib/cluster.ts
+++ b/packages/celotool/src/lib/cluster.ts
@@ -13,7 +13,12 @@ import {
 import { execCmd, execCmdWithExitOnFailure, outputIncludes, switchToProjectFromEnv } from './utils'
 import { networkName } from './vm-testnet-utils'
 
-const SYSTEM_HELM_RELEASES = ['nginx-ingress-release', 'kube-lego-release']
+const SYSTEM_HELM_RELEASES = [
+  'nginx-ingress-release',
+  'kube-lego-release',
+  'cert-manager',
+  'cert-manager-cluster-issuers',
+]
 const HELM_RELEASE_REGEX = new RegExp(/(.*)-\d+\.\d+\.\d+$/)
 
 export async function switchToClusterFromEnv(checkOrPromptIfStagingOrProduction = true) {

--- a/packages/celotool/src/lib/cluster.ts
+++ b/packages/celotool/src/lib/cluster.ts
@@ -6,7 +6,7 @@ import {
   getServiceAccountName,
   grantRoles,
   installAndEnableMetricsDeps,
-  installLegoAndNginx,
+  installCertManagerAndNginx,
   redeployTiller,
   uploadStorageClass,
 } from './helm_deploy'
@@ -108,7 +108,7 @@ export async function setupCluster(celoEnv: string, createdCluster: boolean) {
   await uploadStorageClass()
   await redeployTiller()
 
-  await installLegoAndNginx()
+  await installCertManagerAndNginx()
 
   if (envType !== EnvTypes.DEVELOPMENT) {
     await installAndEnableMetricsDeps()

--- a/packages/celotool/src/lib/helm_deploy.ts
+++ b/packages/celotool/src/lib/helm_deploy.ts
@@ -194,7 +194,7 @@ export async function installLegoAndNginx() {
     `kube-lego-release`,
     `kube-lego-release exists, skipping install`
   )
-  // certManager is the newer version of lego, while we transition
+  // Cert Manager is the newer version of lego,
   // we want to use cert-manager for any new clusters
   const certManagerExists = await outputIncludes(
     `helm list`,

--- a/packages/celotool/src/lib/helm_deploy.ts
+++ b/packages/celotool/src/lib/helm_deploy.ts
@@ -188,20 +188,14 @@ export async function redeployTiller() {
   }
 }
 
-export async function installLegoAndNginx() {
-  const legoReleaseExists = await outputIncludes(
-    `helm list`,
-    `kube-lego-release`,
-    `kube-lego-release exists, skipping install`
-  )
-  // Cert Manager is the newer version of lego,
-  // we want to use cert-manager for any new clusters
+export async function installCertManagerAndNginx() {
+  // Cert Manager is the newer version of lego
   const certManagerExists = await outputIncludes(
     `helm list`,
     `cert-manager-cluster-issuers`,
     `cert-manager-cluster-issuers exists, skipping install`
   )
-  if (!legoReleaseExists && !certManagerExists) {
+  if (!certManagerExists) {
     await installCertManager()
   }
   const nginxIngressReleaseExists = await outputIncludes(

--- a/packages/celotool/src/lib/helm_deploy.ts
+++ b/packages/celotool/src/lib/helm_deploy.ts
@@ -223,6 +223,7 @@ export async function installCertManager() {
   )
   console.info('Updating cert-manager-cluster-issuers dependencies')
   await execCmdWithExitOnFailure(`helm dependency update ${clusterIssuersHelmChartPath}`)
+  console.info('Installing cert-manager-cluster-issuers')
   await execCmdWithExitOnFailure(
     `helm install --name cert-manager-cluster-issuers ${clusterIssuersHelmChartPath}`
   )

--- a/packages/helm-charts/cert-manager-cluster-issuers/Chart.yaml
+++ b/packages/helm-charts/cert-manager-cluster-issuers/Chart.yaml
@@ -1,0 +1,7 @@
+name: cert-manager-issuers
+version: 0.0.1
+description: Chart which is used to deploy let's encrypt issuers
+keywords:
+- "let's encrypt"
+- cert-manager
+appVersion: v1.7.3

--- a/packages/helm-charts/cert-manager-cluster-issuers/README.md
+++ b/packages/helm-charts/cert-manager-cluster-issuers/README.md
@@ -1,0 +1,4 @@
+# cert-manager-cluster-issuers
+
+This is the newer version of kube-lego that automatically gets SSL certificates.
+This specifies staging & staging ClusterIssuers.

--- a/packages/helm-charts/cert-manager-cluster-issuers/README.md
+++ b/packages/helm-charts/cert-manager-cluster-issuers/README.md
@@ -1,4 +1,4 @@
 # cert-manager-cluster-issuers
 
 This is the newer version of kube-lego that automatically gets SSL certificates.
-This specifies staging & staging ClusterIssuers.
+This specifies staging & production ClusterIssuers.

--- a/packages/helm-charts/cert-manager-cluster-issuers/requirements.lock
+++ b/packages/helm-charts/cert-manager-cluster-issuers/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v0.11.0
+digest: sha256:f9f50143931633a76f08ced3a20e0002606f935d71a852620b33432bd33e46ff
+generated: 2019-10-18T11:07:03.460006781-07:00

--- a/packages/helm-charts/cert-manager-cluster-issuers/requirements.yaml
+++ b/packages/helm-charts/cert-manager-cluster-issuers/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: cert-manager
+    version: v0.11.0
+    repository: https://charts.jetstack.io

--- a/packages/helm-charts/cert-manager-cluster-issuers/templates/prod.clusterissuer.yaml
+++ b/packages/helm-charts/cert-manager-cluster-issuers/templates/prod.clusterissuer.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: n@celo.org
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/packages/helm-charts/cert-manager-cluster-issuers/templates/staging.clusterissuer.yaml
+++ b/packages/helm-charts/cert-manager-cluster-issuers/templates/staging.clusterissuer.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: n@celo.org
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/packages/helm-charts/cert-manager-cluster-issuers/values.yaml
+++ b/packages/helm-charts/cert-manager-cluster-issuers/values.yaml
@@ -1,0 +1,9 @@
+imagePullPolicy: IfNotPresent
+
+# Values that are used for the dependency `cert-manager`
+cert-manager:
+  ingressShim:
+    defaultIssuerKind: ClusterIssuer
+    defaultIssuerName: letsencrypt-prod
+  webhook:
+    enabled: false


### PR DESCRIPTION
### Description

This uses https://github.com/jetstack/cert-manager, which is the successor of the now-deprecated lego, to get SSL certificates. Lego doesn't support the v2 let's encrypt ACME protocol, and v1 was recently phased out, so we had to upgrade. I migrated all our clusters a while back to use cert-manager instead of lego (~ a month ago) but never opened this PR.

### Tested

Moved all our clusters over to using cert-manager, let it sit & everything has worked, tested cluster setup

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

Yes- getting an SSL certificate for an ingress is the exact same