### PR TITLE
Add proxy methods for contractkit block-explorer

### DIFF
--- a/packages/contractkit/src/explorer/block-explorer.ts
+++ b/packages/contractkit/src/explorer/block-explorer.ts
@@ -1,6 +1,7 @@
 import { Address } from '@celo/utils/lib/address'
 import abi, { ABIDefinition } from 'web3-eth-abi'
 import { Block, Transaction } from 'web3/eth/types'
+import { PROXY_ABI } from '../governance/proxy'
 import { ContractKit } from '../kit'
 import { parseDecodedParams } from '../utils/web3-utils'
 import { ContractDetails, mapFromPairs, obtainKitContractDetails } from './base'
@@ -41,7 +42,7 @@ export class BlockExplorer {
         {
           details: cd,
           fnMapping: mapFromPairs(
-            (cd.jsonInterface as ABIDefinition[])
+            (cd.jsonInterface.concat(PROXY_ABI) as ABIDefinition[])
               .filter((ad) => ad.type === 'function')
               .map((ad) => [ad.signature, ad])
           ),

--- a/packages/contractkit/src/governance/proxy.ts
+++ b/packages/contractkit/src/governance/proxy.ts
@@ -1,6 +1,7 @@
 import Web3 from 'web3'
+import { ABIDefinition } from 'web3-eth-abi'
 
-const PROXY_ABI = [
+export const PROXY_ABI: ABIDefinition[] = [
   {
     constant: true,
     inputs: [],
@@ -14,6 +15,7 @@ const PROXY_ABI = [
     payable: false,
     stateMutability: 'view',
     type: 'function',
+    signature: '0x42404e07',
   },
   {
     constant: false,
@@ -28,6 +30,7 @@ const PROXY_ABI = [
     payable: false,
     stateMutability: 'nonpayable',
     type: 'function',
+    signature: '0xbb913f41',
   },
 ]
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
@@ -28,7 +28,7 @@
 
 \+ **new BlockExplorer**(`kit`: [ContractKit](_kit_.contractkit.md), `contractDetails`: [ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]): *[BlockExplorer](_explorer_block_explorer_.blockexplorer.md)*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:35](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L35)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:36](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L36)*
 
 **Parameters:**
 
@@ -45,7 +45,7 @@ Name | Type |
 
 • **contractDetails**: *[ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:37](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L37)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:38](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L38)*
 
 ## Methods
 
@@ -53,7 +53,7 @@ Name | Type |
 
 ▸ **fetchBlock**(`blockNumber`: number): *Promise‹Block›*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:57](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L57)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:58](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L58)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **fetchBlockByHash**(`blockHash`: string): *Promise‹Block›*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:53](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L53)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:54](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L54)*
 
 **Parameters:**
 
@@ -85,7 +85,7 @@ ___
 
 ▸ **fetchBlockRange**(`from`: number, `to`: number): *Promise‹Block[]›*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:61](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L61)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:62](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L62)*
 
 **Parameters:**
 
@@ -102,7 +102,7 @@ ___
 
 ▸ **parseBlock**(`block`: Block): *[ParsedBlock](../interfaces/_explorer_block_explorer_.parsedblock.md)*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:69](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L69)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:70](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L70)*
 
 **Parameters:**
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **tryParseTx**(`tx`: Transaction): *null | [ParsedTx](../interfaces/_explorer_block_explorer_.parsedtx.md)*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:84](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L84)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:85](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L85)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.calldetails.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.calldetails.md
@@ -19,7 +19,7 @@
 
 • **argList**: *any[]*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:12](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L12)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L13)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **contract**: *string*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:9](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L9)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:10](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L10)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **function**: *string*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:10](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L10)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:11](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L11)*
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 • **paramMap**: *Record‹string, any›*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:11](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L11)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:12](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L12)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedblock.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedblock.md
@@ -17,7 +17,7 @@
 
 • **block**: *Block*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L21)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L22)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **parsedTx**: *[ParsedTx](_explorer_block_explorer_.parsedtx.md)[]*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L22)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L23)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedtx.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedtx.md
@@ -17,7 +17,7 @@
 
 • **callDetails**: *[CallDetails](_explorer_block_explorer_.calldetails.md)*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:16](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L16)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:17](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L17)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **tx**: *Transaction*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:17](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L17)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:18](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L18)*

--- a/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
@@ -22,7 +22,7 @@
 
 ▸ **newBlockExplorer**(`kit`: [ContractKit](../classes/_kit_.contractkit.md)): *Promise‹[BlockExplorer](../classes/_explorer_block_explorer_.blockexplorer.md)‹››*
 
-*Defined in [contractkit/src/explorer/block-explorer.ts:30](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L30)*
+*Defined in [contractkit/src/explorer/block-explorer.ts:31](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L31)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_governance_proxy_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_governance_proxy_.md
@@ -2,10 +2,53 @@
 
 ## Index
 
+### Variables
+
+* [PROXY_ABI](_governance_proxy_.md#const-proxy_abi)
+
 ### Functions
 
 * [getImplementationOfProxy](_governance_proxy_.md#const-getimplementationofproxy)
 * [setImplementationOnProxy](_governance_proxy_.md#const-setimplementationonproxy)
+
+## Variables
+
+### `Const` PROXY_ABI
+
+• **PROXY_ABI**: *ABIDefinition[]* = [
+  {
+    constant: true,
+    inputs: [],
+    name: '_getImplementation',
+    outputs: [
+      {
+        name: 'implementation',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+    signature: '0x42404e07',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'implementation',
+        type: 'address',
+      },
+    ],
+    name: '_setImplementation',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+    signature: '0xbb913f41',
+  },
+]
+
+*Defined in [contractkit/src/governance/proxy.ts:4](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proxy.ts#L4)*
 
 ## Functions
 
@@ -13,7 +56,7 @@
 
 ▸ **getImplementationOfProxy**(`web3`: Web3, `proxyContractAddress`: string): *Promise‹string›*
 
-*Defined in [contractkit/src/governance/proxy.ts:34](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proxy.ts#L34)*
+*Defined in [contractkit/src/governance/proxy.ts:37](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proxy.ts#L37)*
 
 **Parameters:**
 
@@ -30,7 +73,7 @@ ___
 
 ▸ **setImplementationOnProxy**(`address`: string): *TransactionObject‹any›*
 
-*Defined in [contractkit/src/governance/proxy.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proxy.ts#L42)*
+*Defined in [contractkit/src/governance/proxy.ts:45](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proxy.ts#L45)*
 
 **Parameters:**
 


### PR DESCRIPTION
### Description

Added `_getImplementation` and `_setImplementation` to all contracts.

### Tested

Tested for the proposals in baklava.

### Other changes


### Related issues

- Fixes #2839

### Backwards compatibility

