### PR TITLE
Fixing total balance

### DIFF
--- a/packages/contractkit/src/kit.ts
+++ b/packages/contractkit/src/kit.ts
@@ -121,9 +121,7 @@ export class ContractKit {
     const goldBalance = await goldToken.balanceOf(address)
     const lockedBalance = await lockedGold.getAccountTotalLockedGold(address)
     const dollarBalance = await stableToken.balanceOf(address)
-    const converted = dollarBalance.eq(new BigNumber(0))
-      ? new BigNumber(0)
-      : await exchange.quoteUsdSell(dollarBalance)
+    const converted = await exchange.quoteUsdSell(dollarBalance)
     let pending = new BigNumber(0)
     try {
       pending = await lockedGold.getPendingWithdrawalsTotalValue(address)

--- a/packages/contractkit/src/kit.ts
+++ b/packages/contractkit/src/kit.ts
@@ -121,6 +121,9 @@ export class ContractKit {
     const goldBalance = await goldToken.balanceOf(address)
     const lockedBalance = await lockedGold.getAccountTotalLockedGold(address)
     const dollarBalance = await stableToken.balanceOf(address)
+    const converted = dollarBalance.eq(new BigNumber(0))
+      ? new BigNumber(0)
+      : await exchange.quoteUsdSell(dollarBalance)
     let pending = new BigNumber(0)
     try {
       pending = await lockedGold.getPendingWithdrawalsTotalValue(address)
@@ -133,7 +136,7 @@ export class ContractKit {
       usd: dollarBalance,
       total: goldBalance
         .plus(lockedBalance)
-        .plus(await exchange.quoteUsdSell(dollarBalance))
+        .plus(converted)
         .plus(pending),
       pending,
     }

--- a/packages/contractkit/src/wrappers/Exchange.ts
+++ b/packages/contractkit/src/wrappers/Exchange.ts
@@ -65,14 +65,14 @@ export class ExchangeWrapper extends BaseWrapper<Exchange> {
    * @param sellGold `true` if gold is the sell token
    * @return The corresponding buyToken amount.
    */
-  getBuyTokenAmount: (
-    sellAmount: BigNumber.Value,
-    sellGold: boolean
-  ) => Promise<BigNumber> = proxyCall(
-    this.contract.methods.getBuyTokenAmount,
-    tupleParser(valueToString, identity),
-    valueToBigNumber
-  )
+  async getBuyTokenAmount(buyAmount: BigNumber.Value, sellGold: boolean): Promise<BigNumber> {
+    const buy = valueToString(buyAmount)
+    if (new BigNumber(buy).eq(new BigNumber(0))) {
+      return new BigNumber(0)
+    }
+    const res = await this.contract.methods.getBuyTokenAmount(buy, sellGold).call()
+    return valueToBigNumber(res)
+  }
 
   /**
    * Returns the amount of sellToken a user would need to exchange to receive buyAmount of
@@ -81,14 +81,14 @@ export class ExchangeWrapper extends BaseWrapper<Exchange> {
    * @param sellGold `true` if gold is the sell token
    * @return The corresponding sellToken amount.
    */
-  getSellTokenAmount: (
-    buyAmount: BigNumber.Value,
-    sellGold: boolean
-  ) => Promise<BigNumber> = proxyCall(
-    this.contract.methods.getSellTokenAmount,
-    tupleParser(valueToString, identity),
-    valueToBigNumber
-  )
+  async getSellTokenAmount(buyAmount: BigNumber.Value, sellGold: boolean): Promise<BigNumber> {
+    const buy = valueToString(buyAmount)
+    if (new BigNumber(buy).eq(new BigNumber(0))) {
+      return new BigNumber(0)
+    }
+    const res = await this.contract.methods.getSellTokenAmount(buy, sellGold).call()
+    return valueToBigNumber(res)
+  }
 
   /**
    * Returns the buy token and sell token bucket sizes, in order. The ratio of

--- a/packages/contractkit/src/wrappers/Exchange.ts
+++ b/packages/contractkit/src/wrappers/Exchange.ts
@@ -65,12 +65,12 @@ export class ExchangeWrapper extends BaseWrapper<Exchange> {
    * @param sellGold `true` if gold is the sell token
    * @return The corresponding buyToken amount.
    */
-  async getBuyTokenAmount(buyAmount: BigNumber.Value, sellGold: boolean): Promise<BigNumber> {
-    const buy = valueToString(buyAmount)
-    if (new BigNumber(buy).eq(new BigNumber(0))) {
+  async getBuyTokenAmount(sellAmount: BigNumber.Value, sellGold: boolean): Promise<BigNumber> {
+    const sell = valueToString(sellAmount)
+    if (new BigNumber(sell).eq(0)) {
       return new BigNumber(0)
     }
-    const res = await this.contract.methods.getBuyTokenAmount(buy, sellGold).call()
+    const res = await this.contract.methods.getBuyTokenAmount(sell, sellGold).call()
     return valueToBigNumber(res)
   }
 
@@ -83,7 +83,7 @@ export class ExchangeWrapper extends BaseWrapper<Exchange> {
    */
   async getSellTokenAmount(buyAmount: BigNumber.Value, sellGold: boolean): Promise<BigNumber> {
     const buy = valueToString(buyAmount)
-    if (new BigNumber(buy).eq(new BigNumber(0))) {
+    if (new BigNumber(buy).eq(0)) {
       return new BigNumber(0)
     }
     const res = await this.contract.methods.getSellTokenAmount(buy, sellGold).call()

--- a/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
@@ -100,7 +100,7 @@ ___
 
 • **get defaultAccount**(): *[Address](../modules/_base_.md#address) | undefined*
 
-*Defined in [contractkit/src/kit.ts:215](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L215)*
+*Defined in [contractkit/src/kit.ts:216](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L216)*
 
 Default account for generated transactions (eg. tx.from)
 
@@ -108,7 +108,7 @@ Default account for generated transactions (eg. tx.from)
 
 • **set defaultAccount**(`address`: [Address](../modules/_base_.md#address) | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:207](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L207)*
+*Defined in [contractkit/src/kit.ts:208](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L208)*
 
 Set default account for generated transactions (eg. tx.from )
 
@@ -126,7 +126,7 @@ ___
 
 • **get defaultFeeCurrency**(): *undefined | string*
 
-*Defined in [contractkit/src/kit.ts:248](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L248)*
+*Defined in [contractkit/src/kit.ts:249](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L249)*
 
 Set the ERC20 address for the token to use to pay for transaction fees.
 The ERC20 must be whitelisted for gas.
@@ -137,7 +137,7 @@ Set to `null` to use cGLD
 
 • **set defaultFeeCurrency**(`address`: [Address](../modules/_base_.md#address) | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:244](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L244)*
+*Defined in [contractkit/src/kit.ts:245](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L245)*
 
 Set the ERC20 address for the token to use to pay for transaction fees.
 The ERC20 must be whitelisted for gas.
@@ -158,13 +158,13 @@ ___
 
 • **get gasInflationFactor**(): *number*
 
-*Defined in [contractkit/src/kit.ts:224](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L224)*
+*Defined in [contractkit/src/kit.ts:225](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L225)*
 
 **Returns:** *number*
 
 • **set gasInflationFactor**(`factor`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:220](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L220)*
+*Defined in [contractkit/src/kit.ts:221](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L221)*
 
 **Parameters:**
 
@@ -180,13 +180,13 @@ ___
 
 • **get gasPrice**(): *number*
 
-*Defined in [contractkit/src/kit.ts:232](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L232)*
+*Defined in [contractkit/src/kit.ts:233](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L233)*
 
 **Returns:** *number*
 
 • **set gasPrice**(`price`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:228](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L228)*
+*Defined in [contractkit/src/kit.ts:229](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L229)*
 
 **Parameters:**
 
@@ -202,7 +202,7 @@ Name | Type |
 
 ▸ **addAccount**(`privateKey`: string): *void*
 
-*Defined in [contractkit/src/kit.ts:199](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L199)*
+*Defined in [contractkit/src/kit.ts:200](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L200)*
 
 **Parameters:**
 
@@ -218,7 +218,7 @@ ___
 
 ▸ **getEpochNumberOfBlock**(`blockNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:375](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L375)*
+*Defined in [contractkit/src/kit.ts:376](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L376)*
 
 **Parameters:**
 
@@ -234,7 +234,7 @@ ___
 
 ▸ **getFirstBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:353](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L353)*
+*Defined in [contractkit/src/kit.ts:354](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L354)*
 
 **Parameters:**
 
@@ -250,7 +250,7 @@ ___
 
 ▸ **getLastBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:364](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L364)*
+*Defined in [contractkit/src/kit.ts:365](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L365)*
 
 **Parameters:**
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **getNetworkConfig**(): *Promise‹[NetworkConfig](../interfaces/_kit_.networkconfig.md)›*
 
-*Defined in [contractkit/src/kit.ts:142](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L142)*
+*Defined in [contractkit/src/kit.ts:143](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L143)*
 
 **Returns:** *Promise‹[NetworkConfig](../interfaces/_kit_.networkconfig.md)›*
 
@@ -292,7 +292,7 @@ ___
 
 ▸ **isListening**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:252](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L252)*
+*Defined in [contractkit/src/kit.ts:253](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L253)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -302,7 +302,7 @@ ___
 
 ▸ **isSyncing**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:256](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L256)*
+*Defined in [contractkit/src/kit.ts:257](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L257)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -312,7 +312,7 @@ ___
 
 ▸ **sendTransaction**(`tx`: Tx): *Promise‹[TransactionResult](_utils_tx_result_.transactionresult.md)›*
 
-*Defined in [contractkit/src/kit.ts:280](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L280)*
+*Defined in [contractkit/src/kit.ts:281](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L281)*
 
 Send a transaction to celo-blockchain.
 
@@ -335,7 +335,7 @@ ___
 
 ▸ **sendTransactionObject**(`txObj`: TransactionObject‹any›, `tx?`: Omit‹Tx, "data"›): *Promise‹[TransactionResult](_utils_tx_result_.transactionresult.md)›*
 
-*Defined in [contractkit/src/kit.ts:304](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L304)*
+*Defined in [contractkit/src/kit.ts:305](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L305)*
 
 **Parameters:**
 
@@ -352,7 +352,7 @@ ___
 
 ▸ **setFeeCurrency**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹void›*
 
-*Defined in [contractkit/src/kit.ts:194](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L194)*
+*Defined in [contractkit/src/kit.ts:195](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L195)*
 
 Set CeloToken to use to pay for gas fees
 
@@ -370,6 +370,6 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [contractkit/src/kit.ts:387](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L387)*
+*Defined in [contractkit/src/kit.ts:388](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L388)*
 
 **Returns:** *void*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_exchange_.exchangewrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_exchange_.exchangewrapper.md
@@ -275,7 +275,7 @@ Contract address
 
 ###  getBuyTokenAmount
 
-▸ **getBuyTokenAmount**(`buyAmount`: BigNumber.Value, `sellGold`: boolean): *Promise‹BigNumber›*
+▸ **getBuyTokenAmount**(`sellAmount`: BigNumber.Value, `sellGold`: boolean): *Promise‹BigNumber›*
 
 *Defined in [contractkit/src/wrappers/Exchange.ts:68](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Exchange.ts#L68)*
 
@@ -285,7 +285,7 @@ Contract address
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`buyAmount` | BigNumber.Value | - |
+`sellAmount` | BigNumber.Value | The amount of sellToken the user is selling to the exchange |
 `sellGold` | boolean | `true` if gold is the sell token |
 
 **Returns:** *Promise‹BigNumber›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_exchange_.exchangewrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_exchange_.exchangewrapper.md
@@ -20,8 +20,6 @@ using a Constant Product Market Maker Model
 * [events](_wrappers_exchange_.exchangewrapper.md#events)
 * [exchange](_wrappers_exchange_.exchangewrapper.md#exchange)
 * [getBuyAndSellBuckets](_wrappers_exchange_.exchangewrapper.md#getbuyandsellbuckets)
-* [getBuyTokenAmount](_wrappers_exchange_.exchangewrapper.md#getbuytokenamount)
-* [getSellTokenAmount](_wrappers_exchange_.exchangewrapper.md#getselltokenamount)
 * [lastBucketUpdate](_wrappers_exchange_.exchangewrapper.md#lastbucketupdate)
 * [minimumReports](_wrappers_exchange_.exchangewrapper.md#minimumreports)
 * [reserveFraction](_wrappers_exchange_.exchangewrapper.md#reservefraction)
@@ -34,9 +32,11 @@ using a Constant Product Market Maker Model
 
 ### Methods
 
+* [getBuyTokenAmount](_wrappers_exchange_.exchangewrapper.md#getbuytokenamount)
 * [getConfig](_wrappers_exchange_.exchangewrapper.md#getconfig)
 * [getExchangeRate](_wrappers_exchange_.exchangewrapper.md#getexchangerate)
 * [getGoldExchangeRate](_wrappers_exchange_.exchangewrapper.md#getgoldexchangerate)
+* [getSellTokenAmount](_wrappers_exchange_.exchangewrapper.md#getselltokenamount)
 * [getUsdExchangeRate](_wrappers_exchange_.exchangewrapper.md#getusdexchangerate)
 * [quoteGoldBuy](_wrappers_exchange_.exchangewrapper.md#quotegoldbuy)
 * [quoteGoldSell](_wrappers_exchange_.exchangewrapper.md#quotegoldsell)
@@ -138,69 +138,6 @@ the two also represents the exchange rate between the two.
 
 Name | Type |
 ------ | ------ |
-`sellGold` | boolean |
-
-___
-
-###  getBuyTokenAmount
-
-• **getBuyTokenAmount**: *function* = proxyCall(
-    this.contract.methods.getBuyTokenAmount,
-    tupleParser(valueToString, identity),
-    valueToBigNumber
-  )
-
-*Defined in [contractkit/src/wrappers/Exchange.ts:68](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Exchange.ts#L68)*
-
-**`dev`** Returns the amount of buyToken a user would get for sellAmount of sellToken
-
-**`param`** The amount of sellToken the user is selling to the exchange
-
-**`param`** `true` if gold is the sell token
-
-**`returns`** The corresponding buyToken amount.
-
-#### Type declaration:
-
-▸ (`sellAmount`: BigNumber.Value, `sellGold`: boolean): *Promise‹BigNumber›*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`sellAmount` | BigNumber.Value |
-`sellGold` | boolean |
-
-___
-
-###  getSellTokenAmount
-
-• **getSellTokenAmount**: *function* = proxyCall(
-    this.contract.methods.getSellTokenAmount,
-    tupleParser(valueToString, identity),
-    valueToBigNumber
-  )
-
-*Defined in [contractkit/src/wrappers/Exchange.ts:84](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Exchange.ts#L84)*
-
-Returns the amount of sellToken a user would need to exchange to receive buyAmount of
-buyToken.
-
-**`param`** The amount of buyToken the user would like to purchase.
-
-**`param`** `true` if gold is the sell token
-
-**`returns`** The corresponding sellToken amount.
-
-#### Type declaration:
-
-▸ (`buyAmount`: BigNumber.Value, `sellGold`: boolean): *Promise‹BigNumber›*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`buyAmount` | BigNumber.Value |
 `sellGold` | boolean |
 
 ___
@@ -336,6 +273,27 @@ Contract address
 
 ## Methods
 
+###  getBuyTokenAmount
+
+▸ **getBuyTokenAmount**(`buyAmount`: BigNumber.Value, `sellGold`: boolean): *Promise‹BigNumber›*
+
+*Defined in [contractkit/src/wrappers/Exchange.ts:68](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Exchange.ts#L68)*
+
+**`dev`** Returns the amount of buyToken a user would get for sellAmount of sellToken
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`buyAmount` | BigNumber.Value | - |
+`sellGold` | boolean | `true` if gold is the sell token |
+
+**Returns:** *Promise‹BigNumber›*
+
+The corresponding buyToken amount.
+
+___
+
 ###  getConfig
 
 ▸ **getConfig**(): *Promise‹[ExchangeConfig](../interfaces/_wrappers_exchange_.exchangeconfig.md)›*
@@ -388,6 +346,28 @@ Name | Type | Description |
 **Returns:** *Promise‹BigNumber‹››*
 
 The exchange rate (number of cUsd received for one cGLD)
+
+___
+
+###  getSellTokenAmount
+
+▸ **getSellTokenAmount**(`buyAmount`: BigNumber.Value, `sellGold`: boolean): *Promise‹BigNumber›*
+
+*Defined in [contractkit/src/wrappers/Exchange.ts:84](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Exchange.ts#L84)*
+
+Returns the amount of sellToken a user would need to exchange to receive buyAmount of
+buyToken.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`buyAmount` | BigNumber.Value | The amount of buyToken the user would like to purchase. |
+`sellGold` | boolean | `true` if gold is the sell token |
+
+**Returns:** *Promise‹BigNumber›*
+
+The corresponding sellToken amount.
 
 ___
 

--- a/packages/protocol/contracts/stability/Exchange.sol
+++ b/packages/protocol/contracts/stability/Exchange.sol
@@ -134,6 +134,7 @@ contract Exchange is IExchange, Initializable, Ownable, UsingRegistry, Reentranc
    * @return The corresponding buyToken amount.
    */
   function getBuyTokenAmount(uint256 sellAmount, bool sellGold) external view returns (uint256) {
+    if (sellAmount == 0) return 0;
     uint256 sellTokenBucket;
     uint256 buyTokenBucket;
     (buyTokenBucket, sellTokenBucket) = getBuyAndSellBuckets(sellGold);
@@ -161,6 +162,7 @@ contract Exchange is IExchange, Initializable, Ownable, UsingRegistry, Reentranc
    * @return The corresponding sellToken amount.
    */
   function getSellTokenAmount(uint256 buyAmount, bool sellGold) external view returns (uint256) {
+    if (buyAmount == 0) return 0;
     uint256 sellTokenBucket;
     uint256 buyTokenBucket;
     (buyTokenBucket, sellTokenBucket) = getBuyAndSellBuckets(sellGold);


### PR DESCRIPTION
### Description

When calling `getBuyTokenAmount` or `setSellTokenAmount` with 0 value, the result will be a division by zero. Returning 0 instead in contractkit.

### Other changes


### Tested

Only manual testing

### Related issues

- Fixes #3705

### Backwards compatibility

