### PR TITLE
Added --proxy.allowprivateip to validators opts for k8s testnet

### DIFF
--- a/packages/helm-charts/testnet/templates/validators.statefulset.yaml
+++ b/packages/helm-charts/testnet/templates/validators.statefulset.yaml
@@ -155,7 +155,7 @@ spec:
           [[ "$GETH_DEBUG" == "true" ]] && PROXY_ALLOW_PRIVATE_IP_FLAG="--proxy.allowprivateip"
 
           PROXIED_FLAGS=""
-          [ "$RID" -lt "{{ .Values.geth.proxiedValidators }}" ] && PROXIED_FLAGS="--proxy.proxied --proxy.proxyenodeurlpair=`cat /root/.celo/proxyInternalEnode`;`cat /root/.celo/proxyExternalEnode` --nodiscover $PROXY_ALLOW_PRIVATE_IP_FLAG"
+          [ "$RID" -lt "{{ .Values.geth.proxiedValidators }}" ] && PROXIED_FLAGS="--proxy.proxied --proxy.proxyenodeurlpair=`cat /root/.celo/proxyInternalEnode`;`cat /root/.celo/proxyExternalEnode` --nodiscover $PROXY_ALLOW_PRIVATE_IP_FLAG --proxy.allowprivateip"
 
           PING_IP_FROM_PACKET_FLAG=""
           [[ "$PING_IP_FROM_PACKET" == "true" ]] && PING_IP_FROM_PACKET_FLAG="--ping-ip-from-packet"


### PR DESCRIPTION
### Description

Added --proxy.allowprivateip to validators opts for k8s testnet deployments

### Tested
On k8s testnet
