### PR TITLE
[Wallet][ReDesign] Update terms screen style

### DIFF
--- a/packages/mobile/src/onboarding/registration/RegulatoryTerms.tsx
+++ b/packages/mobile/src/onboarding/registration/RegulatoryTerms.tsx
@@ -1,9 +1,9 @@
-import Button, { BtnTypes } from '@celo/react-components/components/Button'
-import fontStyles from '@celo/react-components/styles/fonts'
+import Button, { BtnSizes, BtnTypes } from '@celo/react-components/components/Button.v2'
+import fontStyles from '@celo/react-components/styles/fonts.v2'
 import * as React from 'react'
 import { Trans, WithTranslation } from 'react-i18next'
-import { ScrollView, StyleSheet, Text, View } from 'react-native'
-import SafeAreaView from 'react-native-safe-area-view'
+import { ScrollView, StyleSheet, Text } from 'react-native'
+import SafeAreaView, { SafeAreaConsumer } from 'react-native-safe-area-view'
 import { connect } from 'react-redux'
 import { acceptTerms } from 'src/account/actions'
 import { PincodeType } from 'src/account/reducer'
@@ -15,6 +15,8 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { RootState } from 'src/redux/reducers'
 import { navigateToURI } from 'src/utils/linking'
+
+const MARGIN = 24
 
 interface StateProps {
   pincodeType: PincodeType
@@ -60,30 +62,34 @@ export class RegulatoryTerms extends React.Component<Props> {
     return (
       <SafeAreaView style={styles.container}>
         <DevSkipButton nextScreen={Screens.PincodeEducation} />
-        <ScrollView contentContainerStyle={styles.scrollContainer} testID="scrollView">
-          <View style={styles.terms}>
-            <Text style={fontStyles.h1} testID="Terms">
-              {t('terms.title')}
-            </Text>
-            <Text style={styles.header}>{t('terms.heading1')}</Text>
-            <Text style={styles.disclaimer}>
-              <Trans ns={Namespaces.nuxNamePin1} i18nKey={'terms.privacy'}>
-                <Text onPress={this.onPressGoToTerms} style={styles.disclamerLink}>
-                  celo.org/terms
-                </Text>
-              </Trans>
-            </Text>
-            <Text style={styles.header}>{t('terms.heading2')}</Text>
-            <Text style={styles.disclaimer}>{t('terms.goldDisclaimer')}</Text>
-          </View>
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          testID="scrollView"
+        >
+          <Text style={styles.header}>{t('terms.heading1')}</Text>
+          <Text style={styles.disclaimer}>
+            <Trans ns={Namespaces.nuxNamePin1} i18nKey={'terms.privacy'}>
+              <Text onPress={this.onPressGoToTerms} style={styles.disclaimerLink}>
+                celo.org/terms
+              </Text>
+            </Trans>
+          </Text>
+          <Text style={styles.header}>{t('terms.heading2')}</Text>
+          <Text style={styles.disclaimer}>{t('terms.goldDisclaimer')}</Text>
         </ScrollView>
-        <Button
-          standard={false}
-          type={BtnTypes.PRIMARY}
-          text={t('global:accept')}
-          onPress={this.onPressAccept}
-          testID={'AcceptTermsButton'}
-        />
+        <SafeAreaConsumer>
+          {(insets) => (
+            <Button
+              style={[styles.button, insets && insets.bottom <= MARGIN && { marginBottom: MARGIN }]}
+              type={BtnTypes.ONBOARDING}
+              size={BtnSizes.FULL}
+              text={t('global:accept')}
+              onPress={this.onPressAccept}
+              testID={'AcceptTermsButton'}
+            />
+          )}
+        </SafeAreaConsumer>
       </SafeAreaView>
     )
   }
@@ -98,9 +104,12 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  scrollContainer: {
-    minHeight: '100%',
-    justifyContent: 'space-between',
+  scrollView: {
+    marginTop: 40,
+  },
+  scrollContent: {
+    paddingTop: 40,
+    paddingHorizontal: MARGIN,
   },
   terms: {
     flex: 1,
@@ -108,16 +117,18 @@ const styles = StyleSheet.create({
     paddingBottom: 15,
   },
   header: {
-    ...fontStyles.body,
-    ...fontStyles.semiBold,
+    ...fontStyles.h2,
     marginBottom: 10,
   },
   disclaimer: {
-    ...fontStyles.body,
+    ...fontStyles.small,
     marginBottom: 15,
   },
-  disclamerLink: {
-    ...fontStyles.body,
+  disclaimerLink: {
     textDecorationLine: 'underline',
+  },
+  button: {
+    marginTop: MARGIN,
+    marginHorizontal: MARGIN,
   },
 })

--- a/packages/mobile/src/onboarding/registration/__snapshots__/RegulatoryTerms.test.tsx.snap
+++ b/packages/mobile/src/onboarding/registration/__snapshots__/RegulatoryTerms.test.tsx.snap
@@ -39,182 +39,145 @@ exports[`RegulatoryTermsScreen renders correctly 1`] = `
   <RCTScrollView
     contentContainerStyle={
       Object {
-        "justifyContent": "space-between",
-        "minHeight": "100%",
+        "paddingHorizontal": 24,
+        "paddingTop": 40,
+      }
+    }
+    style={
+      Object {
+        "marginTop": 40,
       }
     }
     testID="scrollView"
   >
     <View>
-      <View
+      <Text
         style={
           Object {
-            "flex": 1,
-            "paddingBottom": 15,
-            "paddingHorizontal": 20,
+            "color": "#2E3338",
+            "fontFamily": "Inter-SemiBold",
+            "fontSize": 19,
+            "lineHeight": 26,
+            "marginBottom": 10,
+          }
+        }
+      >
+        terms.heading1
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#2E3338",
+            "fontFamily": "Inter-Regular",
+            "fontSize": 14,
+            "lineHeight": 18,
+            "marginBottom": 15,
           }
         }
       >
         <Text
+          onPress={[Function]}
           style={
             Object {
-              "color": "#2E3338",
-              "fontFamily": "Hind-Light",
-              "fontSize": 22,
-              "paddingBottom": 20,
-              "textAlign": "center",
-            }
-          }
-          testID="Terms"
-        >
-          terms.title
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#2E3338",
-              "fontFamily": "Hind-SemiBold",
-              "fontSize": 16,
-              "lineHeight": 24,
-              "marginBottom": 10,
+              "textDecorationLine": "underline",
             }
           }
         >
-          terms.heading1
+          celo.org/terms
         </Text>
-        <Text
-          style={
-            Object {
-              "color": "#2E3338",
-              "fontFamily": "Hind-Regular",
-              "fontSize": 16,
-              "lineHeight": 24,
-              "marginBottom": 15,
-            }
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#2E3338",
+            "fontFamily": "Inter-SemiBold",
+            "fontSize": 19,
+            "lineHeight": 26,
+            "marginBottom": 10,
           }
-        >
-          <Text
-            onPress={[Function]}
-            style={
-              Object {
-                "color": "#2E3338",
-                "fontFamily": "Hind-Regular",
-                "fontSize": 16,
-                "lineHeight": 24,
-                "textDecorationLine": "underline",
-              }
-            }
-          >
-            celo.org/terms
-          </Text>
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#2E3338",
-              "fontFamily": "Hind-SemiBold",
-              "fontSize": 16,
-              "lineHeight": 24,
-              "marginBottom": 10,
-            }
+        }
+      >
+        terms.heading2
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#2E3338",
+            "fontFamily": "Inter-Regular",
+            "fontSize": 14,
+            "lineHeight": 18,
+            "marginBottom": 15,
           }
-        >
-          terms.heading2
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#2E3338",
-              "fontFamily": "Hind-Regular",
-              "fontSize": 16,
-              "lineHeight": 24,
-              "marginBottom": 15,
-            }
-          }
-        >
-          terms.goldDisclaimer
-        </Text>
-      </View>
+        }
+      >
+        terms.goldDisclaimer
+      </Text>
     </View>
   </RCTScrollView>
   <View
     style={
       Array [
         Object {
-          "alignItems": "center",
-          "borderRadius": 3,
-          "flexDirection": "row",
+          "flexDirection": "column",
         },
-        null,
-        null,
-        undefined,
-        Object {
-          "backgroundColor": "#42D689",
-        },
+        Array [
+          Object {
+            "marginHorizontal": 24,
+            "marginTop": 24,
+          },
+          Object {
+            "marginBottom": 24,
+          },
+        ],
       ]
     }
   >
     <View
-      accessible={true}
-      focusable={true}
-      nativeBackgroundAndroid={
+      style={
         Object {
-          "attribute": "selectableItemBackground",
-          "type": "ThemeAttrAndroid",
+          "borderRadius": 100,
+          "overflow": "hidden",
         }
       }
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          Object {
-            "backgroundColor": "#42D689",
-          },
-          Object {
-            "height": 50,
-          },
-          Object {
-            "borderWidth": 0,
-          },
-        ]
-      }
-      testID="AcceptTermsButton"
     >
       <View
+        accessible={true}
+        focusable={true}
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackground",
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "row",
-            "justifyContent": "space-between",
+            "backgroundColor": "#D6E7EF",
+            "flexGrow": 1,
+            "height": 48,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 16,
+            "paddingVertical": 5,
           }
         }
+        testID="AcceptTermsButton"
       >
         <Text
           style={
-            Array [
-              Object {
-                "fontFamily": "Hind-SemiBold",
-                "fontSize": 16,
-              },
-              Object {
-                "color": "#FFFFFF",
-              },
-              Object {
-                "paddingLeft": 5,
-                "paddingRight": 5,
-              },
-            ]
+            Object {
+              "color": "#0C689C",
+              "fontFamily": "Inter-SemiBold",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
           }
         >
           global:accept


### PR DESCRIPTION
### Description

This implements the [terms screen redesign](https://www.figma.com/file/zt7aTQ5wuXycIwxq5oAmF9/Wallet--Refresh?node-id=5404%3A375).

Note: Depends on #4101, review and merge it first!

### Other changes

N/A

### Tested

<img src="https://user-images.githubusercontent.com/57791/84674860-cca45e00-af2b-11ea-832f-fd0c4f1604c2.png" width="50%" /><img src="https://user-images.githubusercontent.com/57791/84674878-cf06b800-af2b-11ea-976a-27a9d48519e6.png" width="50%" />
<img src="https://user-images.githubusercontent.com/57791/84674988-efcf0d80-af2b-11ea-8237-d1eb2978dd99.png" width="50%" />


### Related issues

- Epic #3645

### Backwards compatibility

Yes