### PR TITLE
Prevent crash of `yarn run dev:android` when there are iOS files missing

### DIFF
--- a/packages/mobile/scripts/run_app.sh
+++ b/packages/mobile/scripts/run_app.sh
@@ -63,8 +63,8 @@ sed -i.bak "s/DEV_RESTORE_NAV_STATE_ON_RELOAD=.*/DEV_RESTORE_NAV_STATE_ON_RELOAD
 # Set Firebase settings in google service config files
 ANDROID_GSERVICES_PATH="./android/app/src/debug/google-services.json"
 IOS_GSERVICES_PATH="./ios/GoogleService-Info.plist"
-sed -i.bak "s/celo-org-mobile-.*firebaseio.com/celo-org-mobile-$NETWORK.firebaseio.com/g" $ANDROID_GSERVICES_PATH
-sed -i.bak "s/celo-org-mobile-.*firebaseio.com/celo-org-mobile-$NETWORK.firebaseio.com/g" $IOS_GSERVICES_PATH
+sed -i.bak "s/celo-org-mobile-.*firebaseio.com/celo-org-mobile-$NETWORK.firebaseio.com/g" $ANDROID_GSERVICES_PATH || true
+sed -i.bak "s/celo-org-mobile-.*firebaseio.com/celo-org-mobile-$NETWORK.firebaseio.com/g" $IOS_GSERVICES_PATH || true
 
 # Cleanup artifacts from in-place sed replacement on BSD based systems (macOS)
 rm -f $ENV_FILENAME.bak


### PR DESCRIPTION
### Description

_Prevent crash of `yarn run dev:android` when there are iOS files missing_

### Tested

_On Linux command line_

### Related issues

- Fixes #2282
