### PR TITLE
Fixes typo for addressPayment on rewards:show

### DIFF
--- a/packages/cli/src/commands/rewards/show.ts
+++ b/packages/cli/src/commands/rewards/show.ts
@@ -167,7 +167,7 @@ export default class Show extends BaseCommand {
         voterRewards,
         {
           address: {},
-          aaddressPayment: { get: (e) => e.addressPayment.toFixed() },
+          addressPayment: { get: (e) => e.addressPayment.toFixed() },
           group: { get: (e) => e.group.address },
           averageValidatorScore: { get: (e) => averageValidatorScore(e.validators).toFixed() },
           epochNumber: {},


### PR DESCRIPTION
## Description

Noticed a typo on the output of the rewards:show where addressPayment is printed as `AaddressPayment` this fixes it by changing the key to addressPayment


What is the current behavior, and what is the updated/expected behavior with this PR?

Here's an example of rewards form an address in rc0
```
ackages/cli/bin/run rewards:show --voter=0xcD0db9aFE5c5Cc31B3603D2b5709f8FED82cC5f7 
Running Checks:
   ✔  0xcD0db9aFE5c5Cc31B3603D2b5709f8FED82cC5f7 is a registered Account
Calculating rewards... done
Voter rewards:
Address                                    Aaddresspayment                      Group                                      Averagevalidatorscore Epochnumber
0xcD0db9aFE5c5Cc31B3603D2b5709f8FED82cC5f7 329762712509855.14873775974600355276 0x07b29C6941CAa61Ec815B6250556eb919629d930 0.74852407788562      30
```

After the change

```
./bin/run rewards:show --voter=0xcD0db9aFE5c5Cc31B3603D2b5709f8FED82cC5f7
Running Checks:
   ✔  0xcD0db9aFE5c5Cc31B3603D2b5709f8FED82cC5f7 is a registered Account
Calculating rewards... done

Voter rewards:
Address                                    Addresspayment                       Group                                      Averagevalidatorscore Epochnumber
0xcD0db9aFE5c5Cc31B3603D2b5709f8FED82cC5f7 329762712509855.14873775974600355276 0x07b29C6941CAa61Ec815B6250556eb919629d930 0.74852407788562      30
```

## Other changes

None

## Tested

simple text change and didn't see any unit tests that had the same string

## Related issues

None

## Backwards compatibility

Not applicable unless there's tools that expect to parse output in exact format

## Commit Message
_If using automerge, specify desired commit title_

_And desired commit message body_