### PR TITLE
Update Accounts.sol

### DIFF
--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -562,7 +562,7 @@ contract Accounts is IAccounts, Ownable, ReentrancyGuard, Initializable, UsingRe
     require(isAccount(msg.sender), "Unknown account");
     require(
       isNotAccount(authorized) && isNotAuthorizedSigner(authorized),
-      "delegate or account exists"
+      "Cannot re-authorize address or locked gold account."
     );
 
     address signer = Signatures.getSignerOfAddress(msg.sender, v, r, s);


### PR DESCRIPTION
Clarify error when attempting to re-authorize an account that has been authorized in the past.

## Description

When rotating VALIDATOR_SIGNER key, it is prohibited to re-use a kay.  If re-use is attempted, this error message is displayed.  The old error message was not clear, this proposed error message is more clear.
