### PR TITLE
Attestation Dockerfile fix

### DIFF
--- a/dockerfiles/attestation-service/Dockerfile
+++ b/dockerfiles/attestation-service/Dockerfile
@@ -29,4 +29,4 @@ ENV NODE_ENV production
 RUN yarn build
 
 WORKDIR /celo-monorepo/packages/attestation-service
-CMD ["node lib/index.js"]
+ENTRYPOINT ["node", "lib/index.js"]


### PR DESCRIPTION
## Description

Saw a weird bug when using `CMD node lib/index.js`, changed to `ENTRYPOINT [node, lib/index.js]` and it works now.

## Tested

Yes