### PR TITLE
Add retry unreliable tests

### DIFF
--- a/packages/celotool/ci_test_governance.sh
+++ b/packages/celotool/ci_test_governance.sh
@@ -12,6 +12,7 @@ export TS_NODE_FILES=true
 if [ "${1}" == "checkout" ]; then
     # Test master by default.
     BRANCH_TO_TEST=${2:-"master"}
+    echo "TEST"
     echo "Checking out geth at branch ${BRANCH_TO_TEST}..."
     ../../node_modules/.bin/mocha --retries 3 -r ts-node/register src/e2e-tests/governance_tests.ts --branch ${BRANCH_TO_TEST}
 elif [ "${1}" == "local" ]; then

--- a/packages/celotool/ci_test_governance.sh
+++ b/packages/celotool/ci_test_governance.sh
@@ -13,7 +13,7 @@ if [ "${1}" == "checkout" ]; then
     # Test master by default.
     BRANCH_TO_TEST=${2:-"master"}
     echo "Checking out geth at branch ${BRANCH_TO_TEST}..."
-    ../../node_modules/.bin/mocha -r ts-node/register src/e2e-tests/governance_tests.ts --branch ${BRANCH_TO_TEST}
+    ../../node_modules/.bin/mocha -r ts-node/register src/e2e-tests/governance_tests.ts --branch ${BRANCH_TO_TEST} --retries 3
 elif [ "${1}" == "local" ]; then
     export GETH_DIR="${2}"
     echo "Testing using local geth dir ${GETH_DIR}..."

--- a/packages/celotool/ci_test_governance.sh
+++ b/packages/celotool/ci_test_governance.sh
@@ -13,7 +13,7 @@ if [ "${1}" == "checkout" ]; then
     # Test master by default.
     BRANCH_TO_TEST=${2:-"master"}
     echo "Checking out geth at branch ${BRANCH_TO_TEST}..."
-    ../../node_modules/.bin/mocha -r ts-node/register src/e2e-tests/governance_tests.ts --branch ${BRANCH_TO_TEST} --retries 3
+    ../../node_modules/.bin/mocha --retries 3 -r ts-node/register src/e2e-tests/governance_tests.ts --branch ${BRANCH_TO_TEST}
 elif [ "${1}" == "local" ]; then
     export GETH_DIR="${2}"
     echo "Testing using local geth dir ${GETH_DIR}..."

--- a/packages/celotool/ci_test_governance.sh
+++ b/packages/celotool/ci_test_governance.sh
@@ -12,7 +12,6 @@ export TS_NODE_FILES=true
 if [ "${1}" == "checkout" ]; then
     # Test master by default.
     BRANCH_TO_TEST=${2:-"master"}
-    echo "TEST"
     echo "Checking out geth at branch ${BRANCH_TO_TEST}..."
     ../../node_modules/.bin/mocha --retries 3 -r ts-node/register src/e2e-tests/governance_tests.ts --branch ${BRANCH_TO_TEST}
 elif [ "${1}" == "local" ]; then

--- a/packages/celotool/ci_test_transfers.sh
+++ b/packages/celotool/ci_test_transfers.sh
@@ -13,7 +13,7 @@ if [ "${1}" == "checkout" ]; then
     # Test master by default.
     BRANCH_TO_TEST=${2:-"master"}
     echo "Checking out geth at branch ${BRANCH_TO_TEST}..."
-    ../../node_modules/.bin/mocha -r ts-node/register src/e2e-tests/transfer_tests.ts --branch ${BRANCH_TO_TEST} --retries 3
+    ../../node_modules/.bin/mocha --retries 3 -r ts-node/register src/e2e-tests/transfer_tests.ts --branch ${BRANCH_TO_TEST}
 elif [ "${1}" == "local" ]; then
     export GETH_DIR="${2}"
     echo "Testing using local geth dir ${GETH_DIR}..."

--- a/packages/celotool/ci_test_transfers.sh
+++ b/packages/celotool/ci_test_transfers.sh
@@ -13,7 +13,7 @@ if [ "${1}" == "checkout" ]; then
     # Test master by default.
     BRANCH_TO_TEST=${2:-"master"}
     echo "Checking out geth at branch ${BRANCH_TO_TEST}..."
-    ../../node_modules/.bin/mocha -r ts-node/register src/e2e-tests/transfer_tests.ts --branch ${BRANCH_TO_TEST}
+    ../../node_modules/.bin/mocha -r ts-node/register src/e2e-tests/transfer_tests.ts --branch ${BRANCH_TO_TEST} --retries 3
 elif [ "${1}" == "local" ]; then
     export GETH_DIR="${2}"
     echo "Testing using local geth dir ${GETH_DIR}..."


### PR DESCRIPTION
## Description

Add retries to two unreliable test suites. These tests frequently fail unrelated to the current changes adding a lot of delay to the check-in process.