### PR TITLE
Moved example description above the tenets 

### DIFF
--- a/packages/web/src/experience/eventkit/content/flavor/tenets.md
+++ b/packages/web/src/experience/eventkit/content/flavor/tenets.md
@@ -1,6 +1,13 @@
 ## Community Tenets
 As a global community we are guided by accessible financial tools to make the world a better place. In order to do this we are guided by the Celo Community tenets. In Celo events, these tenets come alive through the content shared, community interactions, and event intentions. Every event has at least one tenet that they are upholding.
 
+For example, for a walking tour event, the description could read something like:
+
+> **Why a walking tour?**
+
+> [Celo](/) is a decentralized community of creators -- developers, designers, dreamers, doers -- who are motivated by the power of accessible financial tools to make the world a better place. We are guided by four community tenets, two of which are Designing for All and Innovating on Money. By interacting with the local history and culture we can design for all. By understanding money’s history within that context we can innovate to create something for all.
+
+
 <DesignForAll/>
 
 <InnovatingOnMoney />
@@ -8,11 +15,5 @@ As a global community we are guided by accessible financial tools to make the wo
 <StrivingForBeauty/>
 
 <EmbodyHumility />
-
-For example, for a walking tour event, the description could read something like:
-
-> **Why a walking tour?**
-
-> [Celo](/) is a decentralized community of creators -- developers, designers, dreamers, doers -- who are motivated by the power of accessible financial tools to make the world a better place. We are guided by four community tenets, two of which are Designing for All and Innovating on Money. By interacting with the local history and culture we can design for all. By understanding money’s history within that context we can innovate to create something for all.
 
 


### PR DESCRIPTION
The flow looks better this way -- was getting lost at the bottom.

### Description

The flow was off when seen on the website. Moving up for more visability.