### PR TITLE
Bumping local cli to 47-dev

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@celo/celocli",
   "description": "CLI Tool for transacting with the Celo protocol",
-  "version": "0.0.46-dev",
+  "version": "0.0.47-dev",
   "author": "Celo",
   "license": "Apache-2.0",
   "repository": "celo-org/celo-monorepo",


### PR DESCRIPTION
## Description

Version 45 of the CLI had to be skipped over as it was published erroneously. Active version is 46, therefore master version should be 47-dev.