### PR TITLE
Increase required Rust version in setup instructions

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -218,8 +218,8 @@ source ~/.bashrc
 With Rust binaries in your PATH you should be able to run:
 
 ```bash
-rustup install 1.36.0
-rustup default 1.36.0
+rustup install 1.42.0
+rustup default 1.42.0
 ```
 
 If you're building Geth for Android, you require an NDK that has a cross-compilation toolchain. You can get it by appropriately defining the relevant environment variables, e.g.:


### PR DESCRIPTION
### Description

A newer version of rust is needed for celo-blockchain setup.

### Tested

`make`ing celo-blockchain was failing with the previous recommended version (1.36), compiles now.