### PR TITLE
Fix bignumber display in rewards:show

### DIFF
--- a/packages/cli/src/commands/rewards/show.ts
+++ b/packages/cli/src/commands/rewards/show.ts
@@ -167,7 +167,7 @@ export default class Show extends BaseCommand {
         voterRewards,
         {
           address: {},
-          addressPayment: {},
+          aaddressPayment: { get: (e) => e.addressPayment.toFixed() },
           group: { get: (e) => e.group.address },
           averageValidatorScore: { get: (e) => averageValidatorScore(e.validators).toFixed() },
           epochNumber: {},
@@ -182,7 +182,7 @@ export default class Show extends BaseCommand {
         {
           groupName: { get: (e) => e.group.name },
           group: { get: (e) => e.group.address },
-          groupVoterPayment: {},
+          groupVoterPayment: { get: (e) => e.groupVoterPayment.toFixed() },
           averageValidatorScore: { get: (e) => averageValidatorScore(e.validators).toFixed() },
           epochNumber: {},
         },
@@ -213,7 +213,7 @@ export default class Show extends BaseCommand {
         {
           validatorName: { get: (e) => e.validator.name },
           validator: { get: (e) => e.validator.address },
-          validatorPayment: {},
+          validatorPayment: { get: (e) => e.validatorPayment.toFixed() },
           validatorScore: { get: (e) => e.validator.score.toFixed() },
           group: { get: (e) => e.group.address },
           epochNumber: {},
@@ -236,7 +236,7 @@ export default class Show extends BaseCommand {
         {
           groupName: { get: (e) => e.group.name },
           group: { get: (e) => e.group.address },
-          groupPayment: {},
+          groupPayment: { get: (e) => e.groupPayment.toFixed() },
           validator: { get: (e) => e.validator.address },
           validatorScore: { get: (e) => e.validator.score.toFixed() },
           epochNumber: {},
@@ -252,9 +252,9 @@ export default class Show extends BaseCommand {
         accountsSlashed,
         {
           slashed: {},
-          penalty: {},
+          penalty: { get: (e) => e.penalty.toFixed() },
           reporter: {},
-          reward: {},
+          reward: { get: (e) => e.reward.toFixed() },
           epochNumber: {},
         },
         { 'no-truncate': !res.flags.truncate }


### PR DESCRIPTION
## Description

Some fields displayed as "BigNumber" objects

## Other changes

None
## Tested

Manually
## Related issues

No
## Backwards compatibility

Yes
## Commit Message
_If using automerge, specify desired commit title_

_And desired commit message body_