### PR TITLE
Update SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -295,6 +295,7 @@ Then install packages:
 
 ```bash
 cd celo-monorepo
+npm install lerna
 yarn # install dependencies and run post-install script
 yarn build # build all packages
 ```


### PR DESCRIPTION
### Description
I tried to follow this guide diligently but I got the following error when I ran `yarn`:
```
$ yarn run lerna run postinstall && patch-package && yarn keys:decrypt
yarn run v1.17.3
error Command "lerna" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
Adding this line `npm install lerna` fixes the problem. I had this problem both for Ubuntu and Mac.
