### PR TITLE
[Wallet] Compatibility with exchange rate in string format

### DIFF
--- a/packages/mobile/src/localCurrency/saga.ts
+++ b/packages/mobile/src/localCurrency/saga.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import gql from 'graphql-tag'
 import { call, put, select, spawn, take, takeLatest } from 'redux-saga/effects'
 import { apolloClient } from 'src/apollo'
@@ -37,11 +38,11 @@ export async function fetchExchangeRate(symbol: string): Promise<number> {
   }
 
   const { rate } = currencyConversion
-  if (typeof rate !== 'number') {
+  if (typeof rate !== 'number' && typeof rate !== 'string') {
     throw new Error(`Invalid response data ${data}`)
   }
 
-  return rate
+  return new BigNumber(rate).toNumber()
 }
 
 export function* fetchLocalCurrencyRateSaga() {


### PR DESCRIPTION
### Description

As part of the work on #834, I intend to switch the output format for the exchange rate api to BigNumber serialized as string.
This makes the wallet compatible with that new format too.
This way we can introduce the breaking change on the blockchain-api when it's ready without disrupting the upcoming release of the wallet (which will be incompatible with the upcoming alfajores network upgrade).

### Tested

Tested that it works correctly when the fetched exchange rate is a number serialised as string.

### Other changes

None

### Related issues

- #834, #2005

### Backwards compatibility

Yes.
