### PR TITLE
Add new recommendations to the vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,11 @@
     "esbenp.prettier-vscode",
     "juanblanco.solidity",
     "redhat.vscode-yaml",
-    "smkamranqadri.vscode-bolt-language"
+    "smkamranqadri.vscode-bolt-language",
+    "pkief.material-icon-theme",
+    "davidanson.vscode-markdownlint",
+    "mikestead.dotenv",
+    "coenraads.bracket-pair-colorizer-2"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []


### PR DESCRIPTION
### Description

Doesn't impact anyone directly, including VS code users. It just presents these as recommendations for our workspace:
pkief.material-icon-theme -> lots of nice, expressive icons for common files
davidanson.vscode-markdownlint -> markdown linter
mikestead.dotenv -> better syntax highlighting in .env files
coenraads.bracket-pair-colorizer-2 -> color diff sets of brackets and braces differently 

### Tested

In VSCode :)

