### PR TITLE
Fix celocli accounts:proof-of-possession command

### DIFF
--- a/packages/docs/operations-manual/using-a-ledger-wallet.md
+++ b/packages/docs/operations-manual/using-a-ledger-wallet.md
@@ -125,7 +125,7 @@ The following commands are an example of how you might authorize a vote signing 
 
 ```bash
 # Plug in the Ledger containing the vote signing key to authorize and run the following command to securely generate the proof-of-possession.
-celocli accounts:proof-of-possession --account $ACCOUNT_ADDRESS --signer $VOTE_SIGNER_ADDRESS --useLedger
+celocli account:proof-of-possession --account $ACCOUNT_ADDRESS --signer $VOTE_SIGNER_ADDRESS --useLedger
 
 # If you wish to authorize a vote signing key for your account, plug in the Ledger containing the account key and run the following command to authorize the vote signing key.
 celocli account:authorize --from $ACCOUNT_ADDRESS --role vote --signer $VOTE_SIGNER_ADDRESS --signature $PROOF_OF_POSSESSION --useLedger


### PR DESCRIPTION
## Description

When trying command celocli accounts:proof-of-possession, celocli reports that it does not exists..
I think it should be celocli account:proof-of-possession instead

## Tested

celocli account:proof-of-possession works

## Commit Message
Fix typo in  celocli accounts:proof-of-possession command