### PR TITLE
Fix DomException on video playing

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,12 +9,13 @@
     "build": "next build && tsc --project tsconfig.server.json",
     "start": "NODE_ENV=production node dist/server/index.js",
     "compile-global": "yarn run node-sass src/layout/global.scss static/global.css",
-    "deploy": "yarn run kill-dev; yarn run build; gcloud app deploy $MANIFEST",
+    "deploy": "yarn run kill-dev; yarn run clean-next-cache; yarn run build; gcloud app deploy $MANIFEST",
     "deploy:dev": "gcloud config set project celo-testnet; NODE_ENV=production DEPLOY_ENV=development MANIFEST=development.yaml yarn run deploy",
     "deploy:staging": "gcloud config set project celo-testnet; NODE_ENV=production DEPLOY_ENV=staging MANIFEST=staging.yaml yarn run deploy",
     "deploy:prod": "gcloud config set project celo-testnet-production; NODE_ENV=production DEPLOY_ENV=production MANIFEST=production.yaml yarn run deploy",
     "lint": "tslint -c tslint.json --project tsconfig.json",
     "kill-dev": "kill -9 $(lsof -ti :3000)",
+    "clean-next-cache": "rm -rf .next",
     "test": "jest --coverage --runInBand"
   },
   "dependencies": {

--- a/packages/web/src/home/HomeAnimation.tsx
+++ b/packages/web/src/home/HomeAnimation.tsx
@@ -25,24 +25,25 @@ class HomeAnimation extends React.Component<Props & ScreenProps> {
   video: any
   started = false
 
-  videoLoaded = () => {
-    try {
-      if (this.video) {
-        if (!this.started) {
+  startVideo = async () => {
+    if (this.video) {
+      if (!this.started) {
+        try {
+          this.started = true
+          await this.video.play()
+
           this.props.onLoaded()
-          this.video.play()
+        } catch {
+          this.props.onError()
         }
-        this.started = true
       }
-    } catch {
-      this.props.onError()
     }
   }
 
   videoRef = (ref) => {
     this.video = ref
     if (this.video) {
-      this.video.oncanplaythrough = () => this.videoLoaded()
+      this.video.oncanplaythrough = () => this.startVideo()
       this.video.load()
       this.video.onended = () => this.restartVideo()
     }
@@ -50,11 +51,12 @@ class HomeAnimation extends React.Component<Props & ScreenProps> {
 
   restartVideo = () => {
     this.props.onFinished()
-    setTimeout(() => {
+
+    setTimeout(async () => {
       if (this.video) {
         this.video.currentTime = 0
         this.started = false
-        this.videoLoaded()
+        await this.startVideo()
       }
     }, 200)
   }
@@ -94,6 +96,7 @@ class HomeAnimation extends React.Component<Props & ScreenProps> {
           style={styles.videoSmall}
           preload={'auto'}
           muted={true}
+          autoPlay={true}
           playsInline={true}
         >
           <Source src={this.source()} type="video/mp4" />


### PR DESCRIPTION
### Description

ensure we revert to still graphic if video fails to play.

### Tested

used ngrok to view dev version as if normal server which allowed the error to surface. Instead of logging 
`DOMException: play() can only be initiated by a user gesture.` the still graphic remained in place

### Other changes

remove next cache before deploy

### Related issues

- Fixes #2974

