### PR TITLE
Update gas fee payment natspecs

### DIFF
--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -480,6 +480,10 @@ contract StableToken is
    * @notice Reserve balance for making payments for gas in this StableToken currency.
    * @param from The account to reserve balance from
    * @param value The amount of balance to reserve
+   * @dev Note that this function is called by the protocol when paying for tx fees in this
+   * currency. After the tx is executed, gas is refunded to the sender and credited to the
+   * various tx fee recipients via a call to `creditGasFees`. Note too that the events emitted
+   * by `creditGasFees` reflect the *net* gas fee payments for the transaction.
    */
   function debitGasFees(address from, uint256 value)
     external
@@ -502,6 +506,10 @@ contract StableToken is
    * @param tipTxFee Coinbase fee
    * @param baseTxFee Community fund fee
    * @param gatewayFee Gateway fee
+   * @dev Note that this function is called by the protocol when paying for tx fees in this
+   * currency. Before the tx is executed, gas is debited from the sender via a call to
+   * `debitGasFees`. Note too that the events emitted by `creditGasFees` reflect the *net* gas fee
+   * payments for the transaction.
    */
   function creditGasFees(
     address from,


### PR DESCRIPTION
## Description

To clarify how these functions are used and the rationale behind event emission only in `creditGasFees`.

## Other changes

None
## Tested

No
## Related issues

None
## Backwards compatibility

Yes
