### PR TITLE
Use fluentd natively for structured logging

### DIFF
--- a/.env
+++ b/.env
@@ -73,6 +73,7 @@ FAUCET_CUSD_WEI=60000000000000000000000
 
 # "og" -> our original 4 validators, "${n}" -> for deriving n validators from the MNEMONIC
 VALIDATORS="3"
+PROXIED_VALIDATORS=1
 STATIC_IPS_FOR_GETH_NODES=false
 # Whether tx_nodes/validators stateful set should use ssd persistent disks
 GETH_NODES_SSD_DISKS=true

--- a/packages/terraform-modules/testnet/modules/bootnode/startup.sh
+++ b/packages/terraform-modules/testnet/modules/bootnode/startup.sh
@@ -5,6 +5,96 @@
 curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
 bash install-logging-agent.sh
 
+echo "
+@include config.d/*.conf
+# Prometheus monitoring.
+<source>
+  @type prometheus
+  port 24231
+</source>
+<source>
+  @type prometheus_monitor
+</source>
+
+# Do not collect fluentd's own logs to avoid infinite loops.
+<match fluent.**>
+  @type null
+</match>
+
+# Add a unique insertId to each log entry that doesn't already have it.
+# This helps guarantee the order and prevent log duplication.
+<filter **>
+@type add_insert_ids
+</filter>
+
+# Configure all sources to output to Google Cloud Logging
+<match **>
+  @type google_cloud
+  buffer_type file
+  buffer_path /var/log/google-fluentd/buffers
+  # Set the chunk limit conservatively to avoid exceeding the recommended
+  # chunk size of 5MB per write request.
+  buffer_chunk_limit 512KB
+  # Flush logs every 5 seconds, even if the buffer is not full.
+  flush_interval 5s
+  # Enforce some limit on the number of retries.
+  disable_retry_limit false
+  # After 3 retries, a given chunk will be discarded.
+  retry_limit 3
+  # Wait 10 seconds before the first retry. The wait interval will be doubled on
+  # each following retry (20s, 40s...) until it hits the retry limit.
+  retry_wait 10
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops.
+  # Given the default config, this limit should never be reached, but if
+  # retry_limit and retry_wait are customized, this limit might take effect.
+  max_retry_wait 300
+  # Use multiple threads for processing.
+  num_threads 8
+  # Use the gRPC transport.
+  use_grpc true
+  # If a request is a mix of valid log entries and invalid ones, ingest the
+  # valid ones and drop the invalid ones instead of dropping everything.
+  partial_success true
+  # Enable monitoring via Prometheus integration.
+  enable_monitoring true
+  monitoring_type opencensus
+  detect_json true
+</match>" > /etc/google-fluentd/google-fluentd.conf
+
+echo "
+<match docker_logs>
+  @type rewrite_tag_filter
+  <rule>
+    key log
+    pattern ^{
+    tag docker_logs_json
+  </rule>
+  <rule>
+    key log
+    pattern ^[^{]
+    tag docker_logs_plain
+  </rule>
+</match>
+
+<filter docker_logs_json>
+  @type parser
+  key_name log
+  reserve_data false
+  <parse>
+    @type json
+  </parse>
+</filter>
+
+<filter docker_logs_plain>
+  @type record_transformer
+  <record>
+    message $${record["log"]}
+  </record>
+</filter>
+" > /etc/google-fluentd/config.d/docker.conf
+systemctl restart google-fluentd
+
 # ---- Install Docker ----
 
 echo "Installing Docker..."

--- a/packages/terraform-modules/testnet/modules/full-node/startup.sh
+++ b/packages/terraform-modules/testnet/modules/full-node/startup.sh
@@ -5,6 +5,96 @@
 curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
 bash install-logging-agent.sh
 
+echo "
+@include config.d/*.conf
+# Prometheus monitoring.
+<source>
+  @type prometheus
+  port 24231
+</source>
+<source>
+  @type prometheus_monitor
+</source>
+
+# Do not collect fluentd's own logs to avoid infinite loops.
+<match fluent.**>
+  @type null
+</match>
+
+# Add a unique insertId to each log entry that doesn't already have it.
+# This helps guarantee the order and prevent log duplication.
+<filter **>
+@type add_insert_ids
+</filter>
+
+# Configure all sources to output to Google Cloud Logging
+<match **>
+  @type google_cloud
+  buffer_type file
+  buffer_path /var/log/google-fluentd/buffers
+  # Set the chunk limit conservatively to avoid exceeding the recommended
+  # chunk size of 5MB per write request.
+  buffer_chunk_limit 512KB
+  # Flush logs every 5 seconds, even if the buffer is not full.
+  flush_interval 5s
+  # Enforce some limit on the number of retries.
+  disable_retry_limit false
+  # After 3 retries, a given chunk will be discarded.
+  retry_limit 3
+  # Wait 10 seconds before the first retry. The wait interval will be doubled on
+  # each following retry (20s, 40s...) until it hits the retry limit.
+  retry_wait 10
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops.
+  # Given the default config, this limit should never be reached, but if
+  # retry_limit and retry_wait are customized, this limit might take effect.
+  max_retry_wait 300
+  # Use multiple threads for processing.
+  num_threads 8
+  # Use the gRPC transport.
+  use_grpc true
+  # If a request is a mix of valid log entries and invalid ones, ingest the
+  # valid ones and drop the invalid ones instead of dropping everything.
+  partial_success true
+  # Enable monitoring via Prometheus integration.
+  enable_monitoring true
+  monitoring_type opencensus
+  detect_json true
+</match>" > /etc/google-fluentd/google-fluentd.conf
+
+echo "
+<match docker_logs>
+  @type rewrite_tag_filter
+  <rule>
+    key log
+    pattern ^{
+    tag docker_logs_json
+  </rule>
+  <rule>
+    key log
+    pattern ^[^{]
+    tag docker_logs_plain
+  </rule>
+</match>
+
+<filter docker_logs_json>
+  @type parser
+  key_name log
+  reserve_data false
+  <parse>
+    @type json
+  </parse>
+</filter>
+
+<filter docker_logs_plain>
+  @type record_transformer
+  <record>
+    message $${record["log"]}
+  </record>
+</filter>
+" > /etc/google-fluentd/config.d/docker.conf
+systemctl restart google-fluentd
+
 # ---- Install Docker ----
 
 echo "Installing Docker..."

--- a/packages/terraform-modules/testnet/modules/tx-node-load-balancer/ssl-startup.sh
+++ b/packages/terraform-modules/testnet/modules/tx-node-load-balancer/ssl-startup.sh
@@ -5,6 +5,96 @@
 curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
 bash install-logging-agent.sh
 
+echo "
+@include config.d/*.conf
+# Prometheus monitoring.
+<source>
+  @type prometheus
+  port 24231
+</source>
+<source>
+  @type prometheus_monitor
+</source>
+
+# Do not collect fluentd's own logs to avoid infinite loops.
+<match fluent.**>
+  @type null
+</match>
+
+# Add a unique insertId to each log entry that doesn't already have it.
+# This helps guarantee the order and prevent log duplication.
+<filter **>
+@type add_insert_ids
+</filter>
+
+# Configure all sources to output to Google Cloud Logging
+<match **>
+  @type google_cloud
+  buffer_type file
+  buffer_path /var/log/google-fluentd/buffers
+  # Set the chunk limit conservatively to avoid exceeding the recommended
+  # chunk size of 5MB per write request.
+  buffer_chunk_limit 512KB
+  # Flush logs every 5 seconds, even if the buffer is not full.
+  flush_interval 5s
+  # Enforce some limit on the number of retries.
+  disable_retry_limit false
+  # After 3 retries, a given chunk will be discarded.
+  retry_limit 3
+  # Wait 10 seconds before the first retry. The wait interval will be doubled on
+  # each following retry (20s, 40s...) until it hits the retry limit.
+  retry_wait 10
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops.
+  # Given the default config, this limit should never be reached, but if
+  # retry_limit and retry_wait are customized, this limit might take effect.
+  max_retry_wait 300
+  # Use multiple threads for processing.
+  num_threads 8
+  # Use the gRPC transport.
+  use_grpc true
+  # If a request is a mix of valid log entries and invalid ones, ingest the
+  # valid ones and drop the invalid ones instead of dropping everything.
+  partial_success true
+  # Enable monitoring via Prometheus integration.
+  enable_monitoring true
+  monitoring_type opencensus
+  detect_json true
+</match>" > /etc/google-fluentd/google-fluentd.conf
+
+echo "
+<match docker_logs>
+  @type rewrite_tag_filter
+  <rule>
+    key log
+    pattern ^{
+    tag docker_logs_json
+  </rule>
+  <rule>
+    key log
+    pattern ^[^{]
+    tag docker_logs_plain
+  </rule>
+</match>
+
+<filter docker_logs_json>
+  @type parser
+  key_name log
+  reserve_data false
+  <parse>
+    @type json
+  </parse>
+</filter>
+
+<filter docker_logs_plain>
+  @type record_transformer
+  <record>
+    message $${record["log"]}
+  </record>
+</filter>
+" > /etc/google-fluentd/config.d/docker.conf
+systemctl restart google-fluentd
+
 # ---- Install Docker ----
 
 echo "Installing Docker..."

--- a/packages/terraform-modules/testnet/modules/validator/startup.sh
+++ b/packages/terraform-modules/testnet/modules/validator/startup.sh
@@ -13,6 +13,96 @@ fi
 curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
 bash install-logging-agent.sh
 
+echo "
+@include config.d/*.conf
+# Prometheus monitoring.
+<source>
+  @type prometheus
+  port 24231
+</source>
+<source>
+  @type prometheus_monitor
+</source>
+
+# Do not collect fluentd's own logs to avoid infinite loops.
+<match fluent.**>
+  @type null
+</match>
+
+# Add a unique insertId to each log entry that doesn't already have it.
+# This helps guarantee the order and prevent log duplication.
+<filter **>
+@type add_insert_ids
+</filter>
+
+# Configure all sources to output to Google Cloud Logging
+<match **>
+  @type google_cloud
+  buffer_type file
+  buffer_path /var/log/google-fluentd/buffers
+  # Set the chunk limit conservatively to avoid exceeding the recommended
+  # chunk size of 5MB per write request.
+  buffer_chunk_limit 512KB
+  # Flush logs every 5 seconds, even if the buffer is not full.
+  flush_interval 5s
+  # Enforce some limit on the number of retries.
+  disable_retry_limit false
+  # After 3 retries, a given chunk will be discarded.
+  retry_limit 3
+  # Wait 10 seconds before the first retry. The wait interval will be doubled on
+  # each following retry (20s, 40s...) until it hits the retry limit.
+  retry_wait 10
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops.
+  # Given the default config, this limit should never be reached, but if
+  # retry_limit and retry_wait are customized, this limit might take effect.
+  max_retry_wait 300
+  # Use multiple threads for processing.
+  num_threads 8
+  # Use the gRPC transport.
+  use_grpc true
+  # If a request is a mix of valid log entries and invalid ones, ingest the
+  # valid ones and drop the invalid ones instead of dropping everything.
+  partial_success true
+  # Enable monitoring via Prometheus integration.
+  enable_monitoring true
+  monitoring_type opencensus
+  detect_json true
+</match>" > /etc/google-fluentd/google-fluentd.conf
+
+echo "
+<match docker_logs>
+  @type rewrite_tag_filter
+  <rule>
+    key log
+    pattern ^{
+    tag docker_logs_json
+  </rule>
+  <rule>
+    key log
+    pattern ^[^{]
+    tag docker_logs_plain
+  </rule>
+</match>
+
+<filter docker_logs_json>
+  @type parser
+  key_name log
+  reserve_data false
+  <parse>
+    @type json
+  </parse>
+</filter>
+
+<filter docker_logs_plain>
+  @type record_transformer
+  <record>
+    message $${record["log"]}
+  </record>
+</filter>
+" > /etc/google-fluentd/config.d/docker.conf
+systemctl restart google-fluentd
+
 # ---- Set Up Persistent Disk ----
 
 # gives a path similar to `/dev/sdb`
@@ -54,7 +144,7 @@ echo "Configuring Docker..."
 gcloud auth configure-docker
 
 # use GCP logging for Docker containers
-echo '{"log-driver":"gcplogs"}' > /etc/docker/daemon.json
+echo '{"log-driver":"fluentd","log-opts":{"fluentd-address":"0.0.0.0:24224","tag":"docker_logs"}}' > /etc/docker/daemon.json
 systemctl restart docker
 
 # ---- Set Up and Run Geth ----


### PR DESCRIPTION
### Description

We have used the `gcplogs` docker logging driver, however that one was basically impossible to configure. Instead, we are using the already installed `google-fluentd` agent with the `fluentd` log driver to parse JSON where possible. This should still print out non json lines as well. We could probably make an actual geth filter, but for now this should do

### Tested

on my testnet `namtest`

### Other changes

_Describe any minor or "drive-by" changes here._

### Related issues

- Fixes #1831 

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
