### PR TITLE
[ContractKit] fix nonce parsing, fix gatewayFee default

### DIFF
--- a/packages/contractkit/src/utils/tx-params-normalizer.test.ts
+++ b/packages/contractkit/src/utils/tx-params-normalizer.test.ts
@@ -67,7 +67,7 @@ describe('TxParamsNormalizer class', () => {
       const celoTx: Tx = { ...completeCeloTx }
       celoTx.nonce = undefined
       const newCeloTx = await populator.populate(celoTx)
-      expect(newCeloTx.nonce).toBe(27)
+      expect(newCeloTx.nonce).toBe(39) // 0x27 => 39
       expect(mockRpcCall.mock.calls.length).toBe(1)
       expect(mockRpcCall.mock.calls[0][0]).toBe('eth_getTransactionCount')
     })

--- a/packages/contractkit/src/utils/tx-params-normalizer.ts
+++ b/packages/contractkit/src/utils/tx-params-normalizer.ts
@@ -1,3 +1,4 @@
+import { ensureLeading0x } from '@celo/utils/lib/address'
 import BigNumber from 'bignumber.js'
 import { Tx } from 'web3-core'
 import { RpcCaller } from './rpc-caller'
@@ -42,7 +43,7 @@ export class TxParamsNormalizer {
     }
 
     if (!isEmpty(txParams.gatewayFeeRecipient) && isEmpty(txParams.gatewayFee)) {
-      txParams.gatewayFee = '0x' + DefaultGatewayFee.toString(16)
+      txParams.gatewayFee = ensureLeading0x(DefaultGatewayFee.toString(16))
     }
 
     if (!txParams.gasPrice || isEmpty(txParams.gasPrice.toString())) {

--- a/packages/contractkit/src/utils/tx-params-normalizer.ts
+++ b/packages/contractkit/src/utils/tx-params-normalizer.ts
@@ -66,8 +66,7 @@ export class TxParamsNormalizer {
     // Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactioncount
     const result = await this.rpcCaller.call('eth_getTransactionCount', [address, 'pending'])
 
-    // tslint:disable-next-line: radix
-    const nonce = parseInt(result.result.toString())
+    const nonce = parseInt(result.result.toString(), 16)
     return nonce
   }
 

--- a/packages/contractkit/src/utils/tx-params-normalizer.ts
+++ b/packages/contractkit/src/utils/tx-params-normalizer.ts
@@ -42,7 +42,7 @@ export class TxParamsNormalizer {
     }
 
     if (!isEmpty(txParams.gatewayFeeRecipient) && isEmpty(txParams.gatewayFee)) {
-      txParams.gatewayFee = DefaultGatewayFee.toString(16)
+      txParams.gatewayFee = '0x' + DefaultGatewayFee.toString(16)
     }
 
     if (!txParams.gasPrice || isEmpty(txParams.gasPrice.toString())) {
@@ -64,7 +64,9 @@ export class TxParamsNormalizer {
   private async getNonce(address: string): Promise<number> {
     // Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactioncount
     const result = await this.rpcCaller.call('eth_getTransactionCount', [address, 'pending'])
-    const nonce = parseInt(result.result.toString(), 10)
+
+    // tslint:disable-next-line: radix
+    const nonce = parseInt(result.result.toString())
     return nonce
   }
 

--- a/packages/contractkit/src/utils/tx-signing.test.ts
+++ b/packages/contractkit/src/utils/tx-signing.test.ts
@@ -38,7 +38,7 @@ async function verifyLocalSigning(web3: Web3, celoTransaction: Tx): Promise<void
       signedCeloTransaction.nonce,
       parseInt(celoTransaction.nonce.toString(), 16)
     )
-    expect(signedCeloTransaction.nonce).toEqual(parseInt(celoTransaction.nonce.toString()))
+    expect(signedCeloTransaction.nonce).toEqual(parseInt(celoTransaction.nonce.toString(), 16))
   }
   if (celoTransaction.gas != null) {
     debug(
@@ -46,7 +46,7 @@ async function verifyLocalSigning(web3: Web3, celoTransaction: Tx): Promise<void
       signedCeloTransaction.gas,
       parseInt(celoTransaction.gas.toString(), 16)
     )
-    expect(signedCeloTransaction.gas).toEqual(parseInt(celoTransaction.gas.toString()))
+    expect(signedCeloTransaction.gas).toEqual(parseInt(celoTransaction.gas.toString(), 16))
   }
   if (celoTransaction.gasPrice != null) {
     debug(

--- a/packages/contractkit/src/utils/tx-signing.test.ts
+++ b/packages/contractkit/src/utils/tx-signing.test.ts
@@ -38,7 +38,7 @@ async function verifyLocalSigning(web3: Web3, celoTransaction: Tx): Promise<void
       signedCeloTransaction.nonce,
       parseInt(celoTransaction.nonce.toString(), 16)
     )
-    expect(signedCeloTransaction.nonce).toEqual(parseInt(celoTransaction.nonce.toString(), 16))
+    expect(signedCeloTransaction.nonce).toEqual(parseInt(celoTransaction.nonce.toString()))
   }
   if (celoTransaction.gas != null) {
     debug(
@@ -46,7 +46,7 @@ async function verifyLocalSigning(web3: Web3, celoTransaction: Tx): Promise<void
       signedCeloTransaction.gas,
       parseInt(celoTransaction.gas.toString(), 16)
     )
-    expect(signedCeloTransaction.gas).toEqual(parseInt(celoTransaction.gas.toString(), 16))
+    expect(signedCeloTransaction.gas).toEqual(parseInt(celoTransaction.gas.toString()))
   }
   if (celoTransaction.gasPrice != null) {
     debug(

--- a/packages/docs/developer-resources/contractkit/reference/classes/_utils_tx_params_normalizer_.txparamsnormalizer.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_utils_tx_params_normalizer_.txparamsnormalizer.md
@@ -24,7 +24,7 @@
 
 \+ **new TxParamsNormalizer**(`rpcCaller`: [RpcCaller](../interfaces/_utils_rpc_caller_.rpccaller.md)): *[TxParamsNormalizer](_utils_tx_params_normalizer_.txparamsnormalizer.md)*
 
-*Defined in [contractkit/src/utils/tx-params-normalizer.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/tx-params-normalizer.ts#L21)*
+*Defined in [contractkit/src/utils/tx-params-normalizer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/tx-params-normalizer.ts#L22)*
 
 **Parameters:**
 
@@ -40,7 +40,7 @@ Name | Type |
 
 • **rpcCaller**: *[RpcCaller](../interfaces/_utils_rpc_caller_.rpccaller.md)*
 
-*Defined in [contractkit/src/utils/tx-params-normalizer.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/tx-params-normalizer.ts#L23)*
+*Defined in [contractkit/src/utils/tx-params-normalizer.ts:24](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/tx-params-normalizer.ts#L24)*
 
 ## Methods
 
@@ -48,7 +48,7 @@ Name | Type |
 
 ▸ **populate**(`celoTxParams`: Tx): *Promise‹Tx›*
 
-*Defined in [contractkit/src/utils/tx-params-normalizer.ts:25](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/tx-params-normalizer.ts#L25)*
+*Defined in [contractkit/src/utils/tx-params-normalizer.ts:26](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/tx-params-normalizer.ts#L26)*
 
 **Parameters:**
 


### PR DESCRIPTION
### Description

Changes to adapt types, broke how the nonce was parsed
Fixed now.

Also the default gatewayFee was an integer assumed as an hex, and that made a lower number

