### PR TITLE
Note on exposing port 80 inside the attestations section of docs

### DIFF
--- a/packages/docs/getting-started/running-a-validator.md
+++ b/packages/docs/getting-started/running-a-validator.md
@@ -519,7 +519,7 @@ celocli validator:show $CELO_VALIDATOR_ADDRESS
 
 ### Running the Attestation Service
 
-As part of the [lightweight identity protocol](/celo-codebase/protocol/identity), Validators are expected to run an [Attestation Service](https://github.com/celo-org/celo-monorepo/tree/master/packages/attestation-service) to provide attestations that allow users to map their phone number to an account on Celo.
+As part of the [lightweight identity protocol](/celo-codebase/protocol/identity), Validators are expected to run an [Attestation Service](https://github.com/celo-org/celo-monorepo/tree/master/packages/attestation-service) to provide attestations that allow users to map their phone number to an account on Celo. Be sure to allow TCP connections to your Attestations machine on port 80 for all IP addresses.
 
 Just like with the Validator signer, we'll want to authorize a separate Attestation signer. For that let's start our node on the Attestations machine:
 


### PR DESCRIPTION
### Description

Added another note on exposing port 80 on the attestations machine inside the section for the attestation service.

### Tested

n/a

### Other changes

n/a

### Related issues

- Fixes #2297 

### Backwards compatibility

Yes