### PR TITLE
ReleaseGold instances that are registered Validators/groups cannot be `expire`d

### DIFF
--- a/packages/protocol/contracts/governance/ReleaseGold.sol
+++ b/packages/protocol/contracts/governance/ReleaseGold.sol
@@ -4,6 +4,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 import "./interfaces/IReleaseGold.sol";
+import "./interfaces/IValidators.sol";
 import "../common/FixidityLib.sol";
 import "../common/libraries/ReentrancyGuard.sol";
 
@@ -367,6 +368,11 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
    * @dev Only callable `EXPIRATION_TIME` after the final gold release.
    */
   function expire() external nonReentrant onlyReleaseOwner onlyExpired {
+    IValidators validators = getValidators();
+    require(
+      !validators.isValidator(address(this)) && !validators.isValidatorGroup(address(this)),
+      "Cannot call `expire` on an instance registered as a validator or group"
+    );
     require(!isRevoked(), "Release schedule instance must not already be revoked");
     revocationInfo.revokeTime = block.timestamp;
     revocationInfo.releasedBalanceAtRevoke = totalWithdrawn;

--- a/packages/protocol/contracts/governance/interfaces/IValidators.sol
+++ b/packages/protocol/contracts/governance/interfaces/IValidators.sol
@@ -12,6 +12,7 @@ interface IValidators {
     external
     returns (bool);
   function isValidator(address) external view returns (bool);
+  function isValidatorGroup(address) external view returns (bool);
   function calculateGroupEpochScore(uint256[] calldata uptimes) external view returns (uint256);
   function groupMembershipInEpoch(address account, uint256 epochNumber, uint256 index)
     external

--- a/packages/protocol/contracts/governance/test/MockValidators.sol
+++ b/packages/protocol/contracts/governance/test/MockValidators.sol
@@ -13,6 +13,7 @@ contract MockValidators is IValidators {
   uint256 private constant FIXED1_UINT = 1000000000000000000000000;
 
   mapping(address => bool) public isValidator;
+  mapping(address => bool) public isValidatorGroup;
   mapping(address => uint256) private numGroupMembers;
   mapping(address => uint256) private lockedGoldRequirements;
   mapping(address => bool) private doesNotMeetAccountLockedGoldRequirements;
@@ -33,6 +34,10 @@ contract MockValidators is IValidators {
 
   function setValidator(address account) external {
     isValidator[account] = true;
+  }
+
+  function setValidatorGroup(address group) external {
+    isValidatorGroup[group] = true;
   }
 
   function affiliate(address group) external returns (bool) {

--- a/packages/protocol/test/governance/release_gold.ts
+++ b/packages/protocol/test/governance/release_gold.ts
@@ -1104,6 +1104,21 @@ contract('ReleaseGold', (accounts: string[]) => {
             )
           })
         })
+
+        describe('when an instance is a registered validator or validator group', () => {
+          describe('registered validator', () => {
+            it('should revert', async () => {
+              await mockValidators.setValidator(releaseGoldInstance.address)
+              await assertRevert(releaseGoldInstance.expire({ from: releaseOwner }))
+            })
+          })
+          describe('registered validator', () => {
+            it('should revert', async () => {
+              await mockValidators.setValidatorGroup(releaseGoldInstance.address)
+              await assertRevert(releaseGoldInstance.expire({ from: releaseOwner }))
+            })
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
### Description

ReleaseGold instances that are registered Validators/groups cannot be `expire`d.

This is to prevent the potentially unfriendly behavior if a user is validating with their `ReleaseGold` instance, they create a popular validator/group, and then 2 years after their schedule completes they have to migrate to a totally different address to avoid expiration.

This change makes it impossible to `expire` a contract if its underlying account is registered as a validator or a validator group.

### Tested

Added unit tests

### Other changes

Added `isValidatorGroup` to `IValidators` so I can call it within `ReleaseGold`. Also added corresponding support in `MockValidators`

### Backwards compatibility

Yes
