### PR TITLE
Update ethers.js library to web3.js

### DIFF
--- a/packages/docs/developer-resources/walkthroughs/hellocelo.md
+++ b/packages/docs/developer-resources/walkthroughs/hellocelo.md
@@ -105,7 +105,7 @@ Don't worry about what this means right now, just understand that it is easier t
 
 Because we are accessing the network remotely, we need to generate an account to sign transactions and fund that account with test cGLD.
 
-There is a short script in `getAccount.js` to either get a Celo account from a mnemonic in the `.secret` file, or create a random account if the file is empty. In the script, we use`ethers.js` to create a new account. [Ethers.js](https://docs.ethers.io/ethers.js/html/index.html) is a popular javascript library for handling Ethereum related functionality. Celo is a cousin of Ethereum, so this library will work well for generating new Celo accounts.
+There is a short script in `getAccount.js` to either get a Celo account from a mnemonic in the `.secret` file, or create a random account if the file is empty. In the script, we use`web3.js` to create a new private key/account pair. [Web3.js](https://web3js.readthedocs.io/en/v1.2.6/) is a popular javascript library for handling Ethereum related functionality. Celo is a cousin of Ethereum, so this library will work well for generating new Celo accounts.
 
 {% hint style="danger" %}
 This is not the standard way of managing Celo accounts. In a production environment, the [Celo Wallet](../../celo-codebase/wallet/) will manage accounts for you. Accessing accounts from the Celo Wallet will be discussed in future guides.


### PR DESCRIPTION
### Description

This is an update to [this documentation page](https://docs.celo.org/v/master/developer-guide/start/hellocelo).

I updated the library that creates Celo accounts in the base [repo](https://github.com/critesjosh/helloCelo) from ethers.js to web3.js. This PR is to update the docs to remain consistent with the base repo.
