### PR TITLE
Allowing for different distribution ratios in deploy script

### DIFF
--- a/packages/protocol/scripts/truffle/deploy_release_contracts.ts
+++ b/packages/protocol/scripts/truffle/deploy_release_contracts.ts
@@ -2,6 +2,7 @@ import { retryTx } from '@celo/protocol/lib/proxy-utils'
 import { _setInitialProxyImplementation } from '@celo/protocol/lib/web3-utils'
 import BigNumber from 'bignumber.js'
 import chalk from 'chalk'
+import fs = require('fs')
 import * as prompts from 'prompts'
 import {
   ReleaseGoldContract,
@@ -9,7 +10,6 @@ import {
   ReleaseGoldMultiSigProxyContract,
   ReleaseGoldProxyContract,
 } from 'types'
-import fs = require('fs')
 
 let argv: any
 let releases: any


### PR DESCRIPTION
### Description

Allows for grant configs to have different `initialDistributionRatio`s within one file.

Leaving as draft since I don't know if we want to merge this into master

### Tested

Manual tests