### PR TITLE
[pgpnp] fix combiner index tests

### DIFF
--- a/packages/phone-number-privacy/combiner/test/index.test.ts
+++ b/packages/phone-number-privacy/combiner/test/index.test.ts
@@ -37,14 +37,14 @@ const fetchMock: jest.Mock = require('node-fetch')
 const FetchResponse: typeof Response = jest.requireActual('node-fetch').Response
 const defaultResponseJson = JSON.stringify({
   success: true,
-  signature: "string"
+  signature: 'string',
 })
 
 describe(`POST /getDistributedBlindedSalt endpoint`, () => {
   beforeEach(() => {
     fetchMock.mockClear()
     fetchMock.mockImplementation(() => Promise.resolve(new FetchResponse(defaultResponseJson)))
-    })
+  })
 
   describe('with valid input', () => {
     const blindedQueryPhoneNumber = '+5555555555'
@@ -57,18 +57,19 @@ describe(`POST /getDistributedBlindedSalt endpoint`, () => {
       hashedPhoneNumber,
       account,
     }
-    const req = { body: mockRequestData, 
-                  headers: {
-                    authorization: mockHeader
-                  }
-                }
+    const req = {
+      body: mockRequestData,
+      headers: {
+        authorization: mockHeader,
+      },
+    }
 
     it('provides signature', async () => {
       const res = {
         json(body: any) {
           expect(body.success).toEqual(true)
           expect(body.combinedSignature).toEqual(BLS_SIGNATURE)
-        }
+        },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
       await getDistributedBlindedSalt(req, res)
@@ -136,11 +137,12 @@ describe(`POST /getDistributedBlindedSalt endpoint`, () => {
         hashedPhoneNumber,
         account,
       }
-      const req = { body: mockRequestData, 
-                    headers: {
-                      authorization: mockHeader
-                    }
-                  }
+      const req = {
+        body: mockRequestData,
+        headers: {
+          authorization: mockHeader,
+        },
+      }
 
       const res = {
         status: (status: any) => {
@@ -168,13 +170,14 @@ describe(`POST /getContactMatches endpoint`, () => {
       userPhoneNumber,
       contactPhoneNumbers,
       account,
-      hashedPhoneNumber
+      hashedPhoneNumber,
     }
-    const req = { body: mockRequestData,
-                  headers: {
-                    authorization: mockHeader
-                  } 
-                }
+    const req = {
+      body: mockRequestData,
+      headers: {
+        authorization: mockHeader,
+      },
+    }
     it('provides matches', async () => {
       mockGetNumberPairContacts.mockReturnValue(contactPhoneNumbers)
       mockIsVerified.mockReturnValue(true)
@@ -226,8 +229,7 @@ describe(`POST /getContactMatches endpoint`, () => {
       const mockRequestData = {
         contactPhoneNumbers,
         account,
-        hashedPhoneNumber
-
+        hashedPhoneNumber,
       }
       const req = { body: mockRequestData }
 
@@ -254,8 +256,7 @@ describe(`POST /getContactMatches endpoint`, () => {
         contactPhoneNumbers,
         userPhoneNumber,
         account,
-        hashedPhoneNumber
-
+        hashedPhoneNumber,
       }
       const req = { body: mockRequestData }
 
@@ -280,7 +281,7 @@ describe(`POST /getContactMatches endpoint`, () => {
       const mockRequestData = {
         userPhoneNumber,
         account,
-        hashedPhoneNumber
+        hashedPhoneNumber,
       }
       const req = { body: mockRequestData }
 

--- a/packages/phone-number-privacy/combiner/test/index.test.ts
+++ b/packages/phone-number-privacy/combiner/test/index.test.ts
@@ -1,3 +1,4 @@
+import { Response } from 'node-fetch'
 import { BLSCryptographyClient } from '../src/bls/bls-cryptography-client'
 import { authenticateUser, isVerified } from '../src/common/identity'
 import { getTransaction } from '../src/database/database'
@@ -31,32 +32,48 @@ jest.mock('../src/database/database')
 const mockGetTransaction = getTransaction as jest.Mock
 mockGetTransaction.mockReturnValue({})
 
-// TODO the failures are nested in the res structure as a deep equality which does not fail
-// the full test
+jest.mock('node-fetch')
+const fetchMock: jest.Mock = require('node-fetch')
+const FetchResponse: typeof Response = jest.requireActual('node-fetch').Response
+const defaultResponseJson = JSON.stringify({
+  success: true,
+  signature: "string"
+})
+
 describe(`POST /getDistributedBlindedSalt endpoint`, () => {
+  beforeEach(() => {
+    fetchMock.mockClear()
+    fetchMock.mockImplementation(() => Promise.resolve(new FetchResponse(defaultResponseJson)))
+    })
+
   describe('with valid input', () => {
     const blindedQueryPhoneNumber = '+5555555555'
     const hashedPhoneNumber = '0x5f6e88c3f724b3a09d3194c0514426494955eff7127c29654e48a361a19b4b96'
     const account = '0x78dc5D2D739606d31509C31d654056A45185ECb6'
+    const mockHeader = 'fdsfdsfs'
 
     const mockRequestData = {
       blindedQueryPhoneNumber,
       hashedPhoneNumber,
       account,
     }
-    const req = { body: mockRequestData }
+    const req = { body: mockRequestData, 
+                  headers: {
+                    authorization: mockHeader
+                  }
+                }
 
-    it('provides signature', () => {
+    it('provides signature', async () => {
       const res = {
         json(body: any) {
           expect(body.success).toEqual(true)
-          expect(body.signature).toEqual(BLS_SIGNATURE)
-        },
+          expect(body.combinedSignature).toEqual(BLS_SIGNATURE)
+        }
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getDistributedBlindedSalt(req, res)
+      await getDistributedBlindedSalt(req, res)
     })
-    it('returns 403 on query count 0', () => {
+    it('returns 403 on query count 0', async () => {
       const res = {
         json() {
           return {}
@@ -68,9 +85,9 @@ describe(`POST /getDistributedBlindedSalt endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getDistributedBlindedSalt(req, res)
+      await getDistributedBlindedSalt(req, res)
     })
-    it('returns 500 on bls error', () => {
+    it('returns 500 on bls error', async () => {
       mockComputeBlindedSignature.mockImplementation(() => {
         throw Error()
       })
@@ -82,7 +99,7 @@ describe(`POST /getDistributedBlindedSalt endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getDistributedBlindedSalt(req, res)
+      await getDistributedBlindedSalt(req, res)
     })
   })
   describe('with invalid input', () => {
@@ -108,17 +125,22 @@ describe(`POST /getDistributedBlindedSalt endpoint`, () => {
       // @ts-ignore TODO fix req type to make it a mock express req
       getDistributedBlindedSalt(req, res)
     })
-    it('invalid hashedPhoneNumber returns 400', () => {
+    it('invalid hashedPhoneNumber returns 400', async () => {
       const blindedQueryPhoneNumber = '+5555555555'
       const hashedPhoneNumber = '+1234567890'
       const account = '0x78dc5D2D739606d31509C31d654056A45185ECb6'
+      const mockHeader = 'fdsfdsfs'
 
       const mockRequestData = {
         blindedQueryPhoneNumber,
         hashedPhoneNumber,
         account,
       }
-      const req = { body: mockRequestData }
+      const req = { body: mockRequestData, 
+                    headers: {
+                      authorization: mockHeader
+                    }
+                  }
 
       const res = {
         status: (status: any) => {
@@ -128,7 +150,7 @@ describe(`POST /getDistributedBlindedSalt endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getDistributedBlindedSalt(req, res)
+      await getDistributedBlindedSalt(req, res)
     })
   })
 })
@@ -138,15 +160,22 @@ describe(`POST /getContactMatches endpoint`, () => {
     const userPhoneNumber = '5555555555'
     const contactPhoneNumber1 = '1234567890'
     const contactPhoneNumbers = [contactPhoneNumber1]
+    const hashedPhoneNumber = '0x5f6e88c3f724b3a09d3194c0514426494955eff7127c29654e48a361a19b4b96'
     const account = '0x78dc5D2D739606d31509C31d654056A45185ECb6'
+    const mockHeader = 'fdsfdsfs'
 
     const mockRequestData = {
       userPhoneNumber,
       contactPhoneNumbers,
       account,
+      hashedPhoneNumber
     }
-    const req = { body: mockRequestData }
-    it('provides matches', () => {
+    const req = { body: mockRequestData,
+                  headers: {
+                    authorization: mockHeader
+                  } 
+                }
+    it('provides matches', async () => {
       mockGetNumberPairContacts.mockReturnValue(contactPhoneNumbers)
       mockIsVerified.mockReturnValue(true)
       const expected = [{ phoneNumber: contactPhoneNumber1 }]
@@ -157,9 +186,9 @@ describe(`POST /getContactMatches endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getContactMatches(req, res)
+      await getContactMatches(req, res)
     })
-    it('provides matches empty array', () => {
+    it('provides matches empty array', async () => {
       mockGetNumberPairContacts.mockReturnValue([])
       mockIsVerified.mockReturnValue(true)
       const res = {
@@ -169,9 +198,9 @@ describe(`POST /getContactMatches endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getContactMatches(req, res)
+      await getContactMatches(req, res)
     })
-    it('rejects more than one attempt to matchmake with 403', () => {
+    it('rejects more than one attempt to matchmake with 403', async () => {
       mockGetDidMatchmaking.mockReturnValue(true)
       mockIsVerified.mockReturnValue(true)
       const res = {
@@ -185,17 +214,20 @@ describe(`POST /getContactMatches endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getContactMatches(req, res)
+      await getContactMatches(req, res)
     })
   })
   describe('with invalid input', () => {
-    it('missing user number returns 400', () => {
+    it('missing user number returns 400', async () => {
       const contactPhoneNumbers = ['1234567890']
       const account = '0x78dc5D2D739606d31509C31d654056A45185ECb6'
+      const hashedPhoneNumber = '0x5f6e88c3f724b3a09d3194c0514426494955eff7127c29654e48a361a19b4b96'
 
       const mockRequestData = {
         contactPhoneNumbers,
         account,
+        hashedPhoneNumber
+
       }
       const req = { body: mockRequestData }
 
@@ -210,17 +242,20 @@ describe(`POST /getContactMatches endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getContactMatches(req, res)
+      await getContactMatches(req, res)
     })
-    it('invalid account returns 400', () => {
+    it('invalid account returns 400', async () => {
       const contactPhoneNumbers = ['1234567890']
       const userPhoneNumber = '5555555555'
       const account = 'garbage'
+      const hashedPhoneNumber = '0x5f6e88c3f724b3a09d3194c0514426494955eff7127c29654e48a361a19b4b96'
 
       const mockRequestData = {
         contactPhoneNumbers,
         userPhoneNumber,
         account,
+        hashedPhoneNumber
+
       }
       const req = { body: mockRequestData }
 
@@ -235,15 +270,17 @@ describe(`POST /getContactMatches endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getContactMatches(req, res)
+      await getContactMatches(req, res)
     })
-    it('missing contact phone numbers returns 400', () => {
+    it('missing contact phone numbers returns 400', async () => {
       const userPhoneNumber = '5555555555'
       const account = '0x78dc5D2D739606d31509C31d654056A45185ECb6'
+      const hashedPhoneNumber = '0x5f6e88c3f724b3a09d3194c0514426494955eff7127c29654e48a361a19b4b96'
 
       const mockRequestData = {
         userPhoneNumber,
         account,
+        hashedPhoneNumber
       }
       const req = { body: mockRequestData }
 
@@ -258,7 +295,7 @@ describe(`POST /getContactMatches endpoint`, () => {
         },
       }
       // @ts-ignore TODO fix req type to make it a mock express req
-      getContactMatches(req, res)
+      await getContactMatches(req, res)
     })
   })
 })


### PR DESCRIPTION
### Description

-failed tests in index.test.ts were not indicated as test failing because the requests were asynchronous and required `await`
- fixed the failing tests
- will update the signer index.test.ts next

### Other changes

NA

### Tested

- ran tests and confirmed when they failed, it was indicated as a test failure

### Related issues

NA

### Backwards compatibility

Yes