### PR TITLE
Add confirmation prompts for locked gold requirement changing events

### DIFF
--- a/packages/cli/src/commands/validator/affiliate.ts
+++ b/packages/cli/src/commands/validator/affiliate.ts
@@ -1,3 +1,4 @@
+import prompts from 'prompts'
 import { IArg } from '@oclif/parser/lib/args'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
@@ -33,6 +34,17 @@ export default class ValidatorAffiliate extends BaseCommand {
       .isValidatorGroup(res.args.groupAddress)
       .runChecks()
 
+    const response = await prompts({
+      type: 'confirm',
+      name: 'confirmation',
+      message:
+        'Are you sure you want to affiliate with this group?\nAffiliating with a Validator Group could result in Locked Gold requirements of up to 10,000 cGLD for 60 days. (y/n)',
+    })
+
+    if (!response.confirmation) {
+      console.info('Aborting due to user response')
+      process.exit(0)
+    }
     await displaySendTx('affiliate', validators.affiliate(res.args.groupAddress))
   }
 }

--- a/packages/cli/src/commands/validator/affiliate.ts
+++ b/packages/cli/src/commands/validator/affiliate.ts
@@ -1,5 +1,5 @@
-import prompts from 'prompts'
 import { IArg } from '@oclif/parser/lib/args'
+import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx } from '../../utils/cli'

--- a/packages/cli/src/commands/validatorgroup/member.ts
+++ b/packages/cli/src/commands/validatorgroup/member.ts
@@ -1,3 +1,4 @@
+import prompts from 'prompts'
 import { flags } from '@oclif/command'
 import { IArg } from '@oclif/parser/lib/args'
 import { BaseCommand } from '../../base'
@@ -53,6 +54,17 @@ export default class ValidatorGroupMembers extends BaseCommand {
 
     const validatorGroup = await validators.signerToAccount(res.flags.from)
     if (res.flags.accept) {
+      const response = await prompts({
+        type: 'confirm',
+        name: 'confirmation',
+        message:
+          'Are you sure you want to accept this member?\nValidator Group Locked Gold requirements increase per member. Adding an additional member could result in an increase in Locked Gold requirements of up to 10,000 cGLD for 180 days. (y/n)',
+      })
+
+      if (!response.confirmation) {
+        console.info('Aborting due to user response')
+        process.exit(0)
+      }
       const tx = await validators.addMember(validatorGroup, res.args.validatorAddress)
       await displaySendTx('addMember', tx)
     } else if (res.flags.remove) {

--- a/packages/cli/src/commands/validatorgroup/member.ts
+++ b/packages/cli/src/commands/validatorgroup/member.ts
@@ -1,6 +1,6 @@
-import prompts from 'prompts'
 import { flags } from '@oclif/command'
 import { IArg } from '@oclif/parser/lib/args'
+import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx } from '../../utils/cli'


### PR DESCRIPTION
### Description

This PR adds confirmation prompts to `validatorgroup:member --accept` and `validator:affiliate`, both of which can result in additional locked gold requirements on the account.

### Tested

No

### Other changes

None

### Related issues

- Introduces #3267 

### Backwards compatibility

Yes