### PR TITLE
[Wallet] Cleanup unused StateProps references

### DIFF
--- a/packages/mobile/src/account/Invite.tsx
+++ b/packages/mobile/src/account/Invite.tsx
@@ -17,7 +17,6 @@ import i18n, { Namespaces, withTranslation } from 'src/i18n'
 import ContactPermission from 'src/icons/ContactPermission'
 import Search from 'src/icons/Search'
 import { importContacts } from 'src/identity/actions'
-import { e164NumberToAddressSelector, E164NumberToAddressType } from 'src/identity/reducer'
 import { headerWithCancelButton } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -43,7 +42,6 @@ interface Section {
 
 interface StateProps {
   defaultCountryCode: string
-  e164PhoneNumberAddressMapping: E164NumberToAddressType
   recipientCache: NumberToRecipient
 }
 
@@ -63,7 +61,6 @@ type Props = StateProps & DispatchProps & WithTranslation & NavigationInjectedPr
 
 const mapStateToProps = (state: RootState): StateProps => ({
   defaultCountryCode: defaultCountryCodeSelector(state),
-  e164PhoneNumberAddressMapping: e164NumberToAddressSelector(state),
   recipientCache: recipientCacheSelector(state),
 })
 

--- a/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
@@ -69,7 +69,8 @@ export class EscrowedPaymentListItem extends React.PureComponent<Props> {
 
   getDisplayName() {
     const { payment } = this.props
-    return payment.recipientContact ? payment.recipientContact.displayName : payment.recipientPhone
+    // TODO(Rossy) Get contact number from recipient cache here
+    return payment.recipientPhone
   }
 
   render() {

--- a/packages/mobile/src/escrow/EscrowedPaymentListScreen.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListScreen.tsx
@@ -9,7 +9,6 @@ import { getReclaimableEscrowPayments } from 'src/escrow/saga'
 import { updatePaymentRequestStatus } from 'src/firebase/actions'
 import i18n, { Namespaces, withTranslation } from 'src/i18n'
 import { fetchPhoneAddresses } from 'src/identity/actions'
-import { e164NumberToAddressSelector, E164NumberToAddressType } from 'src/identity/reducer'
 import {
   NotificationList,
   titleWithBalanceNavigationOptions,
@@ -22,7 +21,6 @@ import { RootState } from 'src/redux/reducers'
 interface StateProps {
   dollarBalance: string | null
   sentEscrowedPayments: EscrowedPayment[]
-  e164PhoneNumberAddressMapping: E164NumberToAddressType
   recipientCache: NumberToRecipient
 }
 
@@ -34,7 +32,6 @@ interface DispatchProps {
 const mapStateToProps = (state: RootState): StateProps => ({
   dollarBalance: state.stableToken.balance,
   sentEscrowedPayments: getReclaimableEscrowPayments(state.escrow.sentEscrowedPayments),
-  e164PhoneNumberAddressMapping: e164NumberToAddressSelector(state),
   recipientCache: recipientCacheSelector(state),
 })
 

--- a/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.tsx
+++ b/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.tsx
@@ -131,7 +131,9 @@ class ReclaimPaymentConfirmationScreen extends React.Component<Props> {
         >
           <ReclaimPaymentConfirmationCard
             recipientPhone={payment.recipientPhone}
-            recipientContact={payment.recipientContact}
+            recipientContact={
+              undefined /* TODO get recipient contact details from recipient cache*/
+            }
             amount={convertedAmount}
             currency={CURRENCY_ENUM.DOLLAR} // User can only request in Dollars
             fee={fee}

--- a/packages/mobile/src/escrow/__mocks__.ts
+++ b/packages/mobile/src/escrow/__mocks__.ts
@@ -2,7 +2,6 @@ import BigNumber from 'bignumber.js'
 import { EscrowedPayment } from 'src/escrow/actions'
 import { SHORT_CURRENCIES } from 'src/geth/consts'
 import { multiplyByWei } from 'src/utils/formatting'
-import { mockInvitableRecipient } from 'test/values'
 
 const recipientPhone = '+491522345678'
 const senderAddress = '0x000000000000000000000ce10'
@@ -16,7 +15,6 @@ export function escrowPaymentDouble(partial: object): EscrowedPayment {
   return {
     senderAddress,
     recipientPhone,
-    recipientContact: mockInvitableRecipient,
     paymentID: 'FAKE_ID_1',
     currency,
     amount: multiplyByWei(new BigNumber(7)),

--- a/packages/mobile/src/escrow/__snapshots__/ReclaimPaymentConfirmationScreen.test.tsx.snap
+++ b/packages/mobile/src/escrow/__snapshots__/ReclaimPaymentConfirmationScreen.test.tsx.snap
@@ -191,24 +191,6 @@ exports[`ReclaimPaymentConfirmationScreen renders correctly 1`] = `
                 }
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2E3338",
-                      "fontFamily": "Hind-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 18,
-                    },
-                    Object {
-                      "paddingTop": 6,
-                      "textAlign": "center",
-                    },
-                  ]
-                }
-              >
-                John Doe
-              </Text>
               <View
                 style={
                   Object {
@@ -836,24 +818,6 @@ exports[`ReclaimPaymentConfirmationScreen renders correctly when fee calculation
                 }
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2E3338",
-                      "fontFamily": "Hind-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 18,
-                    },
-                    Object {
-                      "paddingTop": 6,
-                      "textAlign": "center",
-                    },
-                  ]
-                }
-              >
-                John Doe
-              </Text>
               <View
                 style={
                   Object {
@@ -1481,24 +1445,6 @@ exports[`ReclaimPaymentConfirmationScreen renders correctly when fee calculation
                 }
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2E3338",
-                      "fontFamily": "Hind-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 18,
-                    },
-                    Object {
-                      "paddingTop": 6,
-                      "textAlign": "center",
-                    },
-                  ]
-                }
-              >
-                John Doe
-              </Text>
               <View
                 style={
                   Object {

--- a/packages/mobile/src/escrow/actions.ts
+++ b/packages/mobile/src/escrow/actions.ts
@@ -1,12 +1,10 @@
 import BigNumber from 'bignumber.js'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { SHORT_CURRENCIES } from 'src/geth/consts'
-import { RecipientWithContact } from 'src/recipients/recipient'
 
 export interface EscrowedPayment {
   senderAddress: string
   recipientPhone: string
-  recipientContact?: RecipientWithContact
   paymentID: string
   currency: SHORT_CURRENCIES
   amount: BigNumber

--- a/packages/mobile/src/send/Send.tsx
+++ b/packages/mobile/src/send/Send.tsx
@@ -16,7 +16,6 @@ import { estimateFee, FeeType } from 'src/fees/actions'
 import i18n, { Namespaces, withTranslation } from 'src/i18n'
 import ContactPermission from 'src/icons/ContactPermission'
 import { importContacts } from 'src/identity/actions'
-import { E164NumberToAddressType } from 'src/identity/reducer'
 import { headerWithCancelButton } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -69,7 +68,6 @@ interface StateProps {
   e164PhoneNumber: string
   numberVerified: boolean
   devModeActive: boolean
-  e164PhoneNumberAddressMapping: E164NumberToAddressType
   recentRecipients: Recipient[]
   allRecipients: Recipient[]
 }
@@ -89,7 +87,6 @@ const mapStateToProps = (state: RootState): StateProps => ({
   e164PhoneNumber: state.account.e164PhoneNumber,
   numberVerified: state.app.numberVerified,
   devModeActive: state.account.devModeActive || false,
-  e164PhoneNumberAddressMapping: state.identity.e164NumberToAddress,
   recentRecipients: state.account.devModeActive
     ? [CeloDefaultRecipient, ...state.send.recentRecipients]
     : state.send.recentRecipients,

--- a/packages/mobile/test/values.ts
+++ b/packages/mobile/test/values.ts
@@ -141,7 +141,6 @@ export const mockContactList = [mockContactWithPhone2, mockContactWithPhone]
 export const mockEscrowedPayment: EscrowedPayment = {
   senderAddress: mockAccount2,
   recipientPhone: mockE164Number,
-  recipientContact: mockRecipient,
   paymentID: mockAccount,
   currency: SHORT_CURRENCIES.DOLLAR,
   amount: new BigNumber(10),


### PR DESCRIPTION
### Description

Cleanup unused stateprops references to the e164<->address mappings and remove unused contact field in escrow payments to avoid confusion

No functional changes, just cleanup

### Tested

Ran tests

### Backwards compatibility

Yes
