### PR TITLE
Wait one more block on selectIssuers to deal with light client failures

### DIFF
--- a/packages/contractkit/src/wrappers/Attestations.ts
+++ b/packages/contractkit/src/wrappers/Attestations.ts
@@ -139,7 +139,7 @@ export class AttestationsWrapper extends BaseWrapper<Attestations> {
     // TODO: Use subscription if provider supports
     while (Date.now() - startTime < timeoutSeconds * 1000) {
       const blockNumber = await this.kit.web3.eth.getBlockNumber()
-      if (blockNumber >= unselectedRequest.blockNumber + waitBlocks - 1) {
+      if (blockNumber >= unselectedRequest.blockNumber + waitBlocks) {
         return
       }
       await sleep(pollDurationSeconds * 1000)


### PR DESCRIPTION
### Description

The selectIssuers tx was failing on light clients pretty often - this ensure the state is updated.

### Tested

Ran locally with the app and was able to verify
