### PR TITLE
Changed celostats main domain to celostats-frontend

### DIFF
--- a/packages/helm-charts/celostats/templates/celostats-frontend.deployment.yaml
+++ b/packages/helm-charts/celostats/templates/celostats-frontend.deployment.yaml
@@ -28,7 +28,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
         - name: ETHSTATS_SERVICE
-          value: https://{{ .Release.Namespace }}-celostats.{{ .Values.domain.name }}.org
+          value: https://{{ .Release.Namespace }}-celostats-server.{{ .Values.domain.name }}.org
         - name: BLOCKSCOUT_URL
           value: https://{{ .Release.Namespace }}-blockscout.{{ .Values.domain.name }}.org
         - name: GRAPHQL_BLOCKSCOUT_URL

--- a/packages/helm-charts/celostats/templates/celostats-frontend.ingress.yaml
+++ b/packages/helm-charts/celostats/templates/celostats-frontend.ingress.yaml
@@ -14,10 +14,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Release.Namespace }}-celostats-frontend.{{ .Values.domain.name }}.org
+    - {{ .Release.Namespace }}-celostats.{{ .Values.domain.name }}.org
     secretName: {{ .Release.Namespace }}-celostats-frontend-tls
   rules:
-  - host: {{ .Release.Namespace }}-celostats-frontend.{{ .Values.domain.name }}.org
+  - host: {{ .Release.Namespace }}-celostats.{{ .Values.domain.name }}.org
     http:
       paths:
       - path: /

--- a/packages/helm-charts/celostats/templates/celostats-server.ingress.yaml
+++ b/packages/helm-charts/celostats/templates/celostats-server.ingress.yaml
@@ -14,10 +14,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Release.Namespace }}-celostats.{{ .Values.domain.name }}.org
+    - {{ .Release.Namespace }}-celostats-server.{{ .Values.domain.name }}.org
     secretName: {{ .Release.Namespace }}-celostats-tls
   rules:
-  - host: {{ .Release.Namespace }}-celostats.{{ .Values.domain.name }}.org
+  - host: {{ .Release.Namespace }}-celostats-server.{{ .Values.domain.name }}.org
     http:
       paths:
       - path: /


### PR DESCRIPTION
### Description

Changed the default dns https://{env}-celostats.{dns-domain} to the celostats-frontend service.

### Tested

Tested on rc0 environment
