### PR TITLE
Fix e2e transfer tests

### DIFF
--- a/packages/celotool/src/e2e-tests/transfer_tests.ts
+++ b/packages/celotool/src/e2e-tests/transfer_tests.ts
@@ -64,7 +64,7 @@ class InflationManager {
   setInflationParameters = async (rate: BigNumber, updatePeriod: number) => {
     const stableToken = await this.kit.contracts.getStableToken()
     await stableToken
-      .setInflationParameters(toFixed(rate).toString(), updatePeriod)
+      .setInflationParameters(toFixed(rate).toFixed(), updatePeriod)
       .sendAndWaitForReceipt({ from: this.validatorAddress })
   }
 }


### PR DESCRIPTION
### Description

E2E transfers tests broke in b5dbd68ed8073a1f1f245feb1e3dd4d44c024619, likely due to the upgrade of BigNumber.
This PR makes sure the inflation number doesn't use exponential notation.

### Tested

E2E transfers tests pass (still some remaining flakiness though).

### Other changes

None

### Related issues

Discussed on Slack.

### Backwards compatibility

Yes
