### PR TITLE
Add section for optionally bootstrapping nodes with community-provided nodes

### DIFF
--- a/packages/docs/getting-started/running-a-validator-in-rc1.md
+++ b/packages/docs/getting-started/running-a-validator-in-rc1.md
@@ -239,6 +239,23 @@ export PROXY_ADDRESS=<PROXY-PUBLIC-ADDRESS>
 docker run --name celo-proxy -it --restart unless-stopped -p 30303:30303 -p 30303:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --nousb --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $PROXY_ADDRESS --unlock $PROXY_ADDRESS --password /root/.celo/.password --allow-insecure-unlock --bootnodes $BOOTNODE_ENODES --ethstats=<YOUR-VALIDATOR-NAME>@stats-server.celo.org
 ```
 
+**OPTIONAL**
+In addition to the bootnode enode URLs provided by the cLabs team, the Celo validator community will contribute full node peers to help kickstart your nodes' peer discovery and block synchronisation processes. Here is the current list, set to `COMMUNITY_ENODES`:
+```bash
+export COMMUNITY_ENODES="enode://f65013f1ac6827e275c2d2737ce13357f620d4364124d02227a19321c57f8fbf9214a9411de49d49f180b085b031d9d23211a6ead4499fc5f9d3592b55322123@50.17.60.161:30303"
+```
+
+To use the nodes, set them to the value of the `bootnodes` or `bootnodesv4` options when running your node-starting `docker run...` commands (in this example, we will use `bootnodesv4` to keep the original command intact). To bootstrap your proxy node, you can run the command below (the same command at line 239 appended with `--bootnodesv4 $COMMUNITY_ENODES`):
+```bash
+export COMMUNITY_ENODES="enode://f65013f1ac6827e275c2d2737ce13357f620d4364124d02227a19321c57f8fbf9214a9411de49d49f180b085b031d9d23211a6ead4499fc5f9d3592b55322123@50.17.60.161:30303"
+export PROXY_ADDRESS=<PROXY-PUBLIC-ADDRESS>
+docker run --name celo-proxy -it --restart unless-stopped -p 30303:30303 -p 30303:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --nousb --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $PROXY_ADDRESS --unlock $PROXY_ADDRESS --password /root/.celo/.password --allow-insecure-unlock --bootnodes $BOOTNODE_ENODES --ethstats=<YOUR-VALIDATOR-NAME>@stats-server.celo.org --bootnodesv4 $COMMUNITY_ENODES
+```
+
+Hint: If you are running into trouble peering with the full nodes, one of the first things to check is whether your container's ports are properly configured (i.e. specifically, `-p 30303:30303 -p 30303:30303/udp` - which is set in the proxy node's command, but not the account node's command).
+
+{% endhint %}
+
 {% hint style="info" %}
 You can detach from the running container by pressing `ctrl+p ctrl+q`, or start it with `-d` instead of `-it` to start detached. Access the logs for a container in the background with the `docker logs` command.
 {% endhint %}


### PR DESCRIPTION
An update of [this](https://github.com/celo-org/celo-monorepo/pull/2745) PR for RC1 (will do the same for Baklava after, in case changes are needed), which includes a full node that we are contributing to the community (tested and confirmed functional with the current RC1 tutorial).

### Description

@tkporter suggested a potential reason for node syncing issues experienced by user @thylacine in the #validators channel:

> My only thought is that maybe someone flooded the bootnode with a bunch of nodes with a different genesis so all the discovered peers you're getting are incorrect 

Leading to the addition of this optional setup step that makes use of community-provided peers (inspired by [cosmos/launch#seed-nodes](https://github.com/cosmos/launch#seed-nodes) to mitigate node bootstrapping issues.

### Tested

Started new nodes on new machines (following [these](https://docs.celo.org/getting-started/rc1/running-a-validator-in-rc1) instructions) and confirmed that the new nodes start-up and sync blocks using the enode set as the value of either the `bootnodes` (without the cLabs-provided enode) or the `bootnodesv4` option.