### PR TITLE
Catch exceptions during polling

### DIFF
--- a/packages/transaction-metrics-exporter/src/blockchain.ts
+++ b/packages/transaction-metrics-exporter/src/blockchain.ts
@@ -62,7 +62,14 @@ export async function runMetricExporter(kit: ContractKit): Promise<EndReason> {
     logger: consoleLogger,
     timeInBetweenMS: 5000,
     initialDelayMS: 5000,
-    pollCondition: async () => !(await kit.isListening()),
+    pollCondition: async () => {
+      try {
+        return !(await kit.isListening())
+      } catch (error) {
+        console.error(error)
+        return true
+      }
+    },
     onSuccess: () => endExporter({ reason: 'not-listening' }),
   })
 


### PR DESCRIPTION
### Description

When TME polls for whether it is still actively connected, exceptions during the poll are effectively ignored and possibly let TME hang perpetually without exiting 1. This PR catches those exceptions and assumes negatively.

### Tested

- [x] Deployed to Baklava
