### PR TITLE
Fix election:vote which uses an unstable sort

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "moment": "2.24.0",
     "humanize-duration": "^3.21.0",
     "path": "^0.12.7",
+    "prompts": "^2.0.1",
     "tslib": "^1",
     "web3": "1.2.4"
   },

--- a/packages/contractkit/src/wrappers/Election.ts
+++ b/packages/contractkit/src/wrappers/Election.ts
@@ -420,7 +420,7 @@ export class ElectionWrapper extends BaseWrapper<Election> {
       }
     }
 
-    return { lesserKey, greaterKey }
+    return { lesser: lesserKey, greater: greaterKey }
   }
 
   /**

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_election_.electionwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_election_.electionwrapper.md
@@ -439,7 +439,7 @@ ___
 
 ▸ **getElectedValidators**(`epochNumber`: number): *Promise‹[Validator](../interfaces/_wrappers_validators_.validator.md)[]›*
 
-*Defined in [contractkit/src/wrappers/Election.ts:439](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Election.ts#L439)*
+*Defined in [contractkit/src/wrappers/Election.ts:430](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Election.ts#L430)*
 
 Retrieves the set of validatorsparticipating in BFT at epochNumber.
 
@@ -469,7 +469,7 @@ ___
 
 ▸ **getGroupVoterRewards**(`epochNumber`: number): *Promise‹[GroupVoterReward](../interfaces/_wrappers_election_.groupvoterreward.md)[]›*
 
-*Defined in [contractkit/src/wrappers/Election.ts:452](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Election.ts#L452)*
+*Defined in [contractkit/src/wrappers/Election.ts:443](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Election.ts#L443)*
 
 Retrieves GroupVoterRewards at epochNumber.
 
@@ -573,7 +573,7 @@ ___
 
 ▸ **getVoterRewards**(`address`: [Address](../modules/_base_.md#address), `epochNumber`: number): *Promise‹[VoterReward](../interfaces/_wrappers_election_.voterreward.md)[]›*
 
-*Defined in [contractkit/src/wrappers/Election.ts:476](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Election.ts#L476)*
+*Defined in [contractkit/src/wrappers/Election.ts:467](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Election.ts#L467)*
 
 Retrieves VoterRewards for address at epochNumber.
 

--- a/packages/docs/getting-started/running-a-validator-in-baklava.md
+++ b/packages/docs/getting-started/running-a-validator-in-baklava.md
@@ -394,7 +394,7 @@ To generate the proof-of-possession, run the following command:
 
 ```bash
 # On your local machine
-docker run -v $PWD:/root/.celo --rm -it $CELO_IMAGE --nousb account proof-of-possession $CELO_VALIDATOR_GROUP_SIGNER_ADDRESS $CELO_VALIDATOR_GROUP_RG_ADDRESS
+docker run -v $PWD:/root/.celo --rm -it $CELO_IMAGE --nousb account proof-of-possession $CELO_VALIDATOR_GROUP_VOTE_SIGNER_ADDRESS $CELO_VALIDATOR_GROUP_RG_ADDRESS
 ```
 
 Save the signer address, public key, and proof-of-possession signature to your local machine:


### PR DESCRIPTION
## Description

This PR fixes the election:vote command by removing the unstable sort used in the contract wrapper, and instead relying on the fact that the contract will already return groups in a sorted order.


## Other changes

- Small docs fix
- Add `prompts` to CLI dependencies

## Tested

No
## Related issues

None
## Backwards compatibility

None
