### PR TITLE
Fix transfer e2e tests

### DIFF
--- a/packages/celotool/src/e2e-tests/utils.ts
+++ b/packages/celotool/src/e2e-tests/utils.ts
@@ -110,7 +110,7 @@ export async function migrateContracts(
         frozen: false,
       },
       reserve: {
-        goldBalance: 100000000,
+        initialBalance: 100000000,
       },
       stableToken: {
         initialBalances: {


### PR DESCRIPTION
### Description

Transfer tests are failing due to tobin tax being triggered because reserve funding variable name changed.
