### PR TITLE
Update reconnecting-to-network.md

### DIFF
--- a/packages/docs/getting-started/reconnecting-to-network.md
+++ b/packages/docs/getting-started/reconnecting-to-network.md
@@ -78,7 +78,6 @@ rm -rf geth* && rm static-nodes.json
 ```bash
 # On your Attestation machine
 cd celo-attestations-node
-cd celo-accounts-node
 rm -rf geth* && rm static-nodes.json
 ```
 


### PR DESCRIPTION


### Description

Remove extra line from docs to reconnect to network. This didn't seem to be there.

### Tested

- Docs only change, what I saw on my nodes after following the existing documentation

### Other changes

- Docs only change

### Related issues

- None

### Backwards compatibility

- Docs only change
