### PR TITLE
Sets governance thresholds during migration

### DIFF
--- a/packages/protocol/governanceConstitution.js
+++ b/packages/protocol/governanceConstitution.js
@@ -1,38 +1,37 @@
 const DefaultConstitution = {
-  accounts: {
+  Accounts: {
     default: 0.6,
   },
-  attestations: {
+  Attestations: {
     default: 0.6,
     setRegistry: 0.9,
     setAttestationRequestFee: 0.6,
     setAttestationExpiryBlocks: 0.6,
     setSelectIssuersWaitBlocks: 0.6,
   },
-  blockChainParameters: {
+  BlockchainParameters: {
     default: 0.9,
-    setRegistry: 0.9,
     setMinimumClientVersion: 0.9,
     setBlockGasLimit: 0.8,
     setIntrinsicGasForAlternativeFeeCurrency: 0.8,
   },
-  doubleSigningSlasher: {
+  DoubleSigningSlasher: {
     default: 0.7,
     setSlashingIncentives: 0.7,
   },
-  downtimeSlasher: {
+  DowntimeSlasher: {
     default: 0.7,
     setSlashingIncentives: 0.7,
     setSlashableDowntime: 0.7,
   },
-  election: {
+  Election: {
     default: 0.8,
     setRegistry: 0.9,
     setElectableValidators: 0.8,
     setMaxNumGroupsVotedFor: 0.8,
     setElectabilityThreshold: 0.8,
   },
-  epochRewards: {
+  EpochRewards: {
     default: 0.8,
     setRegistry: 0.9,
     setCommunityRewardFraction: 0.8,
@@ -41,11 +40,11 @@ const DefaultConstitution = {
     setRewardsMultiplierParameters: 0.8,
     setTargetVotingYieldParameters: 0.8,
   },
-  escrow: {
-    default: 0.5,
+  Escrow: {
+    default: 0.6,
     setRegistry: 0.9,
   },
-  exchange: {
+  Exchange: {
     default: 0.8,
     setRegistry: 0.9,
     setUpdateFrequency: 0.8,
@@ -54,24 +53,24 @@ const DefaultConstitution = {
     setSpread: 0.8,
     setReserveFraction: 0.8,
   },
-  feeCurrencyWhitelist: {
+  FeeCurrencyWhitelist: {
     default: 0.8,
     addToken: 0.8,
   },
-  gasPriceMinimum: {
+  GasPriceMinimum: {
     default: 0.7,
     setRegistry: 0.9,
     setAdjustmentSpeed: 0.7,
     setTargetDensity: 0.7,
     setGasPriceMinimumFloor: 0.7,
   },
-  goldToken: {
+  GoldToken: {
     default: 0.9,
     transfer: 0.6,
     transferWithComment: 0.6,
     approve: 0.6,
   },
-  governance: {
+  Governance: {
     default: 0.9,
     setRegistry: 0.9,
     setApprover: 0.9,
@@ -88,12 +87,11 @@ const DefaultConstitution = {
     setBaselineQuorumFactor: 0.9,
     setConstitution: 0.9,
   },
-  governanceSlasher: {
+  GovernanceSlasher: {
     default: 0.7,
-    setSlashingIncentives: 0.7,
     approveSlashing: 0.7,
   },
-  lockedGold: {
+  LockedGold: {
     default: 0.9,
     setRegistry: 0.9,
     setUnlockingPeriod: 0.8,
@@ -106,15 +104,15 @@ const DefaultConstitution = {
     _setAndInitializeImplementation: 0.9,
     _setImplementation: 0.9,
   },
-  random: {
+  Random: {
     default: 0.7,
     setRandomnessBlockRetentionWindow: 0.7,
   },
-  registry: {
+  Registry: {
     default: 0.9,
     setAddressFor: 0.9,
   },
-  reserve: {
+  Reserve: {
     default: 0.9,
     setRegistry: 0.9,
     setTobinTaxStalenessThreshold: 0.7,
@@ -127,13 +125,13 @@ const DefaultConstitution = {
     addSpender: 0.9,
     removeSpender: 0.8,
   },
-  sortedOracles: {
+  SortedOracles: {
     default: 0.7,
     setReportExpiry: 0.7,
     addOracle: 0.8,
     removeOracle: 0.7,
   },
-  stableToken: {
+  StableToken: {
     default: 0.8,
     setRegistry: 0.9,
     setInflationParameters: 0.9,
@@ -141,7 +139,7 @@ const DefaultConstitution = {
     transferWithComment: 0.6,
     approve: 0.6,
   },
-  validators: {
+  Validators: {
     default: 0.7,
     setRegistry: 0.9,
     setMaxGroupSize: 0.7,

--- a/packages/protocol/lib/web3-utils.ts
+++ b/packages/protocol/lib/web3-utils.ts
@@ -311,3 +311,26 @@ export async function sendEscrowedPayment(
   const expirySeconds = 60 * 60 * 24 * 5 // 5 days
   await escrow.transfer(phoneHash, contract.address, value.toString(), expirySeconds, paymentID, 0)
 }
+
+/*
+* Builds and returns mapping of function names to selectors.
+* Each function name maps to an array of selectors to account for overloading.
+*/
+export function getFunctionSelectorsForContract(contract: any, contractName: string, artifacts: Truffle.Artifacts) {
+  const selectors: { [index: string]: string[] } = {}
+  const proxy: any = artifacts.require(contractName + 'Proxy')
+  proxy.abi
+    .concat(contract.abi)
+    .filter((abiEntry: any) => abiEntry.type === 'function')
+    .forEach((func: any) => {
+      if (typeof selectors[func.name] === 'undefined') {
+        selectors[func.name] = []
+      }
+      if (typeof func.signature === 'undefined') {
+        selectors[func.name].push(web3.eth.abi.encodeFunctionSignature(func))
+      } else {
+        selectors[func.name].push(func.signature)
+      }
+    })
+  return selectors
+}

--- a/packages/protocol/migrations/22_governance.ts
+++ b/packages/protocol/migrations/22_governance.ts
@@ -5,6 +5,7 @@ import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import {
   deploymentForCoreContract,
   getDeployedProxiedContract,
+  getFunctionSelectorsForContract,
   transferOwnershipOfProxy,
   transferOwnershipOfProxyAndImplementation,
 } from '@celo/protocol/lib/web3-utils'
@@ -46,53 +47,30 @@ module.exports = deploymentForCoreContract<GovernanceInstance>(
     await reserve.addSpender(governance.address)
 
     console.info('Setting constitution thresholds')
-    Object.keys(constitution)
-      .filter((contractName) => contractName !== 'proxy')
-      .forEach(async (contractName) => {
-        const proxy: any = artifacts.require(contractName + 'Proxy')
-        const contract: any = await getDeployedProxiedContract<Truffle.ContractInstance>(
-          contractName,
-          artifacts
-        )
+    await Promise.all(
+      Object.keys(constitution)
+        .filter((contractName) => contractName !== 'proxy')
+        .map(async (contractName) => {
+          const contract: any = await getDeployedProxiedContract<Truffle.ContractInstance>(
+            contractName,
+            artifacts
+          )
 
-        // Build mapping of function names to selectors
-        // Each function name maps to an array of selectors to account for overloading
-        const selectors: { [index: string]: string[] } = {}
-        proxy.abi
-          .concat(contract.abi)
-          .filter((abiEntry: any) => abiEntry.type === 'function')
-          .forEach((func: any) => {
-            if (typeof selectors[func.name] === 'undefined') {
-              selectors[func.name] = []
-            }
-            selectors[func.name].push(func.signature)
-          })
+          const selectors = getFunctionSelectorsForContract(contract, contractName, artifacts)
+          selectors.default = ['0x00000000']
 
-        const setThresholds = (thresholds: any) => {
-          Object.keys(thresholds)
-            .filter((func) => func !== 'default')
-            .forEach(async (func) => {
-              await Promise.all(
+          const thresholds = { ...constitution.proxy, ...constitution[contractName] }
+          await Promise.all(
+            Object.keys(thresholds).map((func) =>
+              Promise.all(
                 selectors[func].map((selector) =>
-                  governance.setConstitution(
-                    contract.address,
-                    selector,
-                    toFixed(thresholds[func]).toFixed()
-                  )
+                  governance.setConstitution(contract.address, selector, toFixed(thresholds[func]))
                 )
               )
-            })
-        }
-        setThresholds(constitution.proxy)
-        setThresholds(constitution[contractName])
-
-        // set default threshold
-        await governance.setConstitution(
-          contract.address,
-          '0x00000000',
-          toFixed(constitution[contractName].default).toFixed()
-        )
-      })
+            )
+          )
+        })
+    )
 
     const proxyOwnedByGovernance = ['GoldToken']
     await Promise.all(

--- a/packages/protocol/migrations/22_governance.ts
+++ b/packages/protocol/migrations/22_governance.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:no-console */
 
+import { constitution } from '@celo/protocol/governanceConstitution'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import {
   deploymentForCoreContract,
@@ -43,6 +44,55 @@ module.exports = deploymentForCoreContract<GovernanceInstance>(
       artifacts
     )
     await reserve.addSpender(governance.address)
+
+    console.info('Setting constitution thresholds')
+    Object.keys(constitution)
+      .filter((contractName) => contractName !== 'proxy')
+      .forEach(async (contractName) => {
+        const proxy: any = artifacts.require(contractName + 'Proxy')
+        const contract: any = await getDeployedProxiedContract<Truffle.ContractInstance>(
+          contractName,
+          artifacts
+        )
+
+        // Build mapping of function names to selectors
+        // Each function name maps to an array of selectors to account for overloading
+        const selectors: { [index: string]: string[] } = {}
+        proxy.abi
+          .concat(contract.abi)
+          .filter((abiEntry: any) => abiEntry.type === 'function')
+          .forEach((func: any) => {
+            if (typeof selectors[func.name] === 'undefined') {
+              selectors[func.name] = []
+            }
+            selectors[func.name].push(func.signature)
+          })
+
+        const setThresholds = (thresholds: any) => {
+          Object.keys(thresholds)
+            .filter((func) => func !== 'default')
+            .forEach(async (func) => {
+              await Promise.all(
+                selectors[func].map((selector) =>
+                  governance.setConstitution(
+                    contract.address,
+                    selector,
+                    toFixed(thresholds[func]).toFixed()
+                  )
+                )
+              )
+            })
+        }
+        setThresholds(constitution.proxy)
+        setThresholds(constitution[contractName])
+
+        // set default threshold
+        await governance.setConstitution(
+          contract.address,
+          '0x00000000',
+          toFixed(constitution[contractName].default).toFixed()
+        )
+      })
 
     const proxyOwnedByGovernance = ['GoldToken']
     await Promise.all(


### PR DESCRIPTION
### Description

Governance proposals currently pass with a simple majority. This PR sets custom governance thresholds for each governable function as part of migrations.

### Tested

Tested in integration.ts

### Other changes

None.

### Related Issues

Custom thresholds are specified by the governanceConstitution added in [#2748 ](https://github.com/celo-org/celo-monorepo/pull/2748)

### Backwards compatibility

Yes.
