### PR TITLE
Fixing a check for validator:deregister

### DIFF
--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -323,7 +323,7 @@ class CheckBuilder {
       `Account isn't a member of a validator group`,
       this.withValidators(async (v, _signer, account) => {
         const { affiliation } = await v.getValidator(account)
-        if (eqAddress(affiliation!, NULL_ADDRESS)) {
+        if (!affiliation || eqAddress(affiliation, NULL_ADDRESS)) {
           return true
         }
         const { members } = await v.getValidatorGroup(affiliation!)

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -3,7 +3,7 @@ import { AccountsWrapper } from '@celo/contractkit/lib/wrappers/Accounts'
 import { GovernanceWrapper, ProposalStage } from '@celo/contractkit/lib/wrappers/Governance'
 import { LockedGoldWrapper } from '@celo/contractkit/lib/wrappers/LockedGold'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
-import { eqAddress } from '@celo/utils/lib/address'
+import { eqAddress, NULL_ADDRESS } from '@celo/utils/lib/address'
 import { verifySignature } from '@celo/utils/lib/signatureUtils'
 import BigNumber from 'bignumber.js'
 import chalk from 'chalk'
@@ -323,6 +323,9 @@ class CheckBuilder {
       `Account isn't a member of a validator group`,
       this.withValidators(async (v, _signer, account) => {
         const { affiliation } = await v.getValidator(account)
+        if (eqAddress(affiliation!, NULL_ADDRESS)) {
+          return true
+        }
         const { members } = await v.getValidatorGroup(affiliation!)
         return !members.includes(account)
       })


### PR DESCRIPTION
### Description

There was an error in the checks I added last time.
Added an extra case for non-affiliated validators.

### Tested

Checked the case where error occurred.

### Other changes


### Related issues

- Fixes #2993 

### Backwards compatibility

