### PR TITLE
Added network:head command to dump some useful info

### DIFF
--- a/packages/cli/src/commands/network/head.ts
+++ b/packages/cli/src/commands/network/head.ts
@@ -1,0 +1,23 @@
+import { BaseCommand } from '../../base'
+import { printValueMap } from '../../utils/cli'
+
+export default class Head extends BaseCommand {
+  static description = 'Get information about latest block'
+
+  static flags = {
+    ...BaseCommand.flags,
+  }
+
+  async run() {
+    const block = await this.web3.eth.getBlock('latest')
+    console.log(block.miner)
+    let interesting: { [key: string]: string | number | boolean } = {}
+    interesting['timestamp'] = new Date(0).setUTCSeconds(block.timestamp).toLocaleString()
+    interesting['block number'] = block.number
+    interesting['epoch index'] = Math.floor(block.number / 720) // TODO: epoch block duration should come from network:parameters
+    interesting['epoch position'] = Math.floor(block.number % 720) // TODO: epoch block duration should come from network:parameters
+    interesting['block validator'] = block.miner
+
+    printValueMap(interesting)
+  }
+}

--- a/packages/cli/src/commands/network/head.ts
+++ b/packages/cli/src/commands/network/head.ts
@@ -12,11 +12,11 @@ export default class Head extends BaseCommand {
     const block = await this.web3.eth.getBlock('latest')
     console.log(block.miner)
     let interesting: { [key: string]: string | number | boolean } = {}
-    interesting['timestamp'] = new Date(0).setUTCSeconds(block.timestamp).toLocaleString()
+    interesting['timestamp'] = new Date(new Date(0).setUTCSeconds(block.timestamp)).toUTCString()
     interesting['block number'] = block.number
     interesting['epoch index'] = Math.floor(block.number / 720) // TODO: epoch block duration should come from network:parameters
     interesting['epoch position'] = Math.floor(block.number % 720) // TODO: epoch block duration should come from network:parameters
-    interesting['block validator'] = block.miner
+    interesting['block signer'] = block.miner
 
     printValueMap(interesting)
   }


### PR DESCRIPTION
### Description

Added network:head command to dump some useful info

Sample output:

```
timestamp: Fri, 17 Jan 2020 05:37:09 GMT
block number: 107665
epoch index: 149
epoch position: 385
block signer: 0xea0c8e8b18bdE45819483a4D8E64A5e94c4303Cc
```

### Tested

Ran against baklava network by building against the baklava branch on the following environment:

- osx 10.15.2
- yarn 1.21.0, 
- npm 6.11.3
- nodejs v10.17.0