### PR TITLE
[L03] Missing revert messages in require statements (update)

### DIFF
--- a/packages/protocol/contracts/common/FixidityLib.sol
+++ b/packages/protocol/contracts/common/FixidityLib.sol
@@ -241,7 +241,7 @@ library FixidityLib {
   function divide(Fraction memory x, Fraction memory y) internal pure returns (Fraction memory) {
     require(y.value != 0, "can't divide by 0");
     uint256 X = x.value * FIXED1_UINT;
-    require(X / FIXED1_UINT == x.value);
+    require(X / FIXED1_UINT == x.value, "overflow at divide");
     return Fraction(X / y.value);
   }
 


### PR DESCRIPTION
### Description

Looks like one require statement was left.

### Tested


### Other changes


### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/303

### Backwards compatibility
