### PR TITLE
README project team/code owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,18 @@ See the [issue backlog](https://github.com/celo-org/celo-monorepo/issues) for a 
 ## License & Contributing
 
 All packages are licensed under the terms of the Apache 2.0 License unless otherwise specified in the LICENSE file at package's root.
+### Project leaders
+
+Maintainers:
+
+- [timmoreton](https://github.com/timmoreton) (core team)
+- [jmrossy](https://github.com/jmrossy) (core team)
+- [marekolszewski](https://github.com/marekolszewski) (core team)
+- ...
+
+<!--
+Maybe at (core team celo cli), (core team Android)
+Alumni:
+-->
 
 Improvements and contributions are highly encouraged! See the [contributing guide](https://github.com/celo-org/celo-monorepo/tree/master/.github/CONTRIBUTING.md) for details on how to participate.

--- a/packages/docs/getting-started/alfajores-testnet.md
+++ b/packages/docs/getting-started/alfajores-testnet.md
@@ -15,7 +15,7 @@ The Alfajores Testnet is designed for testing and experimentation by developers.
 Please help us improve Celo by asking questions on the [Forum](https://forum.celo.org)!
 
 {% hint style="info" %}
-Your use of the Alfajores Tesnet is subject to the [Alfajores Testnet Disclaimer](../important-information/alfajores-testnet-disclaimer.md).
+Your use of the Alfajores Testnet is subject to the [Alfajores Testnet Disclaimer](../important-information/alfajores-testnet-disclaimer.md).
 {% endhint %}
 
 ## Useful links

--- a/packages/docs/getting-started/faucet.md
+++ b/packages/docs/getting-started/faucet.md
@@ -12,7 +12,7 @@ Getting an account is really being given or generating a public-private keypair.
 
 ### Get an Invitation Code
 
-If you have access to an Android device and would like to try the Celo Wallet, the fastest way to get stared is to get an invitation code, pre-funded with 10 Celo Dollars
+If you have access to an Android device and would like to try the Celo Wallet, the fastest way to get started is to get an invitation code, pre-funded with 10 Celo Dollars.
 
 Visit the [Celo Wallet Page](https://celo.org/build/wallet) and enter your phone number to be messaged an invitation. Following this personalized URL will download the [Celo Wallet App](https://play.google.com/store/apps/details?id=org.celo.mobile.alfajores) from the Play Store, generate an account only you have access to, and transfer escrowed funds into it.
 

--- a/packages/docs/getting-started/using-the-mobile-wallet.md
+++ b/packages/docs/getting-started/using-the-mobile-wallet.md
@@ -18,4 +18,4 @@ For more detailed information on how to get an account please refer to the [Gett
 
 ### Report a Bug
 
-To report a bug, navigate to the settings screen of the Celo Wallet and tap 'Send an Issue Report'. As always, please reach out on [forum.celo.org](https://forum.celo.org) if you have any questions
+To report a bug, navigate to the settings screen of the Celo Wallet and tap 'Send an Issue Report'. As always, please reach out on [forum.celo.org](https://forum.celo.org) if you have any questions.


### PR DESCRIPTION
### Description
Part of a larger README update

Added a section which could be a start of the list of code owners for certain parts of the monorepo.
For an outsider its not really clear who is the core team and who works on celo cli, Android, smart contracts, etc

What do you think?

Rationale: For some users the celo monorepo could be the first impression they have of celo. A 
A nice README is a good way to help people engage in the project as well. A project with nice README and screenshots will get the attention of users better since it’s a direct way to explain why this project matters, and why people should use and contribute to the project. Good README should also include enough details to help a new user get started, e.g. how to compile, how to install, and how to start integrating.

README educational content I used.
[A beginners guide to writing kickass readmes](https://medium.com/@meakaakka/a-beginners-guide-to-writing-a-kickass-readme-7ac01da88ab3)
[AWESOME READMEs](https://github.com/matiassingers/awesome-readme)