### PR TITLE
Set default env in attestation service docker image as production

### DIFF
--- a/dockerfiles/attestation-service/Dockerfile
+++ b/dockerfiles/attestation-service/Dockerfile
@@ -23,6 +23,8 @@ COPY packages/protocol packages/protocol/
 COPY packages/contractkit packages/contractkit/
 COPY packages/attestation-service packages/attestation-service/
 
+ENV NODE_ENV production
+
 # build all
 RUN yarn build
 


### PR DESCRIPTION
### Description

Very simple change to set the default to production

### Tested