### PR TITLE
Changing validator group voting gold

### DIFF
--- a/packages/protocol/migrations/20_elect_validators.ts
+++ b/packages/protocol/migrations/20_elect_validators.ts
@@ -209,10 +209,6 @@ module.exports = async (_deployer: any, networkName: string) => {
     return
   }
 
-  if (config.validators.votesRatioOfLastVsFirstGroup < 1) {
-    throw new Error(`votesRatioOfLastVsFirstGroup needs to be >= 1`)
-  }
-
   // Assumptions about where funds are located:
   // * Validator 0 holds funds for all groups' stakes
   // * Validator 1-n holds funds needed for their own stake

--- a/packages/protocol/migrations/20_elect_validators.ts
+++ b/packages/protocol/migrations/20_elect_validators.ts
@@ -233,12 +233,26 @@ module.exports = async (_deployer: any, networkName: string) => {
     valKeyGroups.push(valKeys.slice(i, Math.min(i + maxGroupSize, valKeys.length)))
   }
 
+  // Calculate per validator locked gold for first group...
+  const lockedGoldPerValAtFirstGroup = new BigNumber(
+    config.validators.groupLockedGoldRequirements.value
+  )
+  // ...and the delta for each subsequent group
+  const lockedGoldPerValEachGroup = new BigNumber(
+    config.validators.votesRatioOfLastVsFirstGroup - 1
+  )
+    .times(lockedGoldPerValAtFirstGroup)
+    .div(Math.max(valKeyGroups.length - 1, 1))
+    .integerValue()
+
   const groups = valKeyGroups.map((keys, i) => ({
     valKeys: keys,
     name: valKeyGroups.length
       ? config.validators.groupName + `(${i + 1})`
       : config.validators.groupName,
-    lockedGold: config.validators.groupLockedGold.value,
+    lockedGold: lockedGoldPerValAtFirstGroup
+      .plus(lockedGoldPerValEachGroup.times(i))
+      .times(keys.length),
     account: null,
   }))
 
@@ -312,7 +326,7 @@ module.exports = async (_deployer: any, networkName: string) => {
     // @ts-ignore
     const voteTx = election.contract.methods.vote(
       group.account.address,
-      '0x' + group.lockedGold.toString(16),
+      '0x' + config.validator.groupLockedGold.value.toString(16),
       lesser,
       greater
     )

--- a/packages/protocol/migrations/20_elect_validators.ts
+++ b/packages/protocol/migrations/20_elect_validators.ts
@@ -242,7 +242,9 @@ module.exports = async (_deployer: any, networkName: string) => {
       : config.validators.groupName,
     // Make first and last group high votes so we can maintain presence.
     lockedGold:
-      i === 0 || i === 13 ? lockedGoldPerValEachGroup.times(10) : lockedGoldPerValEachGroup,
+      i === 0 || i === valKeyGroups.length - 1
+        ? lockedGoldPerValEachGroup.times(5)
+        : lockedGoldPerValEachGroup,
     account: null,
   }))
 

--- a/packages/protocol/migrations/20_elect_validators.ts
+++ b/packages/protocol/migrations/20_elect_validators.ts
@@ -233,26 +233,12 @@ module.exports = async (_deployer: any, networkName: string) => {
     valKeyGroups.push(valKeys.slice(i, Math.min(i + maxGroupSize, valKeys.length)))
   }
 
-  // Calculate per validator locked gold for first group...
-  const lockedGoldPerValAtFirstGroup = new BigNumber(
-    config.validators.groupLockedGoldRequirements.value
-  )
-  // ...and the delta for each subsequent group
-  const lockedGoldPerValEachGroup = new BigNumber(
-    config.validators.votesRatioOfLastVsFirstGroup - 1
-  )
-    .times(lockedGoldPerValAtFirstGroup)
-    .div(Math.max(valKeyGroups.length - 1, 1))
-    .integerValue()
-
   const groups = valKeyGroups.map((keys, i) => ({
     valKeys: keys,
     name: valKeyGroups.length
       ? config.validators.groupName + `(${i + 1})`
       : config.validators.groupName,
-    lockedGold: lockedGoldPerValAtFirstGroup
-      .plus(lockedGoldPerValEachGroup.times(i))
-      .times(keys.length),
+    lockedGold: config.validators.groupLockedGold.value,
     account: null,
   }))
 

--- a/packages/protocol/migrationsConfig.js
+++ b/packages/protocol/migrationsConfig.js
@@ -120,7 +120,6 @@ const DefaultConfig = {
     votesRatioOfLastVsFirstGroup: 2.0,
     groupLockedGold: {
       value: '22000000000000000000000', // 22k gold per group
-      duration: 60 * 24 * 60 * 60, // 60 days
     },
   },
 }

--- a/packages/protocol/migrationsConfig.js
+++ b/packages/protocol/migrationsConfig.js
@@ -118,6 +118,10 @@ const DefaultConfig = {
     groupName: 'C-Labs',
     commission: 0.1,
     votesRatioOfLastVsFirstGroup: 2.0,
+    groupLockedGold: {
+      value: '22000000000000000000000', // 22k gold per group
+      duration: 60 * 24 * 60 * 60, // 60 days
+    },
   },
 }
 

--- a/packages/protocol/migrationsConfig.js
+++ b/packages/protocol/migrationsConfig.js
@@ -117,7 +117,6 @@ const DefaultConfig = {
     attestationKeys: [],
     groupName: 'C-Labs',
     commission: 0.1,
-    votesRatioOfLastVsFirstGroup: 2.0,
     groupLockedGold: {
       value: '22000000000000000000000', // 22k gold per group
     },


### PR DESCRIPTION
### Description

Changed the amount of voted gold from all of group's gold to a configurable parameter of less gold for all the groups except the first and final group, which still vote with ~100k gold to maintain a presence in elections for monitoring.

### Tested

CI tests

### Other changes

Added config var `groupLockedGold`