### PR TITLE
[Wallet] Fix gold charts staying in loading state when USD is the selected currency

### DIFF
--- a/packages/mobile/src/exchange/CeloGoldHistoryChart.tsx
+++ b/packages/mobile/src/exchange/CeloGoldHistoryChart.tsx
@@ -158,7 +158,7 @@ function CeloGoldHistoryChart({ t, testID }: Props) {
   ])
   const localExchangeRate = useSelector(getLocalCurrencyExchangeRate)
   const dollarsToLocal = useCallback(
-    (amount) => convertDollarsToLocalAmount(amount, localExchangeRate),
+    (amount) => convertDollarsToLocalAmount(amount, localCurrencyCode ? localExchangeRate : 1),
     [localExchangeRate]
   )
   const [range] = useState(30 * 24 * 60 * 60 * 1000) // 30 days

--- a/packages/mobile/src/exchange/CeloGoldOverview.tsx
+++ b/packages/mobile/src/exchange/CeloGoldOverview.tsx
@@ -51,11 +51,13 @@ export function CeloGoldOverview({ t, testID }: Props) {
           <Text style={fontStyles.semiBold}>{getMoneyDisplayValue(goldBalance)}</Text>
         )}
       </Text>
-      <Text style={styles.localBalance}>
-        {localValue
-          ? t('equalToAmount', { amount: displayLocalCurrency(localValue) })
-          : t('loadingExchangeRate')}
-      </Text>
+      {!!localCurrencyCode && (
+        <Text style={styles.localBalance}>
+          {localValue
+            ? t('equalToAmount', { amount: displayLocalCurrency(localValue) })
+            : t('loadingExchangeRate')}
+        </Text>
+      )}
     </View>
   )
 }


### PR DESCRIPTION
### Description

Fix gold charts staying in loading state when USD is the selected currency.

### Tested

![image](https://user-images.githubusercontent.com/57791/73360092-7b5c4080-42a2-11ea-9d20-428a42a95819.png)

### Other changes

None

### Related issues

- Fixes #2494

### Backwards compatibility

Yes.
