### PR TITLE
[PGPNP] add phone number verification logic with percent threshold to PGPNP

### DIFF
--- a/packages/phone-number-privacy/package.json
+++ b/packages/phone-number-privacy/package.json
@@ -21,7 +21,7 @@
     "keygen": "ts-node scripts/createBlsKeyPair.ts"
   },
   "dependencies": {
-    "@celo/contractkit": "0.4.4",
+    "@celo/contractkit": "0.4.5",
     "@celo/utils": "0.1.13",
     "blind-threshold-bls": "https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a",
     "firebase-admin": "^8.10.0",


### PR DESCRIPTION
### Description

- bump contractKit version to get `getVerifiedStatus` method
- follows this PR https://github.com/celo-org/celo-monorepo/pull/3829 which updates the verification logic to include a percent threshold (percent of attestations that are completed)

### Other changes

NA

### Tested

Ran tests

### Related issues

https://github.com/celo-org/celo-labs/issues/506

### Backwards compatibility

Yes -- Though adds additional conditions for phone number verification, so numbers formally considered verified may no longer be.