### PR TITLE
Show revert reason in mobile

### DIFF
--- a/packages/mobile/src/web3/utils.ts
+++ b/packages/mobile/src/web3/utils.ts
@@ -1,3 +1,4 @@
+import { estimateGas as ckEstimateGas } from '@celo/contractkit/lib/utils/web3-utils'
 import { ensureLeading0x } from '@celo/utils/src/address'
 import BigNumber from 'bignumber.js'
 import { GAS_INFLATION_FACTOR } from 'src/config'
@@ -9,9 +10,19 @@ import { TransactionObject } from 'web3-eth'
 const TAG = 'web3/utils'
 
 // Estimate gas taking into account the configured inflation factor
-export async function estimateGas(tx: TransactionObject<any>, txParams: Tx) {
-  const gas = new BigNumber(await tx.estimateGas(txParams))
-  return gas.times(GAS_INFLATION_FACTOR).integerValue()
+export async function estimateGas(txObj: TransactionObject<any>, txParams: Tx) {
+  const web3 = getContractKit().web3
+  const gasEstimator = (_tx: Tx) => txObj.estimateGas({ ..._tx })
+  const getCallTx = (_tx: Tx) => {
+    // @ts-ignore missing _parent property from TransactionObject type.
+    return { ..._tx, data: txObj.encodeABI(), to: txObj._parent._address }
+  }
+  const caller = (_tx: Tx) => web3.eth.call(getCallTx(_tx))
+  const gas = new BigNumber(await ckEstimateGas(txParams, gasEstimator, caller))
+    .times(GAS_INFLATION_FACTOR)
+    .integerValue()
+  Logger.debug('Estimated gas: ', gas.toString())
+  return gas
 }
 
 // Note: This returns Promise<Block>

--- a/packages/mobile/src/web3/utils.ts
+++ b/packages/mobile/src/web3/utils.ts
@@ -21,7 +21,6 @@ export async function estimateGas(txObj: TransactionObject<any>, txParams: Tx) {
   const gas = new BigNumber(await ckEstimateGas(txParams, gasEstimator, caller))
     .times(GAS_INFLATION_FACTOR)
     .integerValue()
-  Logger.debug('Estimated gas: ', gas.toString())
   return gas
 }
 


### PR DESCRIPTION
### Description

Building off the work here: http://github.com/celo-org/celo-monorepo/pull/3428, we should now get the revert reason when gas estimation fails