### PR TITLE
change rn-cli.config.js to metro.config.js

### DIFF
--- a/packages/docs/developer-resources/dappkit/setup.md
+++ b/packages/docs/developer-resources/dappkit/setup.md
@@ -40,7 +40,7 @@ npm install node-libs-react-native vm-browserify
 yarn add node-libs-react-native vm-browserify
 ```
 
-You will need to add the following `rn-cli.config.js` to your project root
+You will need to add the following `metro.config.js` to your project root
 
 ```js
 const crypto = require.resolve('crypto-browserify')


### PR DESCRIPTION
see the updated example here https://github.com/celo-org/savings-circle-demo/blob/cmcewen/deploy-update/metro.config.js

### Description

Using DappKit with the config file named rn-cli.config.js doesn't work properly. Updating the config file to metro.config.js, like @cmcewen does in his [update to the savings circle dapp](https://github.com/celo-org/savings-circle-demo/blob/cmcewen/deploy-update/metro.config.js) makes it work.

### Tested

I did manual testing between what is outlined in the docs currently and what connor did. His works, what's currently there doesn't.

