### PR TITLE
[Wallet] Fix type check regression for components wrapped by our custom `withTranslation`

### DIFF
--- a/packages/mobile/src/exchange/CeloGoldHistoryChart.tsx
+++ b/packages/mobile/src/exchange/CeloGoldHistoryChart.tsx
@@ -27,7 +27,7 @@ const CHART_MIN_VERTICAL_RANGE = 0.1
 const CHART_DOMAIN_PADDING = { y: [30, 30], x: [5, 5] }
 
 interface OwnProps {
-  testID: string
+  testID?: string
 }
 
 type Props = WithTranslation & OwnProps

--- a/packages/mobile/src/i18n.ts
+++ b/packages/mobile/src/i18n.ts
@@ -2,7 +2,12 @@ import locales from '@celo/mobile/locales'
 import { currencyTranslations } from '@celo/utils/src/currencies'
 import hoistStatics from 'hoist-non-react-statics'
 import i18n, { LanguageDetectorModule } from 'i18next'
-import { initReactI18next, withTranslation as withTranslationI18Next } from 'react-i18next'
+import {
+  initReactI18next,
+  WithTranslation,
+  withTranslation as withTranslationI18Next,
+  WithTranslationProps,
+} from 'react-i18next'
 import * as RNLocalize from 'react-native-localize'
 import Logger from 'src/utils/Logger'
 
@@ -95,7 +100,12 @@ RNLocalize.addEventListener('change', () => {
 
 // Create HOC wrapper that hoists statics
 // https://react.i18next.com/latest/withtranslation-hoc#hoist-non-react-statics
-export const withTranslation = (namespace: Namespaces) => (component: React.ComponentType<any>) =>
-  hoistStatics(withTranslationI18Next(namespace)(component), component)
+export const withTranslation = (namespace: Namespaces) => <P extends WithTranslation>(
+  component: React.ComponentType<P>
+): React.ComponentType<Omit<P, keyof WithTranslation> & WithTranslationProps> => {
+  const augmented = withTranslationI18Next(namespace)(component)
+  // @ts-ignore
+  return hoistStatics(augmented, component)
+}
 
 export default i18n

--- a/packages/mobile/src/i18n.ts
+++ b/packages/mobile/src/i18n.ts
@@ -102,10 +102,8 @@ RNLocalize.addEventListener('change', () => {
 // https://react.i18next.com/latest/withtranslation-hoc#hoist-non-react-statics
 export const withTranslation = (namespace: Namespaces) => <P extends WithTranslation>(
   component: React.ComponentType<P>
-): React.ComponentType<Omit<P, keyof WithTranslation> & WithTranslationProps> => {
-  const augmented = withTranslationI18Next(namespace)(component)
-  // @ts-ignore
-  return hoistStatics(augmented, component)
-}
+): React.ComponentType<Omit<P, keyof WithTranslation> & WithTranslationProps> =>
+  // cast as `any` here otherwise TypeScript complained
+  hoistStatics(withTranslationI18Next(namespace)(component), component as any)
 
 export default i18n


### PR DESCRIPTION
### Description

Fixes TypeScript failing to type check components wrapped by our custom `withTranslation` at call site (i.e. in JSX).
Their props were considered to be `any`.
Here we reuse the original implementation types to fix it.

### Tested

Tested that errors are raised again when passing props that are of the wrong types or missing when using a component wrapped by our custom `withTranslation` helper

### Other changes

None

### Related issues

Discussed on Slack.

### Backwards compatibility

Yes.
