### PR TITLE
Update Attestations.request natspec

### DIFF
--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -157,7 +157,7 @@ contract Attestations is
    * @param attestationRequestFeeToken The address of the token with which the attestation fee will
    * be paid.
    * @dev Note that if an attestion expires before it is completed, the fee is forfeited. This is
-   * is to prevent folks from attacking validators by requesting attestations that they do not
+   * to prevent folks from attacking validators by requesting attestations that they do not
    * complete, and to increase the cost of validators attempting to manipulate the attestations
    * protocol.
    */

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -156,6 +156,10 @@ contract Attestations is
    * @param attestationsRequested The number of requested attestations for this request.
    * @param attestationRequestFeeToken The address of the token with which the attestation fee will
    * be paid.
+   * @dev Note that if an attestion expires before it is completed, the fee is forfeited. This is
+   * is to prevent folks from attacking validators by requesting attestations that they do not
+   * complete, and to increase the cost of validators attempting to manipulate the attestations
+   * protocol.
    */
   function request(
     bytes32 identifier,


### PR DESCRIPTION
## Description

To clarify that attestation request fees are forfeited if attestations expire incomplete, and why.

## Other changes

None
## Tested

No
## Related issues

None
## Backwards compatibility

Yes
