### PR TITLE
Allow minting of zero value for GoldToken and StableToken

### DIFF
--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -141,7 +141,6 @@ contract GoldToken is Initializable, CalledByVm, Freezable, IERC20, ICeloToken {
    * @param value The amount of cGLD to mint.
    */
   function mint(address to, uint256 value) external onlyVm returns (bool) {
-    require(value >= 0, "mint value must be >= 0");
     if (value == 0) {
       return true;
     }

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -141,7 +141,11 @@ contract GoldToken is Initializable, CalledByVm, Freezable, IERC20, ICeloToken {
    * @param value The amount of cGLD to mint.
    */
   function mint(address to, uint256 value) external onlyVm returns (bool) {
-    require(value > 0, "mint value must be > 0");
+    require(value >= 0, "mint value must be >= 0");
+    if (value == 0) {
+      return true;
+    }
+
     totalSupply_ = totalSupply_.add(value);
 
     bool success;

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -218,7 +218,6 @@ contract StableToken is
    */
   function _mint(address to, uint256 value) private returns (bool) {
     require(to != address(0), "0 is a reserved address");
-    require(value >= 0, "mint value must be >= 0");
     if (value == 0) {
       return true;
     }

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -218,7 +218,11 @@ contract StableToken is
    */
   function _mint(address to, uint256 value) private returns (bool) {
     require(to != address(0), "0 is a reserved address");
-    require(value > 0, "mint value must be > 0");
+    require(value >= 0, "mint value must be >= 0");
+    if (value == 0) {
+      return true;
+    }
+
     uint256 units = _valueToUnits(inflationState.factor, value);
     totalSupply_ = totalSupply_.add(units);
     balances[to] = balances[to].add(units);

--- a/packages/protocol/test/stability/stabletoken.ts
+++ b/packages/protocol/test/stability/stabletoken.ts
@@ -154,10 +154,6 @@ contract('StableToken', (accounts: string[]) => {
       assert.equal(supply, 0)
     })
 
-    it('should not allow the minting negative value', async () => {
-      await assertRevert(stableToken.mint(validators, -amountToMint, { from: validators }))
-    })
-
     it('should not allow anyone else to mint', async () => {
       await assertRevert(stableToken.mint(validators, amountToMint, { from: accounts[2] }))
     })

--- a/packages/protocol/test/stability/stabletoken.ts
+++ b/packages/protocol/test/stability/stabletoken.ts
@@ -146,6 +146,18 @@ contract('StableToken', (accounts: string[]) => {
       assert.equal(supply, amountToMint)
     })
 
+    it('should allow the minting 0 value', async () => {
+      await stableToken.mint(validators, 0, { from: validators })
+      const balance = (await stableToken.balanceOf(validators)).toNumber()
+      assert.equal(balance, 0)
+      const supply = (await stableToken.totalSupply()).toNumber()
+      assert.equal(supply, 0)
+    })
+
+    it('should not allow the minting negative value', async () => {
+      await assertRevert(stableToken.mint(validators, -amountToMint, { from: validators }))
+    })
+
     it('should not allow anyone else to mint', async () => {
       await assertRevert(stableToken.mint(validators, amountToMint, { from: accounts[2] }))
     })

--- a/packages/protocol/test/stability/stabletoken.ts
+++ b/packages/protocol/test/stability/stabletoken.ts
@@ -146,7 +146,7 @@ contract('StableToken', (accounts: string[]) => {
       assert.equal(supply, amountToMint)
     })
 
-    it('should allow the minting 0 value', async () => {
+    it('should allow minting 0 value', async () => {
       await stableToken.mint(validators, 0, { from: validators })
       const balance = (await stableToken.balanceOf(validators)).toNumber()
       assert.equal(balance, 0)


### PR DESCRIPTION
## Description

Minting of zero value is currently disallowed in the GoldToken and StableToken contracts. This PR allows minting zero value.