### PR TITLE
[Wallet] Fix React Native packager failing

### DIFF
--- a/packages/moonpay-auth/package.json
+++ b/packages/moonpay-auth/package.json
@@ -15,14 +15,13 @@
     "lint": "tslint --project ."
   },
   "dependencies": {
-    "crypto": "^1.0.1",
     "firebase-admin": "^8.6.0",
     "firebase-functions": "^3.3.0"
   },
   "devDependencies": {
+    "firebase-functions-test": "^0.1.6",
     "tslint": "^5.12.0",
-    "typescript": "^3.2.2",
-    "firebase-functions-test": "^0.1.6"
+    "typescript": "^3.2.2"
   },
   "engines": {
     "node": "10"

--- a/packages/moonpay-auth/package.json
+++ b/packages/moonpay-auth/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "firebase-functions-test": "^0.1.6",
-    "tslint": "^5.12.0",
-    "typescript": "^3.2.2"
+    "tslint": "^5.20.0",
+    "typescript": "^3.7.3"
   },
   "engines": {
     "node": "10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12828,11 +12828,6 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -34563,25 +34563,6 @@ tslint-react@^4.1.0:
   dependencies:
     tsutils "^3.9.1"
 
-tslint@^5.12.0:
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
-  integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^4.0.1"
-    glob "^7.1.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.29.0"
-
 tslint@^5.20.0:
   version "5.20.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.0.tgz#fac93bfa79568a5a24e7be9cdde5e02b02d00ec1"
@@ -34855,7 +34836,7 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@3.7.x, typescript@^3.2.2:
+typescript@3.7.x:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==


### PR DESCRIPTION
### Description

The addition of the `crypto` package in https://github.com/celo-org/celo-monorepo/commit/40f88f2d71735eddbec60b165df53b9afa573041 broke the React Native packager.
<img width="826" alt="Screenshot 2020-02-13 at 10 15 50" src="https://user-images.githubusercontent.com/57791/74426081-061d6d80-4e55-11ea-9295-baeb118ff157.png">

This package is [deprecated and not needed since it's already in node](https://www.npmjs.com/package/crypto).

### Tested

React Native packager works again.

### Other changes

- For `moonpay-auth`: Use same version of typescript and tslint as the rest of the monorepo

### Related issues

Discussed on Slack https://celo-org.slack.com/archives/CL7BVQPHB/p1581585489026700?thread_ts=1581437902.066300&cid=CL7BVQPHB

### Backwards compatibility

Yes
