### PR TITLE
[L21] Lack of assert statement may produce unexpected slash

### DIFF
--- a/packages/protocol/contracts/governance/SlasherUtil.sol
+++ b/packages/protocol/contracts/governance/SlasherUtil.sol
@@ -75,7 +75,7 @@ contract SlasherUtil is Ownable, Initializable, UsingRegistry, UsingPrecompiles 
       validatorElectionIndices
     );
     address group = groupMembershipAtBlock(validator, startBlock, groupMembershipHistoryIndex);
-    if (group == address(0)) return; // Should never be true
+    assert(group != address(0));
     lockedGold.slash(
       group,
       slashingIncentives.penalty,


### PR DESCRIPTION
### Description

Fail to slash if the validator group membership cannot be retrieved.

### Tested

Unit tests.

### Other changes

None

### Related issues

- Fixes #https://github.com/celo-org/celo-labs/issues/321

### Backwards compatibility

Yes