### PR TITLE
Fix PIN code on enabling Forno mode

### DIFF
--- a/packages/mobile/src/app/Background.tsx
+++ b/packages/mobile/src/app/Background.tsx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     width: '100%',
-    backgroundColor: Platform.OS === 'android' ? colors.white : colors.celoGreen,
+    backgroundColor: colors.white,
   },
 })
 

--- a/packages/mobile/src/app/Background.tsx
+++ b/packages/mobile/src/app/Background.tsx
@@ -1,6 +1,6 @@
 import colors from '@celo/react-components/styles/colors'
 import React, { useCallback, useEffect } from 'react'
-import { Platform, StyleSheet, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { NavigationInjectedProps, StackActions } from 'react-navigation'
 import { useDispatch, useSelector } from 'react-redux'
 import { AppState, lock, unlock } from 'src/app/actions'

--- a/packages/mobile/src/pincode/PincodeConfirmation.tsx
+++ b/packages/mobile/src/pincode/PincodeConfirmation.tsx
@@ -24,8 +24,9 @@ import { Namespaces, withTranslation } from 'src/i18n'
 import { nuxNavigationOptions } from 'src/navigator/Headers'
 import PincodeTextbox from 'src/pincode/PincodeTextbox'
 import { RootState } from 'src/redux/reducers'
+import Logger from 'src/utils/Logger'
 import { web3 } from 'src/web3/contracts'
-import { currentAccountSelector } from 'src/web3/selectors'
+import { currentAccountSelector, fornoSelector } from 'src/web3/selectors'
 
 interface State {
   pin: string
@@ -33,6 +34,7 @@ interface State {
 
 interface StateProps {
   currentAccount: string | null
+  fornoMode: boolean
 }
 
 interface DispatchProps {
@@ -115,13 +117,15 @@ class PincodeConfirmation extends React.Component<Props, State> {
 
   onPressConfirm = () => {
     const { pin } = this.state
-    if (this.props.currentAccount) {
+    const fornoMode = this.props
+    if (this.props.currentAccount && !fornoMode) {
       web3.eth.personal
         .unlockAccount(this.props.currentAccount, pin, UNLOCK_DURATION)
         .then((result: boolean) => (result ? this.onCorrectPin(pin) : this.onWrongPin()))
         .catch(this.onWrongPin)
     } else {
-      // Account is not created yet, so PIN can not be verified
+      // Account is not created yet or fornoMode is ON, so
+      // PIN can not be verified
       this.onCorrectPin(pin)
     }
   }
@@ -188,6 +192,7 @@ const style = StyleSheet.create({
 
 const mapStateToProps = (state: RootState): StateProps => ({
   currentAccount: currentAccountSelector(state),
+  fornoMode: fornoSelector(state),
 })
 
 export default connect(mapStateToProps, { showError })(

--- a/packages/mobile/src/pincode/PincodeConfirmation.tsx
+++ b/packages/mobile/src/pincode/PincodeConfirmation.tsx
@@ -24,7 +24,6 @@ import { Namespaces, withTranslation } from 'src/i18n'
 import { nuxNavigationOptions } from 'src/navigator/Headers'
 import PincodeTextbox from 'src/pincode/PincodeTextbox'
 import { RootState } from 'src/redux/reducers'
-import Logger from 'src/utils/Logger'
 import { web3 } from 'src/web3/contracts'
 import { currentAccountSelector, fornoSelector } from 'src/web3/selectors'
 


### PR DESCRIPTION
### Description

PIN screen would tell, that PIN is incorrect even if PIN is correct, when enabling data saver. This is a fix. 

### Tested

iOS Simulator

### Other changes

I've change the background color of the view, which quickly show up before PIN Screen appears after app is back from background on iOS. Earlier when app is in background - we would show green screen, but after https://github.com/celo-org/celo-monorepo/commit/4c5633314cf8fbfcadb94db955e26e2b413b5d5c we just blur the content, so white screen would make more sense.

### Backwards compatibility

Yes

