### PR TITLE
Dont show this error for now

### DIFF
--- a/packages/web/fullstack/sentry.ts
+++ b/packages/web/fullstack/sentry.ts
@@ -9,6 +9,9 @@ export function initSentry() {
   Sentry.init({
     dsn: `https://${config.KEY}@sentry.io/${config.PROJECT}`,
     environment: publicRuntimeConfig.ENV,
+    ignoreErrors: [
+      "The fetching process for the media resource was aborted by the user agent at the user's request.",
+    ],
   })
 }
 


### PR DESCRIPTION
### Description

There is an error in sentry that is causing us to almost hit out limit. 
`"The fetching process for the media resource was aborted by the user agent at the user's request.",`

This is an error browsers emit when a media resource like a video aborts loading.

### Tested

untested


### Related issues

- Fixes https://sentry.io/organizations/celo/issues/?project=1543594
