### PR TITLE
Added new lint rule

### DIFF
--- a/packages/protocol/test/governance/lockedgold.ts
+++ b/packages/protocol/test/governance/lockedgold.ts
@@ -422,7 +422,7 @@ contract('LockedGold', (accounts: string[]) => {
     })
   })
 
-  describe.only('#slash', () => {
+  describe('#slash', () => {
     const value = 1000
     const group = accounts[1]
     const reporter = accounts[3]

--- a/packages/protocol/tslint.json
+++ b/packages/protocol/tslint.json
@@ -6,6 +6,11 @@
   },
   "rules": {
     "no-global-arrow-functions": false,
-    "no-floating-promises": true
+    "no-floating-promises": true,
+    "ban": [
+      true,
+      { "name": ["describe", "only"], "message": "don't focus tests" },
+      { "name": ["it", "only"], "message": "don't focus tests" }
+    ]
   }
 }


### PR DESCRIPTION
### Description

Add a lint rule banning `it.only` and `describe.only`

### Tested

Let's see if it fails now.

### Other changes

### Related issues

- Fixes #2348

### Backwards compatibility

