### PR TITLE
Update SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -187,10 +187,8 @@ You can find the complete instructions about how to install the tools in Linux e
 
 We need Go for [celo-blockchain](https://github.com/celo-org/celo-blockchain), the Go Celo implementation, and `gobind` to build Java language bindings to Go code for the Android Geth client).
 
-Note: We currently use Go 1.11. Brew installs Go 1.12 by default, which is not entirely compatible with our repositories. [Install Go 1.11 manually](https://golang.org/dl/), then run
-
 ```
-go get golang.org/x/mobile/cmd/gobind
+brew install go
 ```
 
 Execute the following (and make sure the lines are in your `~/.bash_profile`):


### PR DESCRIPTION
## Description

Changed go instructions to use `brew install go` which pulls go 1.14.1
## Other changes

none

## Tested

Using manually installed go 1.11.13, many pkgs were missing and unavailable. After uninstall of 1.11.13 and brew install of 1.14.1 built successfully on MacOS Catalina

```
Done building.
Run "./build/bin/geth" to launch geth.
```