### PR TITLE
[Bug Fix] Explicitly adding the context for the lookupIdentifiers method in contactMapping.ts

### DIFF
--- a/packages/mobile/src/identity/contactMapping.ts
+++ b/packages/mobile/src/identity/contactMapping.ts
@@ -136,9 +136,10 @@ function* getAddresses(e164Number: string, attestationsWrapper: AttestationsWrap
   const phoneHash = phoneHashDetails.phoneHash
 
   // Map of identifier -> (Map of address -> AttestationStat)
-  const results: IdentifierLookupResult = yield call(attestationsWrapper.lookupIdentifiers, [
-    phoneHash,
-  ])
+  const results: IdentifierLookupResult = yield call(
+    [attestationsWrapper, attestationsWrapper.lookupIdentifiers],
+    [phoneHash]
+  )
 
   if (!results || !results[phoneHash]) {
     return null


### PR DESCRIPTION
### Description

Minor fix for an error in the `getAddresses` function in contractMapping.ts. `attestationsWrapper.lookupIdentifiers` was being called without the context being set for the saga.

### Other changes

N/A

### Tested

N/A

### Related issues

N/A

### Backwards compatibility

Yes