### PR TITLE
Fix Twitter Link

### DIFF
--- a/packages/web/src/_page-tests/__snapshots__/community.test.tsx.snap
+++ b/packages/web/src/_page-tests/__snapshots__/community.test.tsx.snap
@@ -7512,7 +7512,7 @@ exports[`Community renders 1`] = `
                     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao css-textHasAncestor-16my406"
                     data-focusable={true}
                     dir="auto"
-                    href="https://twitter.com/@celoOrg"
+                    href="https://twitter.com/CeloOrg"
                     role="link"
                     style={
                       Object {

--- a/packages/web/src/_page-tests/developers/__snapshots__/Index.test.tsx.snap
+++ b/packages/web/src/_page-tests/developers/__snapshots__/Index.test.tsx.snap
@@ -6348,7 +6348,7 @@ exports[`DevelopersPage renders 1`] = `
                   className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao css-textHasAncestor-16my406"
                   data-focusable={true}
                   dir="auto"
-                  href="https://twitter.com/@celoOrg"
+                  href="https://twitter.com/CeloOrg"
                   role="link"
                   style={
                     Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
@@ -5704,7 +5704,7 @@ exports[`Experience/Color renders 1`] = `
             }
           >
             <a
-              href="https://twitter.com/CeloHQ"
+              href="https://twitter.com/CeloOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
@@ -2512,7 +2512,7 @@ exports[`Experience/Composition renders 1`] = `
             }
           >
             <a
-              href="https://twitter.com/CeloHQ"
+              href="https://twitter.com/CeloOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
@@ -1376,7 +1376,7 @@ exports[`Experience/Icons renders 1`] = `
             }
           >
             <a
-              href="https://twitter.com/CeloHQ"
+              href="https://twitter.com/CeloOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
@@ -1351,7 +1351,7 @@ exports[`Experience/Brandkit renders 1`] = `
             }
           >
             <a
-              href="https://twitter.com/CeloHQ"
+              href="https://twitter.com/CeloOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
@@ -1977,7 +1977,7 @@ exports[`Experience/KeyImagery renders 1`] = `
             }
           >
             <a
-              href="https://twitter.com/CeloHQ"
+              href="https://twitter.com/CeloOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
@@ -6011,7 +6011,7 @@ exports[`Experience/Logo renders 1`] = `
             }
           >
             <a
-              href="https://twitter.com/CeloHQ"
+              href="https://twitter.com/CeloOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
@@ -3019,7 +3019,7 @@ exports[`Experience/Typography renders 1`] = `
             }
           >
             <a
-              href="https://twitter.com/CeloHQ"
+              href="https://twitter.com/CeloOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/validators/__snapshots__/index.test.tsx.snap
+++ b/packages/web/src/_page-tests/validators/__snapshots__/index.test.tsx.snap
@@ -6575,7 +6575,7 @@ exports[`BuildPage renders 1`] = `
                   className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao css-textHasAncestor-16my406"
                   data-focusable={true}
                   dir="auto"
-                  href="https://twitter.com/@celoOrg"
+                  href="https://twitter.com/CeloOrg"
                   role="link"
                   style={
                     Object {

--- a/packages/web/src/icons/TwitterLogo.tsx
+++ b/packages/web/src/icons/TwitterLogo.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { CeloLinks } from 'src/shared/menu-items'
 import { colors } from 'src/styles'
 import Svg, { Path } from 'svgs'
 
@@ -18,7 +19,7 @@ export default class TwitterLogo extends React.PureComponent<Props> {
 
     return (
       <a
-        href={'https://twitter.com/CeloHQ'}
+        href={CeloLinks.twitter}
         target="_blank"
         rel="noopener"
         style={{ lineHeight: `${height}px`, height: `${height}px` }}

--- a/packages/web/src/shared/SocialChannels.tsx
+++ b/packages/web/src/shared/SocialChannels.tsx
@@ -97,7 +97,7 @@ export function TwitterChannel({ alignCenter, isDarkMode }: ExternalChannelProps
             style={[fonts.legal, isDarkMode && textStyles.invert]}
             text={'@celoOrg'}
             kind={BTN.INLINE}
-            href="https://twitter.com/@celoOrg"
+            href={CeloLinks.twitter}
           />
         </>
       }

--- a/packages/web/src/shared/menu-items.ts
+++ b/packages/web/src/shared/menu-items.ts
@@ -58,10 +58,6 @@ export const menuItems = {
     name: 'Terms',
     link: '/terms',
   },
-  TWITTER: {
-    name: 'Twitter',
-    link: 'https://twitter.com/CeloHQ',
-  },
   CODE_OF_CONDUCT: {
     name: 'Code of Conduct',
     link: '/code-of-conduct',
@@ -86,6 +82,7 @@ export enum CeloLinks {
   nodeDocs = 'https://docs.celo.org/getting-started/running-a-full-node',
   gettingStarted = 'https://docs.celo.org/getting-started/alfajores-testnet',
   gitHub = 'https://github.com/celo-org',
+  twitter = 'https://twitter.com/CeloOrg',
   fundingRequest = 'https://c-labs.typeform.com/to/gj9aUp',
   linkedIn = 'https://www.linkedin.com/company/celohq/',
   monorepo = 'https://github.com/celo-org/celo-monorepo',


### PR DESCRIPTION

One of the twitter links used the old celohq handle. this updates it and changes them all to use the `CeloLinks.twitter` constant

