### PR TITLE
Support issuer selection under key rotation

### DIFF
--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -572,7 +572,7 @@ contract Attestations is
     while (currentIndex < unselectedRequest.attestationsRequested) {
       seed = keccak256(abi.encodePacked(seed));
       validator = validatorSignerAddressFromCurrentSet(uint256(seed) % numberValidators);
-      issuer = accounts.validatorSignerToAccount(validator);
+      issuer = accounts.signerToAccount(validator);
 
       if (!accounts.hasAuthorizedAttestationSigner(issuer)) {
         continue;


### PR DESCRIPTION
### Description

When we randomly select among validators, we first fetch the validator signer with the precompile and then lookup the account address of the validator. However we use `validatorSignerToAccount` which will be incorrect if the validator has authorized a different validation signer (that would take effect in the next epoch). Thus the solution is to use `signerToAccount` instead.

### Tested

- [x] Unit tests

