### PR TITLE
Add a space on payment request

### DIFF
--- a/packages/mobile/src/home/__snapshots__/NotificationBox.test.tsx.snap
+++ b/packages/mobile/src/home/__snapshots__/NotificationBox.test.tsx.snap
@@ -743,7 +743,7 @@ exports[`NotificationBox Incoming Payment Requests exist 1`] = `
                           ]
                         }
                       >
-                        $12.34
+                         $12.34
                       </Text>
                     </Text>
                   </View>
@@ -952,7 +952,7 @@ exports[`NotificationBox Outgoing Payment Requests exist 1`] = `
                           ]
                         }
                       >
-                        $12.34
+                         $12.34
                       </Text>
                     </Text>
                   </View>

--- a/packages/mobile/src/notifications/__snapshots__/IncomingPaymentRequestSummaryNotification.test.tsx.snap
+++ b/packages/mobile/src/notifications/__snapshots__/IncomingPaymentRequestSummaryNotification.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`IncomingPaymentRequestSummaryNotification renders correctly 1`] = `
                   ]
                 }
               >
-                $200,000
+                 $200,000
               </Text>
             </Text>
             <Text
@@ -169,7 +169,7 @@ exports[`IncomingPaymentRequestSummaryNotification renders correctly 1`] = `
                   ]
                 }
               >
-                $180.89
+                 $180.89
               </Text>
             </Text>
           </View>
@@ -373,7 +373,7 @@ exports[`IncomingPaymentRequestSummaryNotification when more 1 requests renders 
                   ]
                 }
               >
-                $200,000
+                 $200,000
               </Text>
             </Text>
           </View>
@@ -555,7 +555,7 @@ exports[`IncomingPaymentRequestSummaryNotification when more than 2 requests ren
                   ]
                 }
               >
-                $200,000
+                 $200,000
               </Text>
             </Text>
             <Text
@@ -598,7 +598,7 @@ exports[`IncomingPaymentRequestSummaryNotification when more than 2 requests ren
                   ]
                 }
               >
-                $180.89
+                 $180.89
               </Text>
             </Text>
           </View>

--- a/packages/mobile/src/notifications/__snapshots__/OutgoingPaymentRequestSummaryNotification.test.tsx.snap
+++ b/packages/mobile/src/notifications/__snapshots__/OutgoingPaymentRequestSummaryNotification.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`OutgoingPaymentRequestSummaryNotification renders correctly 1`] = `
                   ]
                 }
               >
-                $200,000
+                 $200,000
               </Text>
             </Text>
             <Text
@@ -169,7 +169,7 @@ exports[`OutgoingPaymentRequestSummaryNotification renders correctly 1`] = `
                   ]
                 }
               >
-                $180.89
+                 $180.89
               </Text>
             </Text>
           </View>
@@ -373,7 +373,7 @@ exports[`OutgoingPaymentRequestSummaryNotification when more 1 requests renders 
                   ]
                 }
               >
-                $200,000
+                 $200,000
               </Text>
             </Text>
           </View>
@@ -555,7 +555,7 @@ exports[`OutgoingPaymentRequestSummaryNotification when more than 2 requests ren
                   ]
                 }
               >
-                $200,000
+                 $200,000
               </Text>
             </Text>
             <Text
@@ -598,7 +598,7 @@ exports[`OutgoingPaymentRequestSummaryNotification when more than 2 requests ren
                   ]
                 }
               >
-                $180.89
+                 $180.89
               </Text>
             </Text>
           </View>

--- a/packages/mobile/src/paymentRequest/PaymentRequestNotificationInner.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestNotificationInner.tsx
@@ -20,7 +20,7 @@ export default function PaymentRequestNotificationInner(props: Props) {
         {(requesterRecipient && requesterRecipient.displayName) || requesterE164Number} - {message}
       </Text>
       <Text style={[fontStyles.subSmall, fontStyles.semiBold]}>
-        {CURRENCIES[CURRENCY_ENUM.DOLLAR].symbol + getCentAwareMoneyDisplay(amount)}
+        {' ' + CURRENCIES[CURRENCY_ENUM.DOLLAR].symbol + getCentAwareMoneyDisplay(amount)}
       </Text>
     </Text>
   )

--- a/packages/mobile/src/paymentRequest/__snapshots__/PaymentRequestNotificationInner.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/PaymentRequestNotificationInner.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`renders correctly 1`] = `
       ]
     }
   >
-    $24
+     $24
   </Text>
 </Text>
 `;


### PR DESCRIPTION
### Description

_Space should be shown between “Reason/Note” and “$” sign on “Payment request” section._

### Tested

_**WIP** still not tested_

### Related issues

- Fixes #1672
