### PR TITLE
Fixes #2409 Firefox exception

### DIFF
--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -24,10 +24,10 @@ interface Speeds {
 export async function getNetworkDownloadSpeed() {
   try {
     const testNetworkSpeed = new NetworkSpeed()
-    const fileSize = 5000000
-    const baseUrl = `https://eu.httpbin.org/stream-bytes/${fileSize}`
+    const byteSize = 2000
+    const baseUrl = `https://eu.httpbin.org/stream-byteSize/${byteSize}`
 
-    const speed: Speeds = await testNetworkSpeed.checkDownloadSpeed(baseUrl, fileSize)
+    const speed: Speeds = await testNetworkSpeed.checkDownloadSpeed(baseUrl, byteSize)
     return speed
   } catch (e) {
     return { mbps: '0', kbps: '0', bps: '0' }
@@ -75,6 +75,7 @@ async function multiPartCheck() {
     getNetworkDownloadSpeed(),
     getNetworkDownloadSpeed(),
   ])
+
   const averageSpeed =
     multiPart
       .map((speeds) => speeds.mbps)

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -22,12 +22,16 @@ interface Speeds {
 }
 
 export async function getNetworkDownloadSpeed() {
-  const testNetworkSpeed = new NetworkSpeed()
-  const fileSize = 5000000
-  const baseUrl = `http://eu.httpbin.org/stream-bytes/${fileSize}`
+  try {
+    const testNetworkSpeed = new NetworkSpeed()
+    const fileSize = 5000000
+    const baseUrl = `https://eu.httpbin.org/stream-bytes/${fileSize}`
 
-  const speed: Speeds = await testNetworkSpeed.checkDownloadSpeed(baseUrl, fileSize)
-  return speed
+    const speed: Speeds = await testNetworkSpeed.checkDownloadSpeed(baseUrl, fileSize)
+    return speed
+  } catch (e) {
+    return { mbps: '0', kbps: '0', bps: '0' }
+  }
 }
 
 const MIN_MB_FOR_FAST = 5
@@ -71,14 +75,14 @@ async function multiPartCheck() {
     getNetworkDownloadSpeed(),
     getNetworkDownloadSpeed(),
   ])
-  const averageSped =
+  const averageSpeed =
     multiPart
       .map((speeds) => speeds.mbps)
       .reduce((previous, current) => {
         return Number(previous) + Number(current)
       }, 0) / 3
 
-  return isFast(averageSped)
+  return isFast(averageSpeed)
 }
 
 const MAX_TIME_MS = 1000


### PR DESCRIPTION
### Description

on firefox the net speed check failed

Add try catch around net speed test,

Switch to https as I believe the http might have been part of the issue


### Tested

used ngrok + firefox to see what happens when running not locally

### Other changes

Fix spelling
### Related issues

- Fixes #2409 

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
