### PR TITLE
Animate Line + some minor cleanup

### DIFF
--- a/packages/web/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
@@ -8,9 +8,14 @@ exports[`Experience/Color renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "borderBottomColor": "rgba(221,221,221,1.00)",
-        "marginBottom": "70px",
+        "MozTransitionProperty": "box-shadow",
+        "WebkitTransitionDuration": "400ms",
+        "WebkitTransitionProperty": "box-shadow",
+        "boxShadow": "0px 0px 0px 0px rgba(0,0,0,0)",
+        "marginBottom": "75px",
         "position": "fixed",
+        "transitionDuration": "400ms",
+        "transitionProperty": "box-shadow",
         "width": "100%",
         "zIndex": 10,
       }
@@ -25,8 +30,6 @@ exports[`Experience/Color renders 1`] = `
           "WebkitBoxPack": "center",
           "WebkitJustifyContent": "center",
           "alignItems": "center",
-          "borderBottomColor": "rgba(221,221,221,1.00)",
-          "borderBottomWidth": "1px",
           "justifyContent": "center",
           "msFlexAlign": "center",
           "msFlexPack": "center",
@@ -241,7 +244,7 @@ exports[`Experience/Color renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "marginTop": "70px",
+        "marginTop": "75px",
       }
     }
   />
@@ -5672,8 +5675,8 @@ exports[`Experience/Color renders 1`] = `
           >
             <a
               href="https://github.com/celo-org"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -5739,8 +5742,8 @@ exports[`Experience/Color renders 1`] = `
           >
             <a
               href="https://forum.celo.org/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -5767,8 +5770,8 @@ exports[`Experience/Color renders 1`] = `
           >
             <a
               href="https://discord.gg/6yWMkgM"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -5797,8 +5800,8 @@ exports[`Experience/Color renders 1`] = `
           >
             <a
               href="https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"

--- a/packages/web/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
@@ -8,9 +8,14 @@ exports[`Experience/Composition renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "borderBottomColor": "rgba(221,221,221,1.00)",
-        "marginBottom": "70px",
+        "MozTransitionProperty": "box-shadow",
+        "WebkitTransitionDuration": "400ms",
+        "WebkitTransitionProperty": "box-shadow",
+        "boxShadow": "0px 0px 0px 0px rgba(0,0,0,0)",
+        "marginBottom": "75px",
         "position": "fixed",
+        "transitionDuration": "400ms",
+        "transitionProperty": "box-shadow",
         "width": "100%",
         "zIndex": 10,
       }
@@ -25,8 +30,6 @@ exports[`Experience/Composition renders 1`] = `
           "WebkitBoxPack": "center",
           "WebkitJustifyContent": "center",
           "alignItems": "center",
-          "borderBottomColor": "rgba(221,221,221,1.00)",
-          "borderBottomWidth": "1px",
           "justifyContent": "center",
           "msFlexAlign": "center",
           "msFlexPack": "center",
@@ -241,7 +244,7 @@ exports[`Experience/Composition renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "marginTop": "70px",
+        "marginTop": "75px",
       }
     }
   />
@@ -2480,8 +2483,8 @@ exports[`Experience/Composition renders 1`] = `
           >
             <a
               href="https://github.com/celo-org"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -2547,8 +2550,8 @@ exports[`Experience/Composition renders 1`] = `
           >
             <a
               href="https://forum.celo.org/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -2575,8 +2578,8 @@ exports[`Experience/Composition renders 1`] = `
           >
             <a
               href="https://discord.gg/6yWMkgM"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -2605,8 +2608,8 @@ exports[`Experience/Composition renders 1`] = `
           >
             <a
               href="https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"

--- a/packages/web/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
@@ -8,9 +8,14 @@ exports[`Experience/Icons renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "borderBottomColor": "rgba(221,221,221,1.00)",
-        "marginBottom": "70px",
+        "MozTransitionProperty": "box-shadow",
+        "WebkitTransitionDuration": "400ms",
+        "WebkitTransitionProperty": "box-shadow",
+        "boxShadow": "0px 0px 0px 0px rgba(0,0,0,0)",
+        "marginBottom": "75px",
         "position": "fixed",
+        "transitionDuration": "400ms",
+        "transitionProperty": "box-shadow",
         "width": "100%",
         "zIndex": 10,
       }
@@ -25,8 +30,6 @@ exports[`Experience/Icons renders 1`] = `
           "WebkitBoxPack": "center",
           "WebkitJustifyContent": "center",
           "alignItems": "center",
-          "borderBottomColor": "rgba(221,221,221,1.00)",
-          "borderBottomWidth": "1px",
           "justifyContent": "center",
           "msFlexAlign": "center",
           "msFlexPack": "center",
@@ -241,7 +244,7 @@ exports[`Experience/Icons renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "marginTop": "70px",
+        "marginTop": "75px",
       }
     }
   />
@@ -1344,8 +1347,8 @@ exports[`Experience/Icons renders 1`] = `
           >
             <a
               href="https://github.com/celo-org"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -1411,8 +1414,8 @@ exports[`Experience/Icons renders 1`] = `
           >
             <a
               href="https://forum.celo.org/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -1439,8 +1442,8 @@ exports[`Experience/Icons renders 1`] = `
           >
             <a
               href="https://discord.gg/6yWMkgM"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -1469,8 +1472,8 @@ exports[`Experience/Icons renders 1`] = `
           >
             <a
               href="https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"

--- a/packages/web/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
@@ -8,9 +8,14 @@ exports[`Experience/Brandkit renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "borderBottomColor": "rgba(221,221,221,1.00)",
-        "marginBottom": "70px",
+        "MozTransitionProperty": "box-shadow",
+        "WebkitTransitionDuration": "400ms",
+        "WebkitTransitionProperty": "box-shadow",
+        "boxShadow": "0px 0px 0px 0px rgba(0,0,0,0)",
+        "marginBottom": "75px",
         "position": "fixed",
+        "transitionDuration": "400ms",
+        "transitionProperty": "box-shadow",
         "width": "100%",
         "zIndex": 10,
       }
@@ -25,8 +30,6 @@ exports[`Experience/Brandkit renders 1`] = `
           "WebkitBoxPack": "center",
           "WebkitJustifyContent": "center",
           "alignItems": "center",
-          "borderBottomColor": "rgba(221,221,221,1.00)",
-          "borderBottomWidth": "1px",
           "justifyContent": "center",
           "msFlexAlign": "center",
           "msFlexPack": "center",
@@ -241,7 +244,7 @@ exports[`Experience/Brandkit renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "marginTop": "70px",
+        "marginTop": "75px",
       }
     }
   />
@@ -1319,8 +1322,8 @@ exports[`Experience/Brandkit renders 1`] = `
           >
             <a
               href="https://github.com/celo-org"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -1386,8 +1389,8 @@ exports[`Experience/Brandkit renders 1`] = `
           >
             <a
               href="https://forum.celo.org/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -1414,8 +1417,8 @@ exports[`Experience/Brandkit renders 1`] = `
           >
             <a
               href="https://discord.gg/6yWMkgM"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -1444,8 +1447,8 @@ exports[`Experience/Brandkit renders 1`] = `
           >
             <a
               href="https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"

--- a/packages/web/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
@@ -8,9 +8,14 @@ exports[`Experience/KeyImagery renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "borderBottomColor": "rgba(221,221,221,1.00)",
-        "marginBottom": "70px",
+        "MozTransitionProperty": "box-shadow",
+        "WebkitTransitionDuration": "400ms",
+        "WebkitTransitionProperty": "box-shadow",
+        "boxShadow": "0px 0px 0px 0px rgba(0,0,0,0)",
+        "marginBottom": "75px",
         "position": "fixed",
+        "transitionDuration": "400ms",
+        "transitionProperty": "box-shadow",
         "width": "100%",
         "zIndex": 10,
       }
@@ -25,8 +30,6 @@ exports[`Experience/KeyImagery renders 1`] = `
           "WebkitBoxPack": "center",
           "WebkitJustifyContent": "center",
           "alignItems": "center",
-          "borderBottomColor": "rgba(221,221,221,1.00)",
-          "borderBottomWidth": "1px",
           "justifyContent": "center",
           "msFlexAlign": "center",
           "msFlexPack": "center",
@@ -241,7 +244,7 @@ exports[`Experience/KeyImagery renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "marginTop": "70px",
+        "marginTop": "75px",
       }
     }
   />
@@ -1945,8 +1948,8 @@ exports[`Experience/KeyImagery renders 1`] = `
           >
             <a
               href="https://github.com/celo-org"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -2012,8 +2015,8 @@ exports[`Experience/KeyImagery renders 1`] = `
           >
             <a
               href="https://forum.celo.org/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -2040,8 +2043,8 @@ exports[`Experience/KeyImagery renders 1`] = `
           >
             <a
               href="https://discord.gg/6yWMkgM"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -2070,8 +2073,8 @@ exports[`Experience/KeyImagery renders 1`] = `
           >
             <a
               href="https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"

--- a/packages/web/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
@@ -8,9 +8,14 @@ exports[`Experience/Logo renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "borderBottomColor": "rgba(221,221,221,1.00)",
-        "marginBottom": "70px",
+        "MozTransitionProperty": "box-shadow",
+        "WebkitTransitionDuration": "400ms",
+        "WebkitTransitionProperty": "box-shadow",
+        "boxShadow": "0px 0px 0px 0px rgba(0,0,0,0)",
+        "marginBottom": "75px",
         "position": "fixed",
+        "transitionDuration": "400ms",
+        "transitionProperty": "box-shadow",
         "width": "100%",
         "zIndex": 10,
       }
@@ -25,8 +30,6 @@ exports[`Experience/Logo renders 1`] = `
           "WebkitBoxPack": "center",
           "WebkitJustifyContent": "center",
           "alignItems": "center",
-          "borderBottomColor": "rgba(221,221,221,1.00)",
-          "borderBottomWidth": "1px",
           "justifyContent": "center",
           "msFlexAlign": "center",
           "msFlexPack": "center",
@@ -241,7 +244,7 @@ exports[`Experience/Logo renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "marginTop": "70px",
+        "marginTop": "75px",
       }
     }
   />
@@ -5979,8 +5982,8 @@ exports[`Experience/Logo renders 1`] = `
           >
             <a
               href="https://github.com/celo-org"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -6046,8 +6049,8 @@ exports[`Experience/Logo renders 1`] = `
           >
             <a
               href="https://forum.celo.org/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -6074,8 +6077,8 @@ exports[`Experience/Logo renders 1`] = `
           >
             <a
               href="https://discord.gg/6yWMkgM"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -6104,8 +6107,8 @@ exports[`Experience/Logo renders 1`] = `
           >
             <a
               href="https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"

--- a/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
@@ -8,9 +8,14 @@ exports[`Experience/Typography renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "borderBottomColor": "rgba(221,221,221,1.00)",
-        "marginBottom": "70px",
+        "MozTransitionProperty": "box-shadow",
+        "WebkitTransitionDuration": "400ms",
+        "WebkitTransitionProperty": "box-shadow",
+        "boxShadow": "0px 0px 0px 0px rgba(0,0,0,0)",
+        "marginBottom": "75px",
         "position": "fixed",
+        "transitionDuration": "400ms",
+        "transitionProperty": "box-shadow",
         "width": "100%",
         "zIndex": 10,
       }
@@ -25,8 +30,6 @@ exports[`Experience/Typography renders 1`] = `
           "WebkitBoxPack": "center",
           "WebkitJustifyContent": "center",
           "alignItems": "center",
-          "borderBottomColor": "rgba(221,221,221,1.00)",
-          "borderBottomWidth": "1px",
           "justifyContent": "center",
           "msFlexAlign": "center",
           "msFlexPack": "center",
@@ -241,7 +244,7 @@ exports[`Experience/Typography renders 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "marginTop": "70px",
+        "marginTop": "75px",
       }
     }
   />
@@ -2987,8 +2990,8 @@ exports[`Experience/Typography renders 1`] = `
           >
             <a
               href="https://github.com/celo-org"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -3054,8 +3057,8 @@ exports[`Experience/Typography renders 1`] = `
           >
             <a
               href="https://forum.celo.org/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -3082,8 +3085,8 @@ exports[`Experience/Typography renders 1`] = `
           >
             <a
               href="https://discord.gg/6yWMkgM"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"
@@ -3112,8 +3115,8 @@ exports[`Experience/Typography renders 1`] = `
           >
             <a
               href="https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
+              rel="noopener"
+              target="_blank"
             >
               <svg
                 fill="none"

--- a/packages/web/src/brandkit/common/Page.tsx
+++ b/packages/web/src/brandkit/common/Page.tsx
@@ -14,7 +14,8 @@ import { HEADER_HEIGHT } from 'src/shared/Styles'
 import { colors, standardStyles } from 'src/styles'
 
 const FOOTER_ID = 'experience-footer'
-
+const DISTANCE_TO_HIDE_AT = 25
+const THROTTLE_SCROLL_MS = 200
 export const ROOT = menu.BRAND.link
 
 export const LOGO_PATH = `${ROOT}/logo`
@@ -221,13 +222,13 @@ class Page extends React.Component<Props & ScreenProps, State> {
     window.addEventListener(
       'scroll',
       throttle((event) => {
-        const top = event.target.scrollingElement.scrollTop + 30
+        const top = event.target.scrollingElement.scrollTop + DISTANCE_TO_HIDE_AT
         if (top > HEADER_HEIGHT) {
           this.setState({ isLineVisible: true })
         } else {
           this.setState({ isLineVisible: false })
         }
-      }, 200)
+      }, THROTTLE_SCROLL_MS)
     )
   }
 
@@ -302,10 +303,12 @@ const styles = StyleSheet.create({
     marginTop: HEADER_HEIGHT,
   },
   grayLine: {
-    borderBottomWidth: 1,
-    borderBottomColor: colors.gray,
-  },
+    boxShadow: `0px 1px 1px -1px rgba(0,0,0,0.5)`,
+  } as any,
   topbar: {
+    transitionProperty: 'box-shadow',
+    transitionDuration: '400ms',
+    boxShadow: `0px 0px 0px 0px rgba(0,0,0,0)`,
     position: 'fixed',
     width: '100%',
     zIndex: 10,

--- a/packages/web/src/brandkit/common/Page.tsx
+++ b/packages/web/src/brandkit/common/Page.tsx
@@ -194,7 +194,7 @@ class Page extends React.Component<Props & ScreenProps, State> {
       return
     }
     this.observer = new IntersectionObserver(this.updateSectionHashWhenInView, {
-      threshold: [0.01, 0.1, 0.15, 0.5, 0.9, 1],
+      threshold: [0.1, 0.5, 0.9, 1],
     })
 
     Object.keys(this.sectionRefs).forEach((id) => {
@@ -306,7 +306,7 @@ const styles = StyleSheet.create({
   },
   grayLine: {
     boxShadow: `0px 1px 1px -1px rgba(0,0,0,0.5)`,
-  } as any,
+  },
   topbar: {
     transitionProperty: 'box-shadow',
     transitionDuration: '400ms',

--- a/packages/web/src/brandkit/common/Page.tsx
+++ b/packages/web/src/brandkit/common/Page.tsx
@@ -214,7 +214,9 @@ class Page extends React.Component<Props & ScreenProps, State> {
 
   componentDidMount = () => {
     this.createSectionObservers()
-    this.setLineVisibilityViaScroll()
+    if (this.props.screen !== ScreenSizes.MOBILE) {
+      this.setLineVisibilityViaScroll()
+    }
     window.addEventListener('hashchange', this.onChangeHash, false)
   }
 

--- a/packages/web/src/brandkit/common/Page.tsx
+++ b/packages/web/src/brandkit/common/Page.tsx
@@ -1,3 +1,4 @@
+import throttle from 'lodash.throttle'
 import { SingletonRouter, withRouter } from 'next/router'
 import * as React from 'react'
 import { findNodeHandle, StyleSheet, View } from 'react-native'
@@ -11,6 +12,7 @@ import Footer from 'src/shared/Footer'
 import menu, { hashNav } from 'src/shared/menu-items'
 import { HEADER_HEIGHT } from 'src/shared/Styles'
 import { colors, standardStyles } from 'src/styles'
+
 const FOOTER_ID = 'experience-footer'
 
 export const ROOT = menu.BRAND.link
@@ -109,6 +111,7 @@ interface State {
   routeHash: string
   isSidebarFrozen: boolean
   distanceToTop: number
+  isLineVisible: boolean
 }
 
 class Page extends React.Component<Props & ScreenProps, State> {
@@ -116,6 +119,7 @@ class Page extends React.Component<Props & ScreenProps, State> {
     routeHash: '',
     isSidebarFrozen: true,
     distanceToTop: 0,
+    isLineVisible: false,
   }
 
   ratios: Record<string, { id: string; ratio: number; top: number }> = {}
@@ -134,8 +138,7 @@ class Page extends React.Component<Props & ScreenProps, State> {
   }
 
   updateSectionHashWhenInView = (entries: IntersectionObserverEntry[]) => {
-    const filteredEntries = entries.filter((entry) => entry.target.id !== FOOTER_ID)
-
+    const filteredEntries = entries.filter(({ target }) => target.id !== FOOTER_ID)
     this.ratios = filteredEntries
       .map((entry) => ({
         id: entry.target.id,
@@ -163,7 +166,9 @@ class Page extends React.Component<Props & ScreenProps, State> {
       this.setState({ routeHash: top.id })
       window.history.replaceState({}, top.id, `${location.pathname}#${top.id}`)
     }
-
+    if (this.props.screen === ScreenSizes.MOBILE) {
+      return
+    }
     setImmediate(() => {
       const footer = entries.find((entry) => entry.target.id === FOOTER_ID)
       if (footer) {
@@ -188,25 +193,42 @@ class Page extends React.Component<Props & ScreenProps, State> {
       return
     }
     this.observer = new IntersectionObserver(this.updateSectionHashWhenInView, {
-      threshold: [0.1, 0.5, 0.9, 1],
+      threshold: [0.01, 0.1, 0.15, 0.5, 0.9, 1],
     })
 
     Object.keys(this.sectionRefs).forEach((id) => {
       const value = this.sectionRefs[id]
-      // findNodeHandle is typed to return a number but returns an Element
-      const element = (findNodeHandle(value.current) as unknown) as Element
-      this.observer.observe(element)
+      this.observeRef(value)
     })
 
-    const footer = (findNodeHandle(this.footer.current) as unknown) as Element
+    this.observeRef(this.footer)
+  }
 
-    this.observer.observe(footer)
+  observeRef = (ref: React.RefObject<View>) => {
+    // findNodeHandle is typed to return a number but returns an Element
+    const element = (findNodeHandle(ref.current) as unknown) as Element
+
+    this.observer.observe(element)
   }
 
   componentDidMount = () => {
     this.createSectionObservers()
-
+    this.setLineVisibilityViaScroll()
     window.addEventListener('hashchange', this.onChangeHash, false)
+  }
+
+  setLineVisibilityViaScroll = () => {
+    window.addEventListener(
+      'scroll',
+      throttle((event) => {
+        const top = event.target.scrollingElement.scrollTop + 30
+        if (top > HEADER_HEIGHT) {
+          this.setState({ isLineVisible: true })
+        } else {
+          this.setState({ isLineVisible: false })
+        }
+      }, 200)
+    )
   }
 
   componentWillUnmount = () => {
@@ -226,7 +248,7 @@ class Page extends React.Component<Props & ScreenProps, State> {
           image={require('src/brandkit/images/ogimage-brandkit.png')}
         />
         <View style={styles.conatiner}>
-          <View style={styles.topbar}>
+          <View style={[styles.topbar, (this.state.isLineVisible || isMobile) && styles.grayLine]}>
             <Topbar isMobile={isMobile} />
           </View>
           <View style={styles.justNeedSpace} />
@@ -277,14 +299,17 @@ const styles = StyleSheet.create({
   desktopMain: { flex: 1, flexBasis: 'calc(75% - 50px)' },
   sidebar: { minWidth: 190, paddingLeft: 0 },
   justNeedSpace: {
-    marginTop: 70,
+    marginTop: HEADER_HEIGHT,
+  },
+  grayLine: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray,
   },
   topbar: {
     position: 'fixed',
     width: '100%',
-    borderBottomColor: colors.gray,
     zIndex: 10,
-    marginBottom: 70,
+    marginBottom: HEADER_HEIGHT,
   },
   footer: { zIndex: -10, backgroundColor: colors.white },
   childrenArea: {

--- a/packages/web/src/brandkit/common/TopBar.tsx
+++ b/packages/web/src/brandkit/common/TopBar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
-import { brandStyles } from 'src/brandkit/common/constants'
 import { I18nProps, NameSpaces, withNamespaces } from 'src/i18n'
 import Octocat from 'src/icons/Octocat'
 import LogoLightBg from 'src/logos/LogoLightBg'
@@ -17,7 +16,7 @@ export default withNamespaces(NameSpaces.common)(function TopBar({
   isMobile,
 }: I18nProps & Props) {
   return (
-    <View style={[brandStyles.bottomBorder, standardStyles.centered]}>
+    <View style={standardStyles.centered}>
       <View style={[standardStyles.row, styles.container]}>
         <a href={menuItems.BRAND.link}>
           <TouchableOpacity style={standardStyles.row}>

--- a/packages/web/src/react-native-aug.d.ts
+++ b/packages/web/src/react-native-aug.d.ts
@@ -10,29 +10,34 @@ declare module 'react-native' {
     gridArea?: string
   }
 
+  interface KeyFrame {
+    [string]: ViewStyle
+  }
+
   interface ViewStyle {
-    position?: 'absolute' | 'relative' | 'fixed' | 'static'
-    isolation?: 'isolate'
     appearance?: string
-    transformOrigin?: string | number
-    transitionProperty?: string
-    transitionDuration?: string
     animationDelay?: string
     animationDuration?: string
     animationFillMode?: 'both' | 'backwards' | 'forwards' | 'none'
     animationIterationCount?: 'infinite' | number
-    animationKeyframes?: unknown[]
+    animationKeyframes?: KeyFrame[]
     animationTimingFunction?: string
-    gridArea?: string
-    gridRowGap?: string | number
-    gridColumnGap?: string | number
-    gridTemplateColumns?: string
+    boxShadow?: string
     cursor?: string
     display?: 'none' | 'flex' | 'inline' | 'inline-flex' | 'list-item' | 'block' | 'grid'
     fill?: string
     filter?: string
+    gridArea?: string
+    gridRowGap?: string | number
+    gridColumnGap?: string | number
+    gridTemplateColumns?: string
+    isolation?: 'isolate'
     mixBlendMode?: 'multiply' | 'screen'
+    position?: 'absolute' | 'relative' | 'fixed' | 'static'
     scrollPadding?: number
+    transformOrigin?: string | number
+    transitionProperty?: string
+    transitionDuration?: string
   }
 
   interface ImageProps {

--- a/packages/web/src/shared/Button.3.tsx
+++ b/packages/web/src/shared/Button.3.tsx
@@ -120,7 +120,6 @@ export default class Button extends React.PureComponent<ButtonsProps, State> {
     const { text, href, align, iconRight, iconLeft } = this.props
     const ButtonComponent = this.getButtonComponent()
     const renderedButton = (
-      // @ts-ignore
       <ButtonComponent status={this.getStatus()} {...this.props}>
         {iconLeft && <View style={baseStyles.iconLeft}>{iconLeft}</View>}
         {text}
@@ -157,7 +156,7 @@ interface Props {
   kind?: BTN
   children: React.ReactNode
   size?: SIZE
-  style?: TextStyle
+  style?: TextStyle | TextStyle[]
   href?: string
   target?: string
   onDarkBackground?: boolean

--- a/packages/web/src/shared/Footer.tsx
+++ b/packages/web/src/shared/Footer.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import * as React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { I18nProps, NameSpaces, Trans, withNamespaces } from 'src/i18n'
@@ -64,35 +63,27 @@ const Social = React.memo(function _Social() {
           <MediumLogo color={colors.dark} height={height} />
         </View>
         <View style={styles.socialIcon}>
-          <Link href={CeloLinks.gitHub}>
-            <a>
-              <Octocat color={colors.dark} size={height} />
-            </a>
-          </Link>
+          <a target="_blank" rel="noopener" href={CeloLinks.gitHub}>
+            <Octocat color={colors.dark} size={height} />
+          </a>
         </View>
         <View style={styles.socialIcon}>
           <TwiterLogo color={colors.dark} height={height} />
         </View>
         <View style={styles.socialIcon}>
-          <Link href={CeloLinks.discourse}>
-            <a>
-              <Discourse color={colors.dark} size={height} />
-            </a>
-          </Link>
+          <a target="_blank" rel="noopener" href={CeloLinks.discourse}>
+            <Discourse color={colors.dark} size={height} />
+          </a>
         </View>
         <View style={styles.socialIcon}>
-          <Link href={CeloLinks.discord}>
-            <a>
-              <Discord color={colors.dark} size={height} />
-            </a>
-          </Link>
+          <a target="_blank" rel="noopener" href={CeloLinks.discord}>
+            <Discord color={colors.dark} size={height} />
+          </a>
         </View>
         <View style={styles.socialIcon}>
-          <Link href={CeloLinks.youtube}>
-            <a>
-              <YouTube color={colors.dark} size={height} />
-            </a>
-          </Link>
+          <a target="_blank" rel="noopener" href={CeloLinks.youtube}>
+            <YouTube color={colors.dark} size={height} />
+          </a>
         </View>
       </View>
     </Responsive>


### PR DESCRIPTION
### Description

On BrandKit pages changes the thin gray line on the bottom of top menu bar to only show when content is near it or under it. 


### Tested
![Screen Shot 2020-02-21 at 12 04 58 PM](https://user-images.githubusercontent.com/3814795/75067925-fd571800-54a2-11ea-9c14-c682773bd418.png)
![Screen Shot 2020-02-21 at 12 05 11 PM](https://user-images.githubusercontent.com/3814795/75067930-ff20db80-54a2-11ea-813f-c242c0d3fd83.png)



### Other changes

fix warning about Link getting invalid href (Link should only be used for internal hrefs)

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/224

