### PR TITLE
Enable CORS on forno ingress

### DIFF
--- a/packages/helm-charts/testnet/templates/forno.ingress.yaml
+++ b/packages/helm-charts/testnet/templates/forno.ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     component: forno
   annotations:
     kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
### Description

Add label to enable cors on forno ingress

### Tested

Applied on alfajores forno.

### Related issues

- Fixes #3759