### PR TITLE
Add section for optionally bootstrapping nodes with community-provide…

### DIFF
--- a/packages/docs/getting-started/running-a-validator-in-baklava.md
+++ b/packages/docs/getting-started/running-a-validator-in-baklava.md
@@ -216,6 +216,23 @@ export PROXY_ADDRESS=<PROXY-PUBLIC-ADDRESS>
 docker run --name celo-proxy -it --restart unless-stopped -p 30303:30303 -p 30303:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --nousb --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $PROXY_ADDRESS --unlock $PROXY_ADDRESS --password /root/.celo/.password --allow-insecure-unlock --bootnodes $BOOTNODE_ENODES --ethstats=<YOUR-VALIDATOR-NAME>@baklava-celostats-server.celo-testnet.org
 ```
 
+**OPTIONAL**
+In addition to the bootnode enode URLs provided by the cLabs team, the Celo validator community will contribute full node peers to help kickstart your nodes' peer discovery and block synchronisation processes. Here is the current list, set to `COMMUNITY_ENODES`:
+```bash
+export COMMUNITY_ENODES="enode://7c34cb0b3b9924b21e3c99134a5d46ca8242f4ecc9f722aa548ff80861be246268f1f7d8de815583a970993a7157bb37b3b5478b219c44e05888a659cb22675f@34.193.36.54:30303"
+```
+
+To use the nodes, set them to the value of the `bootnodes` or `bootnodesv4` options when running your node-starting `docker run...` commands (in this example, we will use `bootnodesv4` to keep the original command intact). To bootstrap your proxy node, you can run the command below (the same command at line 239 appended with `--bootnodesv4 $COMMUNITY_ENODES`):
+```bash
+export COMMUNITY_ENODES="enode://7c34cb0b3b9924b21e3c99134a5d46ca8242f4ecc9f722aa548ff80861be246268f1f7d8de815583a970993a7157bb37b3b5478b219c44e05888a659cb22675f@34.193.36.54:30303"
+export PROXY_ADDRESS=<PROXY-PUBLIC-ADDRESS>
+docker run --name celo-proxy -it --restart unless-stopped -p 30303:30303 -p 30303:30303/udp -p 30503:30503 -p 30503:30503/udp -v $PWD:/root/.celo $CELO_IMAGE --verbosity 3 --networkid $NETWORK_ID --nousb --syncmode full --proxy.proxy --proxy.proxiedvalidatoraddress $CELO_VALIDATOR_SIGNER_ADDRESS --proxy.internalendpoint :30503 --etherbase $PROXY_ADDRESS --unlock $PROXY_ADDRESS --password /root/.celo/.password --allow-insecure-unlock --bootnodes $BOOTNODE_ENODES --ethstats=<YOUR-VALIDATOR-NAME>@baklava-celostats-server.celo-testnet.org --bootnodesv4 $COMMUNITY_ENODES
+```
+
+Hint: If you are running into trouble peering with the full nodes, one of the first things to check is whether your container's ports are properly configured (i.e. specifically, `-p 30303:30303 -p 30303:30303/udp` - which is set in the proxy node's command, but not the account node's command).
+
+{% endhint %}
+
 {% hint style="info" %}
 You can detach from the running container by pressing `ctrl+p ctrl+q`, or start it with `-d` instead of `-it` to start detached. Access the logs for a container in the background with the `docker logs` command.
 {% endhint %}

--- a/packages/docs/getting-started/running-a-validator-in-baklava.md
+++ b/packages/docs/getting-started/running-a-validator-in-baklava.md
@@ -222,7 +222,7 @@ In addition to the bootnode enode URLs provided by the cLabs team, the Celo vali
 export COMMUNITY_ENODES="enode://7c34cb0b3b9924b21e3c99134a5d46ca8242f4ecc9f722aa548ff80861be246268f1f7d8de815583a970993a7157bb37b3b5478b219c44e05888a659cb22675f@34.193.36.54:30303"
 ```
 
-To use the nodes, set them to the value of the `bootnodes` or `bootnodesv4` options when running your node-starting `docker run...` commands (in this example, we will use `bootnodesv4` to keep the original command intact). To bootstrap your proxy node, you can run the command below (the same command at line 239 appended with `--bootnodesv4 $COMMUNITY_ENODES`):
+To use the nodes, set them to the value of the `bootnodes` or `bootnodesv4` options when running your node-starting `docker run...` commands (in this example, we will use `bootnodesv4` to keep the original command intact). To bootstrap your proxy node, you can run the command below (the same command at line 216 appended with `--bootnodesv4 $COMMUNITY_ENODES`):
 ```bash
 export COMMUNITY_ENODES="enode://7c34cb0b3b9924b21e3c99134a5d46ca8242f4ecc9f722aa548ff80861be246268f1f7d8de815583a970993a7157bb37b3b5478b219c44e05888a659cb22675f@34.193.36.54:30303"
 export PROXY_ADDRESS=<PROXY-PUBLIC-ADDRESS>


### PR DESCRIPTION
Similar to [this PR](https://github.com/celo-org/celo-monorepo/pull/3755), but with our Baklava node enode and the Baklava version of the proxy's container startup command.

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Tested

Kickstarted the block-syncing process for a new proxy node using the command specified in the optional section.