### PR TITLE
Merge baklava celo-codebase docs into master

### DIFF
--- a/packages/docs/celo-codebase/proof-of-stake/README.md
+++ b/packages/docs/celo-codebase/proof-of-stake/README.md
@@ -1,0 +1,33 @@
+# Proof of Stake
+
+Celo uses a Byzantine Fault Tolerant [consensus protocol](../consensus/README.md) to agree on new blocks to append to the blockchain. The instances of the Celo software that participate in this consensus protocol are known as **validators**. More accurately, they are **active validators** or **elected validators**, to distinguish them from **registered validators** which are configured to participate but are not actively selected.
+
+Celo's Proof of Stake mechanism is the set of processes that determine which nodes become active validators and how incentives are arranged to secure the network.
+
+The first set of active validators are determined in the genesis block. Thereafter at the end of every epoch, a fixed number of blocks fixed at network creation time,an election is run that may lead to validators being added or removed.
+
+![](https://storage.googleapis.com/celo-website/docs/concepts.jpg)
+
+In Celo's [Validator Elections](validator-elections.md), holders of the native asset, Celo Gold, may participate and earn rewards for doing so. Accounts do not make votes for validators directly, but instead vote for [validator groups](validator-groups.md).
+
+Before they can vote, holders of Celo Gold move balances into the [Locked Gold](locked-gold.md) smart contract. Locked Gold can be used concurrently for: placing votes in Validator Elections, maintaining a stake to satisfy the requirements of registering as a validator or validator group, and also voting in on-chain [Governance](../governance.md) proposals. This means that validators and groups can vote and earn rewards with their stake.
+
+Unlike in other Proof of Stake systems, holding Locked Gold or voting for a group does not put that amount 'at risk' from slashing due to the behavior of validators or validator groups. Only the stake put up by a validator or group may be slashed.
+
+## Implementation
+
+Most of Celo's Proof of Stake mechanism is implemented as smart contracts, and as such can be changed through Celo's on-chain [Governance](../governance.md) process.
+
+- [`Accounts.sol`](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/common/Accounts.sol) manages key delegation and metadata for all accounts including Validators, Groups and Locked Gold holders.
+
+- [`LockedGold.sol`](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/LockedGold.sol) manages the lifecycle of Locked Gold.
+
+- [`Validators.sol`](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/Validators.sol) handles registration, deregistration, staking, key management and epoch rewards for validators and validator groups, as well as routines to manage the members of groups.
+
+- [`Election.sol`](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/Election.sol) manages Locked Gold voting and epoch rewards and runs Validator Elections.
+
+In Celo blockchain:
+
+- [`consensus/istanbul/backend/backend.go`](https://github.com/celo-org/celo-blockchain/blob/master/consensus/istanbul/backend/backend.go) performs validator elections in the last block of the epoch and calculates the new [validator set diff](../consensus/validator-set-differences.md).
+
+- [`consensus/istanbul/backend/pos.go`](https://github.com/celo-org/celo-blockchain/blob/master/consensus/istanbul/backend/pos.go) is called in the last block of the epoch to process validator uptime scores and make epoch rewards.

--- a/packages/docs/celo-codebase/proof-of-stake/becoming-a-validator.md
+++ b/packages/docs/celo-codebase/proof-of-stake/becoming-a-validator.md
@@ -1,0 +1,7 @@
+# Becoming a Validator
+
+To participate in the network, an operator must put up a slashable commitment of locked Celo Gold, register as a validator, and join a validator group. A minimum stake of one Celo Gold and a notice period of 60 days is required to be a validator in the Alfajores Testnet.
+
+Any account that meets the minimum stake and notice period requirements can register as a validator. By doing so, the locked funds on that account become ‘at risk’: a fraction of the stake can be slashed automatically for an evolving set of misbehaviors. In addition, the community can use governance proposals to slash funds, which avoids having to anticipate and encode in the protocol every possible misbehavior. As long as the Celo Gold staked for a validator account is not slashed, it’s eligible to earn rewards like any other Locked Gold account.
+
+A validator joins a validator group by affiliating itself with it. However, to avoid untrusted or malicious validators joining a group, the validator group must accept the affiliation. Once done, the validator is added to the list of validators in the group. A validator can remove itself from a validator group at any time. Changes only take effect at the next subsequent election, so if the validator is currently participating in consensus, it’s expected to do so until the end of the epoch in which it deregisters itself.

--- a/packages/docs/celo-codebase/proof-of-stake/carbon-offsetting-fund.md
+++ b/packages/docs/celo-codebase/proof-of-stake/carbon-offsetting-fund.md
@@ -1,0 +1,5 @@
+# Carbon Offsetting Fund
+
+The Carbon Offsetting Fund provides for making the infrastructure of the Celo platform carbon-neutral, by making a transfer every epoch to an organization that commits to using those assets off-chain for carbon offsetting projects.
+
+Through the [on-chain governance process](../governance.md), Celo Gold holders can set the fraction of the total desired epoch rewards, initially planned to be 0.5%, that is received by the carbon offsetting fund, and the address of a carbon offsetting partner to which to direct these transfers. The on-target amount is adjusted by the epoch [rewards mulitplier](epoch-rewards.md), as with all epoch rewards.

--- a/packages/docs/celo-codebase/proof-of-stake/community-fund.md
+++ b/packages/docs/celo-codebase/proof-of-stake/community-fund.md
@@ -1,0 +1,15 @@
+# Community Fund
+
+The Community Fund provides for general upkeep of the Celo platform. Celo Gold holders decide how to allocate these funds through governance proposals. Funds might be used to pay bounties for bugs or vulnerabilities, security audits, or grants for protocol development.
+
+The Community Fund receives assets from three sources:
+
+- The Community Fund obtains a desired epoch reward defined as a fraction of the total desired epoch rewards \(governable, initially planned to be $$25\%$$\). This amount is subject to adjustment up or down in the event of under- or over-spending against the epoch rewards target schedule. The Community Fund epoch rewards may be redirected to [bolster the Reserve](#bolster-reserve).
+
+- The Community Fund is the default destination for slashed assets.
+
+- The Community Fund also receives the 'base' portion of [transaction fees](../transactions/gas-pricing.md).
+
+## <a name="bolster-reserve"></a>Bolstering the Reserve
+
+The rewards to the Community Fund are automatically redirected to the reserve during times in which the reserve ratio \(the ratio of reserve value over stablecoin market capitalization\) is below a cutoff value. This cutoff reduces from two to one over the first of 25 years in a linear fashion and remains at one afterwards.

--- a/packages/docs/celo-codebase/proof-of-stake/epoch-rewards.md
+++ b/packages/docs/celo-codebase/proof-of-stake/epoch-rewards.md
@@ -1,0 +1,26 @@
+# Epoch Rewards
+
+## Overview
+
+**Epoch Rewards** are similar to the familiar notion of block rewards in other blockchains, minting and distributing new units of Celo Gold as blocks are produced, to create several kinds of incentives. Epoch rewards are paid in the final block of the epoch and are used to:
+* Distributed [rewards for validators and validator groups](validator-rewards.md)
+* Distribute [rewards to holders of Locked Celo Gold](locked-gold-rewards.md) voting for groups that elected validators
+* Make payments into a [Community Fund](community-fund.md) for protocol infrastructure grants
+* [Bolster the stablecoin reserve](community-fund.md#bolster-reserve) if it is under-collateralized
+* Make payments into a [Carbon Offsetting Fund](carbon-offsetting-fund.md).
+
+A total of 400 million Celo Gold will be released for epoch rewards over time. Celo Gold is one of Celo’s reserve currencies and can be used as utility token in Celo. It has a fixed total supply and in the long term will exhibit deflationary characteristics like Bitcoin.
+
+The total amount of disbursements is determined at the end of every epoch via a two step process. In step one, economically desired **on-target rewards** are derived. These are explained in the following pages. Several factors can increase or decrease the value of the payments that would ideally be made in a given epoch (including the Celo Gold to Dollar exchange rate, the collateralization of the reserve, and whether payments to validators or groups are held back due to poor uptime or prior slashing).
+
+In step two, these on-target rewards are adjusted to generate a drift towards a predefined target epoch rewards schedule. This process aims to solve the trade-off between paying reasonable rewards in terms of purchasing power and avoiding excessive over- or underspending with respect to a predefined epoch rewards schedule. More detail about the two steps is provided below.
+
+## Adjusting Rewards for Target Schedule
+
+There is a target schedule for the release of Celo Gold epoch rewards. The proposed target curve \(subject to change\) of remaining epoch rewards declines linearly over 15 years to 50% of the initial 400 million Celo Gold, then decays exponentially with half life of $$h = ln(2)\times15 =10.3$$ afterwards. The choice of $$h$$ guarantees a smooth transition from the linear to the exponential regime.
+
+![](https://storage.googleapis.com/celo-website/docs/epoch-rewards-schedule.png)
+
+The total **actual rewards** paid out at the end of a given epoch result from multiplying the total on-target rewards with a `Rewards Multiplier`. This adjustment factor is a function of the percentage deviation of the remaining epoch rewards from the target epoch rewards remaining. It evaluates to `1` if the remaining epoch rewards are at the target and to smaller \(or larger\) than `1` if the remaining rewards are below \(or above, respectively\) the target. This creates a drag towards the target schedule.
+
+The sensitivity of the adjustment factor to the percentage deviation from the target are governable parameters: one for an underspend, one for an overspend.

--- a/packages/docs/celo-codebase/proof-of-stake/locked-gold-rewards.md
+++ b/packages/docs/celo-codebase/proof-of-stake/locked-gold-rewards.md
@@ -1,0 +1,13 @@
+# Rewards to Locked Gold
+
+Holders of Locked Gold that voted in the previous epoch for a group that elected one or more validators and have activated their votes are eligible for rewards. Rewards are added directly to the Locked Gold voting for that group, and re-applied as votes for that same group, so future rewards are compounded without the account holder needing to take any action. The voting process is described further [here](locked-gold.md).
+
+Rewards to Locked Gold are totally independent from validator and validator group rewards, and are not subject to the ‘group share’.
+
+![](https://storage.googleapis.com/celo-website/docs/locked-gold-rewards.jpg)
+
+First, an on-target reward rate is determined. The protocol has a target for the proportion of circulating Celo Gold that is locked and used for voting, and adjusts the reward rate to increase or reduce the attractiveness of locking up additional supply. This aims to balance having sufficient liquidity for Celo Gold, while making it more challenging to buy enough Celo Gold to meaningfully influence the outcome of a validator election.
+
+Adjusting the on-target reward rate to account for under- or over-spending against the target schedule gives a baseline reward, essentially the percentage increase for a unit of Locked Gold voting for a group eligible for rewards.
+
+The reward for activated Locked Gold voting for a given group is determined as follows. First, if the group elected no validators in the current epoch, rewards are zero. Otherwise, the baseline reward rate factors in two deductions. It is multiplied by the slashing penalty for the group, and by the average epoch uptime score for validators in the group elected in the current epoch. Finally, the group's activated pool of Locked Gold is increased by this rate.

--- a/packages/docs/celo-codebase/proof-of-stake/locked-gold.md
+++ b/packages/docs/celo-codebase/proof-of-stake/locked-gold.md
@@ -1,0 +1,39 @@
+# Locked Gold and Voting
+
+To participate in validator elections, users must first make a transfer of Celo Gold to the `LockedGold` smart contract.
+
+## Concurrent Use of Locked Gold
+
+Locking up Celo Gold guarantees that the same asset is not used more than once in the same vote. However every unit of Locked Gold can be deployed in several ways at once. Using an amount for voting for a validator does not preclude that same amount also being used to vote for a governance proposal, or as a stake at the same time. Users do not need to choose whether to have to move funds from validator elections in order to vote on a governance proposal.
+
+## Unlocking Period
+
+Celo implements an **unlocking period**, a delay of 3 days after making a request to unlock Locked Gold before it can be recovered from the escrow.
+
+This value balances two concerns. First, it is long enough that an election will have taken place since the request to unlock, so that those units of Celo Gold will no longer have any impact on which validators are managing the network. This deters an attacker from manipulations in the form of borrowing funds to purchase Celo Gold, then using it to elect malicious validators, since they will not be able to return the borrowed funds until after the attack, when presumably it would have been detected and the borrowed funds’ value have fallen.
+
+Second, the unlocking period is short enough that it does not represent a significant liquidity risk for most users. This limits the attractiveness to users of exchanges creating secondary markets in Locked Celo Gold and thereby pooling voting power.
+
+## Locking and Voting Flow
+
+![](https://storage.googleapis.com/celo-website/docs/locked-gold-flow.jpg)
+
+The flow is as follows:
+
+- An account calls `lock`, transferring an amount of Celo Gold from their balance to the `LockedGold` smart contract. This increments the account's 'non-voting' balance by the same amount.
+
+- Then the account calls `vote`, passing in an amount and the address of the group to vote for. This decrements the account's 'non-voting' balance and increments the 'pending' balance associated with that group by the same amount. This counts immediately towards electing validators. Note that the vote may be rejected if it would mean that the account would be voting for more than 3 distinct groups, or that the [voting cap](validator-elections.md#voting-cap) for the group would be exceeded.
+
+- At the end of the current epoch, the protocol will first deliver [epoch rewards](epoch-rewards.md) to validators, groups and voters based on the current epoch (pending votes do not count for these purposes), and then run an [election](validator-elections.md) to select the active validator set for the following epoch.
+
+- The pending vote continues to contribute towards electing validators until it is changed, but the account must call `activate` (in a subsequent epoch to the one in which the vote was made) to convert the pending vote to one that earns rewards.
+
+- At the end of that epoch, if the group for which the vote was made had elected one or more validators in the prior election, then the activated vote is eligible for [Locked Gold rewards](locked-gold-rewards.md). These are applied to the pool of activated votes for the group. This means that activated voting Locked Gold receives automatically compounds, with the rewards increasing the account's votes for the same group, thereby increasing future rewards, benefitting participants who have elected to continuously participate in governance.
+
+- The account may subsequently choose to `unvote` a specific amount of voting Locked Gold from a group, up to the total balance that the account has accrued there. Due to rewards, this Locked Gold amount may be higher than the original value passed to `vote`.
+
+- This Locked Gold immediately becomes non-voting, receives no further Epoch Rewards, and can be re-used to vote for a different group.
+
+- The account may choose to `unlock` an amount of Locked Gold at any time, provided that it is inactive: this means it is non-voting in Validator Elections, the `deregistrationPeriod` has elasped if the amount has been used as a validator or validator group stake, and not active in any [Governance proposals](../governance.md). Once an unlocking period of 3 days has passed, the account can call `withdraw` to have the `LockedGold` contract transfer them that amount.
+
+Votes persist between epochs, and the same vote is applied to each election unless and until it is changed. Vote withdrawal, vote changes, and additional gold being used to vote have no effect on the validator set until the election finalizes at the end of the epoch.

--- a/packages/docs/celo-codebase/proof-of-stake/penalties.md
+++ b/packages/docs/celo-codebase/proof-of-stake/penalties.md
@@ -1,0 +1,41 @@
+# Slashing
+
+## Overview
+
+Slashing accomplishes punishment of misbehaving validators by seizing a portion of their stake. Without these punishments, for example, the Celo Protocol would be subject to the [nothing at stake](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed) problem. Validator misbehavior is classified as a set of slashing conditions below.
+
+## Enforcement Mechanisms
+
+The protocol has three means of recourse for validator misbehavior. Each slashing condition applies a combination of these, as described below.
+
+- **Slashing of validator and group stake -** Some slashing conditions take a fixed amount of the Locked Gold stake put up by a validator. In these cases, the group through which that validator was elected for the epoch in which the slashing condition was proven is also slashed the same fixed amount.
+
+- **Suppression of future rewards -** Every validator group has a **slashing penalty**, initially `1.0`. All rewards to the group and to voters for the group are weighted by this factor. If a validator is slashed, the group through which that validator was elected for the epoch in which it misbehaved has the value of its slashing penalty halved. So long as no further slashing occurs, the slashing penalty is reset to `1.0` after `slashing_penalty_reset_epochs` epochs.
+
+- **Ejection -** When a validator is slashed, it is immediately removed from the group of which it is currently a member (even if this group is not the group that elected the validator at the point the misbehavior was recorded). Since no changes in the active validator set are made during an epoch, this means an elected validator continues participate in consensus until the end of the epoch. The group can choose to re-add the validator at any point, provided the usual conditions are met (including that the validator has sufficient Locked Gold as stake).
+
+## Slashing Conditions
+
+There are three categories of slashing conditions:
+
+- Automatic \(initiated and verified on-chain\)
+- Provable \(initiated off-chain, verifiable on-chain\)
+- Governed \(verified only by off-chain knowledge\)
+
+### Automatic
+
+Automatic slashing conditions are enforced entirely through the protocol, and require no external information. Any Celo Gold slashed from stakes is transferred to the [Community Fund](community-fund.md).
+
+### Provable
+
+Provable slashing conditions cannot be initiated automatically on chain but information provided from an external source can be definitively verified on-chain.
+
+In exchange for sending a transaction which initiates a successful provable slashing condition on-chain, the initiator receives a portion of the slashed amount (which will always be greater than the gas costs of the proof). The remainder of the slashed amount is sent to the [Community Fund](community-fund.md).
+
+**Persistent downtime -** A validator which can be shown to be absent from 480 consecutive BLS signatures will be slashed 20 Celo Gold, have future rewards suppressed, and (most importantly in this case) will be ejected from its current group.
+
+**Double Signing -** A validator which can be shown to have produced BLS signatures for 2 distinct blocks at the same height but with different hashes will be slashed 100 Celo Gold, have future rewards suppressed, and will be ejected from its current group.
+
+### **Governed**
+
+For misbehavior which is harder to formally classify and requires some off-chain knowledge, slashing can be performed via [governance proposals](../governance.md). These conditions are important for preventing nuanced validator attacks.

--- a/packages/docs/celo-codebase/proof-of-stake/validator-elections.md
+++ b/packages/docs/celo-codebase/proof-of-stake/validator-elections.md
@@ -1,0 +1,29 @@
+# Electing Validators
+
+The active validator set is updated by running an election in the final block of each epoch, after processing transactions and [Epoch Rewards](epoch-rewards.md).
+
+## <a name="voting-cap"></a>Group Voting Caps
+
+One way to consider the security of a Proof of Stake system is the marginal cost of getting a malicious validator elected. In a steady state, assuming the Celo community set the incentives appropriately, we can assume that a full complement of validators is elected, which means the attack cost is the cost of acquiring sufficient Celo Gold to receive more votes than the currently elected validator with fewest votes, and thereby supplant it.
+
+As such, the objective of Celo’s validator elections differs from real-world elections: they aim to translate voter preferences into representation while promoting decentralization and creating a moat around existing, well-performing elected validators. Two design choices influence this: a limit on the maximum number of member validator that a group can list, and a **voting cap** on the number of votes that any one group can receive.
+
+Since voting for a group can cause only the group’s member validators to get elected, and no more, votes in excess of the number needed to achieve that are unproductive in the sense that they do not raise the number of votes needed to get the least-voted-for validator elected. This would translate into a lower cost for a malicious actor to acquire enough Celo Gold to supplant that validator. This is particularly true because the protocol limits the maximum number of members in a group, to promote decentralization.
+
+The Celo protocol addresses this by enforcing a per-group vote cap. This cap is set to be the number of votes that would be needed to elect all of its validators, plus one more validator. The cap is enforced at the point of voting: a user can only cast a vote for a group if it currently has fewer votes than this cap. An account holder may not set or increase the amount of gold they have voting for a particular validator group `j`, if it already has at least `[(group_members_j + 1) / min(total_group_members, max_validators)]` of the total Locked Gold.
+
+If a group adds a new validator, or the total amount of voting Locked Gold increases, the group’s cap rises and new votes are permitted. If a group removes a validator or a validator chooses to leave, or the total amount of voting Locked Gold falls, then the group’s cap falls: if it has more votes than this new cap, then new votes are no longer permitted, but all existing votes continue to be counted.
+
+The Celo protocol allows an account to divide its vote between up to three groups, since there may be cases where the vote cap prevents an account allocating its entire vote to its first choice group.
+
+## Running the Election
+
+![](https://storage.googleapis.com/celo-website/docs/election.jpg)
+
+The `Election` contract is called from the IBFT block finalization code to select the validators for the following epoch. The contract maintains a sorted list of the Locked Gold voting (either pending or activated) for each Validator Group. The [D’Hondt method](https://en.wikipedia.org/wiki/D'Hondt_method), a closed party list form of proportional representation, is applied to iteratively select validators from the Validator Groups with the greatest associated vote balances.
+
+The list of groups is first filtered to remove those that have not achieved a certain fraction of the votes of the total voting Locked Gold.
+
+Then, in the first iteration, the algorithm assigns the first seat to the group that has at least one member and with the most votes. Thereafter, it assigns the seat to the group that would ‘pay’, if its next validator were elected, the highest vote averaged over its candidates that have been selected so far plus the one under consideration.
+
+There is a minimum target and a maximum cap on the number of active validators that may be selected. If the minimum target is not reached, the election aborts and no change is made to the validator set this epoch.

--- a/packages/docs/celo-codebase/proof-of-stake/validator-groups.md
+++ b/packages/docs/celo-codebase/proof-of-stake/validator-groups.md
@@ -1,0 +1,47 @@
+# Validator Groups
+
+Celo's Proof of Stake mechanism introduces the concept of **Validator Groups** as intermediaries between voters and validators.
+
+## Overview
+
+A validator group has **members**, an ordered list of candidate validators. There is a fixed limit to the number of members that a group may have.
+
+Validator groups can help mitigate the information disparity between voters and validators. We anticipate that groups might emerge that do not necessarily operate validators themselves but attract votes for their reputation for ensuring their associated validators have known real-world identities, have high uptime, are well maintained and regularly audited. Since every validator needs to be accepted by a single group to stand for election, that group will be more able to build up long-term judgements on their validators’ operational practices and security setups than each of the numerous Celo Gold holders that might vote for it would.
+
+Equally, a number of organizations may want to attempt to field multiple validators under their own control, or be able to interchange the specific machines or keys under which they validate in the case of hardware or connectivity failure. By switching out validators in the list, groups can accomplish this without users having to change their votes.
+
+Validator groups can have no more than a small, fixed maximum number of validators. This means an organization wanting to get more validators elected than this maximum has the added challenge of managing multiple group identities and reputations simultaneously. This further promotes decentralization and strengthens operational security, making it more likely that the validator set will be composed of nodes operated in different fashions by independent individuals and organizations.
+
+## Registration
+
+Any account that has at least the minimum stake requirement in Locked Gold, whether voting or non-voting, can register an empty validator group. If a validating key is specified it may be used for this registration.
+
+## Deregistration
+
+The account that creates a validator group is able to deregister that group if it has no members.
+
+While an account has a registered validator group, or for up to a `deregistrationPeriod` after it is deregistered, attempts to `unlock` the account's amount of Locked Gold will fail if they would cause the remaining amount to fall below the minimum stake requirement.
+
+## Group Share
+
+Validator groups are compensated by taking a share (the 'Group Share') of the [validator rewards](validator-rewards.md) from any of its member validators that are elected during an epoch. This value is set at registration time and can be changed later.
+
+## Changing Group Members
+
+The account owner controls the list of validators in their group and can at any time add, remove, or re-order validators.
+
+For a validator to be added to a group, several conditions must hold: the number of members in the group must be less than the maximum; the Locked Gold balance of the group's account must be sufficient (the stake is per-member validator); and the validator must first have set its affiliation to the group.
+
+This means that while a group can unilaterally remove a validator, and a validator can unilaterally leave by changing its affiliation, both parties have to agree before a validator can become a member of a group.
+
+## Votes and Voting Cap
+
+Validator Groups can receive votes from Locked Gold up to a [voting cap](validator-elections.md#voting-cap). This value is set to be the number of votes that would be needed to elect all of its validators, plus one more validator. The cap is enforced at the point of voting: a user can only cast a vote for a group if it currently has fewer votes than this cap.
+
+## Slashing Penalty
+
+A [slashing penalty](penalties.md), initially `1.0`, is also tracked for each validator group. This value between may be reduced as a penalty for misbehavior of the validator in the group, and affects the future rewards of the group, its validators, and Locked Gold holders receiving rewards for voting for the group.
+
+## Metadata
+
+Both validators and validator groups can use [Accounts Metadata](../identity/metadata.md) to provide unverified metadata (such as name and organizational affiliation) as well as claims that can be verified off-chain for control of third-party accounts and domain names.

--- a/packages/docs/celo-codebase/proof-of-stake/validator-rewards.md
+++ b/packages/docs/celo-codebase/proof-of-stake/validator-rewards.md
@@ -1,0 +1,51 @@
+# Rewards to Validators and Validator Groups
+
+The protocol aims to incentivize validator uptime performance and penalize past poor behavior in future rewards, while ensuring that payments are economically reasonable in size independent of fluctuations of the price of Celo Gold.
+
+Five factors affect validator and group rewards:
+
+- The on-target reward amount for this epoch
+- The protocol's [overall spending vs target of epoch rewards](epoch-rewards.md)
+- The validator’s ‘uptime score’
+- The current value of the slashing penalty for the group of which it was a member at the last election
+- The group share for the group of which it was a member at the last election
+
+Epoch rewards to validators and validator groups are denominated in Celo Dollars, since it is anticipated that most of their expenses will be incurred in fiat currencies, allowing organizations to understand their likely return regardless of volatility in the price of Celo Gold. To enable this, the protocol mints new Celo Dollars that correspond to the epoch reward equivalent of Celo Gold and transfers those to the Reserve to maintain its collateralization ratio. Of course, the effect on the target schedule depends on the prevailing exchange rate.
+
+![](https://storage.googleapis.com/celo-website/docs/validator-rewards.jpg)
+
+## On-target Rewards
+
+The on-target validator reward is a constant value (as block rewards typically would be) and is intended to cover costs plus an attractive margin for amortized capital and operating expenses associated with a recommended set up that includes redundant hosts with hardware wallets in a secure co-lo facility, proxy nodes at cloud or edge hosting providers, as well as security audits. As with most parameters of the Celo protocol, it can be changed by governance proposal.
+
+In the usual case where no validator in the group has been slashed recently, and the validator has signed almost every block in the epoch, then the validator receives the full amount of the on-target reward, less the fraction sent to the validator group based on the group share. Unlike in some other Proof of Stake schemes, epoch rewards to validators do not depend on the number of votes the validator’s group has received.
+
+## Calculating Uptime Score
+
+The Celo protocol tracks an ‘uptime score’ for each validator. When a validator proposes a block, it also includes in the block body every signature that it has received from validators committing the previous block.
+
+![](https://storage.googleapis.com/celo-website/docs/uptime-score.jpg)
+
+For a validator to be ‘up’ at a given block, it must have its signature included in at least one in the previous ten blocks. This cannot be done during the first 9 blocks of the epoch. At each epoch, this counter is reset to 0. Because the proposer order is shuffled at each election, it is very hard for a malicious actor withholding an honest validator’s signatures to affect this measure.
+
+Then, a validator’s uptime for the epoch is the proportion of blocks in the epoch for which it is ‘up’: `U = counter/ (epoch_size - 9)`. Its epoch uptime score `S_ve = u ^ k`, where `k` is a governable constant. This means that downtime of less than around a minute does not count against the validator, but that longer periods begin to reduce the score rapidly.
+
+The validator’s overall uptime score is an exponential moving average of the uptime score from this and previous epochs. `S_{v} = min(S_ve, S_ve * x + S_{v-1} * (1 -x))` where `0 < x < 1` and is governable. Since `S_v` starts out at zero, validators have a disincentive to change identities and an incentive to prioritize activities that improve long-term availability.
+
+## Calculating Slashing Penalty
+
+The protocol also tracks for each group a ‘slashing penalty’, initially equal to one but successively reduced on each occasion a validator in that group is slashed. The penalty returns to one 30 days after it was last reduced.
+
+This factor is applied to all rewards to validators in that group, to the group itself, and to voters for the group.
+
+The slashing penalty gives groups a further incentive to vet validators they accept as members, not only to avoid reducing their own future rewards from existing validators but to attract and retain the best validators.
+
+Validators have an incentive to be elected through groups with a high value, so a recent slashing makes a group less attractive. Validators also have an incentive to select groups where they believe careful vetting processes are in place, because poor vetting of other validators in the group reduces their own expectation of future rewards.
+
+When a validator is slashed, reduced rewards may lead other validators in the same group to consider equivalently ‘safe’ slots in other groups, if they are available. A validator disassociating from the group would cause the group’s rewards to further decline. While that may cause churn in the set of groups through which validators are elected, it is unlikely that a validator would move to a group where they could not be elected (since in this case they would receive no rewards, as opposed to fewer rewards), hence making the votes by which they were previously elected unproductive.
+
+## Group Share
+
+Validator groups are compensated by taking a share of the rewards allocated to validators. Validator groups set a **group share** rate when they register, and can change that at any time. The protocol automatically deducts this share, sending that portion of the epoch rewards to the validator group of which they were a member at the time of the last election.
+
+Since the sum of a validator’s reward and its validator group’s reward are the same regardless of the ‘group share’ that the group chooses, no side-channel collusion is possible to avoid deductions for downtime or previous slashing.

--- a/packages/docs/celo-codebase/protocol/governance.md
+++ b/packages/docs/celo-codebase/protocol/governance.md
@@ -35,6 +35,14 @@ Once the Approval phase is over, approved proposals graduate to the referendum p
 
 Proposals that graduate from the Referendum phase to the execution phase may be executed by anyone, triggering a “call” operation code with the arguments defined in the proposal, originating from the `Governance` smart contract. Proposals expire from this phase after two days.
 
+## Hotfix
+
+The cadence and transparency of the standard on-chain governance protocol make it poorly suited for proposals that patch issues that may compromise the security of the network, especially when the patch would reveal an exploitable bug in one of the core contracts. Instead, these sorts of changes are better suited for the more responsive, and less transparent, hotfix protocol.
+
+Anyone can make a proposal in the hotfix protocol by submitting the hash of their proposal to the `Governance` smart contract. If that hash is approved by the `approver` and a quorum of validators, the proposer can execute the contents of that proposal immediately.
+
+Note that this means the validators may not always know the contents of the proposal that they are voting on. Revealing the contents of the proposal to all validators may compromise the integrity of the hotfix protocol, as only one validator would need to be malicious in order to exploit the vulnerability or share it publicly. Instead, to convince the validators that the hash represents a proposal that should be executed via the hotfix protocol, the proposer should consider contacting reputable, third party, security firms to publicly vouch for the contents of the proposal.
+
 ## Celo Blockchain Software Upgrades
 
 Some changes cannot be made through the on-chain governance process alone. Examples include changes to the underlying consensus protocol and changes which would result in a hard-fork. When Celo Blockchain software upgrades are required to continue operating correctly on the network, a "Minimum Client Version" parameter is set to indicate the minimum version that it required.

--- a/packages/docs/celo-codebase/protocol/privacy.md
+++ b/packages/docs/celo-codebase/protocol/privacy.md
@@ -6,7 +6,7 @@ At Celo, we are committed to meet the privacy needs of our users at the time of 
 
 As with most public blockchains \(e.g. Bitcoin, Ethereum\), transactions and smart contracts calls on Celo are public for everyone to see. This means that if a user wants to map the hash of their phone number to their wallet address, people with knowledge of that user's phone number will be able to see their transactions and balances.
 
-To address this issue, the cLabs team is working with [Matterlabs](https://matterlabs.dev) and other esteemed zk-SNARK cryptographers to create a framework that makes it easy to create gas-efficient tokens that offer Zcash-like privacy, using a shared anonymity pool. Such an implementation would allow wallets to use the [default identity mode](identity/) easily without the risk that someone with your phone number could see your balance and transaction history.
+To address this issue, the C Labs team is working with [Matterlabs](https://matterlabs.dev) and other esteemed zk-SNARK cryptographers to create a framework that makes it easy to create gas-efficient tokens that offer Zcash-like privacy, using a shared anonymity pool. Such an implementation would allow wallets to use the [default identity mode](identity/) easily without the risk that someone with your phone number could see your balance and transaction history.
 
 Prior to this, we recommend wallet providers to use the [privacy identity mode](identity/#privacy-mode) so that only users that you have explicitly approved can map your phone number to your wallet address and see your balances/transactions.
 


### PR DESCRIPTION
### Description

Merges `docs/celo-codebase` from baklava (what's currently displayed on docs.celo.org) into master.
### Tested

No
### Other changes

None
### Related issues

None
### Backwards compatibility

Yes