### PR TITLE
Update docs with feedback from Baklava launch

### DIFF
--- a/packages/docs/command-line-interface/introduction.md
+++ b/packages/docs/command-line-interface/introduction.md
@@ -17,7 +17,7 @@ description: >-
 The Celo CLI is published as a node module on NPM. Assuming you have [npm installed](https://www.npmjs.com/get-npm), you can install the Celo CLI using the following command:
 
 ```bash
-npm install -g @celo/celocli@baklava
+npm install -g @celo/celocli
 ```
 
 {% hint style="info" %}
@@ -25,7 +25,7 @@ We are currently deploying the CLI with only Node v10.x LTS support. If you are 
 {% endhint %}
 
 {% hint style="info" %}
-If you have trouble installing globally (i.e. with the `-g` flag), try installing to a local directory instead with `npm install @celo/celocli@baklava` and run with `npx celocli`.
+If you have trouble installing globally (i.e. with the `-g` flag), try installing to a local directory instead with `npm install @celo/celocli` and run with `npx celocli`.
 {% endhint %}
 
 ### Overview

--- a/packages/docs/developer-resources/contractkit/reference/README.md
+++ b/packages/docs/developer-resources/contractkit/reference/README.md
@@ -20,9 +20,9 @@ ContractKit supports the following functionality:
 To install:
 
 ```bash
-npm install @celo/contractkit@baklava
+npm install @celo/contractkit
 // or
-yarn add @celo/contractkit@baklava
+yarn add @celo/contractkit
 ```
 
 You will need node version `8.13.0` or higher.

--- a/packages/docs/developer-resources/contractkit/setup.md
+++ b/packages/docs/developer-resources/contractkit/setup.md
@@ -5,9 +5,9 @@
 To install, run the following:
 
 ```bash
-npm install @celo/contractkit@baklava
+npm install @celo/contractkit
 // or
-yarn add @celo/contractkit@baklava
+yarn add @celo/contractkit
 ```
 
 You will need node version `10.0.0` or higher.

--- a/packages/docs/getting-started/running-a-validator-in-baklava.md
+++ b/packages/docs/getting-started/running-a-validator-in-baklava.md
@@ -265,7 +265,7 @@ There are number of new environment variables, and you may use this table as a r
 
 ### Create Accounts from the `ReleaseGold` contracts
 
-In order to use the balances from `ReleaseGold` contracts, we need to create associated Accounts. In the Baklava network, after they have been deployed we will publish a document mapping the Beneficiary address to `ReleaseGold` contract addresses.
+In order to use the balances from `ReleaseGold` contracts, we need to create associated Accounts. In the Baklava network, you can look up your Beneficiary address in [the published mapping](https://gist.githubusercontent.com/nategraf/a87f9c2e488ab2d38a0a3c09f5d4ca2b/raw) to find your `ReleaseGold` contract addresses. If you are a genesis validator, your two Beneficary addresses will be the provided `CELO_VALIDATOR_ADDRESS` and `CELO_VALIDATOR_GROUP_ADDRESS`.
 
 ```bash
 # On your local machine


### PR DESCRIPTION
### Description

* Remove `baklava` tag from package `npm` package download commands
  * Additionally the `baklava` was updated to match `latest` so there is no immediate difference
* Add a link to the ReleaseGold contract address lookup table