### PR TITLE
Update Documentation to use Scientific Notation 

### DIFF
--- a/packages/docs/getting-started/running-a-validator-in-rc1.md
+++ b/packages/docs/getting-started/running-a-validator-in-rc1.md
@@ -352,8 +352,8 @@ celocli account:show $CELO_VALIDATOR_RG_ADDRESS
 Lock cGLD from your `ReleaseGold` contracts to fulfill the lock-up requirements to register a Validator and Validator Group. The current requirement is 10,000 cGLD to register a Validator, and 10,000 cGLD _per member validator_ to register a Validator Group.
 
 ```bash
-celocli releasegold:locked-gold --contract $CELO_VALIDATOR_GROUP_RG_ADDRESS --action lock --value 10000000000000000000000
-celocli releasegold:locked-gold --contract $CELO_VALIDATOR_RG_ADDRESS --action lock --value 10000000000000000000000
+celocli releasegold:locked-gold --contract $CELO_VALIDATOR_GROUP_RG_ADDRESS --action lock --value 10000e18
+celocli releasegold:locked-gold --contract $CELO_VALIDATOR_RG_ADDRESS --action lock --value 10000e18
 ```
 
 Check that your cGLD was successfully locked with the following commands:
@@ -545,8 +545,8 @@ Now the newly authorized vote signers can be used to vote for your validator gro
 
 ```bash
 # On your local machine
-celocli election:vote --from $CELO_VALIDATOR_VOTE_SIGNER_ADDRESS --for $CELO_VALIDATOR_GROUP_RG_ADDRESS --value 10000000000000000000000
-celocli election:vote --from $CELO_VALIDATOR_GROUP_VOTE_SIGNER_ADDRESS --for $CELO_VALIDATOR_GROUP_RG_ADDRESS --value 10000000000000000000000
+celocli election:vote --from $CELO_VALIDATOR_VOTE_SIGNER_ADDRESS --for $CELO_VALIDATOR_GROUP_RG_ADDRESS --value 10000e18
+celocli election:vote --from $CELO_VALIDATOR_GROUP_VOTE_SIGNER_ADDRESS --for $CELO_VALIDATOR_GROUP_RG_ADDRESS --value 10000e18
 ```
 
 Verify that your votes were cast successfully:


### PR DESCRIPTION
## Description

`celocli` can use either fixed numbers (10000000000000000000000) or scientific notation (10000e18). Favor scientific notation with n=18 in the documentation since this produces base10 numbers that humans are actually familiar with. 

If this is accepted, I can make similar changes in Baklava / Alfajores documentation. 

## Other changes

N/A

## Tested

Doc update. I've verified these commands work on the CLI when setting up my New-Baklava / RC1 validators. 

## Related issues

N/A

## Backwards compatibility

N/A 

## Commit Message
N/A