### PR TITLE
Geth --gcmode=archive in txnodes to avoid pruning chain data

### DIFF
--- a/packages/helm-charts/testnet/templates/txnode.statefulset.yaml
+++ b/packages/helm-charts/testnet/templates/txnode.statefulset.yaml
@@ -1,1 +1,1 @@
-{{ include "celo.full-node-statefulset" (dict "Values" $.Values "Release" $.Release "Chart" $.Chart "name" "tx-nodes" "component_label" "tx_nodes" "replicas" .Values.geth.tx_nodes "mnemonic_account_type" "tx_node" "ip_addresses" .Values.geth.tx_node_ip_addresses ) }}
+{{ include "celo.full-node-statefulset" (dict "Values" $.Values "Release" $.Release "Chart" $.Chart "name" "tx-nodes" "geth_flags" "--gcmode=archive" "component_label" "tx_nodes" "replicas" .Values.geth.tx_nodes "mnemonic_account_type" "tx_node" "ip_addresses" .Values.geth.tx_node_ip_addresses ) }}

--- a/packages/terraform-modules-public/testnet/modules/tx-node/startup.sh
+++ b/packages/terraform-modules-public/testnet/modules/tx-node/startup.sh
@@ -83,6 +83,7 @@ ExecStart=/usr/bin/docker run \\
       --wsapi=eth,net,web3,debug \\
       --networkid=${network_id} \\
       --syncmode=full \\
+      --gcmode=archive \\
       --consoleformat=json \\
       --consoleoutput=stdout \\
       --verbosity=${geth_verbosity} \\

--- a/packages/terraform-modules/testnet/main.tf
+++ b/packages/terraform-modules/testnet/main.tf
@@ -153,6 +153,7 @@ module "tx_node" {
   network_id                            = var.network_id
   network_name                          = data.google_compute_network.network.name
   node_count                            = var.tx_node_count
+  txnode                                = true
 }
 
 # used for access by blockscout

--- a/packages/terraform-modules/testnet/modules/full-node/main.tf
+++ b/packages/terraform-modules/testnet/modules/full-node/main.tf
@@ -64,6 +64,7 @@ resource "google_compute_instance" "full_node" {
       network_id : var.network_id,
       node_name : "${var.celo_env}-${var.name}-${count.index}",
       proxy : var.proxy,
+      txnode : var.txnode,
       rid : count.index,
     }
   )

--- a/packages/terraform-modules/testnet/modules/full-node/startup.sh
+++ b/packages/terraform-modules/testnet/modules/full-node/startup.sh
@@ -171,6 +171,9 @@ RPC_APIS="eth,net,web3,debug"
 
 if [[ ${proxy} == "true" ]]; then
   ADDITIONAL_GETH_FLAGS="--proxy.proxy --proxy.internalendpoint :30503 --proxy.proxiedvalidatoraddress $PROXIED_VALIDATOR_ADDRESS"
+elif [[ ${txnode} == "true" ]]; then
+  ADDITIONAL_GETH_FLAGS="--gcmode=archive"
+  RPC_APIS="$RPC_APIS,txpool"
 else
   RPC_APIS="$RPC_APIS,txpool"
 fi

--- a/packages/terraform-modules/testnet/modules/full-node/variables.tf
+++ b/packages/terraform-modules/testnet/modules/full-node/variables.tf
@@ -105,3 +105,9 @@ variable proxy {
   description = "Whether the node is a proxy for a validator"
   default     = false
 }
+
+variable txnode {
+  type        = bool
+  description = "Whether the node is a txnode"
+  default     = false
+}


### PR DESCRIPTION
### Description

Blockscout can fails to sync if the connected ethereum provider have purged chain data. With default geth option `--gcmode=full`, geth automatically purge chain data, which results in errors `missing trie node` in geth and `required historical state unavailable` in blockcout.

### Tested

`--gcmode=full` has been manually tested on an environment with the problem (integration). Deployment has not been tested yet.

### Related issues

- Fixes #2629

### Backwards compatibility

No issues.
