### PR TITLE
Point CI back to celo-blockchain master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ e2e-defaults: &e2e-defaults
   docker:
     - image: celohq/circleci:geth1.9-2
   environment:
-    CELO_BLOCKCHAIN_BRANCH_TO_TEST: mrsmkl/fast-epochs-announce
+    CELO_BLOCKCHAIN_BRANCH_TO_TEST: master
 
 general:
   artifacts:


### PR DESCRIPTION
### Description

Points CI back to `master` on celo-blockchain after https://github.com/celo-org/celo-monorepo/pull/3219

### Tested

Unit tests
### Other changes

None
### Related issues

None
### Backwards compatibility

Yes