### PR TITLE
Use contract deployer address as owner instead of account[0]

### DIFF
--- a/packages/protocol/lib/web3-utils.ts
+++ b/packages/protocol/lib/web3-utils.ts
@@ -257,7 +257,7 @@ export function deploymentForContract<ContractInstance extends Truffle.ContractI
     deployer.deploy(Contract)
     deployer.then(async () => {
       const proxy: ProxyInstance = await ContractProxy.deployed()
-      await proxy._transferOwnership(_accounts[0])
+      await proxy._transferOwnership(ContractProxy.defaults().from)
       const proxiedContract: ContractInstance = await setInitialProxyImplementation<
         ContractInstance
       >(web3, artifacts, name, ...(await args(networkName)))


### PR DESCRIPTION
## Description

During Baklava contract deployment I hit an issue where, because account `0` on the deployer node was not the deployer account, migrations failed after assigning the wrong account as the contract owner.

This PR uses the contract `from` default as the owner to avoid this situation.