### PR TITLE
Backer nav fix + Contributors loading change

### DIFF
--- a/packages/web/server/getContributors.ts
+++ b/packages/web/server/getContributors.ts
@@ -45,19 +45,25 @@ function normalize(asset: Fields): Contributor {
     purpose: asset['Unique Purpose'],
     team: asset.Team,
     company: asset.Company,
-    photo: getPreview(asset),
+    photo: getImageURI(asset, Sizes.large),
+    preview: getImageURI(asset, Sizes.small),
     url: asset['Social Media Link'],
   }
 }
 
-function getPreview(asset: Fields) {
+enum Sizes {
+  large = 'large',
+  small = 'small',
+}
+
+function getImageURI(asset: Fields, size: Sizes) {
   const previewField = asset.Photo
 
   return (
     (previewField &&
       previewField[0] &&
       previewField[0].thumbnails &&
-      previewField[0].thumbnails.large.url) ||
+      previewField[0].thumbnails[size].url) ||
     ''
   )
 }

--- a/packages/web/src/_page-tests/__snapshots__/about.test.tsx.snap
+++ b/packages/web/src/_page-tests/__snapshots__/about.test.tsx.snap
@@ -2130,23 +2130,290 @@ exports[`About renders 1`] = `
           }
         >
           <div
-            aria-label="loading"
             className="css-view-1dbjc4n"
             style={
               Object {
-                "height": "50px",
-                "width": "50px",
+                "WebkitBoxDirection": "normal",
+                "WebkitBoxOrient": "vertical",
+                "WebkitFlexDirection": "column",
+                "flexDirection": "column",
+                "marginBottom": "50px",
+                "marginLeft": "5px",
+                "marginRight": "5px",
+                "marginTop": "5px",
+                "maxWidth": "300px",
+                "minWidth": "250px",
+                "msFlexDirection": "column",
+                "width": "90vw",
               }
             }
           >
-            <span
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "display": "block",
+                  "overflowX": "hidden",
+                  "overflowY": "hidden",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "display": "block",
+                    "paddingBottom": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "bottom": "0px",
+                    "height": "100%",
+                    "left": "0px",
+                    "position": "absolute",
+                    "top": "0px",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="css-view-1dbjc4n"
+                  style={
+                    Object {
+                      "WebkitFilter": "blur(20px)",
+                      "WebkitFlexBasis": "auto",
+                      "filter": "blur(20px)",
+                      "flexBasis": "auto",
+                      "height": "100%",
+                      "msFlexPreferredSize": "auto",
+                      "opacity": 0.5,
+                      "overflowX": "hidden",
+                      "overflowY": "hidden",
+                      "width": "100%",
+                      "zIndex": 0,
+                    }
+                  }
+                >
+                  <div
+                    className="css-view-1dbjc4n"
+                    style={
+                      Object {
+                        "WebkitFilter": "blur(20px)",
+                        "backgroundColor": "rgba(0,0,0,0.00)",
+                        "backgroundImage": "url(\\"test.jpg\\")",
+                        "backgroundPosition": "center",
+                        "backgroundRepeat": "no-repeat",
+                        "backgroundSize": "cover",
+                        "bottom": "0px",
+                        "filter": "blur(20px)",
+                        "height": "100%",
+                        "left": "0px",
+                        "position": "absolute",
+                        "right": "0px",
+                        "top": "0px",
+                        "width": "100%",
+                        "zIndex": -1,
+                      }
+                    }
+                  />
+                  <img
+                    alt=""
+                    className="css-accessibilityImage-9pa8cd"
+                    draggable={false}
+                    src="test.jpg"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="css-view-1dbjc4n"
               style={
                 Object {
                   "height": "100%",
+                  "position": "absolute",
                   "width": "100%",
                 }
               }
-            />
+            >
+              <div
+                className="css-view-1dbjc4n"
+                style={
+                  Object {
+                    "display": "block",
+                    "overflowX": "hidden",
+                    "overflowY": "hidden",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "display": "block",
+                      "paddingBottom": "100%",
+                      "width": "100%",
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "height": "100%",
+                      "left": "0px",
+                      "position": "absolute",
+                      "top": "0px",
+                      "width": "100%",
+                    }
+                  }
+                >
+                  <div
+                    aria-label="Photo of Jon"
+                    className="css-view-1dbjc4n"
+                    style={
+                      Object {
+                        "WebkitFlexBasis": "auto",
+                        "flexBasis": "auto",
+                        "height": "100%",
+                        "msFlexPreferredSize": "auto",
+                        "overflowX": "hidden",
+                        "overflowY": "hidden",
+                        "width": "100%",
+                        "zIndex": 0,
+                      }
+                    }
+                  >
+                    <div
+                      className="css-view-1dbjc4n"
+                      style={
+                        Object {
+                          "backgroundColor": "rgba(0,0,0,0.00)",
+                          "backgroundImage": "url(\\"test.jpg\\")",
+                          "backgroundPosition": "center",
+                          "backgroundRepeat": "no-repeat",
+                          "backgroundSize": "cover",
+                          "bottom": "0px",
+                          "height": "100%",
+                          "left": "0px",
+                          "position": "absolute",
+                          "right": "0px",
+                          "top": "0px",
+                          "width": "100%",
+                          "zIndex": -1,
+                        }
+                      }
+                    />
+                    <img
+                      alt="Photo of Jon"
+                      className="css-accessibilityImage-9pa8cd"
+                      draggable={false}
+                      src="test.jpg"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "WebkitBoxDirection": "normal",
+                  "WebkitBoxOrient": "horizontal",
+                  "WebkitFlexDirection": "row",
+                  "flexDirection": "row",
+                  "msFlexDirection": "row",
+                }
+              }
+            >
+              <div
+                className="css-text-901oao"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(46,51,56,1.00)",
+                    "fontFamily": "EB Garamond, eb-garamond, Garamond, serif",
+                    "fontSize": "20px",
+                    "fontWeight": "bold",
+                    "lineHeight": "28px",
+                    "marginRight": "5px",
+                    "marginTop": "8px",
+                    "textRendering": "geometricPrecision",
+                  }
+                }
+              >
+                Jon
+              </div>
+              <div
+                className="css-view-1dbjc4n"
+                style={
+                  Object {
+                    "WebkitBoxPack": "end",
+                    "WebkitJustifyContent": "flex-end",
+                    "justifyContent": "flex-end",
+                    "msFlexPack": "end",
+                    "paddingBottom": "1px",
+                  }
+                }
+              >
+                <a
+                  href="//www.example.com"
+                  target="_blank"
+                >
+                  <svg
+                    fill="none"
+                    height={12}
+                    style={Object {}}
+                    viewBox="0 0 14 14"
+                    width={12}
+                  >
+                    <path
+                      d="M14 0V7.17528H11.9502V3.49949L6.80322 8.64724L5.35403 7.19578L10.501 2.05008H6.82987V0H14Z"
+                      fill="#2E3338"
+                      style={Object {}}
+                    />
+                    <path
+                      d="M9.90044 9.22533H11.9502V14H0V2.05005H4.77599V4.10013H2.04978V11.9499H9.90044V9.22533Z"
+                      fill="#2E3338"
+                      style={Object {}}
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+            <div
+              className="css-text-901oao"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(46,51,56,1.00)",
+                  "fontFamily": "EB Garamond, eb-garamond, Garamond, serif",
+                  "fontSize": "16px",
+                  "lineHeight": "20px",
+                  "textRendering": "geometricPrecision",
+                }
+              }
+            >
+              Test Collective Inc
+            </div>
+            <div
+              className="css-text-901oao"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(46,51,56,1.00)",
+                  "fontFamily": "EB Garamond, eb-garamond, Garamond, serif",
+                  "fontSize": "26px",
+                  "fontStyle": "italic",
+                  "lineHeight": "28px",
+                  "marginTop": "8px",
+                  "textRendering": "geometricPrecision",
+                }
+              }
+            >
+              To ensure rightness
+            </div>
           </div>
         </div>
       </div>
@@ -2208,7 +2475,7 @@ exports[`About renders 1`] = `
           }
         }
       >
-        
+        celoBackers
       </h3>
     </div>
     <div

--- a/packages/web/src/_page-tests/about.test.tsx
+++ b/packages/web/src/_page-tests/about.test.tsx
@@ -1,10 +1,21 @@
 import About from 'pages/about'
 import * as React from 'react'
 import * as renderer from 'react-test-renderer'
+import { Contributor } from 'src/about/Contributor'
 
+const CONTRIBUTORS: Contributor[] = [
+  {
+    name: 'Jon',
+    preview: 'test.jpg',
+    company: 'Test Collective Inc',
+    purpose: 'To ensure rightness',
+    url: 'www.example.com',
+    photo: 'test.jpg',
+  },
+]
 describe('About', () => {
   it('renders', () => {
-    const tree = renderer.create(<About randomSeed={100} />).toJSON()
+    const tree = renderer.create(<About contributors={CONTRIBUTORS} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/packages/web/src/about/About.test.tsx
+++ b/packages/web/src/about/About.test.tsx
@@ -4,7 +4,11 @@ import About from 'src/about/About'
 
 describe(About, () => {
   it('includes element with #contributors id', async () => {
-    render(<About randomSeed={10} />)
+    render(<About contributors={[]} />)
     expect(document.getElementById('contributors')).toBeTruthy()
+  })
+  it('includes element with #backers id', async () => {
+    render(<About contributors={[]} />)
+    expect(document.getElementById('backers')).toBeTruthy()
   })
 })

--- a/packages/web/src/about/About.tsx
+++ b/packages/web/src/about/About.tsx
@@ -1,7 +1,10 @@
+import fetch from 'cross-fetch'
 import * as React from 'react'
 import { Image, ImageBackground, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import shuffleSeed from 'shuffle-seed'
 import AudioIcon from 'src/about/AudioIcon'
 import Backers from 'src/about/Backers'
+import { Contributor } from 'src/about/Contributor'
 import { sacredEconBack, team } from 'src/about/images'
 import PressMedia from 'src/about/PressMedia'
 import Team from 'src/about/Team'
@@ -21,7 +24,7 @@ import menuItems from 'src/shared/menu-items'
 import { fonts, standardStyles, textStyles } from 'src/styles'
 
 interface Props {
-  randomSeed: number
+  contributors: Contributor[]
 }
 
 async function pronunceCelo() {
@@ -31,12 +34,20 @@ async function pronunceCelo() {
 }
 
 export class About extends React.Component<Props & I18nProps> {
-  static getInitialProps() {
-    return { randomSeed: Math.random() }
+  static async getInitialProps({ req }) {
+    let contributors
+    if (req) {
+      contributors = await fetch(`http://localhost:3000/api/contributors`)
+    } else {
+      contributors = await fetch(`/api/contributors`)
+    }
+
+    const shuffledTeam = shuffleSeed.shuffle(await contributors.json(), Math.random())
+    return { contributors: shuffledTeam }
   }
 
   render() {
-    const { t, randomSeed } = this.props
+    const { t, contributors } = this.props
 
     return (
       <>
@@ -124,7 +135,7 @@ export class About extends React.Component<Props & I18nProps> {
               text={t('learnMore')}
             />
           </BookLayout>
-          <Team randomSeed={randomSeed} />
+          <Team contributors={contributors} />
           <Backers />
           <PressMedia />
         </View>

--- a/packages/web/src/about/About.tsx
+++ b/packages/web/src/about/About.tsx
@@ -37,12 +37,13 @@ export class About extends React.Component<Props & I18nProps> {
   static async getInitialProps({ req }) {
     let contributors
     if (req) {
-      contributors = await fetch(`http://localhost:3000/api/contributors`)
+      const getContributors = await import('src/../server/getContributors')
+      contributors = await getContributors.default()
     } else {
-      contributors = await fetch(`/api/contributors`)
+      contributors = await fetch(`/api/contributors`).then((result) => result.json())
     }
 
-    const shuffledTeam = shuffleSeed.shuffle(await contributors.json(), Math.random())
+    const shuffledTeam = shuffleSeed.shuffle(contributors, Math.random())
     return { contributors: shuffledTeam }
   }
 

--- a/packages/web/src/about/Backers.tsx
+++ b/packages/web/src/about/Backers.tsx
@@ -15,7 +15,7 @@ export class Backers extends React.Component<I18nProps & ScreenProps> {
 
     return (
       <>
-        <BookLayout startBlock={true} label={t('')} nativeID={hashNav.about.backers}>
+        <BookLayout startBlock={true} label={t('celoBackers')} nativeID={hashNav.about.backers}>
           <Text style={fonts.p}>{t('celoBackersText', { count: 80 })}</Text>
         </BookLayout>
         <GridRow

--- a/packages/web/src/about/Contributor.ts
+++ b/packages/web/src/about/Contributor.ts
@@ -4,5 +4,6 @@ export interface Contributor {
   team?: string
   company: string
   photo: string
+  preview: string
   url: string
 }

--- a/packages/web/src/about/Team.test.tsx
+++ b/packages/web/src/about/Team.test.tsx
@@ -3,27 +3,20 @@ import 'jest-fetch-mock'
 import * as React from 'react'
 import Team from 'src/about/Team'
 
-jest.mock('src/brandkit/common/Fetch', () => {
-  return function Fetch({ children }) {
-    return children({
-      data: [
-        {
-          name: 'johnny',
-          purpose: 'reliability',
-          company: 'Decentralized ltd',
-          photo: 'x.jpg',
-          url: '/things',
-        },
-      ],
-      loading: false,
-      error: null,
-    })
-  }
-})
+const CONTRIBUTORS = [
+  {
+    name: 'johnny',
+    purpose: 'reliability',
+    company: 'Decentralized ltd',
+    photo: 'x.jpg',
+    preview: 'y.png',
+    url: '/things',
+  },
+]
 
 describe(Team, () => {
   it('displays an image for each contributor', async () => {
-    const { getByText, getByAltText } = render(<Team randomSeed={1} />)
+    const { getByText, getByAltText } = render(<Team contributors={CONTRIBUTORS} />)
 
     await waitForElement(() => getByText('johnny'))
 
@@ -31,7 +24,7 @@ describe(Team, () => {
   })
 
   it('displays company name', async () => {
-    const { getByText } = render(<Team randomSeed={1} />)
+    const { getByText } = render(<Team contributors={CONTRIBUTORS} />)
 
     await waitForElement(() => getByText('johnny'))
 

--- a/packages/web/src/about/Team.tsx
+++ b/packages/web/src/about/Team.tsx
@@ -41,6 +41,7 @@ export class Team extends React.Component<Props & I18nProps & ScreenProps> {
                     team={person.team}
                     company={person.company}
                     purpose={person.purpose}
+                    preview={{ uri: person.preview }}
                     source={{ uri: person.photo }}
                   />
                 </React.Fragment>
@@ -55,6 +56,7 @@ export class Team extends React.Component<Props & I18nProps & ScreenProps> {
 
 interface PortraitProps {
   source: ImageURISource
+  preview: ImageURISource
   name: string
   purpose: string
   team?: string
@@ -67,6 +69,7 @@ const Portrait = React.memo(function _Portrait({
   name,
   team,
   company,
+  preview,
   purpose,
   url,
 }: PortraitProps) {
@@ -74,18 +77,21 @@ const Portrait = React.memo(function _Portrait({
     <>
       <Responsive medium={styles.mediumPerson} large={styles.largePerson}>
         <View style={styles.person}>
-          <LazyLoadFadin placeholder={<ContributorPlaceHolder />}>
-            {(onLoad) => (
-              <AspectRatio ratio={1}>
-                <Image
-                  accessibilityLabel={`Photo of ${name}`}
-                  source={source}
-                  onLoad={onLoad}
-                  style={styles.photo}
-                />
-              </AspectRatio>
-            )}
-          </LazyLoadFadin>
+          <ContributorPlaceHolder uri={preview.uri} />
+          <View style={styles.realImageContainer}>
+            <LazyLoadFadin>
+              {(onLoad) => (
+                <AspectRatio ratio={1}>
+                  <Image
+                    accessibilityLabel={`Photo of ${name}`}
+                    source={source}
+                    onLoad={onLoad}
+                    style={styles.photo}
+                  />
+                </AspectRatio>
+              )}
+            </LazyLoadFadin>
+          </View>
 
           <View style={standardStyles.row}>
             <Text style={[fonts.p, textStyles.heavy, styles.name]}>{name}</Text>
@@ -109,18 +115,10 @@ const Portrait = React.memo(function _Portrait({
   )
 })
 
-function ContributorPlaceHolder() {
+function ContributorPlaceHolder({ uri }) {
   return (
     <AspectRatio ratio={1}>
-      <Image
-        accessibilityLabel={`Placeholder`}
-        source={{
-          uri:
-            // TODO download and use locally
-            'https://dl.airtable.com/.attachmentThumbnails/1a9a0eb9124b3d5ef15091b9a50ddbd1/dda3632d',
-        }}
-        style={styles.photo}
-      />
+      <Image source={{ uri }} style={styles.imagePreview} />
     </AspectRatio>
   )
 }
@@ -155,6 +153,13 @@ const styles = StyleSheet.create({
     gridTemplateColumns: `repeat(2, 1fr)`,
   },
   photo: {
+    height: '100%',
+    width: '100%',
+  },
+  realImageContainer: { position: 'absolute', height: '100%', width: '100%' },
+  imagePreview: {
+    opacity: 0.5,
+    filter: `blur(20px)`,
     height: '100%',
     width: '100%',
   },

--- a/packages/web/src/about/Team.tsx
+++ b/packages/web/src/about/Team.tsx
@@ -116,6 +116,7 @@ function ContributorPlaceHolder() {
         accessibilityLabel={`Placeholder`}
         source={{
           uri:
+            // TODO download and use locally
             'https://dl.airtable.com/.attachmentThumbnails/1a9a0eb9124b3d5ef15091b9a50ddbd1/dda3632d',
         }}
         style={styles.photo}


### PR DESCRIPTION
### Description

Fixes issue of /about#backers not working for navigation due to the lazy loading of contributors pushing the backers section down post load. This is accomplished by moving the fetching of contributors to `getInitialProps` and loading directly while pre rendering on server. 

### Tested

loaded url of ` /about#backers ` and confirmed backers remained in view. 

also
adds a test confirming 'backers' id is on about page. 

### Other changes

Add a tiny 35x35 pixel preview  for all contributors, blurred and expanded to full size. 


### Related issues

- Fixes #2846 

