### PR TITLE
Update contractkit ver to 4.5

### DIFF
--- a/packages/attestation-service/package.json
+++ b/packages/attestation-service/package.json
@@ -27,7 +27,7 @@
     "lint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
-    "@celo/contractkit": "0.4.4-dev",
+    "@celo/contractkit": "0.4.5-dev",
     "@celo/utils": "0.1.15-dev",
     "bignumber.js": "^9.0.0",
     "body-parser": "1.19.0",

--- a/packages/celotool/package.json
+++ b/packages/celotool/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@celo/verification-pool-api": "^1.0.0",
     "@celo/utils": "0.1.15-dev",
-    "@celo/contractkit": "0.4.4-dev",
+    "@celo/contractkit": "0.4.5-dev",
     "@google-cloud/monitoring": "0.7.1",
     "@google-cloud/pubsub": "^0.28.1",
     "@google-cloud/storage": "^2.4.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "test": "TZ=UTC jest --runInBand"
   },
   "dependencies": {
-    "@celo/contractkit": "0.4.4-dev",
+    "@celo/contractkit": "0.4.5-dev",
     "@celo/utils": "0.1.15-dev",
     "@ledgerhq/hw-transport-node-hid": "^5.11.0",
     "@oclif/command": "^1",

--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/contractkit",
-  "version": "0.4.4-dev",
+  "version": "0.4.5-dev",
   "description": "Celo's ContractKit to interact with Celo network",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/dappkit/package.json
+++ b/packages/dappkit/package.json
@@ -5,7 +5,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@celo/contractkit": "0.4.4-dev",
+    "@celo/contractkit": "0.4.5-dev",
     "@celo/utils": "0.1.15-dev",
     "expo": "^36.0.2",
     "expo-contacts": "8.0.0",

--- a/packages/leaderboard/package.json
+++ b/packages/leaderboard/package.json
@@ -6,7 +6,7 @@
   "author": "Celo",
   "license": "Apache-2.0",
   "dependencies": {
-    "@celo/contractkit": "0.4.4-dev",
+    "@celo/contractkit": "0.4.5-dev",
     "@types/pg": "^7.11.2",
     "google-spreadsheet": "^2.0.8",
     "pg": "^7.12.1",

--- a/packages/metadata-crawler/package.json
+++ b/packages/metadata-crawler/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/celo-org/celo-monorepo/tree/master/packages/metadata-crawler",
   "repository": "https://github.com/celo-org/celo-monorepo/tree/master/packages/metadata-crawler",
   "dependencies": {
-    "@celo/contractkit": "0.4.4-dev",
+    "@celo/contractkit": "0.4.5-dev",
     "@celo/utils": "^0.1.15-dev",
     "@types/pg": "^7.14.3",
     "bunyan": "1.8.12",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@celo/client": "0.0.300",
-    "@celo/contractkit": "0.4.4-dev",
+    "@celo/contractkit": "0.4.5-dev",
     "@celo/react-components": "1.0.0",
     "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#b88e502",
     "@celo/utils": "0.1.15-dev",

--- a/packages/phone-number-privacy/package.json
+++ b/packages/phone-number-privacy/package.json
@@ -29,8 +29,7 @@
   },
   "devDependencies": {
     "@types/uuid": "^7.0.3",
-    "firebase-functions-test": "^0.2.0",
-    "query-string": "^6.12.1"
+    "firebase-functions-test": "^0.2.0"
   },
   "engines": {
     "node": "10"

--- a/packages/phone-number-privacy/package.json
+++ b/packages/phone-number-privacy/package.json
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "@types/uuid": "^7.0.3",
-    "firebase-functions-test": "^0.2.0"
+    "firebase-functions-test": "^0.2.0",
+    "query-string": "^6.12.1"
   },
   "engines": {
     "node": "10"


### PR DESCRIPTION
### Description

Increase ContractKit version to 4.5-dev. Will be publishing ver 4.4 which removes the dependency on libusb in the environment.