### PR TITLE
Removing grant end time check

### DIFF
--- a/packages/protocol/contracts/governance/ReleaseGold.sol
+++ b/packages/protocol/contracts/governance/ReleaseGold.sol
@@ -222,13 +222,6 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
     );
     require(registryAddress != address(0), "The registry address cannot be the zero address");
     require(
-      releaseSchedule.releaseStartTime.add(
-        releaseSchedule.numReleasePeriods.mul(releaseSchedule.releasePeriod)
-      ) >
-        block.timestamp,
-      "Release schedule end time must be in the future"
-    );
-    require(
       address(this).balance ==
         releaseSchedule.amountReleasedPerPeriod.mul(releaseSchedule.numReleasePeriods),
       "Contract balance must equal the entire grant amount"


### PR DESCRIPTION
## Description

The `require` that grant end times must be in the future has caused many headaches and doesn't provide us much value, so we are removing it.

## Other changes

None

## Tested

Unit tests

## Backwards compatibility

Yes

## Commit Message
Removing grant start time check