### PR TITLE
[Wallet] Remove obsolete reference to build:sdk

### DIFF
--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -51,55 +51,48 @@ platform :android do
   desc 'Ship Integration to Playstore Internal'
   lane :integration do
     env = 'integration'
-    sdkEnv = 'integration'
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
     fastlane_supply(env, 'internal', env)
   end
 
   desc 'Ship Staging to Playstore Internal'
   lane :staging do
     env = 'staging'
-    sdkEnv = 'alfajoresstaging'
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
     fastlane_supply(env, 'internal', env)
   end
 
   desc 'Ship Production to Playstore Alpha.'
   lane :production do
     env = 'release'
-    sdkEnv = 'argentinaproduction'
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
     fastlane_supply(env, 'alpha', 'production')
   end
 
   desc 'Ship Alfajores to Playstore Internal'
   lane :alfajores do
     env = 'alfajores'
-    sdkEnv = 'alfajores'
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
     fastlane_supply(env, 'internal', env)
   end
 
   desc 'Ship Pilot to Playstore Internal'
   lane :pilotapp do
     env = 'pilot'
-    sdkEnv = 'pilot'
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
     fastlane_supply(env, 'internal', env)
   end
 
   desc 'Build an Android apk'
   lane :build_apk do |options|
     env = options[:env]
-    sdkEnv = options[:sdkEnv]
-    build(environment: env, sdkEnv: sdkEnv, buildApk: true)
+    build(environment: env, buildApk: true)
   end
 
   desc 'Build an Android bundle'
   lane :build_bundle do |options|
     env = options[:env]
-    sdkEnv = options[:sdkEnv]
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
   end
 end
 
@@ -120,8 +113,7 @@ platform :ios do
   desc 'Ship Alfajores to TestFlight'
   lane :alfajores do
     env = 'alfajores'
-    sdkEnv = 'alfajores'
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
     )
@@ -130,8 +122,7 @@ platform :ios do
   desc 'Ship Pilot to TestFlight'
   lane :pilotapp do
     env = 'pilot'
-    sdkEnv = 'pilot'
-    build(environment: env, sdkEnv: sdkEnv)
+    build(environment: env)
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
     )

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "lint": "tslint -c tslint.json --project tsconfig.json",
     "build": "yarn run build:ts && yarn run build:metro",
-    "build:sdk": "yarn --cwd ../walletkit build:for-env",
     "build:ts": "tsc --noEmit",
     "build:metro": "echo 'NOT WORKING RIGHT NOW'",
     "build:gen-graphql-types": "graphql-codegen --config codegen.yml",


### PR DESCRIPTION
## Description

Remove obsolete reference to build:sdk now that walletkit has been removed.