### PR TITLE
[N06] Lack of consistency

### DIFF
--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -100,7 +100,8 @@ contract Accounts is IAccounts, Ownable, ReentrancyGuard, Initializable, UsingRe
    */
   function setName(string memory name) public {
     require(isAccount(msg.sender), "Unknown account");
-    accounts[msg.sender].name = name;
+    Account storage account = accounts[msg.sender];
+    account.name = name;
     emit AccountNameSet(msg.sender, name);
   }
 
@@ -113,7 +114,8 @@ contract Accounts is IAccounts, Ownable, ReentrancyGuard, Initializable, UsingRe
    */
   function setWalletAddress(address walletAddress) public {
     require(isAccount(msg.sender), "Unknown account");
-    accounts[msg.sender].walletAddress = walletAddress;
+    Account storage account = accounts[msg.sender];
+    account.walletAddress = walletAddress;
     emit AccountWalletAddressSet(msg.sender, walletAddress);
   }
 
@@ -123,7 +125,8 @@ contract Accounts is IAccounts, Ownable, ReentrancyGuard, Initializable, UsingRe
    */
   function setAccountDataEncryptionKey(bytes memory dataEncryptionKey) public {
     require(dataEncryptionKey.length >= 33, "data encryption key length <= 32");
-    accounts[msg.sender].dataEncryptionKey = dataEncryptionKey;
+    Account storage account = accounts[msg.sender];
+    account.dataEncryptionKey = dataEncryptionKey;
     emit AccountDataEncryptionKeySet(msg.sender, dataEncryptionKey);
   }
 
@@ -133,7 +136,8 @@ contract Accounts is IAccounts, Ownable, ReentrancyGuard, Initializable, UsingRe
    */
   function setMetadataURL(string calldata metadataURL) external {
     require(isAccount(msg.sender), "Unknown account");
-    accounts[msg.sender].metadataURL = metadataURL;
+    Account storage account = accounts[msg.sender];
+    account.metadataURL = metadataURL;
     emit AccountMetadataURLSet(msg.sender, metadataURL);
   }
 


### PR DESCRIPTION
### Description

This PR ensures account storage struct pointers are used when assigning values, for consistency.

### Tested

Unit tests

### Other changes

None

### Related issues

- Fixes #https://github.com/celo-org/celo-labs/issues/283

### Backwards compatibility

Yes