### PR TITLE
Add utils as a dep

### DIFF
--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@celo/contractkit": "0.2.0",
+    "@celo/utils": "^0.1.0",
     "apollo-datasource-rest": "^0.3.1",
     "apollo-server-express": "^2.4.2",
     "bignumber.js": "^7.2.0",


### PR DESCRIPTION
### Description

Blockchain api build was failing in mac os x due to missing dep

### Tested

Tested in CI