### PR TITLE
update celoHQ to celoOrg

### DIFF
--- a/packages/web/server/mediumAPI.ts
+++ b/packages/web/server/mediumAPI.ts
@@ -82,7 +82,7 @@ function parseXML(xmlData: string): JSONRSSItem[] {
 }
 
 async function fetchMediumArticles(): Promise<string> {
-  const response = (await abortableFetch('https://medium.com/feed/celohq')) as Response
+  const response = (await abortableFetch('https://medium.com/feed/celoOrg')) as Response
   return response.text()
 }
 

--- a/packages/web/src/_page-tests/__snapshots__/about.test.tsx.snap
+++ b/packages/web/src/_page-tests/__snapshots__/about.test.tsx.snap
@@ -1915,7 +1915,7 @@ exports[`About renders 1`] = `
           className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao"
           data-focusable={true}
           dir="auto"
-          href="https://medium.com/celohq/celos-theory-of-change-b916de44945d"
+          href="https://medium.com/celoOrg/celos-theory-of-change-b916de44945d"
           role="link"
           style={
             Object {

--- a/packages/web/src/_page-tests/__snapshots__/community.test.tsx.snap
+++ b/packages/web/src/_page-tests/__snapshots__/community.test.tsx.snap
@@ -7028,6 +7028,7 @@ exports[`Community renders 1`] = `
             className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao"
             data-focusable={true}
             dir="auto"
+            href="/code-of-conduct"
             role="link"
             style={
               Object {

--- a/packages/web/src/_page-tests/__snapshots__/community.test.tsx.snap
+++ b/packages/web/src/_page-tests/__snapshots__/community.test.tsx.snap
@@ -3306,7 +3306,7 @@ exports[`Community renders 1`] = `
                 className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao"
                 data-focusable={true}
                 dir="auto"
-                href="https://medium.com/celohq/call-for-proposals-the-celo-fellowship-3c43b06b10f9"
+                href="https://medium.com/celoOrg/call-for-proposals-the-celo-fellowship-3c43b06b10f9"
                 role="link"
                 style={
                   Object {

--- a/packages/web/src/_page-tests/developers/__snapshots__/Index.test.tsx.snap
+++ b/packages/web/src/_page-tests/developers/__snapshots__/Index.test.tsx.snap
@@ -5864,6 +5864,7 @@ exports[`DevelopersPage renders 1`] = `
           className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao"
           data-focusable={true}
           dir="auto"
+          href="/code-of-conduct"
           role="link"
           style={
             Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
@@ -5637,7 +5637,7 @@ exports[`Experience/Color renders 1`] = `
             }
           >
             <a
-              href="https://medium.com/CeloHQ"
+              href="https://medium.com/celoOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
@@ -2445,7 +2445,7 @@ exports[`Experience/Composition renders 1`] = `
             }
           >
             <a
-              href="https://medium.com/CeloHQ"
+              href="https://medium.com/celoOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
@@ -1309,7 +1309,7 @@ exports[`Experience/Icons renders 1`] = `
             }
           >
             <a
-              href="https://medium.com/CeloHQ"
+              href="https://medium.com/celoOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
@@ -1284,7 +1284,7 @@ exports[`Experience/Brandkit renders 1`] = `
             }
           >
             <a
-              href="https://medium.com/CeloHQ"
+              href="https://medium.com/celoOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
@@ -1910,7 +1910,7 @@ exports[`Experience/KeyImagery renders 1`] = `
             }
           >
             <a
-              href="https://medium.com/CeloHQ"
+              href="https://medium.com/celoOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
@@ -5944,7 +5944,7 @@ exports[`Experience/Logo renders 1`] = `
             }
           >
             <a
-              href="https://medium.com/CeloHQ"
+              href="https://medium.com/celoOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
@@ -1184,7 +1184,7 @@ exports[`Experience/Typography renders 1`] = `
                     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao css-textHasAncestor-16my406"
                     data-focusable={true}
                     dir="auto"
-                    href="https://medium.com/celohq/the-why-of-the-celo-coin-part-1-of-3-5e5701805847"
+                    href="https://medium.com/celoOrg/the-why-of-the-celo-coin-part-1-of-3-5e5701805847"
                     role="link"
                     style={
                       Object {

--- a/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
+++ b/packages/web/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
@@ -2952,7 +2952,7 @@ exports[`Experience/Typography renders 1`] = `
             }
           >
             <a
-              href="https://medium.com/CeloHQ"
+              href="https://medium.com/celoOrg"
               rel="noopener"
               style={
                 Object {

--- a/packages/web/src/_page-tests/validators/__snapshots__/index.test.tsx.snap
+++ b/packages/web/src/_page-tests/validators/__snapshots__/index.test.tsx.snap
@@ -6091,6 +6091,7 @@ exports[`BuildPage renders 1`] = `
           className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao"
           data-focusable={true}
           dir="auto"
+          href="/code-of-conduct"
           role="link"
           style={
             Object {

--- a/packages/web/src/_page-tests/validators/__snapshots__/index.test.tsx.snap
+++ b/packages/web/src/_page-tests/validators/__snapshots__/index.test.tsx.snap
@@ -5124,7 +5124,7 @@ exports[`BuildPage renders 1`] = `
                 className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao"
                 data-focusable={true}
                 dir="auto"
-                href="https://medium.com/celohq/announcing-the-great-celo-stake-off-12eb15dd5eb0"
+                href="https://medium.com/celoOrg/announcing-the-great-celo-stake-off-12eb15dd5eb0"
                 role="link"
                 style={
                   Object {
@@ -5658,7 +5658,7 @@ exports[`BuildPage renders 1`] = `
                 className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao"
                 data-focusable={true}
                 dir="auto"
-                href="https://medium.com/celohq/consensus-and-proof-of-stake-in-the-celo-protocol-3ff8eee331f6"
+                href="https://medium.com/celoOrg/consensus-and-proof-of-stake-in-the-celo-protocol-3ff8eee331f6"
                 role="link"
                 style={
                   Object {

--- a/packages/web/src/about/About.tsx
+++ b/packages/web/src/about/About.tsx
@@ -132,7 +132,7 @@ export class About extends React.Component<Props & I18nProps> {
             </Text>
             <Button
               kind={BTN.PRIMARY}
-              href="https://medium.com/celohq/celos-theory-of-change-b916de44945d"
+              href="https://medium.com/celoOrg/celos-theory-of-change-b916de44945d"
               text={t('learnMore')}
             />
           </BookLayout>

--- a/packages/web/src/brandkit/Typography.tsx
+++ b/packages/web/src/brandkit/Typography.tsx
@@ -56,7 +56,7 @@ const Overview = withNamespaces(NameSpaces.brand)(
           <Text style={fonts.h5}>{t('typography.facesTitle')}</Text>
           <Text style={[fonts.p, standardStyles.elementalMargin]}>
             <Trans ns={NameSpaces.brand} i18nKey={'typography.facesText'}>
-              <InlineAnchor href="https://medium.com/celohq/the-why-of-the-celo-coin-part-1-of-3-5e5701805847">
+              <InlineAnchor href="https://medium.com/celoOrg/the-why-of-the-celo-coin-part-1-of-3-5e5701805847">
                 philosophy
               </InlineAnchor>
             </Trans>

--- a/packages/web/src/community/connect/ArticlesSection.tsx
+++ b/packages/web/src/community/connect/ArticlesSection.tsx
@@ -8,7 +8,7 @@ import { I18nProps, withNamespaces } from 'src/i18n'
 import MediumLogo from 'src/icons/MediumLogo'
 import { Cell, GridRow, Spans } from 'src/layout/GridRow'
 import Button, { BTN, SIZE } from 'src/shared/Button.3'
-import menuItems, { hashNav } from 'src/shared/menu-items'
+import { CeloLinks, hashNav } from 'src/shared/menu-items'
 import { colors, standardStyles } from 'src/styles'
 
 interface OwnProps {
@@ -45,7 +45,7 @@ class ArticlesSection extends React.PureComponent<Props> {
               text={t('common:readMoreFromOurBlog')}
               kind={BTN.DARKNAKED}
               size={SIZE.normal}
-              href={menuItems.MEDIUM.link}
+              href={CeloLinks.mediumOrg}
               target={'_blog'}
               iconRight={<MediumLogo height={16} color={colors.dark} wrapWithLink={false} />}
             />

--- a/packages/web/src/community/connect/ArticlesSection.tsx
+++ b/packages/web/src/community/connect/ArticlesSection.tsx
@@ -45,7 +45,7 @@ class ArticlesSection extends React.PureComponent<Props> {
               text={t('common:readMoreFromOurBlog')}
               kind={BTN.DARKNAKED}
               size={SIZE.normal}
-              href={CeloLinks.mediumOrg}
+              href={CeloLinks.mediumUser}
               target={'_blog'}
               iconRight={<MediumLogo height={16} color={colors.dark} wrapWithLink={false} />}
             />

--- a/packages/web/src/community/connect/Contribute.tsx
+++ b/packages/web/src/community/connect/Contribute.tsx
@@ -21,7 +21,9 @@ function Contribute({ t }: I18nProps) {
               size={SIZE.normal}
               text={t('contribute.button')}
               target={'_cfp'}
-              href={'https://medium.com/celohq/call-for-proposals-the-celo-fellowship-3c43b06b10f9'}
+              href={
+                'https://medium.com/celoOrg/call-for-proposals-the-celo-fellowship-3c43b06b10f9'
+              }
             />
           </View>
         </Cell>

--- a/packages/web/src/dev/Engage.tsx
+++ b/packages/web/src/dev/Engage.tsx
@@ -212,7 +212,7 @@ export function EngageAsValidator() {
           caption={t('engage.validators.caption')}
           primaryAction={{
             text: t('engage.validators.primaryAction'),
-            href: 'https://medium.com/celohq/announcing-the-great-celo-stake-off-12eb15dd5eb0',
+            href: 'https://medium.com/celoOrg/announcing-the-great-celo-stake-off-12eb15dd5eb0',
           }}
         />
       </Cell>
@@ -229,7 +229,7 @@ export function EngageAsValidator() {
           screen={screen}
           text={t('engage.blog.copy')}
           title={t('engage.blog.title')}
-          href="https://medium.com/celohq/consensus-and-proof-of-stake-in-the-celo-protocol-3ff8eee331f6"
+          href="https://medium.com/celoOrg/consensus-and-proof-of-stake-in-the-celo-protocol-3ff8eee331f6"
           btnText={t('engage.blog.btnText')}
           image={require('src/icons/blog-dark.png')}
         />

--- a/packages/web/src/icons/MediumLogo.tsx
+++ b/packages/web/src/icons/MediumLogo.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { CeloLinks } from 'src/shared/menu-items'
 import { colors } from 'src/styles'
 import Svg, { Path } from 'svgs'
 
@@ -20,7 +21,7 @@ export default class MediumLogo extends React.PureComponent<Props> {
     if (wrapWithLink) {
       return (
         <a
-          href={'https://medium.com/CeloHQ'}
+          href={CeloLinks.mediumPublication}
           target="_blank"
           rel="noopener"
           style={{ lineHeight: `${height}px`, height: `${height}px` }}

--- a/packages/web/src/press/Press.tsx
+++ b/packages/web/src/press/Press.tsx
@@ -35,7 +35,7 @@ class Press extends React.PureComponent<I18nProps> {
             ))}
           </View>
           <View style={[styles.linkContainer, standardStyles.elementalMarginTop]}>
-            {/* <Button text={t('recentNews')} kind={BTN.NAKED} href={'https://medium.com/celohq'} /> */}
+            {/* <Button text={t('recentNews')} kind={BTN.NAKED} href={'https://medium.com/celoOrg'} /> */}
             <Button
               text={t('recentNews')}
               kind={BTN.NAKED}

--- a/packages/web/src/shared/ConnectionFooter.tsx
+++ b/packages/web/src/shared/ConnectionFooter.tsx
@@ -6,6 +6,7 @@ import { I18nProps, NameSpaces, withNamespaces } from 'src/i18n'
 import BookLayout from 'src/layout/BookLayout'
 import { GridRow } from 'src/layout/GridRow'
 import Button, { BTN } from 'src/shared/Button.3'
+import menuItems from 'src/shared/menu-items'
 import {
   BrandChannel,
   DiscordChannel,
@@ -32,7 +33,7 @@ function ConnectionFooter({ t, includeDividerLine }: I18nProps & Props) {
       </GridRow>
       <BookLayout label={t('conductLabel')}>
         <Text style={[fonts.p, standardStyles.elementalMarginBottom]}>{t('conductText')}</Text>
-        <Button kind={BTN.PRIMARY} text={t('conductBtn')} />
+        <Button kind={BTN.PRIMARY} text={t('conductBtn')} href={menuItems.CODE_OF_CONDUCT.link} />
       </BookLayout>
       <BookLayout label={t('experienceLabel')} isWide={true}>
         <View style={styles.engageArea}>

--- a/packages/web/src/shared/menu-items.ts
+++ b/packages/web/src/shared/menu-items.ts
@@ -78,7 +78,7 @@ export enum CeloLinks {
   gettingStarted = 'https://docs.celo.org/getting-started/alfajores-testnet',
   gitHub = 'https://github.com/celo-org',
   twitter = 'https://twitter.com/CeloOrg',
-  mediumOrg = 'https://medium.com/@celo.org',
+  mediumUser = 'https://medium.com/@celo.org',
   mediumPublication = 'https://medium.com/celoOrg',
   fundingRequest = 'https://c-labs.typeform.com/to/gj9aUp',
   linkedIn = 'https://www.linkedin.com/company/celoOrg/',

--- a/packages/web/src/shared/menu-items.ts
+++ b/packages/web/src/shared/menu-items.ts
@@ -41,15 +41,10 @@ export const menuItems = {
     name: 'Join',
     link: '/jobs',
   },
-  MEDIUM: {
-    name: 'Medium',
-    link: 'https://medium.com/@celo.org',
-  },
   PRIVACY: {
     name: 'Privacy Policy',
     link: '/privacy',
   },
-
   TECH: {
     name: 'Technology',
     link: '/technology',
@@ -83,8 +78,10 @@ export enum CeloLinks {
   gettingStarted = 'https://docs.celo.org/getting-started/alfajores-testnet',
   gitHub = 'https://github.com/celo-org',
   twitter = 'https://twitter.com/CeloOrg',
+  mediumOrg = 'https://medium.com/@celo.org',
+  mediumPublication = 'https://medium.com/celoOrg',
   fundingRequest = 'https://c-labs.typeform.com/to/gj9aUp',
-  linkedIn = 'https://www.linkedin.com/company/celohq/',
+  linkedIn = 'https://www.linkedin.com/company/celoOrg/',
   monorepo = 'https://github.com/celo-org/celo-monorepo',
   blockChainRepo = 'https://github.com/celo-org/celo-blockchain',
   playStoreWallet = 'https://play.google.com/store/apps/details?id=org.celo.mobile.alfajores',


### PR DESCRIPTION
### Description

updates medium and linkedIn links to go to the canonical celoOrg versions instead of the old celoHQ versions. (which will redirect)

also fixes code of conduct button

### Tested

tried out the links by hand 

### Other changes

also changes medium blog to go to publication instead of user page



