### PR TITLE
[Wallet] Remove onPress delay in Touchable

### DIFF
--- a/packages/mobile/src/language/Language.test.tsx
+++ b/packages/mobile/src/language/Language.test.tsx
@@ -22,8 +22,6 @@ describe('Language', () => {
     })
 
     fireEvent.press(getByText('Español (América Latina)'))
-    // Run timers, because Touchable adds some delay
-    jest.runAllTimers()
     expect(mockNavigation.navigate).toHaveBeenCalledWith(Screens.JoinCelo)
     expect(store.getActions()).toMatchInlineSnapshot(`
       Array [

--- a/packages/react-components/components/Button.test.tsx
+++ b/packages/react-components/components/Button.test.tsx
@@ -28,7 +28,7 @@ describe('Button', () => {
           testID={'ButtonTestId'}
         />
       )
-      const button = getByName('TouchableDefault')
+      const button = getByName('Touchable')
       fireEvent.press(button)
       fireEvent.press(button)
       fireEvent.press(button)
@@ -68,7 +68,7 @@ describe('Button', () => {
           <Text>child text</Text>
         </Button>
       )
-      expect(getByName('TouchableDefault').props).toMatchObject({
+      expect(getByName('Touchable').props).toMatchObject({
         testID: 'jest-test',
         disabled: true,
       })

--- a/packages/react-components/components/SegmentedControl.test.tsx
+++ b/packages/react-components/components/SegmentedControl.test.tsx
@@ -32,8 +32,6 @@ describe(SegmentedControl, () => {
     // expect(tab2.props.accessibilityStates).toBe(['selected'])
 
     fireEvent.press(tab1)
-    // Run timers, because Touchable adds some delay
-    jest.runAllTimers()
     expect(onChange).toHaveBeenCalledWith('Tab1', 0)
   })
 })

--- a/packages/react-components/components/Touchable.tsx
+++ b/packages/react-components/components/Touchable.tsx
@@ -1,28 +1,15 @@
 import * as React from 'react'
 import { TouchableWithoutFeedbackProps } from 'react-native'
-import Touchable from 'react-native-platform-touchable'
+import PlatformTouchable from 'react-native-platform-touchable'
 
 export interface Props extends TouchableWithoutFeedbackProps {
   borderless?: boolean
   children: React.ReactNode // must only have one direct child. see https://github.com/react-native-community/react-native-platform-touchable#touchable
 }
 
-export default class TouchableDefault extends React.PureComponent<Props> {
-  delayedOnPress = () => {
-    // Add a small delay so animations are seen
-    setTimeout(this.props.onPress, 50)
-  }
-  effect = () => {
-    return this.props.borderless
-      ? Touchable.SelectableBackgroundBorderless()
-      : Touchable.SelectableBackground()
-  }
-  render() {
-    const { onPress, children, ...passThroughProps } = this.props
-    return (
-      <Touchable {...passThroughProps} onPress={this.delayedOnPress} background={this.effect()}>
-        {children}
-      </Touchable>
-    )
-  }
+export default function Touchable({ borderless, ...passThroughProps }: Props) {
+  const background = borderless
+    ? PlatformTouchable.SelectableBackgroundBorderless()
+    : PlatformTouchable.SelectableBackground()
+  return <PlatformTouchable {...passThroughProps} background={background} />
 }


### PR DESCRIPTION
### Description

This PR removes the delay handling the Touchable `onPress` event.
It doesn't feel right to delay it.

### Related issues

Discussed on Slack.

### Backwards compatibility

Yes.