### PR TITLE
Add issue templates and update CODEOWNERS for auto labeling and assigning - non-collaborators cant add labels or assignees

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,20 +2,33 @@
 # Each line is a file pattern followed by one or more owners.
 # For details on acceptable file patterns, please refer to the [Github Documentation](https://help.github.com/articles/about-codeowners/)
 
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @XXXX will be requested for
+# review when someone opens a pull request.
+* @timmoreton
+
 # directory and file-level owners. Feel free to add to this!
 /packages/analytics/ @nambrot @timmoreton
+/packages/attestation-service/ @timmoreton
 /packages/blockchain-api/ @jmrossy @cmcewen
+/packages/celotool/ @timmoreton
 /packages/cli/ @mcortesi @asaj
+/packages/contractkit/ @timmoreton
+/packages/dappkit/ @timmoreton
+/packages/dev-utils/ @timmoreton
+/packages/docs/ @timmoreton @cla-bel
+/packages/faucet/ @timmoreton
 /packages/helm-charts/ @nambrot @timmoreton
 /packages/mobile/ @cmcewen @jmrossy
 /packages/notification-service/ @annakaz @cmcewen
 /packages/protocol/ @asaj @m-chrzan
 /packages/react-components/ @cmcewen @jmrossy
-/packages/walletkit/ @ashishb @yerdua
 /packages/terraform-modules/ @tkporter
 /packages/transaction-metrics-exporter @nambrot
 /packages/typescript/ @cmcewen
 /packages/utils/ @jmrossy
 /packages/verification-pool-api/ @jmrossy @nambrot
 /packages/verifier/ @jmrossy @cmcewen
+/packages/walletkit/ @ashishb @yerdua
 /packages/web/ @cmcewen @aaronmgdr

--- a/.github/ISSUE_TEMPLATE/cli-issue.md
+++ b/.github/ISSUE_TEMPLATE/cli-issue.md
@@ -1,0 +1,16 @@
+---
+name: cli issue
+about: Create an issue to ask a question or improve the bash client.
+title: ''
+labels: cli
+assignees: mcortesi, asaj
+
+---
+
+### Expected Behavior
+
+Please describe the behavior you are expecting
+
+### Current Behavior
+
+What is the current behavior?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Celo Dev Community Forum
+    url: https://forum.celo.org/
+    about: Please ask your non-code related questions or questions about the documentation here.

--- a/.github/ISSUE_TEMPLATE/custom-issue-collaborator.md
+++ b/.github/ISSUE_TEMPLATE/custom-issue-collaborator.md
@@ -1,0 +1,24 @@
+---
+name: custom issue - collaborator (repo-member)
+about: Ask a question or make a suggestion which does not fit under a default category.
+title: ''
+labels: custom-issue
+assignees: ''
+
+---
+
+### Expected Behavior
+
+Please describe the behavior you are expecting
+
+### Current Behavior
+
+What is the current behavior?
+
+
+# to-do
+- manually adjust the assignee
+- manually add extra labels
+
+# extra
+Help a non-collaborator in need GitHub does not allow them to assign labels or assignees. Should your label and assignee combination be available to non-collaborators? Pls add an [ISSUE_TEMPLATE](master/.github/ISSUE_TEMPLATE).

--- a/.github/ISSUE_TEMPLATE/custom-issue-non-collaborator.md
+++ b/.github/ISSUE_TEMPLATE/custom-issue-non-collaborator.md
@@ -1,0 +1,16 @@
+---
+name: custom issue - non collaborator (not a repo-member)
+about: Ask a question or make a suggestion which does not fit under a default category.
+title: ''
+labels: custom-issue
+assignees: timmoreton
+
+---
+
+### Expected Behavior
+
+Please describe the behavior you are expecting
+
+### Current Behavior
+
+What is the current behavior?

--- a/.github/ISSUE_TEMPLATE/docs-issue.md
+++ b/.github/ISSUE_TEMPLATE/docs-issue.md
@@ -1,0 +1,18 @@
+---
+name: docs issue
+about: Create an issue to ask a question or improve the documentation website.
+title: ''
+labels: docs
+assignees: cla-bel
+
+---
+
+### question | improvement
+
+### Link to documentation section
+
+Copy-paste the link to the specific section in the documentation.
+
+### Description
+
+Describe your issue here.

--- a/.github/ISSUE_TEMPLATE/wallet-issue.md
+++ b/.github/ISSUE_TEMPLATE/wallet-issue.md
@@ -1,0 +1,17 @@
+---
+name: wallet issue
+about: Create an issue to ask a question or improve the wallet (aka Android app, mobile
+  package).
+title: ''
+labels: wallet
+assignees: cmcewen, jmrossy
+
+---
+
+### Expected Behavior
+
+Please describe the behavior you are expecting
+
+### Current Behavior
+
+What is the current behavior?

--- a/.github/ISSUE_TEMPLATE/web-issue.md
+++ b/.github/ISSUE_TEMPLATE/web-issue.md
@@ -1,0 +1,16 @@
+---
+name: web issue
+about: Create an issue to ask a question or improve the website.
+title: ''
+labels: web
+assignees: cmcewen, aaronmgdr
+
+---
+
+### Expected Behavior
+
+Please describe the behavior you are expecting
+
+### Current Behavior
+
+What is the current behavior?


### PR DESCRIPTION
Expected Behavior
Non-collaborators (non repo members) SBAT assign labels and an assignee.
A non-collaborator (NC) is someone who is not added as a collaborator under settings on the project.

Current Behavior
An NC can't add labels or assignee to issues or PRs.
Confirmed in help:
[Anyone with read access to a repository can view and search the repository’s labels. To create, edit, apply, or delete a label, you must have write access to the repository.](https://help.github.com/en/github/managing-your-work-on-github/about-labels)

personal note: I (a new repo contributor) am not certain which label to assign or am not comfortable to push my issue in someone's bucket if I'm not sure if he/she is working on part X of the project or I don't know her/him.

Ideas:
All guidance is welcome for newcomers. Auto assigning assignees and labels would be the way to go.

a possible solution for issues:
[issue templates for your repo](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository)

⚠️ This will change the issue creation flow for everyone check how creating an issue flow looks in my repo. (Assignee and Label will not work because the users are not available.) Creating issues and PRs should improve for non-collaborators but it should not get less productive for collaborators... im aware that an extra step is created. What do you think?

Other ideas (not further explored)
Use a [issue actions](https://github.com/marketplace?utf8=%E2%9C%93&type=actions&query=issue)?

A possible solution adding assignees to PRs:
[The CODEOWNERS file](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) (which is already implemented).
Updated such that each PR will receive a reviewer from now on. Code owners for each package should be checked though.

Note that PRs do not get labels assigned! This could be done using actions.

Other ideas (not further explored)
[A Probot app that adds reviewers to pull requests when pull requests are opened](https://github.com/kentaro-m/auto-assign)
[Monorepo PR repo labeler](https://github.com/marketplace/actions/monorepo-pr-repo-labeler)
Other [PR actions](https://github.com/marketplace?utf8=%E2%9C%93&type=actions&query=PR)?

@timmoreton @asaj 