### PR TITLE
[Wallet] Fix invite redemption gas handling and gas price calculation

### DIFF
--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -31,6 +31,7 @@ export const DEV_SETTINGS_ACTIVE_INITIALLY = stringToBoolean(
 
 // VALUES
 export const GAS_INFLATION_FACTOR = 1.5 // Used when estimating gas for txs
+export const GAS_PRICE_INFLATION_FACTOR = 5 // Used when getting gas price, must match what Geth does
 export const BALANCE_OUT_OF_SYNC_THRESHOLD = 5 * 60 // 5 minutes
 export const ALERT_BANNER_DURATION = 5000
 export const NUMBER_INPUT_MAX_DECIMALS = 2

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -30,6 +30,7 @@ export const DEV_SETTINGS_ACTIVE_INITIALLY = stringToBoolean(
 )
 
 // VALUES
+export const GAS_INFLATION_FACTOR = 1.5 // Used when estimating gas for txs
 export const BALANCE_OUT_OF_SYNC_THRESHOLD = 5 * 60 // 5 minutes
 export const ALERT_BANNER_DURATION = 5000
 export const NUMBER_INPUT_MAX_DECIMALS = 2

--- a/packages/mobile/src/escrow/saga.ts
+++ b/packages/mobile/src/escrow/saga.ts
@@ -196,7 +196,7 @@ export async function getReclaimEscrowGas(account: string, paymentID: string) {
     from: account,
     feeCurrency: await getCurrencyAddress(CURRENCY_ENUM.DOLLAR),
   }
-  const gas = estimateGas(tx, txParams)
+  const gas = await estimateGas(tx, txParams)
   Logger.debug(`${TAG}/getReclaimEscrowGas`, `Estimated gas of ${gas.toString()}}`)
   return gas
 }

--- a/packages/mobile/src/escrow/saga.ts
+++ b/packages/mobile/src/escrow/saga.ts
@@ -39,6 +39,7 @@ import Logger from 'src/utils/Logger'
 import { addLocalAccount, getContractKit } from 'src/web3/contracts'
 import { getConnectedAccount, getConnectedUnlockedAccount } from 'src/web3/saga'
 import { fornoSelector } from 'src/web3/selectors'
+import { estimateGas } from 'src/web3/utils'
 
 const TAG = 'escrow/saga'
 
@@ -195,7 +196,7 @@ export async function getReclaimEscrowGas(account: string, paymentID: string) {
     from: account,
     feeCurrency: await getCurrencyAddress(CURRENCY_ENUM.DOLLAR),
   }
-  const gas = new BigNumber(await tx.estimateGas(txParams))
+  const gas = estimateGas(tx, txParams)
   Logger.debug(`${TAG}/getReclaimEscrowGas`, `Estimated gas of ${gas.toString()}}`)
   return gas
 }

--- a/packages/mobile/src/fees/saga.test.ts
+++ b/packages/mobile/src/fees/saga.test.ts
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { call, select } from 'redux-saga/effects'
+import { GAS_PRICE_INFLATION_FACTOR } from 'src/config'
 import { getReclaimEscrowGas } from 'src/escrow/saga'
 import { feeEstimated, FeeType } from 'src/fees/actions'
 import { estimateFeeSaga } from 'src/fees/saga'
@@ -31,6 +32,7 @@ describe(estimateFeeSaga, () => {
           FeeType.INVITE,
           new BigNumber(10000)
             .times(GAS_AMOUNT)
+            .times(GAS_PRICE_INFLATION_FACTOR)
             .plus(getInvitationVerificationFeeInWei())
             .toString()
         )
@@ -45,7 +47,15 @@ describe(estimateFeeSaga, () => {
         [matchers.call.fn(getSendTxGas), new BigNumber(GAS_AMOUNT)],
         [select(stableTokenBalanceSelector), '1'],
       ])
-      .put(feeEstimated(FeeType.SEND, new BigNumber(10000).times(GAS_AMOUNT).toString()))
+      .put(
+        feeEstimated(
+          FeeType.SEND,
+          new BigNumber(10000)
+            .times(GAS_PRICE_INFLATION_FACTOR)
+            .times(GAS_AMOUNT)
+            .toString()
+        )
+      )
       .run()
   })
 
@@ -56,7 +66,15 @@ describe(estimateFeeSaga, () => {
         [matchers.call.fn(getReclaimEscrowGas), new BigNumber(GAS_AMOUNT)],
         [select(stableTokenBalanceSelector), '1'],
       ])
-      .put(feeEstimated(FeeType.SEND, new BigNumber(10000).times(GAS_AMOUNT).toString()))
+      .put(
+        feeEstimated(
+          FeeType.SEND,
+          new BigNumber(10000)
+            .times(GAS_PRICE_INFLATION_FACTOR)
+            .times(GAS_AMOUNT)
+            .toString()
+        )
+      )
       .run()
   })
 

--- a/packages/mobile/src/invite/saga.test.ts
+++ b/packages/mobile/src/invite/saga.test.ts
@@ -22,6 +22,7 @@ import {
   watchSendInvite,
   withdrawFundsFromTempAccount,
 } from 'src/invite/saga'
+import { getSendFee } from 'src/send/saga'
 import { fetchDollarBalance } from 'src/stableToken/actions'
 import { transactionConfirmed } from 'src/transactions/actions'
 import { getContractKit } from 'src/web3/contracts'
@@ -106,6 +107,7 @@ describe(watchRedeemInvite, () => {
       .provide([
         [call(waitWeb3LastBlock), true],
         [call(getOrCreateAccount), mockAccount],
+        [matchers.call.fn(getSendFee), 0.1],
       ])
       .withState(state)
       .dispatch(redeemInvite(mockKey))

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -32,13 +32,14 @@ import {
 } from 'src/invite/actions'
 import { createInviteCode } from 'src/invite/utils'
 import { navigateHome } from 'src/navigator/NavigationService'
-import { getSendTxGas } from 'src/send/saga'
+import { getSendFee, getSendTxGas } from 'src/send/saga'
 import { fetchDollarBalance, transferStableToken } from 'src/stableToken/actions'
-import { createTransaction, fetchTokenBalanceInWeiWithRetry } from 'src/tokens/saga'
+import { createTokenTransferTransaction, fetchTokenBalanceInWeiWithRetry } from 'src/tokens/saga'
 import { generateStandbyTransactionId } from 'src/transactions/actions'
 import { waitForTransactionWithId } from 'src/transactions/saga'
 import { sendTransaction } from 'src/transactions/send'
 import { getAppStoreId } from 'src/utils/appstore'
+import { divideByWei } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { addLocalAccount, getContractKit } from 'src/web3/contracts'
 import { getConnectedUnlockedAccount, getOrCreateAccount, waitWeb3LastBlock } from 'src/web3/saga'
@@ -52,7 +53,7 @@ const INVITE_FEE = '0.25'
 export async function getInviteTxGas(
   account: string,
   currency: CURRENCY_ENUM,
-  amount: string,
+  amount: BigNumber.Value,
   comment: string
 ) {
   const contractKit = getContractKit()
@@ -353,19 +354,26 @@ export function* withdrawFundsFromTempAccount(
   if (!fornoMode) {
     yield call(contractKit.web3.eth.personal.unlockAccount, tempAccount, TEMP_PW, 600)
   }
-  const tempAccountBalance = new BigNumber(
-    contractKit.web3.utils.fromWei(tempAccountBalanceWei.toString())
+  const tempAccountBalance = divideByWei(tempAccountBalanceWei)
+
+  Logger.debug(TAG + '@withdrawFundsFromTempAccount', 'Calculating withdrawal fee')
+  const sendTokenFee: BigNumber = yield call(getSendFee, tempAccount, CURRENCY_ENUM.DOLLAR, {
+    recipientAddress: newAccount,
+    amount: tempAccountBalance,
+    comment: SENTINEL_INVITE_COMMENT,
+  })
+  Logger.debug(TAG + '@withdrawFundsFromTempAccount', `Using fee of ${sendTokenFee.toString()}`)
+
+  const tx: CeloTransactionObject<boolean> = yield call(
+    createTokenTransferTransaction,
+    CURRENCY_ENUM.DOLLAR,
+    {
+      recipientAddress: newAccount,
+      comment: SENTINEL_INVITE_COMMENT,
+      amount: tempAccountBalance.minus(sendTokenFee),
+    }
   )
 
-  Logger.debug(TAG + '@withdrawFundsFromTempAccount', 'Creating send transaction')
-  const tx: CeloTransactionObject<boolean> = yield call(createTransaction, CURRENCY_ENUM.DOLLAR, {
-    recipientAddress: newAccount,
-    comment: SENTINEL_INVITE_COMMENT,
-    // TODO: appropriately withdraw the balance instead of using gas fees will be less than 1 cent
-    amount: tempAccountBalance.minus(0.01).toString(),
-  })
-
-  Logger.debug(TAG + '@withdrawFundsFromTempAccount', 'Sending transaction')
   yield call(sendTransaction, tx.txo, tempAccount, TAG, 'Transfer from temp wallet')
   Logger.debug(TAG + '@withdrawFundsFromTempAccount', 'Done withdrawal')
 }

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -365,7 +365,8 @@ export function* withdrawFundsFromTempAccount(
     amount: tempAccountBalance,
     comment: SENTINEL_INVITE_COMMENT,
   })
-  const sendTokenFee = divideByWei(sendTokenFeeInWei).times(5)
+  // Inflate fee by 10% to harden against minor gas changes
+  const sendTokenFee = divideByWei(sendTokenFeeInWei).times(1.1)
 
   if (sendTokenFee.isGreaterThanOrEqualTo(tempAccountBalance)) {
     throw new Error('Fee is too large for amount in temp wallet')
@@ -374,7 +375,7 @@ export function* withdrawFundsFromTempAccount(
   const netSendAmount = tempAccountBalance.minus(sendTokenFee)
   Logger.debug(
     TAG + '@withdrawFundsFromTempAccount',
-    `Withdrwaing net amount of ${netSendAmount.toString()}`
+    `Withdrawing net amount of ${netSendAmount.toString()}`
   )
 
   const tx: CeloTransactionObject<boolean> = yield call(
@@ -382,8 +383,8 @@ export function* withdrawFundsFromTempAccount(
     CURRENCY_ENUM.DOLLAR,
     {
       recipientAddress: newAccount,
-      comment: SENTINEL_INVITE_COMMENT,
       amount: netSendAmount,
+      comment: SENTINEL_INVITE_COMMENT,
     }
   )
 

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -23,10 +23,15 @@ import {
   sendPaymentOrInviteSuccess,
 } from 'src/send/actions'
 import { transferStableToken } from 'src/stableToken/actions'
-import { BasicTokenTransfer, createTransaction, getCurrencyAddress } from 'src/tokens/saga'
+import {
+  BasicTokenTransfer,
+  createTokenTransferTransaction,
+  getCurrencyAddress,
+} from 'src/tokens/saga'
 import { generateStandbyTransactionId } from 'src/transactions/actions'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
+import { estimateGas } from 'src/web3/utils'
 
 const TAG = 'send/saga'
 
@@ -36,9 +41,9 @@ export async function getSendTxGas(
   params: BasicTokenTransfer
 ) {
   Logger.debug(`${TAG}/getSendTxGas`, 'Getting gas estimate for send tx')
-  const tx = await createTransaction(currency, params)
+  const tx = await createTokenTransferTransaction(currency, params)
   const txParams = { from: account, feeCurrency: await getCurrencyAddress(currency) }
-  const gas = new BigNumber(await tx.txo.estimateGas(txParams))
+  const gas = estimateGas(tx.txo, txParams)
   Logger.debug(`${TAG}/getSendTxGas`, `Estimated gas of ${gas.toString()}`)
   return gas
 }

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -43,7 +43,7 @@ export async function getSendTxGas(
   Logger.debug(`${TAG}/getSendTxGas`, 'Getting gas estimate for send tx')
   const tx = await createTokenTransferTransaction(currency, params)
   const txParams = { from: account, feeCurrency: await getCurrencyAddress(currency) }
-  const gas = estimateGas(tx.txo, txParams)
+  const gas = await estimateGas(tx.txo, txParams)
   Logger.debug(`${TAG}/getSendTxGas`, `Estimated gas of ${gas.toString()}`)
   return gas
 }

--- a/packages/mobile/src/tokens/saga.ts
+++ b/packages/mobile/src/tokens/saga.ts
@@ -87,7 +87,7 @@ export function tokenFetchFactory({ actionName, token, actionCreator, tag }: Tok
 
 export interface BasicTokenTransfer {
   recipientAddress: string
-  amount: string
+  amount: BigNumber.Value
   comment: string
 }
 
@@ -108,7 +108,7 @@ interface TokenTransferFactory {
 }
 
 // TODO(martinvol) this should go to the SDK
-export async function createTransaction(
+export async function createTokenTransferTransaction(
   currency: CURRENCY_ENUM,
   transferAction: BasicTokenTransfer
 ) {
@@ -168,11 +168,15 @@ export function tokenTransferFactory({
       try {
         const account = yield call(getConnectedUnlockedAccount)
 
-        const tx: CeloTransactionObject<boolean> = yield call(createTransaction, currency, {
-          recipientAddress,
-          amount,
-          comment,
-        })
+        const tx: CeloTransactionObject<boolean> = yield call(
+          createTokenTransferTransaction,
+          currency,
+          {
+            recipientAddress,
+            amount,
+            comment,
+          }
+        )
 
         yield call(sendAndMonitorTransaction, txId, tx, account, currency)
       } catch (error) {

--- a/packages/mobile/src/transactions/contract-utils.ts
+++ b/packages/mobile/src/transactions/contract-utils.ts
@@ -1,8 +1,7 @@
 import { values } from 'lodash'
+import { estimateGas } from 'src/web3/utils'
 import { Tx } from 'web3-core'
 import { TransactionObject, TransactionReceipt } from 'web3-eth'
-
-const gasInflateFactor = 1.5
 
 export type TxLogger = (event: SendTransactionLogEvent) => void
 
@@ -174,7 +173,7 @@ export async function sendTransactionAsync<T>(
     }
 
     if (estimatedGas === undefined) {
-      estimatedGas = Math.round((await tx.estimateGas(txParams)) * gasInflateFactor)
+      estimatedGas = (await estimateGas(tx, txParams)).toNumber()
       logger(EstimatedGas(estimatedGas))
     }
 

--- a/packages/mobile/src/web3/gas.test.ts
+++ b/packages/mobile/src/web3/gas.test.ts
@@ -3,6 +3,6 @@ import { getGasPrice } from 'src/web3/gas'
 describe('getGasPrice', () => {
   it('refreshes the gas price correctly', async () => {
     const gasPrice = await getGasPrice()
-    expect(gasPrice.toNumber()).toBe(10000)
+    expect(gasPrice.toNumber()).toBe(50000)
   })
 })

--- a/packages/mobile/src/web3/gas.ts
+++ b/packages/mobile/src/web3/gas.ts
@@ -1,5 +1,6 @@
 import { CURRENCY_ENUM } from '@celo/utils'
 import BigNumber from 'bignumber.js'
+import { GAS_PRICE_INFLATION_FACTOR } from 'src/config'
 import { getCurrencyAddress } from 'src/tokens/saga'
 import Logger from 'src/utils/Logger'
 import { getContractKit } from 'src/web3/contracts'
@@ -33,10 +34,11 @@ async function fetchGasPrice(currency: CURRENCY_ENUM) {
   const gasPriceMinimum = await getContractKit().contracts.getGasPriceMinimum()
   const address = await getCurrencyAddress(currency)
   const latestGasPrice = await gasPriceMinimum.getGasPriceMinimum(address)
+  const inflatedGasPrice = latestGasPrice.times(GAS_PRICE_INFLATION_FACTOR)
   Logger.debug(
     TAG,
     'fetchGasPrice',
-    `Gas price fetched in ${currency} with value: ${latestGasPrice.toString()}`
+    `Result price in ${currency} with inflation: ${inflatedGasPrice.toString()}`
   )
-  return latestGasPrice
+  return inflatedGasPrice
 }

--- a/packages/mobile/src/web3/utils.ts
+++ b/packages/mobile/src/web3/utils.ts
@@ -8,7 +8,7 @@ import { TransactionObject } from 'web3-eth'
 
 const TAG = 'web3/utils'
 
-// Estimate gas taking into account the cofigured inflation factor
+// Estimate gas taking into account the configured inflation factor
 export async function estimateGas(tx: TransactionObject<any>, txParams: Tx) {
   const gas = new BigNumber(await tx.estimateGas(txParams))
   return gas.times(GAS_INFLATION_FACTOR).integerValue()

--- a/packages/mobile/src/web3/utils.ts
+++ b/packages/mobile/src/web3/utils.ts
@@ -1,8 +1,18 @@
 import { ensureLeading0x } from '@celo/utils/src/address'
+import BigNumber from 'bignumber.js'
+import { GAS_INFLATION_FACTOR } from 'src/config'
 import Logger from 'src/utils/Logger'
 import { getContractKit } from 'src/web3/contracts'
+import { Tx } from 'web3-core'
+import { TransactionObject } from 'web3-eth'
 
 const TAG = 'web3/utils'
+
+// Estimate gas taking into account the cofigured inflation factor
+export async function estimateGas(tx: TransactionObject<any>, txParams: Tx) {
+  const gas = new BigNumber(await tx.estimateGas(txParams))
+  return gas.times(GAS_INFLATION_FACTOR).integerValue()
+}
 
 // Note: This returns Promise<Block>
 export function getLatestBlock() {


### PR DESCRIPTION
## Description

Calculate gas for withdrawing from invite codes more precisely

## Other changes

Improve organization of some gas related things

## Tested

As part of alfajroes release prep

## Backwards compatibility

Yes

## Commit Message
[Wallet] Fix invite redemption gas handling and gas price calculation

The app now calculates invite code withdrawal fees dynamically and also inflates gas prices to match what Geth does.