### PR TITLE
README backers sponsors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ See the [issue backlog](https://github.com/celo-org/celo-monorepo/issues) for a 
 All packages are licensed under the terms of the Apache 2.0 License unless otherwise specified in the LICENSE file at package's root.
 
 Improvements and contributions are highly encouraged! See the [contributing guide](https://github.com/celo-org/celo-monorepo/tree/master/.github/CONTRIBUTING.md) for details on how to participate.
+<!--
+
+### Backers
+
+Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/shields#backer)]
+
+<a href="https://opencollective.com/shields#backers" target="_blank"><img src="https://opencollective.com/shields/backers.svg?width=890"></a>
+
+### Sponsors
+
+Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/shields#sponsor)]
+
+<a href="https://opencollective.com/shields/sponsor/0/website" target="_blank"><img src="https://opencollective.com/shields/sponsor/0/avatar.svg"></a>
+
+-->

--- a/packages/docs/getting-started/alfajores-testnet.md
+++ b/packages/docs/getting-started/alfajores-testnet.md
@@ -15,7 +15,7 @@ The Alfajores Testnet is designed for testing and experimentation by developers.
 Please help us improve Celo by asking questions on the [Forum](https://forum.celo.org)!
 
 {% hint style="info" %}
-Your use of the Alfajores Tesnet is subject to the [Alfajores Testnet Disclaimer](../important-information/alfajores-testnet-disclaimer.md).
+Your use of the Alfajores Testnet is subject to the [Alfajores Testnet Disclaimer](../important-information/alfajores-testnet-disclaimer.md).
 {% endhint %}
 
 ## Useful links

--- a/packages/docs/getting-started/faucet.md
+++ b/packages/docs/getting-started/faucet.md
@@ -12,7 +12,7 @@ Getting an account is really being given or generating a public-private keypair.
 
 ### Get an Invitation Code
 
-If you have access to an Android device and would like to try the Celo Wallet, the fastest way to get stared is to get an invitation code, pre-funded with 10 Celo Dollars
+If you have access to an Android device and would like to try the Celo Wallet, the fastest way to get started is to get an invitation code, pre-funded with 10 Celo Dollars.
 
 Visit the [Celo Wallet Page](https://celo.org/build/wallet) and enter your phone number to be messaged an invitation. Following this personalized URL will download the [Celo Wallet App](https://play.google.com/store/apps/details?id=org.celo.mobile.alfajores) from the Play Store, generate an account only you have access to, and transfer escrowed funds into it.
 

--- a/packages/docs/getting-started/using-the-mobile-wallet.md
+++ b/packages/docs/getting-started/using-the-mobile-wallet.md
@@ -18,4 +18,4 @@ For more detailed information on how to get an account please refer to the [Gett
 
 ### Report a Bug
 
-To report a bug, navigate to the settings screen of the Celo Wallet and tap 'Send an Issue Report'. As always, please reach out on [forum.celo.org](https://forum.celo.org) if you have any questions
+To report a bug, navigate to the settings screen of the Celo Wallet and tap 'Send an Issue Report'. As always, please reach out on [forum.celo.org](https://forum.celo.org) if you have any questions.


### PR DESCRIPTION
### Description
Added a hidden section with widgets for OpenCollective backers and sponsors

Could an OpenCollective account be created?
Is this legally a bad idea? 
Should an ETH and BTC address be added? 
How should this be done?

more about sponsors on GitHub
https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository

README educational content I used.
[A beginners guide to writing kickass readmes](https://medium.com/@meakaakka/a-beginners-guide-to-writing-a-kickass-readme-7ac01da88ab3)
[AWESOME READMEs](https://github.com/matiassingers/awesome-readme)