### PR TITLE
remove deprecated --account flag from unlock command

### DIFF
--- a/packages/docs/getting-started/running-a-validator.md
+++ b/packages/docs/getting-started/running-a-validator.md
@@ -353,8 +353,8 @@ Once these accounts have a balance, unlock them so that we can sign transactions
 
 ```bash
 # On your local machine
-celocli account:unlock --account $CELO_VALIDATOR_GROUP_ADDRESS
-celocli account:unlock --account $CELO_VALIDATOR_ADDRESS
+celocli account:unlock $CELO_VALIDATOR_GROUP_ADDRESS
+celocli account:unlock $CELO_VALIDATOR_ADDRESS
 celocli account:register --from $CELO_VALIDATOR_GROUP_ADDRESS --name <NAME YOUR VALIDATOR GROUP>
 celocli account:register --from $CELO_VALIDATOR_ADDRESS --name <NAME YOUR VALIDATOR>
 ```


### PR DESCRIPTION
### Description

This PR fixes an documentation error referring to an old flag

### Related issues

Fixes https://github.com/celo-org/celo-blockchain/issues/806