### PR TITLE
Emit GoldRelocked instead of GoldLocked in LockedGold.relock()

### DIFF
--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -56,6 +56,7 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
   event UnlockingPeriodSet(uint256 period);
   event GoldLocked(address indexed account, uint256 value);
   event GoldUnlocked(address indexed account, uint256 value, uint256 available);
+  event GoldRelocked(address indexed account, uint256 value);
   event GoldWithdrawn(address indexed account, uint256 value);
   event SlasherWhitelistAdded(string indexed slasherIdentifier);
   event SlasherWhitelistRemoved(string indexed slasherIdentifier);
@@ -182,7 +183,7 @@ contract LockedGold is ILockedGold, ReentrancyGuard, Initializable, UsingRegistr
       pendingWithdrawal.value = pendingWithdrawal.value.sub(value);
     }
     _incrementNonvotingAccountBalance(msg.sender, value);
-    emit GoldLocked(msg.sender, value);
+    emit GoldRelocked(msg.sender, value);
   }
 
   /**

--- a/packages/protocol/test/governance/lockedgold.ts
+++ b/packages/protocol/test/governance/lockedgold.ts
@@ -308,10 +308,10 @@ contract('LockedGold', (accounts: string[]) => {
           assertEqualBN(await lockedGold.getTotalLockedGold(), value)
         })
 
-        it('should emit a GoldLocked event', async () => {
+        it('should emit a GoldRelocked event', async () => {
           assert.equal(resp.logs.length, 1)
           const log = resp.logs[0]
-          assertLogMatches(log, 'GoldLocked', {
+          assertLogMatches(log, 'GoldRelocked', {
             account,
             value: new BigNumber(value),
           })
@@ -346,10 +346,10 @@ contract('LockedGold', (accounts: string[]) => {
           assertEqualBN(await lockedGold.getTotalLockedGold(), value)
         })
 
-        it('should emit a GoldLocked event', async () => {
+        it('should emit a GoldRelocked event', async () => {
           assert.equal(resp.logs.length, 1)
           const log = resp.logs[0]
-          assertLogMatches(log, 'GoldLocked', {
+          assertLogMatches(log, 'GoldRelocked', {
             account,
             value: new BigNumber(value),
           })


### PR DESCRIPTION
## Description

Emit GoldRelocked event in LockedGold.relock() to distinguish from LockedGold.lock(), and be more auditable for custodians.

## Tested

E2e tests.

## Backwards compatibility

Yes for everything not using GoldLocked event.  Those cases may now need to handle GoldRelocked.
