### PR TITLE
Improve attestation service init error message when the node is not synced

### DIFF
--- a/packages/attestation-service/src/db.ts
+++ b/packages/attestation-service/src/db.ts
@@ -40,7 +40,7 @@ export async function initializeKit() {
           }
         }
       } else {
-        throw new Error('Node is not syncing')
+        throw new Error('Node is still syncing')
       }
     } catch (error) {
       rootLogger.error(


### PR DESCRIPTION
### Description

The error received while the node sync was under way but not yet complete:
```
2019-12-27T07:29:49.020Z attestation-service[61] ERROR: Initializing Kit failed, are you running your node and specified it with the "CELO_PROVIDER" env var?. It' currently set as http://localhost:8545
2019-12-27T07:29:49.034Z attestation-service[61] ERROR: Node is not syncing
```

When the node is still syncing, `web3.eth.isSyncing()` will return `false`. In that case, telling the operator that the node is "not syncing" is misleading, so let's use a more accurate error message.

### Tested

Error message string. Tested manually.

### Other changes

None.

### Related issues

None.

### Backwards compatibility

Fully backwards compatible, unless some tool is actually parsing the error message.
