### PR TITLE
Docs SBAT specify the correct proxy ip address and port

### DIFF
--- a/packages/docs/getting-started/running-a-validator.md
+++ b/packages/docs/getting-started/running-a-validator.md
@@ -242,9 +242,8 @@ docker run --name celo-proxy -it --restart always -p 30303:30303 -p 30303:30303/
 Once the proxy is running, we will need to retrieve its enode and IP address so that the validator will be able to connect to it.
 
 ```bash
-# On the proxy machine, retrieve the proxy enode and IP
+# On the proxy machine, retrieve the proxy enode
 echo $(docker exec celo-proxy geth --exec "admin.nodeInfo['enode'].split('//')[1].split('@')[0]" attach | tr -d '"')
-echo $(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' celo-proxy)
 ```
 
 Now we need to set the proxy enode and proxy IP address in environment variables on the validator machine.
@@ -252,7 +251,7 @@ Now we need to set the proxy enode and proxy IP address in environment variables
 ```bash
 # On the validator machine
 export PROXY_ENODE=<YOUR-PROXY-ENODE>
-export PROXY_IP=<YOUR-PROXY-IP>
+export PROXY_IP=<PROXY-MACHINE-EXTERNAL-IP-ADDRESS>
 ```
 
 Let's connect the validator to the proxy:

--- a/packages/docs/getting-started/running-a-validator.md
+++ b/packages/docs/getting-started/running-a-validator.md
@@ -236,7 +236,7 @@ You can then run the proxy with the following command. Be sure to replace `<YOUR
 # Note that you'll have to export CELO_VALIDATOR_SIGNER_ADDRESS and $NETWORK_ID on this machine
 export NETWORK_ID=12219
 export CELO_VALIDATOR_SIGNER_ADDRESS=<YOUR-VALIDATOR-SIGNER-ADDRESS>
-docker run --name celo-proxy -it --restart always -p 30313:30303 -p 30313:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $CELO_VALIDATOR_SIGNER_ADDRESS --ethstats=<YOUR-VALIDATOR-NAME>-proxy@baklava-ethstats.celo-testnet.org
+docker run --name celo-proxy -it --restart always -p 30303:30303 -p 30303:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $CELO_VALIDATOR_SIGNER_ADDRESS --ethstats=<YOUR-VALIDATOR-NAME>-proxy@baklava-ethstats.celo-testnet.org
 ```
 
 Once the proxy is running, we will need to retrieve its enode and IP address so that the validator will be able to connect to it.
@@ -274,6 +274,8 @@ docker run --name celo-validator -it --restart always -p 30303:30303 -p 30303:30
 The `mine` flag does not mean the node starts mining blocks, but rather starts trying to participate in the BFT consensus protocol. It cannot do this until it gets elected -- so next we need to stand for election.
 
 The `networkid` parameter value of `12219` indicates we are connecting to the Baklava network, Stake Off Phase 1.
+
+Note that if you are running the validator and the proxy on the same machine, then you should set the validator's listening port to something other than `30303`.  E.g. you could use the flag `--port 30313` and set the docker port forwarding rules accordingly (e.g. use the flags `-p 30313:30313` and `-p 30313:30313/udp`).
 
 ### Register the Accounts
 


### PR DESCRIPTION
### Description

Fix to the docs so that it the proxy docker command will use the correct port forwarding rule and instruct to use the external ip address for the proxy.

### Tested

Tested using an external validator and verified that it established the necessary number of peers.

### Other changes


### Related issues

Fixes:  https://github.com/celo-org/celo-monorepo/issues/2067

### Backwards compatibility

Is backwards compatible.