### PR TITLE
[Wallet] Fix android e2e test

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -317,7 +317,7 @@ if (enableFirebase.toBoolean()){
 // https://github.com/facebook/react-native/issues/26400#issuecomment-539395814
 configurations.all {
      resolutionStrategy {
-       force "com.facebook.soloader:soloader:0.8.0"
+       force "com.facebook.soloader:soloader:0.8.1"
      }
 }
 

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -102,12 +102,21 @@ apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.grad
 apply from: "./react.gradle"
 apply from: "../../../../node_modules/@sentry/react-native/sentry.gradle"
 
-
- /**
- * Build for Detox has to have a universal apk and should be minSdkVersion >= 18
+/**
+ * Build for Detox should be minSdkVersion >= 18
  * Use the taskname to recognize the build is for detox
  */
-def isDetoxTestBuild = !gradle.startParameter.taskNames.contains("assembleAndroidTest")
+def isDetoxTestBuild = gradle.startParameter.taskNames.contains("assembleAndroidTest")
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
@@ -148,7 +157,7 @@ android {
 
     defaultConfig {
         applicationId "org.celo.mobile"
-        minSdkVersion isDetoxTestBuild ? rootProject.ext.minSdkVersion : 18
+        minSdkVersion isDetoxTestBuild ? 18 : rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode appVersionCode
         versionName "1.6.0"
@@ -177,15 +186,7 @@ android {
     splits {
         abi {
             reset()
-            /**
-             * Set this to true to create two separate APKs instead of one:
-             *   - An APK that only works on ARM devices
-             *   - An APK that only works on x86 devices
-             * The advantage is the size of the APK is reduced by about 4MB.
-             * Upload all the APKs to the Play Store and people will download
-             * the correct one based on the CPU architecture of their device.
-             */
-            enable isDetoxTestBuild
+            enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -185,18 +185,22 @@
     "test-runner": "jest",
     "configurations": {
       "android.emu.debug": {
-        "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
+        "binaryPath": "android/app/build/outputs/apk/debug/app-x86-debug.apk",
+        "testBinaryPath": "android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk",
         "build": "cd android && ENVFILE=.env.test ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "name": "Nexus_5X_API_28_x86",
-        "__comment": "Nexus_5X_API_28_x86 is currently harcoded but it should be the result from $ANDROID_SDK_ROOT/emulator/emulator -list-avds | grep 'x86' | head -n 1`"
+        "__comment": "Nexus_5X_API_28_x86 is currently hardcoded but it should be the result from $ANDROID_SDK_ROOT/emulator/emulator -list-avds | grep 'x86' | head -n 1`",
+        "__comment2": "Specifying 'testBinaryPath' otherwise detox infers the wrong APK name because we're using split APKs"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
+        "testBinaryPath": "android/app/build/outputs/apk/androidTest/release/app-release-androidTest.apk",
         "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "name": "Nexus_5X_API_28_x86",
-        "__comment": "Nexus_5X_API_28_x86 is currently harcoded but it should be the result from $ANDROID_SDK_ROOT/emulator/emulator -list-avds | grep 'x86' | head -n 1`"
+        "__comment": "Nexus_5X_API_28_x86 is currently hardcoded but it should be the result from $ANDROID_SDK_ROOT/emulator/emulator -list-avds | grep 'x86' | head -n 1`",
+        "__comment2": "Specifying 'testBinaryPath' otherwise detox infers the wrong APK name because we're using split APKs"
       },
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/celo.app",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -187,7 +187,7 @@
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-x86-debug.apk",
         "testBinaryPath": "android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk",
-        "build": "cd android && ENVFILE=.env.test ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
+        "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "name": "Nexus_5X_API_28_x86",
         "__comment": "Nexus_5X_API_28_x86 is currently hardcoded but it should be the result from $ANDROID_SDK_ROOT/emulator/emulator -list-avds | grep 'x86' | head -n 1`",
@@ -204,7 +204,7 @@
       },
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/celo.app",
-        "build": "set -o pipefail && ENVFILE=.env.test xcodebuild -workspace ios/celo.xcworkspace -scheme celo -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | bundle exec xcpretty",
+        "build": "set -o pipefail && xcodebuild -workspace ios/celo.xcworkspace -scheme celo -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | bundle exec xcpretty",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 11"

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -211,7 +211,7 @@
         }
       },
       "ios.sim.release": {
-        "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/celo.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/celo.app",
         "build": "set -o pipefail && xcodebuild -workspace ios/celo.xcworkspace -scheme celo -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | bundle exec xcpretty",
         "type": "ios.simulator",
         "device": {

--- a/packages/mobile/scripts/run_app.sh
+++ b/packages/mobile/scripts/run_app.sh
@@ -47,7 +47,7 @@ ENV_FILENAME="${ENVFILE:-.env}"
 export $(grep -v '^#' $ENV_FILENAME | xargs)
 
 if [ -z "$NETWORK" ]; then
-  echo "No network set, using $DEFAULT_TESTNET network set in .env file."
+  echo "No network set, using $DEFAULT_TESTNET network set in $ENV_FILENAME file."
   NETWORK=$DEFAULT_TESTNET
 fi
 

--- a/packages/mobile/scripts/run_e2e.sh
+++ b/packages/mobile/scripts/run_e2e.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Default ENVFILE if not set
+export ENVFILE="${ENVFILE:-.env.test}"
+
 # ========================================
 # Build and run the end-to-end tests
 # ========================================


### PR DESCRIPTION
### Description

This PR fixes e2e test on Android.

- Fixed crash at runtime when running e2e test on Android. 
`java.lang.UnsatisfiedLinkError: dlopen failed: "/data/data/org.celo.mobile.debug/lib-main/libc++_shared.so" has unexpected e_machine: 40 (EM_ARM)`
Problem was with SoLoader, see facebook/SoLoader@20198bf
We didn't see this when running the app outside of the detox test because only the detox test was building a universal APK.
- Made detox test work using split APKs too so it's closer to our standard build.
- Fixed inverted logic for `isDetoxBuild` in `build.gralde`. It was previously `false` when building for detox and `true` when NOT building for detox :upside_down_face: 
- Allow ENVFILE to be specified outside of the build config, but still defaults to .env.test
This makes it easy to test the app across networks (though today the test is too limited).
Example: `ENVFILE=.env.pilot yarn run test:e2e:android`

Future work:
- Run the Android e2e test on CircleCI.

### Tested

`yarn run test:e2e:android` succeeds again.

### Other changes

N/A

### Related issues

- Epic #2641

### Backwards compatibility

Yes
