### PR TITLE
[N04] MockReserve.sol has mintToken function

### DIFF
--- a/packages/protocol/contracts/stability/test/MockReserve.sol
+++ b/packages/protocol/contracts/stability/test/MockReserve.sol
@@ -37,10 +37,6 @@ contract MockReserve {
     return true;
   }
 
-  function mintToken(address, address, uint256) external pure returns (bool) {
-    return true;
-  }
-
   function getUnfrozenReserveGoldBalance() external view returns (uint256) {
     return address(this).balance;
   }


### PR DESCRIPTION
### Description

The MockReserve contract has a mintToken function, while the contract it is based on, Reserve, does not.


### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/439

