### PR TITLE
WIP - Add 'connection not open' to EndReason set for Transaction Metrics Exporter

### DIFF
--- a/packages/transaction-metrics-exporter/src/blockchain.ts
+++ b/packages/transaction-metrics-exporter/src/blockchain.ts
@@ -50,6 +50,7 @@ type EndReason =
   | { reason: 'connection-error'; error: any }
   | { reason: 'subscription-error'; error: any }
   | { reason: 'not-listening' }
+  | { reason: 'connection not open' }
 
 export async function runMetricExporter(kit: ContractKit): Promise<EndReason> {
   const blockProcessor = await newBlockHeaderProcessor(kit)


### PR DESCRIPTION
### Description

When the transaction metrics exporter gets disconnected from it's full node, it should exit with 1, so that kubernetes will restart itself (and presumably it will then successfully establish a connection with it's full node).

### Tested

TODO

### Other changes


### Related issues


### Backwards compatibility

Yes