### PR TITLE
[cli] Verify Proof of Possession

### DIFF
--- a/packages/cli/src/commands/account/authorize.ts
+++ b/packages/cli/src/commands/account/authorize.ts
@@ -17,7 +17,7 @@ export default class Authorize extends BaseCommand {
       description: 'Role to delegate',
       required: true,
     }),
-    signature: flags.string({
+    signature: Flags.proofOfPossession({
       description: 'Signature (a.k.a proof-of-possession) of the signer key',
       required: true,
     }),

--- a/packages/cli/src/commands/account/verify-proof-of-possession.ts
+++ b/packages/cli/src/commands/account/verify-proof-of-possession.ts
@@ -18,8 +18,7 @@ export default class VerifyProofOfPossession extends BaseCommand {
     }),
     signature: Flags.proofOfPossession({
       required: true,
-      description:
-        'A hex-encoded 0x-prefixed 65-byte signature from "account:proof-of-possession" command',
+      description: 'Signature (a.k.a. proof-of-possession) of the signer key',
     }),
   }
 

--- a/packages/cli/src/commands/account/verify-proof-of-possession.ts
+++ b/packages/cli/src/commands/account/verify-proof-of-possession.ts
@@ -1,0 +1,51 @@
+import { serializeSignature } from '@celo/utils/lib/signatureUtils'
+import { BaseCommand } from '../../base'
+import { printValueMap } from '../../utils/cli'
+import { Flags } from '../../utils/command'
+export default class VerifyProofOfPossession extends BaseCommand {
+  static description =
+    'Verify a proof-of-possession. See the "account:proof-of-possession" command for more details.'
+
+  static flags = {
+    ...BaseCommand.flags,
+    signer: Flags.address({
+      required: true,
+      description: 'Address of the signer key to verify proof of possession.',
+    }),
+    account: Flags.address({
+      required: true,
+      description: 'Address of the account that needs to prove possession of the signer key.',
+    }),
+    signature: Flags.proofOfPossession({
+      required: true,
+      description:
+        'A hex-encoded 0x-prefixed 65-byte signature from "account:proof-of-possession" command',
+    }),
+  }
+
+  static examples = [
+    'verify-proof-of-possession --account 0x199eDF79ABCa29A2Fa4014882d3C13dC191A5B58 --signer 0x0EdeDF7B1287f07db348997663EeEb283D70aBE7 --signature 0x1c5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a84c01b89ec91ca3',
+  ]
+
+  async run() {
+    const res = this.parse(VerifyProofOfPossession)
+    const accounts = await this.kit.contracts.getAccounts()
+    let valid = false
+    let signature = res.flags.signature
+    try {
+      const { v, r, s } = accounts.parseSignatureOfAddress(
+        res.flags.account,
+        res.flags.signer,
+        res.flags.signature
+      )
+      signature = serializeSignature({ v, r, s })
+      valid = true
+    } catch (error) {
+      console.error('Error: Failed to parse signature')
+    }
+    printValueMap({
+      valid: valid,
+      signature: signature,
+    })
+  }
+}

--- a/packages/cli/src/commands/releasegold/authorize.ts
+++ b/packages/cli/src/commands/releasegold/authorize.ts
@@ -15,7 +15,7 @@ export default class Authorize extends ReleaseGoldCommand {
       required: true,
       description: 'The signer key that is to be used for voting through the ReleaseGold instance',
     }),
-    signature: flags.string({
+    signature: Flags.proofOfPossession({
       description: 'Signature (a.k.a. proof-of-possession) of the signer key',
       required: true,
     }),

--- a/packages/cli/src/utils/command.ts
+++ b/packages/cli/src/utils/command.ts
@@ -2,6 +2,7 @@ import { ensureLeading0x, trimLeading0x } from '@celo/utils/lib/address'
 import { BLS_POP_SIZE, BLS_PUBLIC_KEY_SIZE } from '@celo/utils/lib/bls'
 import { URL_REGEX } from '@celo/utils/lib/io'
 import { isE164NumberStrict } from '@celo/utils/lib/phoneNumbers'
+import { POP_SIZE } from '@celo/utils/lib/signatureUtils'
 import { flags } from '@oclif/command'
 import { CLIError } from '@oclif/errors'
 import { IArg, ParseFn } from '@oclif/parser/lib/args'
@@ -33,6 +34,9 @@ const parseBlsPublicKey: ParseFn<string> = (input) => {
 }
 const parseBlsProofOfPossession: ParseFn<string> = (input) => {
   return parseBytes(input, BLS_POP_SIZE, `${input} is not a BLS proof-of-possession`)
+}
+const parseProofOfPossession: ParseFn<string> = (input) => {
+  return parseBytes(input, POP_SIZE, `${input} is not a proof-of-possession`)
 }
 const parseAddress: ParseFn<string> = (input) => {
   if (Web3.utils.isAddress(input)) {
@@ -110,6 +114,11 @@ export const Flags = {
     parse: parsePhoneNumber,
     description: 'Phone Number in E164 Format',
     helpValue: '+14152223333',
+  }),
+  proofOfPossession: flags.build({
+    parse: parseProofOfPossession,
+    description: 'Proof-of-Possession',
+    helpValue: '0x',
   }),
   url: flags.build({
     parse: parseUrl,

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -582,3 +582,42 @@ EXAMPLE
 ```
 
 _See code: [packages/cli/src/commands/account/unlock.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/unlock.ts)_
+
+### Verify-proof-of-possession
+
+Verify a proof-of-possession. See the "account:proof-of-possession" command for more details.
+
+```
+USAGE
+  $ celocli account:verify-proof-of-possession
+
+OPTIONS
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account that needs to prove possession
+                                                        of the signer key.
+
+  --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
+                                                        addresses for local signing
+
+  --ledgerConfirmAddress                                Set it to ask confirmation for the address of the transaction
+                                                        from the ledger
+
+  --ledgerCustomAddresses=ledgerCustomAddresses         [default: [0]] If --useLedger is set, this will get the array of
+                                                        index addresses for local signing. Example
+                                                        --ledgerCustomAddresses "[4,99]"
+
+  --signature=0x                                        (required) A hex-encoded 0x-prefixed 65-byte signature from
+                                                        "account:proof-of-possession" command
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer key to verify proof of
+                                                        possession.
+
+  --useLedger                                           Set it to use a ledger wallet
+
+EXAMPLE
+  verify-proof-of-possession --account 0x199eDF79ABCa29A2Fa4014882d3C13dC191A5B58 --signer
+  0x0EdeDF7B1287f07db348997663EeEb283D70aBE7 --signature
+  0x1c5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a8
+  4c01b89ec91ca3
+```
+
+_See code: [packages/cli/src/commands/account/verify-proof-of-possession.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/verify-proof-of-possession.ts)_

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -33,7 +33,7 @@ OPTIONS
                                                        index addresses for local signing. Example
                                                        --ledgerCustomAddresses "[4,99]"
 
-  --signature=signature                                (required) Signature (a.k.a proof-of-possession) of the signer
+  --signature=0x                                       (required) Signature (a.k.a proof-of-possession) of the signer
                                                        key
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
@@ -605,8 +605,8 @@ OPTIONS
                                                         index addresses for local signing. Example
                                                         --ledgerCustomAddresses "[4,99]"
 
-  --signature=0x                                        (required) A hex-encoded 0x-prefixed 65-byte signature from
-                                                        "account:proof-of-possession" command
+  --signature=0x                                        (required) Signature (a.k.a. proof-of-possession) of the signer
+                                                        key
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer key to verify proof of
                                                         possession.

--- a/packages/docs/command-line-interface/releasegold.md
+++ b/packages/docs/command-line-interface/releasegold.md
@@ -33,7 +33,7 @@ OPTIONS
 
   --role=vote|validator|attestation                      (required)
 
-  --signature=signature                                  (required) Signature (a.k.a. proof-of-possession) of the signer
+  --signature=0x                                         (required) Signature (a.k.a. proof-of-possession) of the signer
                                                          key
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) The signer key that is to be used for voting through

--- a/packages/utils/src/signatureUtils.ts
+++ b/packages/utils/src/signatureUtils.ts
@@ -1,6 +1,8 @@
 import * as Web3Utils from 'web3-utils'
 import { eqAddress, privateKeyToAddress } from './address'
 
+export const POP_SIZE = 65
+
 const ethjsutil = require('ethereumjs-util')
 
 // If messages is a hex, the length of it should be the number of bytes


### PR DESCRIPTION
## Description

A common use-case has emerged in which a client submits a proof-of-possession signature for authorization of signers to a custodian.  In that case, prior to performing on-chain operations it is desirable to be able to easily validate that the signature is correct.

Moreover this PR serializes the parsed signature to the form that the contract expects.

*Signtaure is VRS*
```
./bin/run  account:verify-proof-of-possession --account 0x199eDF79ABCa29A2Fa4014882d3C13dC191A5B58 --signer 0x0EdeDF7B1287f07db348997663EeEb283D70aBE7 --signature 0x1c5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a84c01b89ec91ca3
valid: true
signature: 0x1c5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a84c01b89ec91ca3
```
*Signature is RSV*
```
./bin/run  account:verify-proof-of-possession --account 0x199eDF79ABCa29A2Fa4014882d3C13dC191A5B58 --signer 0x0EdeDF7B1287f07db348997663EeEb283D70aBE7 --signature 0x5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a84c01b89ec91ca301
valid: true
signature: 0x1c5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a84c01b89ec91ca3
```
> Note: the signature has been serialized to VRS 
