### PR TITLE
Fix a typo in spanish verification success message

### DIFF
--- a/packages/mobile/locales/es-419/nuxVerification2.json
+++ b/packages/mobile/locales/es-419/nuxVerification2.json
@@ -75,7 +75,7 @@
     "enterCodesBody": " Si ya recibió tres códigos por SMS, aún puede ingresarlos.",
     "enterCodesButton": "Ingresar códigos"
   },
-  "congratsVerified": "¡Felicitaciones se ha verificado tu suario!",
+  "congratsVerified": "¡Felicitaciones se ha verificado tu usuario!",
   "notification": {
     "title": "Verificar el Teléfono",
     "body": "La verificación le permite enviar y recibir con sus contactos telefónicos.",


### PR DESCRIPTION
### Description

Typo correction based on feedback from Colombia

### Other changes

n/a

### Tested

copy change

### Related issues

No Issue Created

### Backwards compatibility

copy change