### PR TITLE
Add RC1 truffle config

### DIFF
--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -58,6 +58,14 @@ const networks = {
     network_id: 200312,
     gasPrice: 100000000000,
   },
+  rc1: {
+    host: '127.0.0.1',
+    port: 8545,
+    from: '0xE23a4c6615669526Ab58E9c37088bee4eD2b2dEE',
+    network_id: 42220,
+    gas: gasLimit,
+    gasPrice: 100000000000,
+  },
   coverage: {
     host: 'localhost',
     network_id: '*',


### PR DESCRIPTION
## Description

Truffle config for RC1 contract deployment.


## Other changes

None

## Tested

Somewhat, @mcortesi used to run migrations against a test network with a genesis block similar to RC1.

## Related issues

None

## Backwards compatibility

Yes

