### PR TITLE
Add dockerfile for devchain

### DIFF
--- a/dockerfiles/devchain/Dockerfile
+++ b/dockerfiles/devchain/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:10
+WORKDIR /celo-monorepo
+
+COPY lerna.json package*.json yarn*.lock ./
+COPY scripts/ scripts/
+
+COPY packages/typescript/ packages/typescript/
+COPY packages/utils/ packages/utils/
+COPY packages/dev-utils/ packages/dev-utils/
+COPY packages/protocol/ packages/protocol/
+COPY packages/contractkit/ packages/contractkit/
+
+RUN yarn install --frozen-lockfile --network-timeout 100000 && yarn cache clean && yarn build
+
+RUN cd /celo-monorepo/packages/contractkit && yarn test:reset
+
+COPY . .
+
+EXPOSE 8545
+
+WORKDIR /celo-monorepo/packages/contractkit
+
+ENTRYPOINT ["yarn", "test:livechain"]

--- a/dockerfiles/devchain/Dockerfile
+++ b/dockerfiles/devchain/Dockerfile
@@ -1,23 +1,21 @@
 FROM node:10
 WORKDIR /celo-monorepo
 
-COPY lerna.json package*.json yarn*.lock ./
+COPY lerna.json package.json yarn*.lock ./
 COPY scripts/ scripts/
-
 COPY packages/typescript/ packages/typescript/
 COPY packages/utils/ packages/utils/
 COPY packages/dev-utils/ packages/dev-utils/
 COPY packages/protocol/ packages/protocol/
 COPY packages/contractkit/ packages/contractkit/
 
-RUN yarn install --frozen-lockfile --network-timeout 100000 && yarn cache clean && yarn build
-
-RUN cd /celo-monorepo/packages/contractkit && yarn test:reset
-
-COPY . .
-
-EXPOSE 8545
+RUN yarn install --frozen-lockfile --prefer-offline
+RUN yarn --prefer-offline build
 
 WORKDIR /celo-monorepo/packages/contractkit
+
+RUN yarn test:reset
+
+EXPOSE 8545
 
 ENTRYPOINT ["yarn", "test:livechain"]


### PR DESCRIPTION
### Description

Containerizes build process for a Celo devchain/testnet.

### Tested

1. Build container locally (from repo dir root)
`docker build -f ./dockerfiles/devchain/Dockerfile .`

2. Run the container (get `CONTAINER_ID` with `docker image ls`)
`docker run -p 8545:8545 <CONTAINER_ID>`

3. Get network ID from devchain's JSON RPC API (should be `1101`)
`curl -X POST --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' http://localhost:8545`

Optional: Use Celo CLI to get list of testnet accounts (there should be 10)
`celocli config:set -n http://localhost:8545 && celocli account:list`.

### Related issues

N/A

### Backwards compatibility

Is backward compatible because it uses existing components without making modifications to them.