### PR TITLE
Optional validator setup step: using community-sourced node peers

### DIFF
--- a/packages/docs/getting-started/running-a-validator.md
+++ b/packages/docs/getting-started/running-a-validator.md
@@ -269,6 +269,20 @@ export CELO_VALIDATOR_SIGNER_ADDRESS=<YOUR-VALIDATOR-SIGNER-ADDRESS>
 docker run --name celo-proxy -it --restart always -p 30303:30303 -p 30303:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $CELO_VALIDATOR_SIGNER_ADDRESS --bootnodes $BOOTNODE_ENODES --ethstats=<YOUR-VALIDATOR-NAME>-proxy@baklava-ethstats.celo-testnet.org
 ```
 
+**OPTIONAL**
+In addition to the bootnode enode URLs provided by the cLabs team above, the Celo validator community has contributed a list of peers to help kickstart your nodes' peer discovery and block synchronisation processes:
+```bash
+export BOOTNODESV4_ENODES="enode://a22aad7e907a6936c19e0cd1f473eb53ecdb3c8d930dc0d03a4e2202f6d9f16a138daa073d9dcf73288c22edb3097509de7e5970a09b3df73797c01d1bd7d1fc@3.218.232.227:30303,enode://eb9bd6a3c582d687600e64c7ff567f10fd08f56c1175292bc9576c887caa71a4f866ff40830a53385623e7b5d843c8777aa5e0b0a4c898986e597011eeec15d6@34.202.147.96:30303"
+```
+
+The `BOOTNODESV4_ENODES` can then be used by adding `--bootnodesv4 $BOOTNODESV4_ENODES` to any of your `docker run...` commands. For example, to start your proxy node with the full nodes as peers (note the new option at the end):
+```bash
+
+docker run --name celo-proxy -it --restart always -p 30303:30303 -p 30303:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $CELO_VALIDATOR_SIGNER_ADDRESS --bootnodes $BOOTNODE_ENODES --ethstats=<YOUR-VALIDATOR-NAME>-proxy@baklava-ethstats.celo-testnet.org --bootnodesv4 $BOOTNODESV4_ENODES
+```
+
+{% endhint %}
+
 {% hint style="info" %}
 You can detach from the running container by pressing `ctrl+p ctrl+q`, or start it with `-d` instead of `-it` to start detached. Access the logs for a container in the background with the `docker logs` command.
 {% endhint %}
@@ -591,7 +605,7 @@ Twilio is the most common and popular provider. For that you will need to provis
 After you signed up for Twilio at [https://www.twilio.com/try-twilio](https://www.twilio.com/try-twilio), you should see your `ACCOUNT SID` and your `AUTH_TOKEN` in the top right of the console. You'll also want to enter in a credit card to fund the account. For most text messages, the costs will be very low (and on mainnet easily exceeded by the attestation fee paid by the user). Find a more comprehensive price list at [https://www.twilio.com/sms/pricing](https://www.twilio.com/sms/pricing). If there are countries that you do not want to serve, you can specify them with the `TWILIO_BLACKLIST`. In any case, you'll want to adjust your Geo settings to serve phone numbers globally under [https://www.twilio.com/console/sms/settings/geo-permissions](https://www.twilio.com/console/sms/settings/geo-permissions).
 
 {% hint style="info" %}
-Make sure you can serve requests for numbers in US, Europe, Australia, Mexico, Argentina, the Philippines, and Kenya. 
+Make sure you can serve requests for numbers in US, Europe, Australia, Mexico, Argentina, the Philippines, and Kenya.
 {% endhint %}
 
 To actually be able to send SMS, you need to create a messaging service under [Programmable SMS > SMS](https://www.twilio.com/console/sms/services). The resulting `SID` you want to specify under the `TWILIO_MESSAGING_SERVICE_SID`. Now that you have provisioned your messaging service, you need to buy at least 1 phone number to send SMS from. You can do so under the `Numbers` option of the messaging service page. To maximize the chances of reliable and prompt SMS sending (and thus attestation fee revenue), you can buy numbers in many locales, and Twilio will intelligently select the best number to send each SMS.


### PR DESCRIPTION
### Description

@tkporter suggested a potential reason for node syncing issues experienced by user @thylacine in the #validators channel:

> My only thought is that maybe someone flooded the bootnode with a bunch of nodes with a different genesis so all the discovered peers you're getting are incorrect 

Leading to the addition of this optional setup step that makes use of community-provided peers (inspired by [cosmos/launch#seed-nodes](https://github.com/cosmos/launch#seed-nodes) to mitigate node bootstrapping issues.

### Tested

Started new nodes on new machines (following [these](https://docs.celo.org/getting-started/baklava-testnet/running-a-validator#start-your-accounts-node) instructions) and confirmed that the new nodes start-up and sync blocks using the `bootnodesv4` option, both with and without `bootnodes` (fresh setup for each).

### Backwards compatibility

Works as expected for the current Baklava Geth version (1.8.23) and appears to be supported in the upcoming 1.9 update as well (based on the available CLI options).