### PR TITLE
Implementation of tickets 1604, 1597 and 1365

### DIFF
--- a/packages/contractkit/src/wrappers/SortedOracles.ts
+++ b/packages/contractkit/src/wrappers/SortedOracles.ts
@@ -98,9 +98,13 @@ export class SortedOraclesWrapper extends BaseWrapper<SortedOracles> {
       oracleAddress
     )
 
+    const reportedValue = toBigNumber(numerator.toString())
+      .dividedBy(toBigNumber(denominator.toString()))
+      .multipliedBy(await this.getInternalDenominator())
+
     return toTransactionObject(
       this.kit,
-      this.contract.methods.report(tokenAddress, numerator, denominator, lesserKey, greaterKey),
+      this.contract.methods.report(tokenAddress, reportedValue, lesserKey, greaterKey),
       { from: oracleAddress }
     )
   }
@@ -158,7 +162,7 @@ export class SortedOraclesWrapper extends BaseWrapper<SortedOracles> {
   }
 
   private async getInternalDenominator(): Promise<BigNumber> {
-    return toBigNumber(await this.contract.methods.DENOMINATOR().call())
+    return toBigNumber(await this.contract.methods.getDenominator().call())
   }
 
   private async findLesserAndGreaterKeys(

--- a/packages/contractkit/src/wrappers/SortedOracles.ts
+++ b/packages/contractkit/src/wrappers/SortedOracles.ts
@@ -1,4 +1,5 @@
 import { eqAddress } from '@celo/utils/lib/address'
+import { toFixed } from '@celo/utils/src/fixidity'
 import BigNumber from 'bignumber.js'
 import { Address, CeloContract, CeloToken, NULL_ADDRESS } from '../base'
 import { SortedOracles } from '../generated/types/SortedOracles'
@@ -98,9 +99,9 @@ export class SortedOraclesWrapper extends BaseWrapper<SortedOracles> {
       oracleAddress
     )
 
-    const reportedValue = toBigNumber(numerator.toString())
-      .dividedBy(toBigNumber(denominator.toString()))
-      .multipliedBy(await this.getInternalDenominator())
+    const reportedValue = toFixed(
+      toBigNumber(numerator.toString()).dividedBy(toBigNumber(denominator.toString()))
+    ).toString()
 
     return toTransactionObject(
       this.kit,

--- a/packages/contractkit/src/wrappers/SortedOracles.ts
+++ b/packages/contractkit/src/wrappers/SortedOracles.ts
@@ -57,7 +57,7 @@ export class SortedOraclesWrapper extends BaseWrapper<SortedOracles> {
     const tokenAddress = await this.kit.registry.addressFor(token)
     const response = await this.contract.methods.medianRate(tokenAddress).call()
     return {
-      rate: toBigNumber(response[0]).div(toBigNumber(response[1])),
+      rate: toFixed(toBigNumber(response[0]).div(toBigNumber(response[1]))),
     }
   }
 
@@ -149,21 +149,16 @@ export class SortedOraclesWrapper extends BaseWrapper<SortedOracles> {
     const tokenAddress = await this.kit.registry.addressFor(token)
     const response = await this.contract.methods.getRates(tokenAddress).call()
     const rates: OracleRate[] = []
-    const denominator = await this.getInternalDenominator()
 
     for (let i = 0; i < response[0].length; i++) {
       const medRelIndex = parseInt(response[2][i], 10)
       rates.push({
         address: response[0][i],
-        rate: toBigNumber(response[1][i]).div(denominator),
+        rate: toFixed(toBigNumber(response[1][i]).div(toBigNumber(response[2][i]))),
         medianRelation: medRelIndex,
       })
     }
     return rates
-  }
-
-  private async getInternalDenominator(): Promise<BigNumber> {
-    return toBigNumber(await this.contract.methods.getDenominator().call())
   }
 
   private async findLesserAndGreaterKeys(

--- a/packages/protocol/contracts/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts/common/GasPriceMinimum.sol
@@ -82,7 +82,11 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
       uint256 rateNumerator;
       uint256 rateDenominator;
       (rateNumerator, rateDenominator) = sortedOracles.medianRate(tokenAddress);
-      return (gasPriceMinimum.mul(rateNumerator).div(rateDenominator));
+      FixidityLib.Fraction memory ratio = FixidityLib.newFixedFraction(
+        rateNumerator,
+        rateDenominator
+      );
+      return (FixidityLib.newFixed(gasPriceMinimum)).multiply(ratio).fromFixed();
     }
   }
 

--- a/packages/protocol/contracts/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts/common/GasPriceMinimum.sol
@@ -79,13 +79,10 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
       ISortedOracles sortedOracles = ISortedOracles(
         registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID)
       );
-      uint256 rateNumerator;
+      uint256 rate;
       uint256 rateDenominator;
-      (rateNumerator, rateDenominator) = sortedOracles.medianRate(tokenAddress);
-      FixidityLib.Fraction memory ratio = FixidityLib.newFixedFraction(
-        rateNumerator,
-        rateDenominator
-      );
+      (rate, rateDenominator) = sortedOracles.medianRate(tokenAddress);
+      FixidityLib.Fraction memory ratio = FixidityLib.newFixedFraction(rate, rateDenominator);
       return (FixidityLib.newFixed(gasPriceMinimum)).multiply(ratio).fromFixed();
     }
   }

--- a/packages/protocol/contracts/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts/common/GasPriceMinimum.sol
@@ -79,11 +79,14 @@ contract GasPriceMinimum is Ownable, Initializable, UsingRegistry {
       ISortedOracles sortedOracles = ISortedOracles(
         registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID)
       );
-      uint256 rate;
+      uint256 rateNumerator;
       uint256 rateDenominator;
-      (rate, rateDenominator) = sortedOracles.medianRate(tokenAddress);
-      FixidityLib.Fraction memory ratio = FixidityLib.newFixedFraction(rate, rateDenominator);
-      return (FixidityLib.newFixed(gasPriceMinimum)).multiply(ratio).fromFixed();
+      (rateNumerator, rateDenominator) = sortedOracles.medianRate(tokenAddress);
+      FixidityLib.Fraction memory rate = FixidityLib.newFixedFraction(
+        rateNumerator,
+        rateDenominator
+      );
+      return (FixidityLib.newFixed(gasPriceMinimum)).multiply(rate).fromFixed();
     }
   }
 

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -26,6 +26,8 @@ contract GoldToken is Initializable, IERC20Token, ICeloToken {
 
   event Approval(address indexed owner, address indexed spender, uint256 value);
 
+  event TotalSupplySet(uint256 totalSupply);
+
   /**
    * Only VM would be able to set the caller address to 0x0 unless someone
    * really has the private key for 0x0
@@ -40,7 +42,16 @@ contract GoldToken is Initializable, IERC20Token, ICeloToken {
    */
   // solhint-disable-next-line no-empty-blocks
   function initialize() external initializer {
-    totalSupply_ = 0;
+    setInitialTotalSupply(0);
+  }
+
+  /**
+   * @notice Sets the token initial supply
+   * @param _totalSupply new token initial supply.
+   */
+  function setInitialTotalSupply(uint256 _totalSupply) private {
+    totalSupply_ = _totalSupply;
+    emit TotalSupplySet(_totalSupply);
   }
 
   /**

--- a/packages/protocol/contracts/common/MultiSig.sol
+++ b/packages/protocol/contracts/common/MultiSig.sol
@@ -125,6 +125,7 @@ contract MultiSig is Initializable {
         "owner was null or already given owner status"
       );
       isOwner[_owners[i]] = true;
+      emit OwnerAddition(_owners[i]);
     }
     owners = _owners;
   }

--- a/packages/protocol/contracts/common/MultiSig.sol
+++ b/packages/protocol/contracts/common/MultiSig.sol
@@ -110,47 +110,29 @@ contract MultiSig is Initializable {
     initializer
     validRequirement(_owners.length, _required)
   {
-    setInitialOwners(_owners);
-    setInitialRequired(_required);
-  }
-
-  /**
-   * @notice Sets the initial owners of the wallet.
-   * @param _owners List of initial owners.
-   */
-  function setInitialOwners(address[] memory _owners) private {
     for (uint256 i = 0; i < _owners.length; i++) {
-      require(
-        !isOwner[_owners[i]] && _owners[i] != address(0),
-        "owner was null or already given owner status"
-      );
-      isOwner[_owners[i]] = true;
+      _addOwner(_owners[i]);
     }
-    owners = _owners;
-  }
-
-  /**
-   * @notice Sets the required number of tx confirmations.
-   * @param _required The number of required tx confirmations.
-   */
-  function setInitialRequired(uint256 _required) private {
-    require(_required > 0, "Required confirmations must be greater than zero");
-    required = _required;
-    emit RequirementSet(_required);
+    changeRequirement(_required);
   }
 
   /// @dev Allows to add a new owner. Transaction has to be sent by wallet.
   /// @param owner Address of new owner.
-  function addOwner(address owner)
-    external
-    onlyWallet
+  function addOwner(address owner) external onlyWallet {
+    _addOwner(owner);
+  }
+
+  /// @dev adding new owner
+  /// @param owner Address of new owner.
+  function _addOwner(address _owner)
+    private
     ownerDoesNotExist(owner)
     notNull(owner)
     validRequirement(owners.length + 1, required)
   {
-    isOwner[owner] = true;
-    owners.push(owner);
-    emit OwnerAddition(owner);
+    isOwner[_owner] = true;
+    owners.push(_owner);
+    emit OwnerAddition(_owner);
   }
 
   /// @dev Allows to remove an owner. Transaction has to be sent by wallet.

--- a/packages/protocol/contracts/common/MultiSig.sol
+++ b/packages/protocol/contracts/common/MultiSig.sol
@@ -113,26 +113,25 @@ contract MultiSig is Initializable {
     for (uint256 i = 0; i < _owners.length; i++) {
       _addOwner(_owners[i]);
     }
-    changeRequirement(_required);
+    _changeRequirement(_required);
   }
 
   /// @dev Allows to add a new owner. Transaction has to be sent by wallet.
   /// @param owner Address of new owner.
-  function addOwner(address owner) external onlyWallet {
+  function addOwner(address owner)
+    external
+    onlyWallet
+    validRequirement(owners.length + 1, required)
+  {
     _addOwner(owner);
   }
 
   /// @dev adding new owner
   /// @param owner Address of new owner.
-  function _addOwner(address _owner)
-    private
-    ownerDoesNotExist(owner)
-    notNull(owner)
-    validRequirement(owners.length + 1, required)
-  {
-    isOwner[_owner] = true;
-    owners.push(_owner);
-    emit OwnerAddition(_owner);
+  function _addOwner(address owner) private ownerDoesNotExist(owner) notNull(owner) {
+    isOwner[owner] = true;
+    owners.push(owner);
+    emit OwnerAddition(owner);
   }
 
   /// @dev Allows to remove an owner. Transaction has to be sent by wallet.
@@ -177,6 +176,10 @@ contract MultiSig is Initializable {
     onlyWallet
     validRequirement(owners.length, _required)
   {
+    _changeRequirement(_required);
+  }
+
+  function _changeRequirement(uint256 _required) private {
     required = _required;
     emit RequirementChange(_required);
   }

--- a/packages/protocol/contracts/common/MultiSig.sol
+++ b/packages/protocol/contracts/common/MultiSig.sol
@@ -20,6 +20,7 @@ contract MultiSig is Initializable {
   event OwnerAddition(address indexed owner);
   event OwnerRemoval(address indexed owner);
   event RequirementChange(uint256 required);
+  event RequirementSet(uint256 required);
 
   /*
    *  Constants
@@ -109,6 +110,15 @@ contract MultiSig is Initializable {
     initializer
     validRequirement(_owners.length, _required)
   {
+    setInitialOwners(_owners);
+    setInitialRequired(_required);
+  }
+
+  /**
+   * @notice Sets the initial owners of the wallet.
+   * @param _owners List of initial owners.
+   */
+  function setInitialOwners(address[] memory _owners) private {
     for (uint256 i = 0; i < _owners.length; i++) {
       require(
         !isOwner[_owners[i]] && _owners[i] != address(0),
@@ -117,7 +127,16 @@ contract MultiSig is Initializable {
       isOwner[_owners[i]] = true;
     }
     owners = _owners;
+  }
+
+  /**
+   * @notice Sets the required number of tx confirmations.
+   * @param _required The number of required tx confirmations.
+   */
+  function setInitialRequired(uint256 _required) private {
+    require(_required > 0, "Required confirmations must be greater than zero");
     required = _required;
+    emit RequirementSet(_required);
   }
 
   /// @dev Allows to add a new owner. Transaction has to be sent by wallet.

--- a/packages/protocol/contracts/common/MultiSig.sol
+++ b/packages/protocol/contracts/common/MultiSig.sol
@@ -20,7 +20,6 @@ contract MultiSig is Initializable {
   event OwnerAddition(address indexed owner);
   event OwnerRemoval(address indexed owner);
   event RequirementChange(uint256 required);
-  event RequirementSet(uint256 required);
 
   /*
    *  Constants

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -165,6 +165,7 @@ contract EpochRewards is Ownable, Initializable, UsingPrecompiles, UsingRegistry
    * @notice Sets the target voting yield for validators.
    * @param _targetVotingYield The value of the target voting yield.
    * @return True upon success.
+   * @dev unwrapped Fixidity value expected for _targetVotingYield
    */
   function setTargetVotingYield(uint256 _targetVotingYield) public onlyOwner returns (bool) {
     targetVotingYieldParams.target = FixidityLib.wrap(_targetVotingYield);

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -166,7 +166,7 @@ contract EpochRewards is Ownable, Initializable, UsingPrecompiles, UsingRegistry
    * @param _targetVotingYield The value of the target voting yield.
    * @return True upon success.
    */
-  function setTargetVotingYield(uint256 _targetVotingYield) public onlyOwner returns (bool) {
+  function setTargetVotingYield(uint256 _targetVotingYield) private returns (bool) {
     targetVotingYieldParams.target = FixidityLib.wrap(_targetVotingYield);
     emit TargetVotingYield(_targetVotingYield);
     return true;
@@ -177,7 +177,7 @@ contract EpochRewards is Ownable, Initializable, UsingPrecompiles, UsingRegistry
    * @param _startTime The time in unix.
    * @return True upon success.
    */
-  function setStartTime(uint256 _startTime) public onlyOwner returns (bool) {
+  function setStartTime(uint256 _startTime) private returns (bool) {
     require(_startTime >= block.timestamp, "The start time must not be in the past");
     startTime = _startTime;
     emit StartTimeSet(_startTime);

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -64,6 +64,8 @@ contract EpochRewards is Ownable, Initializable, UsingPrecompiles, UsingRegistry
     uint256 underspendAdjustmentFactor,
     uint256 overspendAdjustmentFactor
   );
+  event StartTimeSet(uint256 startTime);
+  event TargetVotingYield(uint256 targetVotingYield);
 
   /**
    * @notice Initializes critical variables.
@@ -101,8 +103,8 @@ contract EpochRewards is Ownable, Initializable, UsingPrecompiles, UsingRegistry
     );
     setTargetVotingGoldFraction(_targetVotingGoldFraction);
     setTargetValidatorEpochPayment(_targetValidatorEpochPayment);
-    targetVotingYieldParams.target = FixidityLib.wrap(targetVotingYieldInitial);
-    startTime = now;
+    setTargetVotingYield(targetVotingYieldInitial);
+    setStartTime(block.timestamp);
   }
 
   /**
@@ -156,6 +158,29 @@ contract EpochRewards is Ownable, Initializable, UsingPrecompiles, UsingRegistry
     require(value != targetValidatorEpochPayment);
     targetValidatorEpochPayment = value;
     emit TargetValidatorEpochPaymentSet(value);
+    return true;
+  }
+
+  /**
+   * @notice Sets the target voting yield for validators.
+   * @param _targetVotingYield The value of the target voting yield.
+   * @return True upon success.
+   */
+  function setTargetVotingYield(uint256 _targetVotingYield) public onlyOwner returns (bool) {
+    targetVotingYieldParams.target = FixidityLib.wrap(_targetVotingYield);
+    emit TargetVotingYield(_targetVotingYield);
+    return true;
+  }
+
+  /**
+   * @notice Sets the start time.
+   * @param _startTime The time in unix.
+   * @return True upon success.
+   */
+  function setStartTime(uint256 _startTime) public onlyOwner returns (bool) {
+    require(_startTime >= block.timestamp, "The start time must not be in the past");
+    startTime = _startTime;
+    emit StartTimeSet(_startTime);
     return true;
   }
 

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -238,7 +238,7 @@ contract Governance is
    * @notice Updates the last dequeue timestamp.
    * @param _lastDequeue The last dequeue timestamp.
    */
-  function setLastDequeue(uint256 _lastDequeue) public onlyOwner {
+  function setLastDequeue(uint256 _lastDequeue) private {
     require(_lastDequeue >= block.timestamp, "last dequeuing time must not be in the past");
     // solhint-disable-next-line not-rely-on-time
     lastDequeue = _lastDequeue;

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -118,6 +118,8 @@ contract Governance is
 
   event ExecutionStageDurationSet(uint256 executionStageDuration);
 
+  event LastDequeueSet(uint256 lastDequeue);
+
   event ConstitutionSet(address indexed destination, bytes4 indexed functionId, uint256 threshold);
 
   event ProposalQueued(
@@ -217,27 +219,37 @@ contract Governance is
     );
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
-    approver = _approver;
-    concurrentProposals = _concurrentProposals;
-    minDeposit = _minDeposit;
-    queueExpiry = _queueExpiry;
-    dequeueFrequency = _dequeueFrequency;
-    stageDurations.approval = approvalStageDuration;
-    stageDurations.referendum = referendumStageDuration;
-    stageDurations.execution = executionStageDuration;
+    setApprover(_approver);
+    setConcurrentProposals(_concurrentProposals);
+    setMinDeposit(_minDeposit);
+    setQueueExpiry(_queueExpiry);
+    setDequeueFrequency(_dequeueFrequency);
+    setApprovalStageDuration(approvalStageDuration);
+    setReferendumStageDuration(referendumStageDuration);
+    setExecutionStageDuration(executionStageDuration);
     setParticipationBaseline(participationBaseline);
     setParticipationFloor(participationFloor);
     setBaselineUpdateFactor(baselineUpdateFactor);
     setBaselineQuorumFactor(baselineQuorumFactor);
+    setLastDequeue(block.timestamp);
+  }
+
+  /**
+   * @notice Updates the last dequeue timestamp.
+   * @param _lastDequeue The last dequeue timestamp.
+   */
+  function setLastDequeue(uint256 _lastDequeue) public onlyOwner {
+    require(_lastDequeue >= block.timestamp, "last dequeuing time must not be in the past");
     // solhint-disable-next-line not-rely-on-time
-    lastDequeue = now;
+    lastDequeue = _lastDequeue;
+    emit LastDequeueSet(_lastDequeue);
   }
 
   /**
    * @notice Updates the address that has permission to approve proposals in the approval stage.
    * @param _approver The address that has permission to approve proposals in the approval stage.
    */
-  function setApprover(address _approver) external onlyOwner {
+  function setApprover(address _approver) public onlyOwner {
     require(_approver != address(0) && _approver != approver);
     approver = _approver;
     emit ApproverSet(_approver);
@@ -247,7 +259,7 @@ contract Governance is
    * @notice Updates the number of proposals to dequeue at a time.
    * @param _concurrentProposals The number of proposals to dequeue at at a time.
    */
-  function setConcurrentProposals(uint256 _concurrentProposals) external onlyOwner {
+  function setConcurrentProposals(uint256 _concurrentProposals) public onlyOwner {
     require(_concurrentProposals > 0 && _concurrentProposals != concurrentProposals);
     concurrentProposals = _concurrentProposals;
     emit ConcurrentProposalsSet(_concurrentProposals);
@@ -257,7 +269,7 @@ contract Governance is
    * @notice Updates the minimum deposit needed to make a proposal.
    * @param _minDeposit The minimum Celo Gold deposit needed to make a proposal.
    */
-  function setMinDeposit(uint256 _minDeposit) external onlyOwner {
+  function setMinDeposit(uint256 _minDeposit) public onlyOwner {
     require(_minDeposit != minDeposit);
     minDeposit = _minDeposit;
     emit MinDepositSet(_minDeposit);
@@ -267,7 +279,7 @@ contract Governance is
    * @notice Updates the number of seconds before a queued proposal expires.
    * @param _queueExpiry The number of seconds a proposal can stay in the queue before expiring.
    */
-  function setQueueExpiry(uint256 _queueExpiry) external onlyOwner {
+  function setQueueExpiry(uint256 _queueExpiry) public onlyOwner {
     require(_queueExpiry > 0 && _queueExpiry != queueExpiry);
     queueExpiry = _queueExpiry;
     emit QueueExpirySet(_queueExpiry);
@@ -279,7 +291,7 @@ contract Governance is
    * @param _dequeueFrequency The number of seconds before the next batch of proposals can be
    *   dequeued.
    */
-  function setDequeueFrequency(uint256 _dequeueFrequency) external onlyOwner {
+  function setDequeueFrequency(uint256 _dequeueFrequency) public onlyOwner {
     require(_dequeueFrequency > 0 && _dequeueFrequency != dequeueFrequency);
     dequeueFrequency = _dequeueFrequency;
     emit DequeueFrequencySet(_dequeueFrequency);
@@ -289,7 +301,7 @@ contract Governance is
    * @notice Updates the number of seconds proposals stay in the approval stage.
    * @param approvalStageDuration The number of seconds proposals stay in the approval stage.
    */
-  function setApprovalStageDuration(uint256 approvalStageDuration) external onlyOwner {
+  function setApprovalStageDuration(uint256 approvalStageDuration) public onlyOwner {
     require(approvalStageDuration > 0 && approvalStageDuration != stageDurations.approval);
     stageDurations.approval = approvalStageDuration;
     emit ApprovalStageDurationSet(approvalStageDuration);
@@ -299,7 +311,7 @@ contract Governance is
    * @notice Updates the number of seconds proposals stay in the referendum stage.
    * @param referendumStageDuration The number of seconds proposals stay in the referendum stage.
    */
-  function setReferendumStageDuration(uint256 referendumStageDuration) external onlyOwner {
+  function setReferendumStageDuration(uint256 referendumStageDuration) public onlyOwner {
     require(referendumStageDuration > 0 && referendumStageDuration != stageDurations.referendum);
     stageDurations.referendum = referendumStageDuration;
     emit ReferendumStageDurationSet(referendumStageDuration);
@@ -309,7 +321,7 @@ contract Governance is
    * @notice Updates the number of seconds proposals stay in the execution stage.
    * @param executionStageDuration The number of seconds proposals stay in the execution stage.
    */
-  function setExecutionStageDuration(uint256 executionStageDuration) external onlyOwner {
+  function setExecutionStageDuration(uint256 executionStageDuration) public onlyOwner {
     require(executionStageDuration > 0 && executionStageDuration != stageDurations.execution);
     stageDurations.execution = executionStageDuration;
     emit ExecutionStageDurationSet(executionStageDuration);

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -65,14 +65,14 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
   function initialize(address registryAddress, uint256 _unlockingPeriod) external initializer {
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
-    unlockingPeriod = _unlockingPeriod;
+    setUnlockingPeriod(_unlockingPeriod);
   }
 
   /**
    * @notice Sets the duration in seconds users must wait before withdrawing gold after unlocking.
    * @param value The unlocking period in seconds.
    */
-  function setUnlockingPeriod(uint256 value) external onlyOwner {
+  function setUnlockingPeriod(uint256 value) public onlyOwner {
     require(value != unlockingPeriod);
     unlockingPeriod = value;
     emit UnlockingPeriodSet(value);

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -48,14 +48,14 @@ contract Reserve is IReserve, Ownable, Initializable, UsingRegistry, ReentrancyG
   {
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
-    tobinTaxStalenessThreshold = _tobinTaxStalenessThreshold;
+    setTobinTaxStalenessThreshold(_tobinTaxStalenessThreshold);
   }
 
   /**
    * @notice Sets the number of seconds to cache the tobin tax value for.
    * @param value The number of seconds to cache the tobin tax value for.
    */
-  function setTobinTaxStalenessThreshold(uint256 value) external onlyOwner {
+  function setTobinTaxStalenessThreshold(uint256 value) public onlyOwner {
     require(value > 0, "value was zero");
     tobinTaxStalenessThreshold = value;
     emit TobinTaxStalenessThresholdSet(value);

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -172,7 +172,10 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
    * @return The median exchange rate for `token`.
    */
   function medianRate(address token) external view returns (uint256, uint256) {
-    return (rates[token].getMedianValue(), numRates(token));
+    return (
+      rates[token].getMedianValue(),
+      numRates(token) == 0 ? 0 : FixidityLib.fixed1().unwrap()
+    );
   }
 
   /**
@@ -241,7 +244,7 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
     emit OracleReportRemoved(token, oracle);
     uint256 newMedian = rates[token].getMedianValue();
     if (newMedian != originalMedian) {
-      emit MedianUpdated(token, newMedian);
+      emit MedianUpdated(token, newMedian == 0 ? 0 : FixidityLib.fixed1().unwrap());
     }
   }
 }

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -124,7 +124,7 @@ contract SortedOracles is ISortedOracles, Ownable, Initializable {
   /**
    * @notice Updates an oracle value and the median.
    * @param token The address of the token for which the Celo Gold exchange rate is being reported.
-   * @param value The amount of tokens equal to Celo Gold represented as a FixidityLib fraction
+   * @param value The amount of tokens equal to Celo Gold represented as a FixidityLib fraction, premultiplied with the denominator
    * @param lesserKey The element which should be just left of the new oracle value.
    * @param greaterKey The element which should be just right of the new oracle value.
    * @dev Note that only one of `lesserKey` or `greaterKey` needs to be correct to reduce friction.

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -170,6 +170,7 @@ contract StableToken is
    * @notice Sets initial inflation Parameters.
    * @param inflationRate new rate.
    * @param inflationFactorUpdatePeriod how often inflationFactor is updated.
+   * @dev unwrapped Fixidity value expected for inflationRate
    */
   function setInitialInflationParameters(uint256 inflationRate, uint256 inflationFactorUpdatePeriod)
     private

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -61,6 +61,8 @@ contract StableToken is
 
   InflationState inflationState;
 
+  uint256 constant eighteenMonthsInSeconds = 47340000;
+
   /**
    * Only VM would be able to set the caller address to 0x0 unless someone
    * really has the private key for 0x0
@@ -142,7 +144,7 @@ contract StableToken is
     );
 
     inflationState.factor = FixidityLib.fixed1();
-    inflationState.factorLastUpdated = now;
+    inflationState.factorLastUpdated = now.add(eighteenMonthsInSeconds);
 
     emit InflationFactorUpdated(inflationState.factor.unwrap(), inflationState.factorLastUpdated);
   }

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -35,14 +35,6 @@ contract StableToken is
 
   event TransferComment(string comment);
 
-  event TotalSupplySet(address sender, uint256 totalSupply);
-
-  event TokenNameSet(address sender, string name);
-
-  event TokenSymbolSet(address sender, string symbol);
-
-  event TokenDecimalslSet(address sender, uint8 decimals);
-
   string internal name_;
   string internal symbol_;
   uint8 internal decimals_;
@@ -117,10 +109,9 @@ contract StableToken is
     require(inflationRate != 0, "Must provide a non-zero inflation rate.");
 
     _transferOwnership(msg.sender);
-    setTotalSupply(0);
-    setName(_name);
-    setSymbol(_symbol);
-    setDecimals(_decimals);
+    name_ = _name;
+    symbol_ = _symbol;
+    decimals_ = _decimals;
     setInitialInflationParameters(inflationRate, inflationFactorUpdatePeriod);
 
     require(initialBalanceAddresses.length == initialBalanceValues.length);
@@ -128,42 +119,6 @@ contract StableToken is
       require(_mint(initialBalanceAddresses[i], initialBalanceValues[i]));
     }
     setRegistry(registryAddress);
-  }
-
-  /**
-   * @notice Setter for the total supply.
-   * @param totalSupply The total supply to set.
-   */
-  function setTotalSupply(uint256 totalSupply) public {
-    totalSupply_ = totalSupply;
-    emit TotalSupplySet(msg.sender, totalSupply);
-  }
-
-  /**
-   * @notice Setter for the name of the token.
-   * @param name The name to set.
-   */
-  function setName(string memory name) public {
-    name_ = name;
-    emit TokenNameSet(msg.sender, name);
-  }
-
-  /**
-   * @notice Setter for the symbol of the token.
-   * @param symbol The symbol to set.
-   */
-  function setSymbol(string memory symbol) public {
-    symbol_ = symbol;
-    emit TokenSymbolSet(msg.sender, symbol);
-  }
-
-  /**
-   * @notice Setter for the decimals of the token.
-   * @param decimals The decimals to set.
-   */
-  function setDecimals(uint8 decimals) public {
-    decimals_ = decimals;
-    emit TokenDecimalslSet(msg.sender, decimals);
   }
 
   /**

--- a/packages/protocol/contracts/stability/interfaces/ISortedOracles.sol
+++ b/packages/protocol/contracts/stability/interfaces/ISortedOracles.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.3;
 interface ISortedOracles {
   function addOracle(address, address) external;
   function removeOracle(address, address, uint256) external;
-  function report(address, uint256, uint256, address, address) external;
+  function report(address, uint256, address, address) external;
   function removeExpiredReports(address, uint256) external;
   function numRates(address) external view returns (uint256);
   function medianRate(address) external view returns (uint256, uint256);

--- a/packages/protocol/migrations/08_stabletoken.ts
+++ b/packages/protocol/migrations/08_stabletoken.ts
@@ -59,9 +59,7 @@ module.exports = deploymentForCoreContract<StableTokenInstance>(
 
     await sortedOracles.report(
       stableToken.address,
-      new BigNumber(config.stableToken.goldPrice / 1).multipliedBy(
-        await sortedOracles.getDenominator()
-      ),
+      new BigNumber(config.stableToken.goldPrice / 1),
       NULL_ADDRESS,
       NULL_ADDRESS
     )

--- a/packages/protocol/migrations/08_stabletoken.ts
+++ b/packages/protocol/migrations/08_stabletoken.ts
@@ -59,7 +59,7 @@ module.exports = deploymentForCoreContract<StableTokenInstance>(
 
     await sortedOracles.report(
       stableToken.address,
-      new BigNumber(config.stableToken.goldPrice / 1),
+      toFixed(new BigNumber(config.stableToken.goldPrice).dividedBy(new BigNumber(1))),
       NULL_ADDRESS,
       NULL_ADDRESS
     )

--- a/packages/protocol/migrations/08_stabletoken.ts
+++ b/packages/protocol/migrations/08_stabletoken.ts
@@ -8,6 +8,7 @@ import {
 } from '@celo/protocol/lib/web3-utils'
 import { config } from '@celo/protocol/migrationsConfig'
 import { toFixed } from '@celo/utils/lib/fixidity'
+import BigNumber from 'bignumber.js'
 import {
   FeeCurrencyWhitelistInstance,
   ReserveInstance,
@@ -55,10 +56,12 @@ module.exports = deploymentForCoreContract<StableTokenInstance>(
     if (!(await sortedOracles.isOracle(stableToken.address, minerAddress))) {
       await sortedOracles.addOracle(stableToken.address, minerAddress)
     }
+
     await sortedOracles.report(
       stableToken.address,
-      config.stableToken.goldPrice,
-      1,
+      new BigNumber(config.stableToken.goldPrice / 1).multipliedBy(
+        await sortedOracles.getDenominator()
+      ),
       NULL_ADDRESS,
       NULL_ADDRESS
     )

--- a/packages/protocol/scripts/truffle/set_exchange_rate.ts
+++ b/packages/protocol/scripts/truffle/set_exchange_rate.ts
@@ -135,7 +135,7 @@ module.exports = async (callback: (error?: any) => number) => {
     // Report it
     await oracles.report(
       stableToken.address,
-      numerator.dividedBy(denominator).multipliedBy(await oracles.getDenominator()),
+      numerator.dividedBy(denominator),
       lesserKey,
       greaterKey
     )

--- a/packages/protocol/scripts/truffle/set_exchange_rate.ts
+++ b/packages/protocol/scripts/truffle/set_exchange_rate.ts
@@ -2,6 +2,7 @@
 import { getDeployedProxiedContract } from '@celo/protocol/lib/web3-utils'
 import { BigNumber } from 'bignumber.js'
 import { SortedOraclesInstance, StableTokenInstance } from 'types'
+import { toFixed } from '@celo/utils/lib/fixidity'
 
 const fs = require('fs')
 const parse = require('csv-parser')
@@ -135,7 +136,7 @@ module.exports = async (callback: (error?: any) => number) => {
     // Report it
     await oracles.report(
       stableToken.address,
-      numerator.dividedBy(denominator),
+      toFixed(new BigNumber(numerator).dividedBy(new BigNumber(denominator))),
       lesserKey,
       greaterKey
     )

--- a/packages/protocol/scripts/truffle/set_exchange_rate.ts
+++ b/packages/protocol/scripts/truffle/set_exchange_rate.ts
@@ -136,7 +136,7 @@ module.exports = async (callback: (error?: any) => number) => {
     // Report it
     await oracles.report(
       stableToken.address,
-      toFixed(new BigNumber(numerator).dividedBy(new BigNumber(denominator))),
+      toFixed(numerator.dividedBy(denominator)),
       lesserKey,
       greaterKey
     )

--- a/packages/protocol/scripts/truffle/set_exchange_rate.ts
+++ b/packages/protocol/scripts/truffle/set_exchange_rate.ts
@@ -133,7 +133,12 @@ module.exports = async (callback: (error?: any) => number) => {
       elements
     )
     // Report it
-    await oracles.report(stableToken.address, numerator, denominator, lesserKey, greaterKey)
+    await oracles.report(
+      stableToken.address,
+      numerator.dividedBy(denominator).multipliedBy(await oracles.getDenominator()),
+      lesserKey,
+      greaterKey
+    )
     callback()
   } catch (error) {
     callback(error)

--- a/packages/protocol/test/governance/epochrewards.ts
+++ b/packages/protocol/test/governance/epochrewards.ts
@@ -416,7 +416,7 @@ contract('EpochRewards', (accounts: string[]) => {
       })
 
       it('should return one', async () => {
-        assertEqualBN(await epochRewards.getRewardsMultiplier(), toFixed(new BigNumber(1)))
+        assertEqualBN(await epochRewards.getRewardsMultiplier(), toFixed(1))
       })
     })
 

--- a/packages/protocol/test/governance/epochrewards.ts
+++ b/packages/protocol/test/governance/epochrewards.ts
@@ -416,7 +416,7 @@ contract('EpochRewards', (accounts: string[]) => {
       })
 
       it('should return one', async () => {
-        assertEqualBN(await epochRewards.getRewardsMultiplier(), toFixed(1))
+        assertEqualBN(await epochRewards.getRewardsMultiplier(), toFixed(new BigNumber(1)))
       })
     })
 

--- a/packages/protocol/test/stability/sortedoracles.ts
+++ b/packages/protocol/test/stability/sortedoracles.ts
@@ -119,7 +119,7 @@ contract('SortedOracles', (accounts: string[]) => {
       beforeEach(async () => {
         await sortedOracles.report(
           aToken,
-          new BigNumber(1 / 1).multipliedBy(fractionDenominator),
+          new BigNumber(1).multipliedBy(fractionDenominator),
           NULL_ADDRESS,
           NULL_ADDRESS,
           {
@@ -140,7 +140,7 @@ contract('SortedOracles', (accounts: string[]) => {
             await sortedOracles.addOracle(aToken, anotherOracle)
             await sortedOracles.report(
               aToken,
-              new BigNumber(2 / 1).multipliedBy(fractionDenominator),
+              new BigNumber(2).multipliedBy(fractionDenominator),
               anOracle,
               NULL_ADDRESS,
               {
@@ -188,7 +188,7 @@ contract('SortedOracles', (accounts: string[]) => {
       beforeEach(async () => {
         await sortedOracles.report(
           aToken,
-          new BigNumber(10 / 1).multipliedBy(fractionDenominator),
+          new BigNumber(10).multipliedBy(fractionDenominator),
           NULL_ADDRESS,
           NULL_ADDRESS,
           {
@@ -294,7 +294,9 @@ contract('SortedOracles', (accounts: string[]) => {
     it('should increase the number of rates', async () => {
       await sortedOracles.report(
         aToken,
-        new BigNumber(numerator / denominator).multipliedBy(fractionDenominator),
+        new BigNumber(numerator)
+          .dividedBy(new BigNumber(denominator))
+          .multipliedBy(fractionDenominator),
         NULL_ADDRESS,
         NULL_ADDRESS,
         {
@@ -307,7 +309,9 @@ contract('SortedOracles', (accounts: string[]) => {
     it('should set the median rate', async () => {
       await sortedOracles.report(
         aToken,
-        new BigNumber(numerator / denominator).multipliedBy(fractionDenominator),
+        new BigNumber(numerator)
+          .dividedBy(new BigNumber(denominator))
+          .multipliedBy(fractionDenominator),
         NULL_ADDRESS,
         NULL_ADDRESS,
         {
@@ -322,7 +326,9 @@ contract('SortedOracles', (accounts: string[]) => {
     it('should increase the number of timestamps', async () => {
       await sortedOracles.report(
         aToken,
-        new BigNumber(numerator / denominator).multipliedBy(fractionDenominator),
+        new BigNumber(numerator)
+          .dividedBy(new BigNumber(denominator))
+          .multipliedBy(fractionDenominator),
         NULL_ADDRESS,
         NULL_ADDRESS,
         {
@@ -335,7 +341,9 @@ contract('SortedOracles', (accounts: string[]) => {
     it('should set the median timestamp', async () => {
       await sortedOracles.report(
         aToken,
-        new BigNumber(numerator / denominator).multipliedBy(fractionDenominator),
+        new BigNumber(numerator)
+          .dividedBy(new BigNumber(denominator))
+          .multipliedBy(fractionDenominator),
         NULL_ADDRESS,
         NULL_ADDRESS,
         {
@@ -349,7 +357,9 @@ contract('SortedOracles', (accounts: string[]) => {
     it('should emit the OracleReported and MedianUpdated events', async () => {
       const resp = await sortedOracles.report(
         aToken,
-        new BigNumber(numerator / denominator).multipliedBy(fractionDenominator),
+        new BigNumber(numerator)
+          .dividedBy(new BigNumber(denominator))
+          .multipliedBy(fractionDenominator),
         NULL_ADDRESS,
         NULL_ADDRESS,
         {
@@ -396,7 +406,9 @@ contract('SortedOracles', (accounts: string[]) => {
       beforeEach(async () => {
         await sortedOracles.report(
           aToken,
-          new BigNumber(numerator / denominator).multipliedBy(fractionDenominator),
+          new BigNumber(numerator)
+            .dividedBy(new BigNumber(denominator))
+            .multipliedBy(fractionDenominator),
           NULL_ADDRESS,
           NULL_ADDRESS,
           {
@@ -411,7 +423,9 @@ contract('SortedOracles', (accounts: string[]) => {
 
         await sortedOracles.report(
           aToken,
-          new BigNumber(newNumerator / denominator).multipliedBy(fractionDenominator),
+          new BigNumber(newNumerator)
+            .dividedBy(new BigNumber(denominator))
+            .multipliedBy(fractionDenominator),
           NULL_ADDRESS,
           NULL_ADDRESS,
           {
@@ -427,7 +441,9 @@ contract('SortedOracles', (accounts: string[]) => {
         const initialNumReports = await sortedOracles.numRates(aToken)
         await sortedOracles.report(
           aToken,
-          new BigNumber(numerator / denominator).multipliedBy(fractionDenominator),
+          new BigNumber(newNumerator)
+            .dividedBy(new BigNumber(denominator))
+            .multipliedBy(fractionDenominator),
           NULL_ADDRESS,
           NULL_ADDRESS,
           {
@@ -457,7 +473,7 @@ contract('SortedOracles', (accounts: string[]) => {
         sortedOracles.addOracle(aToken, anotherOracle)
         await sortedOracles.report(
           aToken,
-          new BigNumber(anotherOracleNumerator / 1).multipliedBy(fractionDenominator),
+          new BigNumber(anotherOracleNumerator).multipliedBy(fractionDenominator),
           NULL_ADDRESS,
           NULL_ADDRESS,
           {
@@ -467,7 +483,7 @@ contract('SortedOracles', (accounts: string[]) => {
         await timeTravel(5, web3)
         await sortedOracles.report(
           aToken,
-          new BigNumber(anOracleNumerator1 / 1).multipliedBy(fractionDenominator),
+          new BigNumber(anOracleNumerator1).multipliedBy(fractionDenominator),
           anotherOracle,
           NULL_ADDRESS,
           {
@@ -485,7 +501,7 @@ contract('SortedOracles', (accounts: string[]) => {
       it('updates the list of rates correctly', async () => {
         await sortedOracles.report(
           aToken,
-          new BigNumber(anOracleNumerator2 / 1).multipliedBy(fractionDenominator),
+          new BigNumber(anOracleNumerator2).multipliedBy(fractionDenominator),
           anotherOracle,
           NULL_ADDRESS,
           {
@@ -501,7 +517,7 @@ contract('SortedOracles', (accounts: string[]) => {
         const initialTimestamps = await sortedOracles.getTimestamps(aToken)
         await sortedOracles.report(
           aToken,
-          new BigNumber(anOracleNumerator2 / 1).multipliedBy(fractionDenominator),
+          new BigNumber(anOracleNumerator2).multipliedBy(fractionDenominator),
           anotherOracle,
           NULL_ADDRESS,
           {

--- a/packages/protocol/test/stability/sortedoracles.ts
+++ b/packages/protocol/test/stability/sortedoracles.ts
@@ -274,7 +274,7 @@ contract('SortedOracles', (accounts: string[]) => {
       })
       const [actualMedianRate, numberOfRates] = await sortedOracles.medianRate(aToken)
       assertEqualBN(actualMedianRate, givenMedianRate)
-      assertEqualBN(numberOfRates.toNumber(), 1)
+      assertEqualBN(numberOfRates, toFixed(new BigNumber(1)))
     })
 
     it('should increase the number of timestamps', async () => {

--- a/packages/protocol/test/stability/sortedoracles.ts
+++ b/packages/protocol/test/stability/sortedoracles.ts
@@ -117,7 +117,7 @@ contract('SortedOracles', (accounts: string[]) => {
 
     describe('when a report has been made', () => {
       beforeEach(async () => {
-        await sortedOracles.report(aToken, toFixed(new BigNumber(1)), NULL_ADDRESS, NULL_ADDRESS, {
+        await sortedOracles.report(aToken, toFixed(1), NULL_ADDRESS, NULL_ADDRESS, {
           from: anOracle,
         })
       })
@@ -132,7 +132,7 @@ contract('SortedOracles', (accounts: string[]) => {
           for (let i = 7; i > 3; i--) {
             const anotherOracle = accounts[i]
             await sortedOracles.addOracle(aToken, anotherOracle)
-            await sortedOracles.report(aToken, toFixed(new BigNumber(2)), anOracle, NULL_ADDRESS, {
+            await sortedOracles.report(aToken, toFixed(2), anOracle, NULL_ADDRESS, {
               from: anotherOracle,
             })
           }
@@ -174,7 +174,7 @@ contract('SortedOracles', (accounts: string[]) => {
 
     describe('when a report has been made', () => {
       beforeEach(async () => {
-        await sortedOracles.report(aToken, toFixed(new BigNumber(10)), NULL_ADDRESS, NULL_ADDRESS, {
+        await sortedOracles.report(aToken, toFixed(10), NULL_ADDRESS, NULL_ADDRESS, {
           from: anOracle,
         })
       })
@@ -256,7 +256,7 @@ contract('SortedOracles', (accounts: string[]) => {
   })
 
   describe('#report', () => {
-    const givenMedianRate = toFixed(new BigNumber(5).dividedBy(new BigNumber(1)))
+    const givenMedianRate = toFixed(5)
     beforeEach(async () => {
       await sortedOracles.addOracle(aToken, anOracle)
     })
@@ -274,7 +274,7 @@ contract('SortedOracles', (accounts: string[]) => {
       })
       const [actualMedianRate, numberOfRates] = await sortedOracles.medianRate(aToken)
       assertEqualBN(actualMedianRate, givenMedianRate)
-      assertEqualBN(numberOfRates, toFixed(new BigNumber(1)))
+      assertEqualBN(numberOfRates, toFixed(1))
     })
 
     it('should increase the number of timestamps', async () => {
@@ -321,7 +321,7 @@ contract('SortedOracles', (accounts: string[]) => {
     })
 
     describe('when there exists exactly one other report, made by this oracle', () => {
-      const newExpectedMedianRate = toFixed(new BigNumber(12).dividedBy(new BigNumber(1)))
+      const newExpectedMedianRate = toFixed(12)
 
       beforeEach(async () => {
         await sortedOracles.report(aToken, newExpectedMedianRate, NULL_ADDRESS, NULL_ADDRESS, {
@@ -350,63 +350,31 @@ contract('SortedOracles', (accounts: string[]) => {
 
     describe('when there are multiple reports, the most recent one done by this oracle', () => {
       const anotherOracle = accounts[6]
-      const anOracleMedianRate1 = 2
-      const anOracleMedianRate2 = 3
-      const anotherOracleMedianRate = 1
-
-      const anOracleExpectedMedianRate1 = toFixed(
-        new BigNumber(anOracleMedianRate1).dividedBy(new BigNumber(1))
-      )
-      const anOracleExpectedMedianRate2 = toFixed(
-        new BigNumber(anOracleMedianRate2).dividedBy(new BigNumber(1))
-      )
-
-      const anotherOracleExpectedMedianRate = toFixed(
-        new BigNumber(anotherOracleMedianRate).dividedBy(new BigNumber(1))
-      )
 
       beforeEach(async () => {
         sortedOracles.addOracle(aToken, anotherOracle)
-        await sortedOracles.report(
-          aToken,
-          anotherOracleExpectedMedianRate,
-          NULL_ADDRESS,
-          NULL_ADDRESS,
-          {
-            from: anotherOracle,
-          }
-        )
+        await sortedOracles.report(aToken, toFixed(1), NULL_ADDRESS, NULL_ADDRESS, {
+          from: anotherOracle,
+        })
         await timeTravel(5, web3)
-        await sortedOracles.report(
-          aToken,
-          anOracleExpectedMedianRate1,
-          anotherOracle,
-          NULL_ADDRESS,
-          {
-            from: anOracle,
-          }
-        )
+        await sortedOracles.report(aToken, toFixed(2), anotherOracle, NULL_ADDRESS, {
+          from: anOracle,
+        })
         await timeTravel(5, web3)
 
         // confirm the setup worked
         const initialRates = await sortedOracles.getRates(aToken)
-        assertEqualBN(initialRates['1'][0], anOracleExpectedMedianRate1)
-        assertEqualBN(initialRates['1'][1], anotherOracleExpectedMedianRate)
+        assertEqualBN(initialRates['1'][0], toFixed(2))
+        assertEqualBN(initialRates['1'][1], toFixed(1))
       })
 
       it('updates the list of rates correctly', async () => {
-        await sortedOracles.report(
-          aToken,
-          anOracleExpectedMedianRate2,
-          anotherOracle,
-          NULL_ADDRESS,
-          {
-            from: anOracle,
-          }
-        )
+        await sortedOracles.report(aToken, toFixed(3), anotherOracle, NULL_ADDRESS, {
+          from: anOracle,
+        })
         const resultRates = await sortedOracles.getRates(aToken)
-        assertEqualBN(resultRates['1'][0], anOracleExpectedMedianRate2)
-        assertEqualBN(resultRates['1'][1], anotherOracleExpectedMedianRate)
+        assertEqualBN(resultRates['1'][0], toFixed(3))
+        assertEqualBN(resultRates['1'][1], toFixed(1))
       })
 
       it('updates the latest timestamp', async () => {


### PR DESCRIPTION
### Description

Implementation of tickets 1604, 1597 and 1365

### Related issues

- Fixes #1604, #1597, #1365 

### Note
Regarding SortedOracles.sol, we are changing the type of values stored in the state variable r"ates" to unwrapped Fixidity fractions meaning those changes are not backwards compatible and shall remain as so onwards. The latter is to take effect on all interacting package levels.