### PR TITLE
[Wallet] Fix vertical alignment of text in inputs

### DIFF
--- a/packages/mobile/src/account/__snapshots__/EditProfile.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/EditProfile.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`renders the EditProfile Component 1`] = `
             "flex": 1,
             "fontFamily": "Hind-Regular",
             "padding": 8,
-            "textAlignVertical": "top",
           }
         }
         underlineColorAndroid="transparent"

--- a/packages/mobile/src/account/__snapshots__/Invite.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Invite.test.tsx.snap
@@ -113,7 +113,6 @@ exports[`Invite renders correctly with no recipients 1`] = `
               "flex": 1,
               "fontFamily": "Hind-Regular",
               "padding": 8,
-              "textAlignVertical": "top",
             }
           }
           underlineColorAndroid="transparent"
@@ -352,7 +351,6 @@ exports[`Invite renders correctly with recipients 1`] = `
               "flex": 1,
               "fontFamily": "Hind-Regular",
               "padding": 8,
-              "textAlignVertical": "top",
             }
           }
           underlineColorAndroid="transparent"

--- a/packages/mobile/src/components/__snapshots__/CodeRow.test.tsx.snap
+++ b/packages/mobile/src/components/__snapshots__/CodeRow.test.tsx.snap
@@ -68,7 +68,6 @@ exports[`CodeRow renders correctly for all CodeRowStatus states 2`] = `
         "flex": 1,
         "fontFamily": "Hind-Regular",
         "padding": 8,
-        "textAlignVertical": "top",
       }
     }
     underlineColorAndroid="transparent"

--- a/packages/mobile/src/invite/__snapshots__/EnterInviteCode.test.tsx.snap
+++ b/packages/mobile/src/invite/__snapshots__/EnterInviteCode.test.tsx.snap
@@ -128,7 +128,6 @@ exports[`EnterInviteCode Screen renders correctly 1`] = `
                 "flex": 1,
                 "fontFamily": "Hind-Regular",
                 "padding": 8,
-                "textAlignVertical": "top",
               }
             }
             underlineColorAndroid="transparent"

--- a/packages/mobile/src/invite/__snapshots__/JoinCelo.test.tsx.snap
+++ b/packages/mobile/src/invite/__snapshots__/JoinCelo.test.tsx.snap
@@ -140,7 +140,6 @@ exports[`JoinCeloScreen renders correctly 1`] = `
               "flex": 1,
               "fontFamily": "Hind-Regular",
               "padding": 8,
-              "textAlignVertical": "top",
             }
           }
           testID="NameEntry"
@@ -286,7 +285,6 @@ exports[`JoinCeloScreen renders correctly 1`] = `
                     "flex": 1,
                     "fontFamily": "Hind-Regular",
                     "padding": 8,
-                    "textAlignVertical": "top",
                   }
                 }
                 testID="CountryNameField"
@@ -384,7 +382,6 @@ exports[`JoinCeloScreen renders correctly 1`] = `
                   "flex": 1,
                   "fontFamily": "Hind-Regular",
                   "padding": 8,
-                  "textAlignVertical": "top",
                 }
               }
               testID="PhoneNumberField"
@@ -653,7 +650,6 @@ exports[`JoinCeloScreen renders with an error 1`] = `
               "flex": 1,
               "fontFamily": "Hind-Regular",
               "padding": 8,
-              "textAlignVertical": "top",
             }
           }
           testID="NameEntry"
@@ -799,7 +795,6 @@ exports[`JoinCeloScreen renders with an error 1`] = `
                     "flex": 1,
                     "fontFamily": "Hind-Regular",
                     "padding": 8,
-                    "textAlignVertical": "top",
                   }
                 }
                 testID="CountryNameField"
@@ -897,7 +892,6 @@ exports[`JoinCeloScreen renders with an error 1`] = `
                   "flex": 1,
                   "fontFamily": "Hind-Regular",
                   "padding": 8,
-                  "textAlignVertical": "top",
                 }
               }
               testID="PhoneNumberField"

--- a/packages/mobile/src/send/__snapshots__/SendAmount.test.tsx.snap
+++ b/packages/mobile/src/send/__snapshots__/SendAmount.test.tsx.snap
@@ -277,7 +277,6 @@ exports[`SendAmount renders correctly for request payment confirmation 1`] = `
                 "flex": 1,
                 "fontFamily": "Hind-Regular",
                 "padding": 8,
-                "textAlignVertical": "top",
               }
             }
             title="$"
@@ -380,7 +379,6 @@ exports[`SendAmount renders correctly for request payment confirmation 1`] = `
                 "flex": 1,
                 "fontFamily": "Hind-Regular",
                 "padding": 8,
-                "textAlignVertical": "top",
               }
             }
             title="global:for"

--- a/packages/mobile/src/verify/__snapshots__/VerificationInputScreen.test.tsx.snap
+++ b/packages/mobile/src/verify/__snapshots__/VerificationInputScreen.test.tsx.snap
@@ -233,7 +233,6 @@ exports[`VerificationInputScreen renders correctly 1`] = `
                 "flex": 1,
                 "fontFamily": "Hind-Regular",
                 "padding": 8,
-                "textAlignVertical": "top",
               }
             }
             underlineColorAndroid="transparent"

--- a/packages/react-components/components/TextInput.tsx
+++ b/packages/react-components/components/TextInput.tsx
@@ -69,7 +69,10 @@ export class CTextInput extends React.Component<Props, State> {
       <View style={[style.container, propsStyle]}>
         <RNTextInput
           ref={forwardedRef}
-          style={style.borderedText}
+          style={{
+            ...style.borderedText,
+            ...(passThroughProps.multiline && { textAlignVertical: 'top' }),
+          }}
           value={value}
           {...passThroughProps}
           onFocus={this.handleInputFocus}
@@ -112,7 +115,6 @@ const style = StyleSheet.create({
     borderRadius: 3,
     padding: 8,
     backgroundColor: '#FFFFFF',
-    textAlignVertical: 'top',
   },
   iconStyle: {
     marginRight: 8,

--- a/packages/react-components/components/__snapshots__/PhoneNumberInput.test.tsx.snap
+++ b/packages/react-components/components/__snapshots__/PhoneNumberInput.test.tsx.snap
@@ -138,7 +138,6 @@ exports[`PhoneNumberInput when defaultCountry is falsy renders an AutoComplete a
               "flex": 1,
               "fontFamily": "Hind-Regular",
               "padding": 8,
-              "textAlignVertical": "top",
             }
           }
           testID="CountryNameField"
@@ -235,7 +234,6 @@ exports[`PhoneNumberInput when defaultCountry is falsy renders an AutoComplete a
             "flex": 1,
             "fontFamily": "Hind-Regular",
             "padding": 8,
-            "textAlignVertical": "top",
           }
         }
         testID="PhoneNumberField"
@@ -377,7 +375,6 @@ exports[`when defaultCountry is truthy does not render an AutoComplete 1`] = `
             "flex": 1,
             "fontFamily": "Hind-Regular",
             "padding": 8,
-            "textAlignVertical": "top",
           }
         }
         testID="PhoneNumberField"

--- a/packages/verifier/src/components/__snapshots__/PhoneNumberInput.test.tsx.snap
+++ b/packages/verifier/src/components/__snapshots__/PhoneNumberInput.test.tsx.snap
@@ -131,7 +131,6 @@ exports[`PhoneNumberInput when defaultCountry renders defaults 1`] = `
             "flex": 1,
             "fontFamily": "Hind-Regular",
             "padding": 8,
-            "textAlignVertical": "top",
           }
         }
         testID="PhoneNumberField"
@@ -282,7 +281,6 @@ exports[`PhoneNumberInput when no defaultCountry renders AutoComplete 1`] = `
               "flex": 1,
               "fontFamily": "Hind-Regular",
               "padding": 8,
-              "textAlignVertical": "top",
             }
           }
           testID="CountryNameField"
@@ -379,7 +377,6 @@ exports[`PhoneNumberInput when no defaultCountry renders AutoComplete 1`] = `
             "flex": 1,
             "fontFamily": "Hind-Regular",
             "padding": 8,
-            "textAlignVertical": "top",
           }
         }
         testID="PhoneNumberField"


### PR DESCRIPTION
### Description

Fixes the bug, when text in inputs is not centered. With this fix text will align to top, only when it's multiline.

### Tested

Android emulator

### Backwards compatibility

Yes

### Screenshot

![xdSaLx925banyzno2bgx0SiMfjPi9wMt](https://user-images.githubusercontent.com/6160124/77027804-29968380-69d2-11ea-89c0-8b318d5387a8.png)

