### PR TITLE
Error on method to set fee currency

### DIFF
--- a/packages/docs/developer-resources/contractkit/setup.md
+++ b/packages/docs/developer-resources/contractkit/setup.md
@@ -40,7 +40,7 @@ import { CeloContract } from '@celo/contractkit'
 // default from
 kit.defaultAccount = myAddress
 // paid gas in celo dollars
-await kit.setGasCurrency(CeloContract.StableToken)
+await kit.setFeeCurrency(CeloContract.StableToken)
 ```
 
 You're ready to start using ContractKit! See the [Examples](examples.md) section to learn more.


### PR DESCRIPTION
Changed line 43 from 'setGasCurrency' to 'setFeeCurrency' because the first method doesn't exist

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Other changes

_Describe any minor or "drive-by" changes here._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
