### PR TITLE
registers whitelist with migration

### DIFF
--- a/packages/protocol/lib/registry-utils.ts
+++ b/packages/protocol/lib/registry-utils.ts
@@ -21,6 +21,7 @@ export enum CeloContractName {
   ReserveSpenderMultiSig = 'ReserveSpenderMultiSig',
   SortedOracles = 'SortedOracles',
   StableToken = 'StableToken',
+  TransferWhitelist = 'TransferWhitelist',
   Validators = 'Validators',
 }
 

--- a/packages/protocol/lib/registry-utils.ts
+++ b/packages/protocol/lib/registry-utils.ts
@@ -51,5 +51,4 @@ export const hasEntryInRegistry: string[] = [
   CeloContractName.Reserve,
   CeloContractName.SortedOracles,
   CeloContractName.StableToken,
-  CeloContractName.TransferWhitelist,
 ]

--- a/packages/protocol/lib/registry-utils.ts
+++ b/packages/protocol/lib/registry-utils.ts
@@ -51,4 +51,5 @@ export const hasEntryInRegistry: string[] = [
   CeloContractName.Reserve,
   CeloContractName.SortedOracles,
   CeloContractName.StableToken,
+  CeloContractName.TransferWhitelist,
 ]

--- a/packages/protocol/migrations/03_transferwhitelist.ts
+++ b/packages/protocol/migrations/03_transferwhitelist.ts
@@ -1,6 +1,6 @@
+import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { getDeployedProxiedContract } from '@celo/protocol/lib/web3-utils'
 import { config } from '@celo/protocol/migrationsConfig'
-import { CeloContractName } from 'lib/registry-utils'
 import { RegistryInstance, TransferWhitelistInstance } from 'types'
 
 const name = CeloContractName.TransferWhitelist

--- a/packages/protocol/migrations/03_transferwhitelist.ts
+++ b/packages/protocol/migrations/03_transferwhitelist.ts
@@ -1,8 +1,9 @@
 import { getDeployedProxiedContract } from '@celo/protocol/lib/web3-utils'
 import { config } from '@celo/protocol/migrationsConfig'
+import { CeloContractName } from 'lib/registry-utils'
 import { RegistryInstance, TransferWhitelistInstance } from 'types'
 
-const name = 'TransferWhitelist'
+const name = CeloContractName.TransferWhitelist
 const Contract = artifacts.require(name)
 
 module.exports = (deployer: any) => {

--- a/packages/protocol/migrations/03_transferwhitelist.ts
+++ b/packages/protocol/migrations/03_transferwhitelist.ts
@@ -1,5 +1,6 @@
+import { getDeployedProxiedContract } from '@celo/protocol/lib/web3-utils'
 import { config } from '@celo/protocol/migrationsConfig'
-import { TransferWhitelistInstance } from 'types'
+import { RegistryInstance, TransferWhitelistInstance } from 'types'
 
 const name = 'TransferWhitelist'
 const Contract = artifacts.require(name)
@@ -10,5 +11,7 @@ module.exports = (deployer: any) => {
     const contract: TransferWhitelistInstance = await Contract.deployed()
     await contract.setWhitelist(config.transferWhitelist.addresses)
     await contract.setRegisteredContracts(config.transferWhitelist.registryIds)
+    const registry = await getDeployedProxiedContract<RegistryInstance>('Registry', artifacts)
+    await registry.setAddressFor(name, contract.address)
   })
 }


### PR DESCRIPTION
### Description

Registers transferWhitelist contract with registry so its address can be read from layer 1.

### Tested

Not tested.

### Other changes

None

### Related issues

- Related to #[251](https://github.com/celo-org/celo-labs/issues/251)

### Backwards compatibility

Yes.