### PR TITLE
[Wallet] Fix PIN entering screen, when account is not created yet

### DIFF
--- a/packages/mobile/src/pincode/PincodeConfirmation.tsx
+++ b/packages/mobile/src/pincode/PincodeConfirmation.tsx
@@ -120,6 +120,9 @@ class PincodeConfirmation extends React.Component<Props, State> {
         .unlockAccount(this.props.currentAccount, pin, UNLOCK_DURATION)
         .then((result: boolean) => (result ? this.onCorrectPin(pin) : this.onWrongPin()))
         .catch(this.onWrongPin)
+    } else {
+      // Account is not created yet, so PIN can not be verified
+      this.onCorrectPin(pin)
     }
   }
 


### PR DESCRIPTION
### Description

This fixed the following bug:
1) Choose lang -> enter phone + name -> enter pin two times
2) Close the app or wait until cached PIN is expired
3) Paste invite code
4) **PIN screen would hang** (this PR fixes this)


### Tested

Ran on Android device

### Backwards compatibility

Yes
