### PR TITLE
Only allow external RPCs for tx nodes

### DIFF
--- a/packages/terraform-modules/testnet/main.tf
+++ b/packages/terraform-modules/testnet/main.tf
@@ -27,7 +27,7 @@ locals {
   target_tag_tx_node   = "${var.celo_env}-tx-node"
   target_tag_validator = "${var.celo_env}-validator"
 
-  target_tag_all = [
+  target_tags_all = [
     local.target_tag_bootnode,
     local.target_tag_node
   ]
@@ -41,7 +41,7 @@ resource "google_compute_firewall" "ssh_firewall" {
   name    = "${var.celo_env}-ssh-firewall"
   network = data.google_compute_network.network.name
 
-  target_tags = local.target_tag_all
+  target_tags = local.target_tags_all
 
   allow {
     protocol = "tcp"

--- a/packages/terraform-modules/testnet/main.tf
+++ b/packages/terraform-modules/testnet/main.tf
@@ -21,8 +21,16 @@ data "terraform_remote_state" "state" {
 }
 
 locals {
-  firewall_target_tags_bootnode = ["${var.celo_env}-bootnode"]
-  firewall_target_tags_node = ["${var.celo_env}-node"]
+  target_tag_bootnode = "${var.celo_env}-bootnode"
+  # any geth node (tx nodes & validators)
+  target_tag_node      = "${var.celo_env}-node"
+  target_tag_tx_node   = "${var.celo_env}-tx-node"
+  target_tag_validator = "${var.celo_env}-validator"
+
+  target_tag_all = [
+    local.target_tag_bootnode,
+    local.target_tag_node
+  ]
 }
 
 data "google_compute_network" "network" {
@@ -33,7 +41,7 @@ resource "google_compute_firewall" "ssh_firewall" {
   name    = "${var.celo_env}-ssh-firewall"
   network = data.google_compute_network.network.name
 
-  target_tags = concat(local.firewall_target_tags_bootnode, local.firewall_target_tags_node)
+  target_tags = local.target_tag_all
 
   allow {
     protocol = "tcp"
@@ -45,7 +53,7 @@ resource "google_compute_firewall" "geth_firewall" {
   name    = "${var.celo_env}-geth-firewall"
   network = data.google_compute_network.network.name
 
-  target_tags = local.firewall_target_tags_node
+  target_tags = [local.target_tag_node]
 
   allow {
     protocol = "tcp"
@@ -62,7 +70,7 @@ resource "google_compute_firewall" "geth_metrics_firewall" {
   name    = "${var.celo_env}-geth-metrics-firewall"
   network = data.google_compute_network.network.name
 
-  target_tags = local.firewall_target_tags_node
+  target_tags = [local.target_tag_node]
 
   # allow all IPs internal to the VPC
   source_ranges = ["10.0.0.0/8"]
@@ -77,7 +85,7 @@ resource "google_compute_firewall" "rpc_firewall" {
   name    = "${var.celo_env}-rpc-firewall"
   network = data.google_compute_network.network.name
 
-  target_tags = local.firewall_target_tags_node
+  target_tags = [local.target_tag_tx_node]
 
   allow {
     protocol = "tcp"
@@ -89,7 +97,7 @@ resource "google_compute_firewall" "bootnode_firewall" {
   name    = "${var.celo_env}-bootnode-firewall"
   network = data.google_compute_network.network.name
 
-  target_tags = local.firewall_target_tags_bootnode
+  target_tags = [local.target_tag_bootnode]
 
   allow {
     protocol = "udp"
@@ -113,23 +121,23 @@ module "bootnode" {
 module "tx_node" {
   source = "./modules/tx-node"
   # variables
-  block_time                        = var.block_time
-  bootnode_ip_address               = module.bootnode.ip_address
-  celo_env                          = var.celo_env
-  ethstats_host                     = var.ethstats_host
-  gcloud_secrets_base_path          = var.gcloud_secrets_base_path
-  gcloud_secrets_bucket             = var.gcloud_secrets_bucket
-  gcloud_vm_service_account_email   = var.gcloud_vm_service_account_email
-  genesis_content_base64            = var.genesis_content_base64
+  block_time                            = var.block_time
+  bootnode_ip_address                   = module.bootnode.ip_address
+  celo_env                              = var.celo_env
+  ethstats_host                         = var.ethstats_host
+  gcloud_secrets_base_path              = var.gcloud_secrets_base_path
+  gcloud_secrets_bucket                 = var.gcloud_secrets_bucket
+  gcloud_vm_service_account_email       = var.gcloud_vm_service_account_email
+  genesis_content_base64                = var.genesis_content_base64
   geth_exporter_docker_image_repository = var.geth_exporter_docker_image_repository
-  geth_exporter_docker_image_tag    = var.geth_exporter_docker_image_tag
-  geth_node_docker_image_repository = var.geth_node_docker_image_repository
-  geth_node_docker_image_tag        = var.geth_node_docker_image_tag
-  geth_verbosity                    = var.geth_verbosity
-  in_memory_discovery_table         = var.in_memory_discovery_table
-  network_id                        = var.network_id
-  network_name                      = data.google_compute_network.network.name
-  tx_node_count                     = var.tx_node_count
+  geth_exporter_docker_image_tag        = var.geth_exporter_docker_image_tag
+  geth_node_docker_image_repository     = var.geth_node_docker_image_repository
+  geth_node_docker_image_tag            = var.geth_node_docker_image_tag
+  geth_verbosity                        = var.geth_verbosity
+  in_memory_discovery_table             = var.in_memory_discovery_table
+  network_id                            = var.network_id
+  network_name                          = data.google_compute_network.network.name
+  tx_node_count                         = var.tx_node_count
 }
 
 # used for access by blockscout
@@ -144,23 +152,23 @@ module "tx_node_lb" {
 module "validator" {
   source = "./modules/validator"
   # variables
-  block_time                        = var.block_time
-  bootnode_ip_address               = module.bootnode.ip_address
-  celo_env                          = var.celo_env
-  ethstats_host                     = var.ethstats_host
-  gcloud_secrets_base_path          = var.gcloud_secrets_base_path
-  gcloud_secrets_bucket             = var.gcloud_secrets_bucket
-  gcloud_vm_service_account_email   = var.gcloud_vm_service_account_email
-  genesis_content_base64            = var.genesis_content_base64
+  block_time                            = var.block_time
+  bootnode_ip_address                   = module.bootnode.ip_address
+  celo_env                              = var.celo_env
+  ethstats_host                         = var.ethstats_host
+  gcloud_secrets_base_path              = var.gcloud_secrets_base_path
+  gcloud_secrets_bucket                 = var.gcloud_secrets_bucket
+  gcloud_vm_service_account_email       = var.gcloud_vm_service_account_email
+  genesis_content_base64                = var.genesis_content_base64
   geth_exporter_docker_image_repository = var.geth_exporter_docker_image_repository
-  geth_exporter_docker_image_tag    = var.geth_exporter_docker_image_tag
-  geth_node_docker_image_repository = var.geth_node_docker_image_repository
-  geth_node_docker_image_tag        = var.geth_node_docker_image_tag
-  geth_verbosity                    = var.geth_verbosity
-  in_memory_discovery_table         = var.in_memory_discovery_table
-  istanbul_request_timeout_ms       = var.istanbul_request_timeout_ms
-  network_id                        = var.network_id
-  network_name                      = data.google_compute_network.network.name
-  tx_node_count                     = var.tx_node_count
-  validator_count                   = var.validator_count
+  geth_exporter_docker_image_tag        = var.geth_exporter_docker_image_tag
+  geth_node_docker_image_repository     = var.geth_node_docker_image_repository
+  geth_node_docker_image_tag            = var.geth_node_docker_image_tag
+  geth_verbosity                        = var.geth_verbosity
+  in_memory_discovery_table             = var.in_memory_discovery_table
+  istanbul_request_timeout_ms           = var.istanbul_request_timeout_ms
+  network_id                            = var.network_id
+  network_name                          = data.google_compute_network.network.name
+  tx_node_count                         = var.tx_node_count
+  validator_count                       = var.validator_count
 }

--- a/packages/terraform-modules/testnet/modules/tx-node/main.tf
+++ b/packages/terraform-modules/testnet/modules/tx-node/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_instance" "tx_node" {
 
   count = var.tx_node_count
 
-  tags = ["${var.celo_env}-node"]
+  tags = ["${var.celo_env}-node", "${var.celo_env}-tx-node"]
 
   allow_stopping_for_update = true
 

--- a/packages/terraform-modules/testnet/modules/validator/main.tf
+++ b/packages/terraform-modules/testnet/modules/validator/main.tf
@@ -24,7 +24,7 @@ resource "google_compute_instance" "validator" {
 
   count = var.validator_count
 
-  tags = ["${var.celo_env}-node"]
+  tags = ["${var.celo_env}-node", "${var.celo_env}-validator"]
 
   allow_stopping_for_update = true
 


### PR DESCRIPTION
### Description

Ensures that incoming RPCs can only reach tx nodes

### Tested

Haven't deployed a testnet yet, but ran `terraform validate` to make sure that everything is syntactically correct

### Other changes

Ran `terraform fmt`

### Related issues

n/a

### Backwards compatibility

Yes