### PR TITLE
Swallowing error for more friendly cli UX

### DIFF
--- a/packages/cli/src/utils/helpers.ts
+++ b/packages/cli/src/utils/helpers.ts
@@ -32,15 +32,16 @@ export async function nodeIsSynced(web3: Web3): Promise<boolean> {
     }
     return false
   } catch (error) {
-    console.log('An error occurred while trying to reach the node.')
-    console.log(error)
+    console.log(
+      "An error occurred while trying to reach the node. Perhaps your node isn't running?"
+    )
     return false
   }
 }
 
 export async function requireNodeIsSynced(web3: Web3) {
   if (!(await nodeIsSynced(web3))) {
-    failWith('Node is not currently synced. Run node:synced to check its status')
+    failWith('Node is not currently synced. Run node:synced to check its status.')
   }
 }
 


### PR DESCRIPTION
### Description
Added a bit more description to node syncing failing, while removing the printing of the error so it doesn't alarm users.