### PR TITLE
Fix Contribution Guildelines in the docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,13 +3,4 @@
 Thank you for considering making a contribution to the Celo community!
 Everyone is encouraged to contribute, even the smallest fixes are welcome.
 
-If you'd like to contribute to Celo, please fork, fix, commit and send a
-pull request for the maintainers to review.
-
-If you wish to submit more complex changes, please sync with a core developer first.
-This will help ensure those changes are in line with the general philosophy of the project
-and enable you to get some early feedback.
-
-## Pull requests
-
-Please follow the issue and PR templates and include details about how the changeset has been tested.
+See the [contributing guide](https://docs.celo.org/community/contributing) for details on how to participate.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Code owners for each package can be found in [.github/CODEOWNERS](.github/CODEOW
 
 Feel free to jump on the Celo 🚂🚋🚋🚋. Improvements and contributions are highly encouraged! 🙏👊
 
-See the [contributing guide](CONTRIBUTING.md) for details on how to participate.
+See the [contributing guide](https://docs.celo.org/community/contributing) for details on how to participate.
 [![GitHub issues by-label](https://img.shields.io/github/issues/celo-org/celo-monorepo/1%20hour%20tasks)](https://github.com/celo-org/celo-monorepo/issues?q=is%3Aopen+is%3Aissue+label%3A%221+hour+tasks%22)
 
 Not yet ready to contribute but do like the project? Support Celo with a ⭐ or share the love in a [![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fcelo.org%2F)](https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DkKggE5OvyhE&via=celohq&text=Checkout%20celo%21%20Love%20what%20they%20are%20building.&hashtags=celo)


### PR DESCRIPTION
### Description

Fix two problems with the contribution guidelines in the repo:

1. The README had a broken link
2. The CONTRIBUTING.md didn't reference the official guidance on celo.org

### Tested

Ran the changes in Markdown preview and made sure the links work.

### Other changes

N/A

### Related issues

- Fixes #2080 

### Backwards compatibility

N/A