### PR TITLE
cli: Fix voter rewards presentation

### DIFF
--- a/packages/contractkit/src/wrappers/Validators.ts
+++ b/packages/contractkit/src/wrappers/Validators.ts
@@ -472,9 +472,9 @@ export class ValidatorsWrapper extends BaseWrapper<Validators> {
       (e: EventLog, index: number): ValidatorReward => ({
         epochNumber,
         validator: validator[index],
-        validatorPayment: e.returnValues.validatorPayment,
+        validatorPayment: valueToBigNumber(e.returnValues.validatorPayment),
         group: validatorGroup[index],
-        groupPayment: e.returnValues.groupPayment,
+        groupPayment: valueToBigNumber(e.returnValues.groupPayment),
       })
     )
   }

--- a/packages/utils/src/address.ts
+++ b/packages/utils/src/address.ts
@@ -8,8 +8,9 @@ import {
 
 export type Address = string
 
-export const eqAddress = (a: Address, b: Address) =>
-  trimLeading0x(a).toLowerCase() === trimLeading0x(b).toLowerCase()
+export const eqAddress = (a: Address, b: Address) => normalizeAddress(a) === normalizeAddress(b)
+
+export const normalizeAddress = (a: Address) => trimLeading0x(a).toLowerCase()
 
 export const trimLeading0x = (input: string) => (input.startsWith('0x') ? input.slice(2) : input)
 


### PR DESCRIPTION
### Description

Fix address normalization issue affecting `celocli rewards:show --voter`.

### Tested

Tested command failing in #2470 now succeeds.

### Other changes

Adds `normalizeAddress` to utils.

### Related issues

- Fixes #2470 