### PR TITLE
README contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Contents:
 - [Issues](#issues)
 - [Repo Structure](#repo)
 - [Contributing](#contributing)
+- [Contributors](#contributors)
 - [Ask Questions, Find Answers, Get in Touch](#ask)
 - [License](#license)
   <!-- /TOC -->
@@ -145,6 +146,17 @@ Not yet ready to contribute but do like the project? Support Celo with a ⭐ or 
 Twitter
 twitter intent generator - http://tech.cymi.org/tweet-intents
 -->
+
+## 🤝 <a id="contributors"></a>Contributors
+This project exists thanks to all the people who contribute.
+
+<!--
+<a href="https://github.com/badges/shields/graphs/contributors"><img src="https://opencollective.com/shields/contributors.svg?width=890" /></a>
+-->
+
+Special thanks to our 🏆 hall-of-fame contributors 🥇
+
+[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/0)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/0)[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/1)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/1)[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/2)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/2)[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/3)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/3)[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/4)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/4)[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/5)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/5)[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/6)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/6)[![](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/images/7)](https://sourcerer.io/fame/KoenBal/celo-org/celo-monorepo/links/7)
 
 ## 💬 <a id="ask"></a>Ask Questions, Find Answers, Get in Touch
 

--- a/packages/docs/getting-started/running-a-validator.md
+++ b/packages/docs/getting-started/running-a-validator.md
@@ -694,7 +694,7 @@ celocli account:register-metadata --url <GROUP_METADATA_URL> --from $CELO_VALIDA
 Now when you run `celocli account:get-metadata $CELO_VALIDATOR_ADDRESS`, you should see your claim for the group account to be verified. By now, you should have setup your Validator account appropriately. Note that you need to add these claims for any other addresses that are yours to calculate your score for the leaderboard appropriately.
 
 {% hint style="tip" %}
-Congratulations on setting up your validator. If you want to win the TGCSO, it may be helpful to familiar with the inner workings of the Celo network. Dig into the [protocol documentation](../celo-codebase/protocol) for more information.
+Congratulations on setting up your validator. If you want to win the TGCSO, it may be helpful to get familiar with the inner workings of the Celo network. Dig into the [protocol documentation](../celo-codebase/protocol) for more information.
 {% endhint %}
 
 ## Deployment Tips


### PR DESCRIPTION
### Descriptions

Added a Hall of Fame widget
Added a hidden section for opencollective contributors widget

Rationale: For some users the celo monorepo could be the first impression they have of celo. A 
A nice README is a good way to help people engage in the project as well. A project with nice README and screenshots will get the attention of users better since it’s a direct way to explain why this project matters, and why people should use and contribute to the project. Good README should also include enough details to help a new user get started, e.g. how to compile, how to install, and how to start integrating.

README educational content I used.
[A beginners guide to writing kickass readmes](https://medium.com/@meakaakka/a-beginners-guide-to-writing-a-kickass-readme-7ac01da88ab3)
[AWESOME READMEs](https://github.com/matiassingers/awesome-readme)