### PR TITLE
[contractkit] Fix signature with 0 padding

### DIFF
--- a/packages/contractkit/src/utils/signing-utils.ts
+++ b/packages/contractkit/src/utils/signing-utils.ts
@@ -34,7 +34,7 @@ export function getHashFromEncoded(rlpEncode: string): string {
 
 function trimLeadingZero(hex: string) {
   while (hex && hex.startsWith('0x0')) {
-    hex = '0x' + hex.slice(3)
+    hex = ensureLeading0x(hex.slice(3))
   }
   return hex
 }

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
@@ -38,7 +38,7 @@ ___
 
 ▸ **encodeTransaction**(`rlpEncoded`: [RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md), `signature`: object): *Promise‹EncodedTransaction›*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:94](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L94)*
+*Defined in [contractkit/src/utils/signing-utils.ts:120](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L120)*
 
 **Parameters:**
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **recoverMessageSigner**(`signingDataHex`: string, `signedData`: string): *string*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:155](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L155)*
+*Defined in [contractkit/src/utils/signing-utils.ts:182](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L182)*
 
 **Parameters:**
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **recoverTransaction**(`rawTx`: string): *[Tx, string]*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:129](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L129)*
+*Defined in [contractkit/src/utils/signing-utils.ts:156](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L156)*
 
 **Parameters:**
 
@@ -109,7 +109,7 @@ ___
 
 ▸ **rlpEncodedTx**(`tx`: Tx): *[RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md)*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L43)*
+*Defined in [contractkit/src/utils/signing-utils.ts:69](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L69)*
 
 **Parameters:**
 
@@ -125,7 +125,7 @@ ___
 
 ▸ **verifyEIP712TypedDataSigner**(`typedData`: [EIP712TypedData](../interfaces/_utils_sign_typed_data_utils_.eip712typeddata.md), `signedData`: string, `expectedAddress`: string): *boolean*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:165](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L165)*
+*Defined in [contractkit/src/utils/signing-utils.ts:192](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L192)*
 
 **Parameters:**
 


### PR DESCRIPTION
## Description

Fix: the s, and r fields of the signature can't be send it in the encode raw transaction without removing the 0 padding

## Related issues

Fixes #3568 