### PR TITLE
【Celo Gallery】Celo Toolkit - web interface for managing Celo accounts

### DIFF
--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -97,6 +97,7 @@ Browse the code, raise an issue, or contribute a PR:
 
 Try Celo out:
 
+- [Using the Web Wallet](getting-started/using-the-web-wallet.md) on the Alfajores Testnet
 - [Using the Mobile Wallet](getting-started/using-the-mobile-wallet.md) on the Alfajores Testnet
 - [Introduction to the CLI ](command-line-interface/introduction.md)on the Alfajores Testnet
 

--- a/packages/docs/SUMMARY.md
+++ b/packages/docs/SUMMARY.md
@@ -6,6 +6,7 @@
 ## Getting Started
 
 - [Alfajores Testnet](getting-started/alfajores-testnet.md)
+  - [Using the Web Wallet](getting-started/using-the-web-wallet.md)
   - [Using the Mobile Wallet](getting-started/using-the-mobile-wallet.md)
   - [Getting an Account and Funds](getting-started/faucet.md)
 - [Baklava Testnet](getting-started/baklava-testnet.md)

--- a/packages/docs/developer-resources/celo-dapp-gallery.md
+++ b/packages/docs/developer-resources/celo-dapp-gallery.md
@@ -2,6 +2,12 @@
 
 Welcome to the DApp Gallery! Here are some featured examples to help you get started building on Celo.
 
+## Celo Toolkit
+
+Celo Toolkit is the open source interface for managing Celo accounts on Web. Start with Celo now in 1 minutes. Phone number or app downloads are not necessary.
+
+Github: https://github.com/MugglePay/celo-toolkit
+
 ## Savings Circle
 
 Savings Circles let you pool funds with your friends to save for large purchases. They are known by a variety of names around the world and are a common way to get liquidity and access to loans without access to formal financial institutions.

--- a/packages/docs/getting-started/using-the-web-wallet.md
+++ b/packages/docs/getting-started/using-the-web-wallet.md
@@ -1,0 +1,58 @@
+# Using the Web Wallet
+
+One easy way to experiment with the Alfajores Testnet is to play with it online. Start with Celo now in 1 minutes. 
+
+### Getting Started
+
+Go to [Celo Toolkit](http://celo.mugglepay.com/), and it's your web wallet. Phone number or app downloads are not necessary.
+
+### Create an account
+
+Click on the button 'Generate Account'. It will generates your Celo account for you, which includes address and PrivateKey as follows:
+
+> Address: 0x1bD6a6c2957194AF6888a950fB9B49ac3012a5d9
+> PrivateKey: 0x7ed5e09e3725984021fed755ef08f47361086ab514dbb17c60fb0acd5f4f3fb6
+
+<p align="center">
+  <a href=" https://www.mugglepay.com">
+    <img src="http://dcdn.mugglepay.com/pay/celo/celo5.png" />
+  </a>
+</p>
+
+### Get More Funds
+
+If you don't have balance in your account, please click the [Topup (Celo Faucet)](https://celo.org/build/faucet) button. It will give you 10 cUSD and 5 cGLD for free.
+
+
+If you already have an account, click 'Import Private Keys', and it will load your account and show your account balance.
+
+
+### Pay with Celo on Web
+
+Once you have Celo Dollar in your account, you can make an online payment to others. Enter the recipient address and amount, and then click 'Pay'.
+
+The transaction will be sent to Celo network, and you can check the explorer by clicking 'Check Status on Celo Blockchain'.
+
+<p align="center">
+  <a href=" https://www.mugglepay.com">
+    <img src="http://dcdn.mugglepay.com/pay/celo/celo6.png" />
+  </a>
+</p>
+
+### Run it locally
+
+Feel free to download from github. It's html and javascript files. No installment is needed.
+
+ [Github: Celo Toolkit](https://github.com/MugglePay/celo-toolkit.git)
+
+
+### Security
+
+Please copy or write down the PrivateKey and keep it safe. It shows only once. 
+
+The website is targeted for the testnet now, and more security about the private keys management will be taken more seriously for the mainnet.
+
+Source code is open-sourced. The account is generated and showed on the client side.
+
+We used the version celo@0.3.1, which is generated from Celo NodeJS SDK (@celo/contractkit). It connects with the Celo blockchain. 
+


### PR DESCRIPTION
### Description

Celo Toolkit is the web interface for managing Celo accounts. It will lower the barrier for developers and newbies. Phone number or app downloads are not necessary.

It's [LIVE](http://celo.mugglepay.com/).
[Github](https://github.com/MugglePay/celo-toolkit)

### Tested

No tests. It's a web portal (user interface) to make it easy for new developers and newbies.

### Other changes

No

### Related issues

No.

I've dapp experience on Ethererum, EOS, Tron. When I develop with the current Celo Network SDK, I still found few things frustrated.
1) Celo app cannot be downloaded in my country, and it took me some time to get around this.
2) The process of invitation code and Celo registration is not stable in Asia area.

It took me an hour but it might take more time for developers new to blockchain. So we build the web wallet help the reduce the cost for celo developers or newbies.

### Backwards compatibility

It's a new feature.