### PR TITLE
[M02] Inputs are not checked in setReserveFraction

### DIFF
--- a/packages/protocol/contracts/stability/Exchange.sol
+++ b/packages/protocol/contracts/stability/Exchange.sol
@@ -236,6 +236,7 @@ contract Exchange is IExchange, Initializable, Ownable, UsingRegistry, Reentranc
     */
   function setReserveFraction(uint256 newReserveFraction) public onlyOwner {
     reserveFraction = FixidityLib.wrap(newReserveFraction);
+    require(reserveFraction.lt(FixidityLib.fixed1()), "reserve fraction must be smaller than 1");
     emit ReserveFractionSet(newReserveFraction);
   }
 

--- a/packages/protocol/test/stability/exchange.ts
+++ b/packages/protocol/test/stability/exchange.ts
@@ -296,7 +296,11 @@ contract('Exchange', (accounts: string[]) => {
       })
     })
 
-    it('should not allow a non-owner not set the minimum reports', async () => {
+    it('should not allow to set the reserve fraction greater or equal to one', async () => {
+      await assertRevert(exchange.setReserveFraction(toFixed(1)))
+    })
+
+    it('should not allow a non-owner not set the reserve fraction', async () => {
       await assertRevert(exchange.setReserveFraction(newReserveFraction, { from: accounts[1] }))
     })
   })


### PR DESCRIPTION
### Description


### Tested


### Other changes


### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/435

### Backwards compatibility

