### PR TITLE
[Slashing] Allow voting gold to be slashable

### DIFF
--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -357,7 +357,7 @@ contract Election is
   function _decrementVotes(
     address account,
     address group,
-    uint256 value,
+    uint256 maxValue,
     address lesser,
     address greater,
     uint256 index

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -309,8 +309,8 @@ contract Election is
     address lesser,
     address greater,
     uint256 index
-  ) public returns (uint256) {
-    require(group != address(0) && 0 < value, "null group");
+  ) internal returns (uint256) {
+    require(group != address(0) && 0 < value);
     uint256 remainingValue = value;
     uint256 pendingVotes = getPendingVotesForGroupByAccount(group, account);
     if (pendingVotes > 0) {
@@ -331,12 +331,14 @@ contract Election is
       remainingValue = remainingValue.sub(maxValue);
     }
     uint256 difference = value.sub(remainingValue);
-    decrementTotalVotes(group, difference, lesser, greater);
-    getLockedGold().incrementNonvotingAccountBalance(account, difference);
+    if (difference > 0) {
+      decrementTotalVotes(group, difference, lesser, greater);
+      getLockedGold().incrementNonvotingAccountBalance(account, difference);
+      emit ValidatorGroupVoteRevoked(account, group, difference);
+    }
     if (getTotalVotesForGroupByAccount(group, account) == 0) {
       deleteElement(votes.groupsVotedFor[account], group, index);
     }
-    emit ValidatorGroupVoteRevoked(account, group, difference);
     return difference;
   }
 
@@ -929,6 +931,6 @@ contract Election is
         return true;
       }
     }
-    return false;
+    require(false, "Cannot slash all provided votes");
   }
 }

--- a/packages/protocol/test/governance/election.ts
+++ b/packages/protocol/test/governance/election.ts
@@ -1213,7 +1213,7 @@ contract('Election', (accounts: string[]) => {
     })
   })
 
-  describe('#forceRevokeVotes', () => {
+  describe('#forceDecrementVotes', () => {
     const voter = accounts[0]
     const group = accounts[1]
     const value = 1000
@@ -1237,7 +1237,7 @@ contract('Election', (accounts: string[]) => {
           const slashedValue = value
           const remaining = value - slashedValue
           beforeEach(async () => {
-            await election.forceRevokeVotes(
+            await election.forceDecrementVotes(
               voter,
               slashedValue,
               [NULL_ADDRESS],
@@ -1277,7 +1277,7 @@ contract('Election', (accounts: string[]) => {
           const slashedValue = value
           const remaining = value - slashedValue
           beforeEach(async () => {
-            await election.forceRevokeVotes(
+            await election.forceDecrementVotes(
               voter,
               slashedValue,
               [NULL_ADDRESS],
@@ -1331,7 +1331,7 @@ contract('Election', (accounts: string[]) => {
           const remaining = value - slashedValue
 
           beforeEach(async () => {
-            await election.forceRevokeVotes(
+            await election.forceDecrementVotes(
               voter,
               slashedValue,
               [group2, NULL_ADDRESS],
@@ -1379,7 +1379,7 @@ contract('Election', (accounts: string[]) => {
         await election.vote(group, value / 2, NULL_ADDRESS, group2)
       })
 
-      describe('when both groups have both passive and active votes', async () => {
+      describe('when both groups have both pending and active votes', async () => {
         beforeEach(async () => {
           await mineBlocks(EPOCH, web3)
           await election.activate(group)
@@ -1390,11 +1390,11 @@ contract('Election', (accounts: string[]) => {
           await registry.setAddressFor(CeloContractName.LockedGold, accounts[2])
         })
 
-        describe("when we slash 1 more vote than group 1's passive vote total", async () => {
+        describe("when we slash 1 more vote than group 1's pending vote total", async () => {
           const slashedValue = value / 2 + 1
           const remaining = value - slashedValue
           beforeEach(async () => {
-            await election.forceRevokeVotes(
+            await election.forceDecrementVotes(
               voter,
               slashedValue,
               [NULL_ADDRESS, NULL_ADDRESS],
@@ -1436,7 +1436,7 @@ contract('Election', (accounts: string[]) => {
           const group2PendingRemaining = value2 / 2 - 1
           const group2ActiveRemaining = value2 / 2
           beforeEach(async () => {
-            await election.forceRevokeVotes(
+            await election.forceDecrementVotes(
               voter,
               slashedValue,
               [group, NULL_ADDRESS],
@@ -1503,7 +1503,7 @@ contract('Election', (accounts: string[]) => {
           await election.activate(group2)
           initialGroupOrdering = (await election.getTotalVotesForEligibleValidatorGroups())[0]
           await registry.setAddressFor(CeloContractName.LockedGold, accounts[2])
-          await election.forceRevokeVotes(
+          await election.forceDecrementVotes(
             voter,
             slashedValue,
             [group, NULL_ADDRESS],
@@ -1529,11 +1529,11 @@ contract('Election', (accounts: string[]) => {
         })
       })
 
-      describe('when `forceRevokeVotes` is called with malformed inputs', () => {
+      describe('when `forceDecrementVotes` is called with malformed inputs', () => {
         describe('when called to slash more value than groups have', () => {
           it('should revert', async () => {
             await assertRevert(
-              election.forceRevokeVotes(
+              election.forceDecrementVotes(
                 voter,
                 value + value2 + 1,
                 [group, NULL_ADDRESS],
@@ -1550,7 +1550,7 @@ contract('Election', (accounts: string[]) => {
             const slashedValue = value
             // `group` should be listed as a lesser for index 0 (group2's lesser)
             await assertRevert(
-              election.forceRevokeVotes(
+              election.forceDecrementVotes(
                 voter,
                 slashedValue,
                 [NULL_ADDRESS, NULL_ADDRESS],
@@ -1566,7 +1566,7 @@ contract('Election', (accounts: string[]) => {
           it('should revert', async () => {
             const slashedValue = value
             await assertRevert(
-              election.forceRevokeVotes(
+              election.forceDecrementVotes(
                 voter,
                 slashedValue,
                 [group, NULL_ADDRESS],
@@ -1581,7 +1581,7 @@ contract('Election', (accounts: string[]) => {
         describe('when called from an address other than the locked gold contract', () => {
           it('should revert', async () => {
             await assertRevert(
-              election.forceRevokeVotes(
+              election.forceDecrementVotes(
                 voter,
                 value,
                 [group, NULL_ADDRESS],


### PR DESCRIPTION
### Description

Adding function `slashVotes` within `Election.sol` that relies on another new function `revokeVotes` which combines `revokePending` and `revokeActive` in order to only sort internal group lists once. 

Points of focus: 
* Cannot make the contract `onlyRegisteredContract(LOCKED_GOLD_REGISTRY_ID)` because if I override `mockLockedGold`'s address the tests revert because that contract cannot be properly called, but I also can't use `mockLockedGold`'s address as the caller since that address is unknown to truffle/ganache. Any guidance on this would be helpful, there don't appear to be any examples of doing this anywhere else.

### Tested

Added unit tests

### Related issues

- Fixes #2083

### Backwards compatibility

yes
