### PR TITLE
Add cmd for naming a validator group in rc1 docs

### DIFF
--- a/packages/docs/getting-started/running-a-validator-in-rc1.md
+++ b/packages/docs/getting-started/running-a-validator-in-rc1.md
@@ -477,6 +477,12 @@ You can view information about your Validator Group by running the following com
 celocli validatorgroup:show $CELO_VALIDATOR_GROUP_RG_ADDRESS
 ```
 
+You will want to associate a human-friendly name with your Validator Group, by running the following command:
+```
+# On your local machine
+celocli releasegold:set-account --contract $CELO_VALIDATOR_GROUP_RG_ADDRESS --property name --value <GROUP_NAME>
+```
+
 ### Affiliate the Validator with the group
 
 Now that the Validator and the group are registered, you can affiliate the Validator with the group, indicating that Validator's desire to join the group.


### PR DESCRIPTION
# Description

Added the command for setting the name of a validator group, that were missing in the rc1 docs.

## Other changes

N/A

## Tested

N/A

## Related issues

N/A

## Backwards compatibility

N/A

## Commit Message
Add cmd for naming a validator group in rc1 docs

Add cmd for naming a validator group in rc1 docs