### PR TITLE
Release celocli 0.0.38 and bump version numbers

### DIFF
--- a/packages/attestation-service/package.json
+++ b/packages/attestation-service/package.json
@@ -27,8 +27,8 @@
     "lint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
-    "@celo/contractkit": "0.3.4-dev",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/contractkit": "0.3.5-dev",
+    "@celo/utils": "0.1.10-dev",
     "bignumber.js": "^9.0.0",
     "body-parser": "1.19.0",
     "bunyan": "1.8.12",

--- a/packages/celotool/package.json
+++ b/packages/celotool/package.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@celo/verification-pool-api": "^1.0.0",
-    "@celo/utils": "0.1.9-dev",
-    "@celo/contractkit": "0.3.4-dev",
+    "@celo/utils": "0.1.10-dev",
+    "@celo/contractkit": "0.3.5-dev",
     "@google-cloud/monitoring": "0.7.1",
     "@google-cloud/pubsub": "^0.28.1",
     "@google-cloud/storage": "^2.4.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@celo/celocli",
   "description": "CLI Tool for transacting with the Celo protocol",
-  "version": "0.0.38-dev",
+  "version": "0.0.39-dev",
   "author": "Celo",
   "license": "Apache-2.0",
   "repository": "celo-org/celo-monorepo",
@@ -31,8 +31,8 @@
     "test": "TZ=UTC jest --runInBand"
   },
   "dependencies": {
-    "@celo/contractkit": "0.3.4-dev",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/contractkit": "0.3.5-dev",
+    "@celo/utils": "0.1.10-dev",
     "@ledgerhq/hw-transport-node-hid": "^5.11.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/contractkit",
-  "version": "0.3.4-dev",
+  "version": "0.3.5-dev",
   "description": "Celo's ContractKit to interact with Celo network",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -27,7 +27,7 @@
     "lint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
-    "@celo/utils": "0.1.9-dev",
+    "@celo/utils": "0.1.10-dev",
     "@ledgerhq/hw-app-eth": "^5.11.0",
     "@ledgerhq/hw-transport": "^5.11.0",
     "@types/debug": "^4.1.5",

--- a/packages/dappkit/package.json
+++ b/packages/dappkit/package.json
@@ -5,8 +5,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@celo/contractkit": "0.3.4-dev",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/contractkit": "0.3.5-dev",
+    "@celo/utils": "0.1.10-dev",
     "expo": "^36.0.2",
     "expo-contacts": "8.0.0",
     "libphonenumber-js": "^1.7.22",

--- a/packages/leaderboard/package.json
+++ b/packages/leaderboard/package.json
@@ -6,7 +6,7 @@
   "author": "Celo",
   "license": "Apache-2.0",
   "dependencies": {
-    "@celo/contractkit": "0.3.4-dev",
+    "@celo/contractkit": "0.3.5-dev",
     "@types/pg": "^7.11.2",
     "google-spreadsheet": "^2.0.8",
     "pg": "^7.12.1",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -37,10 +37,10 @@
   },
   "dependencies": {
     "@celo/client": "0.0.266",
-    "@celo/contractkit": "0.3.4-dev",
+    "@celo/contractkit": "0.3.5-dev",
     "@celo/react-components": "1.0.0",
     "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#b88e502",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/utils": "0.1.10-dev",
     "@react-native-community/async-storage": "^1.6.2",
     "@react-native-community/netinfo": "^4.4.0",
     "@segment/analytics-react-native": "^1.1.0-beta.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -41,7 +41,7 @@
     "@0x/sol-trace": "^2.0.16",
     "@0x/subproviders": "^5.0.0",
     "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#d5ff1f1",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/utils": "0.1.10-dev",
     "apollo-client": "^2.4.13",
     "bip39": "^3.0.2",
     "bls12377js": "https://github.com/celo-org/bls12377js#400bcaeec9e7620b040bfad833268f5289699cac",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#b88e502",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/utils": "0.1.10-dev",
     "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.14",
     "react-native-autocomplete-input": "^4.1.0",

--- a/packages/transaction-metrics-exporter/package.json
+++ b/packages/transaction-metrics-exporter/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "dependencies": {
     "@celo/contractkit": "0.2.9",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/utils": "0.1.10-dev",
     "express": "4.16.4",
     "prom-client": "11.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/utils",
-  "version": "0.1.9-dev",
+  "version": "0.1.10-dev",
   "description": "Celo common utils",
   "author": "Celo",
   "license": "Apache-2.0",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@celo/react-components": "1.0.0",
     "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#b88e502",
-    "@celo/utils": "0.1.9-dev",
+    "@celo/utils": "0.1.10-dev",
     "@react-native-community/async-storage": "^1.6.2",
     "@react-native-community/netinfo": "^4.4.0",
     "@segment/analytics-react-native": "^1.1.0-beta.2",


### PR DESCRIPTION
## Description

This PR increments the versions of the CLI, contractkit, and utils packages after publishing to NPM.

## Other changes

None.

## Tested

No
## Related issues

None
## Backwards compatibility

Yes
