### PR TITLE
Rename to eventName

### DIFF
--- a/packages/transaction-metrics-exporter/src/blockchain.ts
+++ b/packages/transaction-metrics-exporter/src/blockchain.ts
@@ -166,6 +166,10 @@ async function newBlockHeaderProcessor(kit: ContractKit): Promise<(block: BlockH
             log: event.event,
           })
 
+          // @ts-ignore We want to rename event => eventName to avoid overwriting
+          event.eventName = event.event
+          delete event.event
+
           logEvent('RECEIVED_PARSED_LOG', event)
         }
       }


### PR DESCRIPTION
### Description

We use `event` in our structured logs to denote the type of event we are emitting, however ethereum logs also have a property called `event` for the name of the log. Here we are renaming it to `eventName` so that we avoid the collision.
