### PR TITLE
Add group affiliation to current-attestation-services

### DIFF
--- a/packages/cli/src/commands/identity/current-attestation-services.ts
+++ b/packages/cli/src/commands/identity/current-attestation-services.ts
@@ -84,6 +84,7 @@ export default class AttestationServicesCurrent extends BaseCommand {
       validatorInfo,
       {
         address: {},
+        affiliation: {},
         name: {},
         hasAttestationSigner: {},
         attestationServiceURL: {},


### PR DESCRIPTION
### Description

Add the display of group affililation to `identity:current-attestation-services`
