### PR TITLE
[Pilot] Add Earn screen skeleton to wallet

### DIFF
--- a/packages/mobile/.env
+++ b/packages/mobile/.env
@@ -1,8 +1,8 @@
-ENVIRONMENT=local
-DEFAULT_TESTNET=alfajores
+ENVIRONMENT=pilot
+DEFAULT_TESTNET=pilot
 # If FORNO_ENABLED_INITIALLY, local geth will not run initially.
 # If toggled on, it will use DEFAULT_SYNC_MODE. See src/geth/consts.ts for more info
-FORNO_ENABLED_INITIALLY=false
+FORNO_ENABLED_INITIALLY=true
 DEFAULT_SYNC_MODE=5
 FIREBASE_ENABLED=true
 SECRETS_KEY=debug

--- a/packages/mobile/src/account/Account.tsx
+++ b/packages/mobile/src/account/Account.tsx
@@ -96,6 +96,10 @@ export class Account extends React.Component<Props, State> {
     navigate(Screens.Invite)
   }
 
+  goToEarn() {
+    navigate(Screens.Earn)
+  }
+
   goToLanguageSetting() {
     navigate(Screens.Language, { nextScreen: Screens.Account })
   }
@@ -239,6 +243,7 @@ export class Account extends React.Component<Props, State> {
             {features.SHOW_ADD_FUNDS && (
               <SettingsItem title={t('addFunds')} onPress={this.goToFiatExchange} />
             )}
+            {features.SHOW_EARN && <SettingsItem title={'Earn'} onPress={this.goToEarn} />}
             <SettingsItem
               title={t('backupKeyFlow6:backupAndRecovery')}
               onPress={this.goToBackupScreen}

--- a/packages/mobile/src/account/Earn.tsx
+++ b/packages/mobile/src/account/Earn.tsx
@@ -12,8 +12,7 @@ import { connect } from 'react-redux'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
 import { CustomEventNames } from 'src/analytics/constants'
 import componentWithAnalytics from 'src/analytics/wrapper'
-import { setFigureEightAccount } from 'src/app/actions'
-import { AVAILABLE_LANGUAGES } from 'src/config'
+import { refreshFigureEightEarned, setFigureEightAccount } from 'src/app/actions'
 import i18n, { Namespaces, withTranslation } from 'src/i18n'
 import logo from 'src/images/celo-logo.png'
 import { Screens } from 'src/navigator/Screens'
@@ -21,16 +20,27 @@ import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import Logger from 'src/utils/Logger'
 
+interface StateProps {
+  figureEightEarned: number | null
+}
+
 interface State {
   userId: string | null
 }
 
 interface DispatchProps {
   setFigureEightAccount: typeof setFigureEightAccount
+  refreshFigureEightEarned: typeof refreshFigureEightEarned
   showError: typeof showError
 }
 
-type Props = DispatchProps & WithTranslation
+const mapStateToProps = (state: RootState): StateProps => {
+  return {
+    figureEightEarned: state.app.figureEightEarned,
+  }
+}
+
+type Props = DispatchProps & WithTranslation & StateProps
 
 export class Earn extends React.Component<Props, State> {
   state = {
@@ -41,6 +51,7 @@ export class Earn extends React.Component<Props, State> {
     if (this.state.userId) {
       Logger.debug(`Setting userId: ${this.state.userId}`)
       this.props.setFigureEightAccount(this.state.userId)
+      this.props.refreshFigureEightEarned()
     } else {
       this.props.showError(ErrorMessages.INCORRECT_PIN) // TODO right error
     }
@@ -48,6 +59,10 @@ export class Earn extends React.Component<Props, State> {
 
   onChangeInput = (userId: string) => {
     this.setState({ userId })
+  }
+
+  componentDidMount = () => {
+    this.props.refreshFigureEightEarned()
   }
 
   render() {
@@ -66,15 +81,18 @@ export class Earn extends React.Component<Props, State> {
         />
         <TextButton onPress={this.onSubmitUserId}>{'Submit'}</TextButton>
         <Text style={fontStyles.body}>{this.state.userId}</Text>
+        <Text style={fontStyles.body}>{this.props.figureEightEarned}</Text>
       </ScrollView>
     )
   }
 }
 
 export default componentWithAnalytics(
-  connect<any, DispatchProps, {}, RootState>(null, { setFigureEightAccount, showError })(
-    withTranslation(Namespaces.accountScreen10)(Earn)
-  )
+  connect<any, DispatchProps, {}, RootState>(mapStateToProps, {
+    refreshFigureEightEarned,
+    setFigureEightAccount,
+    showError,
+  })(withTranslation(Namespaces.accountScreen10)(Earn))
 )
 
 const style = StyleSheet.create({

--- a/packages/mobile/src/account/Earn.tsx
+++ b/packages/mobile/src/account/Earn.tsx
@@ -72,11 +72,11 @@ export class Earn extends React.Component<Props, State> {
   }
 
   render() {
-    // const { t } = this.props
     const amountEarned = this.props.figureEightEarned || 0
     return (
       <ScrollView style={style.scrollView} keyboardShouldPersistTaps="handled">
         {this.props.figureEightUserId ? (
+          // Complete work when logged in
           <View>
             <Text style={fontStyles.body}>Work will go here</Text>
             <Text style={fontStyles.body}>User ID: {this.props.figureEightUserId}</Text>
@@ -85,14 +85,14 @@ export class Earn extends React.Component<Props, State> {
             <TextButton onPress={this.onSubmitLogout}>{'Log out'}</TextButton>
           </View>
         ) : (
-          // Log In to work
+          // Require log in before displaying work
           <View>
             <Text style={fontStyles.body}>Please enter your userId</Text>
             <TextInput
               onChangeText={this.onChangeInput}
               value={this.state.userId}
               style={style.inputField}
-              // placeholderTextColor={colors.inactive}
+              // placeholderTextColor={colors.inactive} // TODO(anna) styling
               // underlineColorAndroid="transparent"
               // enablesReturnKeyAutomatically={true}
               // placeholder={t('fullName')}

--- a/packages/mobile/src/account/Earn.tsx
+++ b/packages/mobile/src/account/Earn.tsx
@@ -6,7 +6,7 @@ import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import * as React from 'react'
 import { WithTranslation } from 'react-i18next'
-import { ScrollView, StyleSheet, Text } from 'react-native'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { NavigationInjectedProps } from 'react-navigation'
 import { connect } from 'react-redux'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
@@ -19,9 +19,11 @@ import { Screens } from 'src/navigator/Screens'
 import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import Logger from 'src/utils/Logger'
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
 
 interface StateProps {
   figureEightEarned: number | null
+  figureEightUserId: string | null
 }
 
 interface State {
@@ -37,6 +39,7 @@ interface DispatchProps {
 const mapStateToProps = (state: RootState): StateProps => {
   return {
     figureEightEarned: state.app.figureEightEarned,
+    figureEightUserId: state.app.figureEightUserId,
   }
 }
 
@@ -44,7 +47,7 @@ type Props = DispatchProps & WithTranslation & StateProps
 
 export class Earn extends React.Component<Props, State> {
   state = {
-    userId: '',
+    userId: this.props.figureEightUserId,
   }
 
   onSubmitUserId = () => {
@@ -57,6 +60,17 @@ export class Earn extends React.Component<Props, State> {
     }
   }
 
+  onSubmitLogout = () => {
+    this.props.setFigureEightAccount('')
+    this.props.refreshFigureEightEarned()
+  }
+
+  onTransferToWallet = () => {
+    // TODO(anna) transfer balance to wallet
+    // TODO add notification
+    navigateHome()
+  }
+
   onChangeInput = (userId: string) => {
     this.setState({ userId })
   }
@@ -67,21 +81,34 @@ export class Earn extends React.Component<Props, State> {
 
   render() {
     // const { t } = this.props
+    const amountEarned = this.props.figureEightEarned || 0
     return (
       <ScrollView style={style.scrollView} keyboardShouldPersistTaps="handled">
-        <TextInput
-          onChangeText={this.onChangeInput}
-          value={this.state.userId}
-          // style={styles.nameInputField}
-          // placeholderTextColor={colors.inactive}
-          // underlineColorAndroid="transparent"
-          // enablesReturnKeyAutomatically={true}
-          // placeholder={t('fullName')}
-          // testID={'NameEntry'}
-        />
-        <TextButton onPress={this.onSubmitUserId}>{'Submit'}</TextButton>
-        <Text style={fontStyles.body}>{this.state.userId}</Text>
-        <Text style={fontStyles.body}>{this.props.figureEightEarned}</Text>
+        {this.props.figureEightUserId ? (
+          <View>
+            <Text style={fontStyles.body}>Work will go here</Text>
+            <Text style={fontStyles.body}>User ID: {this.props.figureEightUserId}</Text>
+            <TextButton onPress={this.onTransferToWallet}>{'Transfer to wallet'}</TextButton>
+            <Text style={fontStyles.body}>{`Amount earned: ${amountEarned} dollars`}</Text>
+            <TextButton onPress={this.onSubmitLogout}>{'Log out'}</TextButton>
+          </View>
+        ) : (
+          // Log In to work
+          <View>
+            <Text style={fontStyles.body}>Please enter your userId</Text>
+            <TextInput
+              onChangeText={this.onChangeInput}
+              value={this.state.userId}
+              style={style.inputField}
+              // placeholderTextColor={colors.inactive}
+              // underlineColorAndroid="transparent"
+              // enablesReturnKeyAutomatically={true}
+              // placeholder={t('fullName')}
+              // testID={'NameEntry'}
+            />
+            <TextButton onPress={this.onSubmitUserId}>{'Submit'}</TextButton>
+          </View>
+        )}
       </ScrollView>
     )
   }
@@ -99,5 +126,17 @@ const style = StyleSheet.create({
   scrollView: {
     flex: 1,
     backgroundColor: colors.background,
+    padding: 20,
+  },
+  inputField: {
+    marginTop: 25,
+    alignItems: 'center',
+    borderColor: colors.inputBorder,
+    borderRadius: 3,
+    borderWidth: 1,
+    marginBottom: 6,
+    paddingLeft: 9,
+    color: colors.inactive,
+    height: 50,
   },
 })

--- a/packages/mobile/src/account/Earn.tsx
+++ b/packages/mobile/src/account/Earn.tsx
@@ -1,0 +1,85 @@
+import { RootState } from '@celo/mobile/src/redux/reducers'
+import LanguageSelectUI from '@celo/react-components/components/LanguageSelectUI'
+import TextButton from '@celo/react-components/components/TextButton'
+import TextInput from '@celo/react-components/components/TextInput'
+import colors from '@celo/react-components/styles/colors'
+import fontStyles from '@celo/react-components/styles/fonts'
+import * as React from 'react'
+import { WithTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, Text } from 'react-native'
+import { NavigationInjectedProps } from 'react-navigation'
+import { connect } from 'react-redux'
+import CeloAnalytics from 'src/analytics/CeloAnalytics'
+import { CustomEventNames } from 'src/analytics/constants'
+import componentWithAnalytics from 'src/analytics/wrapper'
+import { setFigureEightAccount } from 'src/app/actions'
+import { AVAILABLE_LANGUAGES } from 'src/config'
+import i18n, { Namespaces, withTranslation } from 'src/i18n'
+import logo from 'src/images/celo-logo.png'
+import { Screens } from 'src/navigator/Screens'
+import { showError } from 'src/alert/actions'
+import { ErrorMessages } from 'src/app/ErrorMessages'
+import Logger from 'src/utils/Logger'
+
+interface State {
+  userId: string | null
+}
+
+interface DispatchProps {
+  setFigureEightAccount: typeof setFigureEightAccount
+  showError: typeof showError
+}
+
+type Props = DispatchProps & WithTranslation
+
+export class Earn extends React.Component<Props, State> {
+  state = {
+    userId: '',
+  }
+
+  onSubmitUserId = () => {
+    if (this.state.userId) {
+      Logger.debug(`Setting userId: ${this.state.userId}`)
+      this.props.setFigureEightAccount(this.state.userId)
+    } else {
+      this.props.showError(ErrorMessages.INCORRECT_PIN) // TODO right error
+    }
+  }
+
+  onChangeInput = (userId: string) => {
+    this.setState({ userId })
+  }
+
+  render() {
+    // const { t } = this.props
+    return (
+      <ScrollView style={style.scrollView} keyboardShouldPersistTaps="handled">
+        <TextInput
+          onChangeText={this.onChangeInput}
+          value={this.state.userId}
+          // style={styles.nameInputField}
+          // placeholderTextColor={colors.inactive}
+          // underlineColorAndroid="transparent"
+          // enablesReturnKeyAutomatically={true}
+          // placeholder={t('fullName')}
+          // testID={'NameEntry'}
+        />
+        <TextButton onPress={this.onSubmitUserId}>{'Submit'}</TextButton>
+        <Text style={fontStyles.body}>{this.state.userId}</Text>
+      </ScrollView>
+    )
+  }
+}
+
+export default componentWithAnalytics(
+  connect<any, DispatchProps, {}, RootState>(null, { setFigureEightAccount, showError })(
+    withTranslation(Namespaces.accountScreen10)(Earn)
+  )
+)
+
+const style = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+})

--- a/packages/mobile/src/account/Earn.tsx
+++ b/packages/mobile/src/account/Earn.tsx
@@ -1,5 +1,4 @@
 import { RootState } from '@celo/mobile/src/redux/reducers'
-import LanguageSelectUI from '@celo/react-components/components/LanguageSelectUI'
 import TextButton from '@celo/react-components/components/TextButton'
 import TextInput from '@celo/react-components/components/TextInput'
 import colors from '@celo/react-components/styles/colors'
@@ -7,19 +6,13 @@ import fontStyles from '@celo/react-components/styles/fonts'
 import * as React from 'react'
 import { WithTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
-import { NavigationInjectedProps } from 'react-navigation'
 import { connect } from 'react-redux'
-import CeloAnalytics from 'src/analytics/CeloAnalytics'
-import { CustomEventNames } from 'src/analytics/constants'
+import { showError } from 'src/alert/actions'
 import componentWithAnalytics from 'src/analytics/wrapper'
 import { refreshFigureEightEarned, setFigureEightAccount } from 'src/app/actions'
-import i18n, { Namespaces, withTranslation } from 'src/i18n'
-import logo from 'src/images/celo-logo.png'
-import { Screens } from 'src/navigator/Screens'
-import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import Logger from 'src/utils/Logger'
-import { navigate, navigateHome } from 'src/navigator/NavigationService'
+import { Namespaces, withTranslation } from 'src/i18n'
+import { navigateHome } from 'src/navigator/NavigationService'
 
 interface StateProps {
   figureEightEarned: number | null
@@ -52,11 +45,10 @@ export class Earn extends React.Component<Props, State> {
 
   onSubmitUserId = () => {
     if (this.state.userId) {
-      Logger.debug(`Setting userId: ${this.state.userId}`)
       this.props.setFigureEightAccount(this.state.userId)
       this.props.refreshFigureEightEarned()
     } else {
-      this.props.showError(ErrorMessages.INCORRECT_PIN) // TODO right error
+      this.props.showError(ErrorMessages.INVALID_FIGURE_EIGHT_USER_ID)
     }
   }
 

--- a/packages/mobile/src/app/ErrorMessages.ts
+++ b/packages/mobile/src/app/ErrorMessages.ts
@@ -48,4 +48,5 @@ export enum ErrorMessages {
   FAILED_TO_SWITCH_SYNC_MODES = 'failedToSwitchSyncModes',
   SMS_ERROR = 'walletFlow5:SMSError',
   PAYMENT_REQUEST_UPDATE_FAILED = 'paymentRequestFlow:paymentRequestUpdateFailed',
+  INVALID_FIGURE_EIGHT_USER_ID = 'Invalid Earn User ID',
 }

--- a/packages/mobile/src/app/actions.ts
+++ b/packages/mobile/src/app/actions.ts
@@ -21,6 +21,7 @@ export enum Actions {
   NAVIGATE_PIN_PROTECTED = 'APP/NAVIGATE_PIN_PROTECTED',
   START_PIN_VERIFICATION = 'APP/START_PIN_VERIFICATION',
   FINISH_PIN_VERIFICATION = 'APP/FINISH_PIN_VERIFICATION',
+  SET_FIGURE_EIGHT_ACCOUNT = 'APP/SET_FIGURE_EIGHT_ACCOUNT',
 }
 
 interface SetLoggedIn {
@@ -36,6 +37,11 @@ interface SetNumberVerifiedAction {
 export interface SetLanguage {
   type: Actions.SET_LANGUAGE
   language: string
+}
+
+export interface SetFigureEightAccount {
+  type: Actions.SET_FIGURE_EIGHT_ACCOUNT
+  userId: string
 }
 
 export interface OpenDeepLink {
@@ -86,6 +92,7 @@ export type ActionTypes =
   | NavigatePinProtected
   | StartPinVerification
   | FinishPinVerification
+  | SetFigureEightAccount
 
 export const setLoggedIn = (loggedIn: boolean) => ({
   type: Actions.SET_LOGGED_IN,
@@ -111,6 +118,11 @@ export const setLanguage = (language: string, nextScreen?: Screens) => {
     language,
   }
 }
+
+export const setFigureEightAccount = (userId: string) => ({
+  type: Actions.SET_FIGURE_EIGHT_ACCOUNT,
+  userId,
+})
 
 export const openDeepLink = (deepLink: string) => {
   return {

--- a/packages/mobile/src/app/actions.ts
+++ b/packages/mobile/src/app/actions.ts
@@ -22,6 +22,8 @@ export enum Actions {
   START_PIN_VERIFICATION = 'APP/START_PIN_VERIFICATION',
   FINISH_PIN_VERIFICATION = 'APP/FINISH_PIN_VERIFICATION',
   SET_FIGURE_EIGHT_ACCOUNT = 'APP/SET_FIGURE_EIGHT_ACCOUNT',
+  REFRESH_FIGURE_EIGHT_EARNED = 'APP/REFRESH_FIGURE_EIGHT_EARNED',
+  SET_FIGURE_EIGHT_EARNED = 'APP/SET_FIGURE_EIGHT_EARNED',
 }
 
 interface SetLoggedIn {
@@ -42,6 +44,15 @@ export interface SetLanguage {
 export interface SetFigureEightAccount {
   type: Actions.SET_FIGURE_EIGHT_ACCOUNT
   userId: string
+}
+
+export interface RefreshFigureEightEarned {
+  type: Actions.REFRESH_FIGURE_EIGHT_EARNED
+}
+
+export interface SetFigureEightEarned {
+  type: Actions.SET_FIGURE_EIGHT_EARNED
+  amount: number
 }
 
 export interface OpenDeepLink {
@@ -93,6 +104,8 @@ export type ActionTypes =
   | StartPinVerification
   | FinishPinVerification
   | SetFigureEightAccount
+  | RefreshFigureEightEarned
+  | SetFigureEightEarned
 
 export const setLoggedIn = (loggedIn: boolean) => ({
   type: Actions.SET_LOGGED_IN,
@@ -124,6 +137,14 @@ export const setFigureEightAccount = (userId: string) => ({
   userId,
 })
 
+export const setFigureEightEarned = (amount: number) => ({
+  type: Actions.SET_FIGURE_EIGHT_EARNED,
+  amount,
+})
+
+export const refreshFigureEightEarned = () => ({
+  type: Actions.REFRESH_FIGURE_EIGHT_EARNED,
+})
 export const openDeepLink = (deepLink: string) => {
   return {
     type: Actions.OPEN_DEEP_LINK,

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -10,6 +10,7 @@ export interface State {
   doingPinVerification: boolean
   analyticsEnabled: boolean
   figureEightUserId: string | null
+  figureEightEarned: number | null
 }
 
 const initialState = {
@@ -21,6 +22,7 @@ const initialState = {
   doingPinVerification: false,
   analyticsEnabled: true,
   figureEightUserId: null,
+  figureEightEarned: null,
 }
 
 export const currentLanguageSelector = (state: RootState) => state.app.language
@@ -58,6 +60,11 @@ export const appReducer = (
         ...state,
         figureEightUserId: action.userId,
       }
+    case Actions.SET_FIGURE_EIGHT_EARNED:
+      return {
+        ...state,
+        figureEightEarned: action.amount,
+      }
     case Actions.RESET_APP_OPENED_STATE:
       return {
         ...state,
@@ -94,3 +101,5 @@ export const appReducer = (
       return state
   }
 }
+
+export const figureEightUserIdSelector = (state: RootState) => state.app.figureEightUserId

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -9,6 +9,7 @@ export interface State {
   doingBackupFlow: boolean
   doingPinVerification: boolean
   analyticsEnabled: boolean
+  figureEightUserId: string | null
 }
 
 const initialState = {
@@ -19,6 +20,7 @@ const initialState = {
   doingBackupFlow: false,
   doingPinVerification: false,
   analyticsEnabled: true,
+  figureEightUserId: null,
 }
 
 export const currentLanguageSelector = (state: RootState) => state.app.language
@@ -50,6 +52,11 @@ export const appReducer = (
       return {
         ...state,
         language: action.language,
+      }
+    case Actions.SET_FIGURE_EIGHT_ACCOUNT:
+      return {
+        ...state,
+        figureEightUserId: action.userId,
       }
     case Actions.RESET_APP_OPENED_STATE:
       return {

--- a/packages/mobile/src/firebase/db-rules.json
+++ b/packages/mobile/src/firebase/db-rules.json
@@ -29,8 +29,8 @@
       ".indexOn": ["requesterAddress", "requesteeAddress"]
     },
     "earnPilot": {
-      ".read": true,
-      ".write": true
+      ".read": "auth.uid != null",
+      ".write": "auth.uid != null"
     },
     "exchangeRates": {
       ".read": true,

--- a/packages/mobile/src/firebase/db-rules.json
+++ b/packages/mobile/src/firebase/db-rules.json
@@ -28,6 +28,10 @@
       ".write": true,
       ".indexOn": ["requesterAddress", "requesteeAddress"]
     },
+    "earnPilot": {
+      ".read": true,
+      ".write": true
+    },
     "exchangeRates": {
       ".read": true,
       ".write": false,

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -227,8 +227,7 @@ export async function setFigureEightUserId(userId: string, account: string) {
     const database = firebase.database().ref()
     Logger.info(TAG, `Setting userId for user ${JSON.stringify(database)}`)
     await database
-      .child('earnPilot')
-      .child('participants')
+      .child('earnPilot/participants')
       .child(userId)
       .update({ account })
     Logger.info(TAG, 'UserId and account synced successfully', userId)
@@ -236,4 +235,12 @@ export async function setFigureEightUserId(userId: string, account: string) {
     Logger.error(TAG, 'Failed to sync userId', error)
     throw error
   }
+}
+
+export async function doRefreshFigureEightEarned(userId: string) {
+  const result = await firebase
+    .database()
+    .ref('earnPilot/participants/' + userId + '/earned')
+    .once('value')
+  return result.val()
 }

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -220,3 +220,20 @@ export async function setUserLanguage(address: string, language: string) {
     throw error
   }
 }
+
+export async function setFigureEightUserId(userId: string, account: string) {
+  try {
+    Logger.info(TAG, `Setting userId for user ${userId}`)
+    const database = firebase.database().ref()
+    Logger.info(TAG, `Setting userId for user ${JSON.stringify(database)}`)
+    await database
+      .child('earnPilot')
+      .child('participants')
+      .child(userId)
+      .update({ account })
+    Logger.info(TAG, 'UserId and account synced successfully', userId)
+  } catch (error) {
+    Logger.error(TAG, 'Failed to sync userId', error)
+    throw error
+  }
+}

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -18,6 +18,8 @@ import Logger from 'src/utils/Logger'
 
 const TAG = 'firebase/firebase'
 
+const EARN_PILOT_DB = 'earnPilot/participants'
+
 // only exported for testing
 export function* watchFirebaseNotificationChannel(
   channel: EventChannel<{ notification: Notification; stateType: NotificationReceiveState }>
@@ -227,7 +229,7 @@ export async function setFigureEightUserId(userId: string, account: string) {
     const database = firebase.database().ref()
     Logger.info(TAG, `Setting userId for user ${JSON.stringify(database)}`)
     await database
-      .child('earnPilot/participants')
+      .child(EARN_PILOT_DB)
       .child(userId)
       .update({ account })
     Logger.info(TAG, 'UserId and account synced successfully', userId)
@@ -240,7 +242,9 @@ export async function setFigureEightUserId(userId: string, account: string) {
 export async function doRefreshFigureEightEarned(userId: string) {
   const result = await firebase
     .database()
-    .ref('earnPilot/participants/' + userId + '/earned')
+    .ref(EARN_PILOT_DB)
+    .child(userId)
+    .child('earned')
     .once('value')
   return result.val()
 }

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -227,7 +227,6 @@ export async function setFigureEightUserId(userId: string, account: string) {
   try {
     Logger.info(TAG, `Setting userId for user ${userId}`)
     const database = firebase.database().ref()
-    Logger.info(TAG, `Setting userId for user ${JSON.stringify(database)}`)
     await database
       .child(EARN_PILOT_DB)
       .child(userId)

--- a/packages/mobile/src/firebase/saga.ts
+++ b/packages/mobile/src/firebase/saga.ts
@@ -10,6 +10,7 @@ import {
   spawn,
   take,
   takeEvery,
+  takeLatest,
   takeLeading,
 } from 'redux-saga/effects'
 import {
@@ -22,7 +23,7 @@ import { PaymentRequest, PaymentRequestStatus } from 'src/account/types'
 import { showError } from 'src/alert/actions'
 import CeloAnalytics from 'src/analytics/CeloAnalytics'
 import { CustomEventNames } from 'src/analytics/constants'
-import { Actions as AppActions, SetLanguage } from 'src/app/actions'
+import { Actions as AppActions, SetFigureEightAccount, SetLanguage } from 'src/app/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { FIREBASE_ENABLED } from 'src/config'
 import { updateCeloGoldExchangeRateHistory } from 'src/exchange/actions'
@@ -39,6 +40,7 @@ import {
   initializeAuth,
   initializeCloudMessaging,
   paymentRequestWriter,
+  setFigureEightUserId,
   setUserLanguage,
 } from 'src/firebase/firebase'
 import Logger from 'src/utils/Logger'
@@ -230,8 +232,18 @@ export function* syncLanguageSelection({ language }: SetLanguage) {
   }
 }
 
+function* setFigureEightUserIdSaga({ userId }: SetFigureEightAccount) {
+  Logger.debug(TAG, 'setFigureEightUserIdSaga')
+  const account = yield select(currentAccountSelector)
+  yield call(setFigureEightUserId, userId, account)
+}
+
 export function* watchLanguage() {
   yield takeEvery(AppActions.SET_LANGUAGE, syncLanguageSelection)
+}
+
+export function* watchFigureEightAccount() {
+  yield takeLatest(AppActions.SET_FIGURE_EIGHT_ACCOUNT, setFigureEightUserIdSaga)
 }
 
 export function* watchWritePaymentRequest() {
@@ -301,6 +313,7 @@ export function* subscribeToCeloGoldExchangeRateHistory() {
 export function* firebaseSaga() {
   yield spawn(initializeFirebase)
   yield spawn(watchLanguage)
+  yield spawn(watchFigureEightAccount)
   yield spawn(subscribeToIncomingPaymentRequests)
   yield spawn(subscribeToOutgoingPaymentRequests)
   yield spawn(subscribeToCeloGoldExchangeRateHistory)

--- a/packages/mobile/src/firebase/saga.ts
+++ b/packages/mobile/src/firebase/saga.ts
@@ -240,13 +240,11 @@ export function* syncLanguageSelection({ language }: SetLanguage) {
 }
 
 function* setFigureEightUserIdSaga({ userId }: SetFigureEightAccount) {
-  Logger.debug(TAG, 'setFigureEightUserIdSaga')
   const account = yield select(currentAccountSelector)
   yield call(setFigureEightUserId, userId, account)
 }
 
 function* refreshFigureEightEarnedSaga() {
-  Logger.debug(TAG, 'setFigureEightUserIdSaga')
   const userId = yield select(figureEightUserIdSelector)
   const earned = yield call(doRefreshFigureEightEarned, userId)
   yield put(setFigureEightEarned(earned))

--- a/packages/mobile/src/flags.ts
+++ b/packages/mobile/src/flags.ts
@@ -2,4 +2,5 @@ export const features = {
   SHOW_SHOW_REWARDS_APP_LINK: false,
   USE_COMMENT_ENCRYPTION: true,
   SHOW_ADD_FUNDS: false,
+  SHOW_EARN: true,
 }

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -15,6 +15,7 @@ import Account from 'src/account/Account'
 import Analytics from 'src/account/Analytics'
 import DataSaver from 'src/account/DataSaver'
 import DollarEducation from 'src/account/DollarEducation'
+import Earn from 'src/account/Earn'
 import EditProfile from 'src/account/EditProfile'
 import FiatExchange from 'src/account/FiatExchange'
 import GoldEducation from 'src/account/GoldEducation'
@@ -263,6 +264,7 @@ const SettingsStack = createStackNavigator(
     [Screens.SelectLocalCurrency]: { screen: SelectLocalCurrency },
     [Screens.Licenses]: { screen: Licenses },
     [Screens.FiatExchange]: { screen: FiatExchange },
+    [Screens.Earn]: { screen: Earn },
     ...verificationScreens,
   },
   {

--- a/packages/mobile/src/navigator/Screens.tsx
+++ b/packages/mobile/src/navigator/Screens.tsx
@@ -27,6 +27,7 @@ export enum Screens {
   DappKitTxDataScreen = 'DappKitTxDataScreen',
   Debug = 'Debug',
   DollarEducation = 'DollarEducation',
+  Earn = 'Earn',
   EditProfile = 'EditProfile',
   EnterInviteCode = 'EnterInviteCode',
   ErrorScreen = 'ErrorScreen',


### PR DESCRIPTION
### Description

Add skeleton of Earn screen to wallet for upcoming Earn pilot. Allows users to enter a Figure Eight ID (which will be precreated for pilot participants) and displays amount earned. 

Note that the Figure Eight iFrame will be added in a future PR so this PR alone will not allow users to complete work, just to login with their ID and view the amount earned. 

### Tested

With celo-org-mobile-pilot firebase