### PR TITLE
[Wallet] Fix withTranslation HOC typing

### DIFF
--- a/packages/mobile/src/account/Account.tsx
+++ b/packages/mobile/src/account/Account.tsx
@@ -347,4 +347,4 @@ const style = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.accountScreen10)(Account))
+)(withTranslation<Props>(Namespaces.accountScreen10)(Account))

--- a/packages/mobile/src/account/Analytics.tsx
+++ b/packages/mobile/src/account/Analytics.tsx
@@ -57,4 +57,4 @@ const style = StyleSheet.create({
 
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   setAnalyticsEnabled,
-})(withTranslation(Namespaces.accountScreen10)(Analytics))
+})(withTranslation<Props>(Namespaces.accountScreen10)(Analytics))

--- a/packages/mobile/src/account/DataSaver.tsx
+++ b/packages/mobile/src/account/DataSaver.tsx
@@ -141,4 +141,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.accountScreen10)(DataSaver))
+)(withTranslation<Props>(Namespaces.accountScreen10)(DataSaver))

--- a/packages/mobile/src/account/EditProfile.tsx
+++ b/packages/mobile/src/account/EditProfile.tsx
@@ -89,4 +89,4 @@ const style = StyleSheet.create({
 
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   setName,
-})(withTranslation(Namespaces.accountScreen10)(EditProfile))
+})(withTranslation<Props>(Namespaces.accountScreen10)(EditProfile))

--- a/packages/mobile/src/account/Invite.tsx
+++ b/packages/mobile/src/account/Invite.tsx
@@ -190,4 +190,4 @@ const style = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.sendFlow7)(Invite))
+)(withTranslation<Props>(Namespaces.sendFlow7)(Invite))

--- a/packages/mobile/src/account/InviteReview.tsx
+++ b/packages/mobile/src/account/InviteReview.tsx
@@ -286,4 +286,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.inviteFlow11)(InviteReview))
+)(withTranslation<Props>(Namespaces.inviteFlow11)(InviteReview))

--- a/packages/mobile/src/account/Licenses.tsx
+++ b/packages/mobile/src/account/Licenses.tsx
@@ -42,4 +42,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.accountScreen10)(Licenses)
+export default withTranslation<Props>(Namespaces.accountScreen10)(Licenses)

--- a/packages/mobile/src/account/Profile.tsx
+++ b/packages/mobile/src/account/Profile.tsx
@@ -83,5 +83,5 @@ const style = StyleSheet.create({
 })
 
 export default connect<StateProps, {}, OwnProps, RootState>(mapStateToProps)(
-  withTranslation(Namespaces.accountScreen10)(Profile)
+  withTranslation<Props>(Namespaces.accountScreen10)(Profile)
 )

--- a/packages/mobile/src/app/AppLoading.tsx
+++ b/packages/mobile/src/app/AppLoading.tsx
@@ -77,4 +77,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.global)(AppLoading)
+export default withTranslation<Props>(Namespaces.global)(AppLoading)

--- a/packages/mobile/src/app/ErrorBoundary.tsx
+++ b/packages/mobile/src/app/ErrorBoundary.tsx
@@ -38,4 +38,4 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 }
 
-export default withTranslation(Namespaces.global)(ErrorBoundary)
+export default withTranslation<Props>(Namespaces.global)(ErrorBoundary)

--- a/packages/mobile/src/app/ErrorScreen.tsx
+++ b/packages/mobile/src/app/ErrorScreen.tsx
@@ -43,4 +43,4 @@ class ErrorScreen extends React.Component<Props> {
   }
 }
 
-export default withTranslation(Namespaces.global)(ErrorScreen)
+export default withTranslation<Props>(Namespaces.global)(ErrorScreen)

--- a/packages/mobile/src/app/UpgradeScreen.tsx
+++ b/packages/mobile/src/app/UpgradeScreen.tsx
@@ -22,4 +22,4 @@ class UpgradeScreen extends React.Component<Props> {
   }
 }
 
-export default withTranslation(Namespaces.global)(UpgradeScreen)
+export default withTranslation<Props>(Namespaces.global)(UpgradeScreen)

--- a/packages/mobile/src/backup/BackupComplete.tsx
+++ b/packages/mobile/src/backup/BackupComplete.tsx
@@ -86,4 +86,4 @@ const styles = StyleSheet.create({
 
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   exitBackupFlow,
-})(withTranslation(Namespaces.backupKeyFlow6)(BackupComplete))
+})(withTranslation<Props>(Namespaces.backupKeyFlow6)(BackupComplete))

--- a/packages/mobile/src/backup/BackupPhrase.tsx
+++ b/packages/mobile/src/backup/BackupPhrase.tsx
@@ -174,4 +174,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   showError,
   hideAlert,
-})(withTranslation(Namespaces.backupKeyFlow6)(BackupPhrase))
+})(withTranslation<Props>(Namespaces.backupKeyFlow6)(BackupPhrase))

--- a/packages/mobile/src/backup/BackupPhraseContainer.tsx
+++ b/packages/mobile/src/backup/BackupPhraseContainer.tsx
@@ -166,4 +166,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.backupKeyFlow6)(BackupPhraseContainer)
+export default withTranslation<Props>(Namespaces.backupKeyFlow6)(BackupPhraseContainer)

--- a/packages/mobile/src/backup/BackupQuiz.tsx
+++ b/packages/mobile/src/backup/BackupQuiz.tsx
@@ -309,7 +309,7 @@ function getShuffledWordSet(mnemonic: string) {
 export default connect<{}, DispatchProps, OwnProps, RootState>(null, {
   setBackupCompleted,
   showError,
-})(withTranslation(Namespaces.backupKeyFlow6)(BackupQuiz))
+})(withTranslation<Props>(Namespaces.backupKeyFlow6)(BackupQuiz))
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/backup/BackupSocial.tsx
+++ b/packages/mobile/src/backup/BackupSocial.tsx
@@ -174,4 +174,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   setSocialBackupCompleted,
   showError,
-})(withTranslation(Namespaces.backupKeyFlow6)(BackupSocial))
+})(withTranslation<Props>(Namespaces.backupKeyFlow6)(BackupSocial))

--- a/packages/mobile/src/backup/BackupSocialIntro.tsx
+++ b/packages/mobile/src/backup/BackupSocialIntro.tsx
@@ -108,4 +108,4 @@ const styles = StyleSheet.create({
 
 export default connect<{}, DispatchProps, OwnProps, RootState>(null, {
   exitBackupFlow,
-})(withTranslation(Namespaces.backupKeyFlow6)(BackupSocialIntro))
+})(withTranslation<Props>(Namespaces.backupKeyFlow6)(BackupSocialIntro))

--- a/packages/mobile/src/components/Avatar.tsx
+++ b/packages/mobile/src/components/Avatar.tsx
@@ -62,4 +62,4 @@ export function Avatar(props: Props) {
   )
 }
 
-export default withTranslation(Namespaces.sendFlow7)(Avatar)
+export default withTranslation<Props>(Namespaces.sendFlow7)(Avatar)

--- a/packages/mobile/src/components/CancelButton.tsx
+++ b/packages/mobile/src/components/CancelButton.tsx
@@ -47,4 +47,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.global)(CancelButton)
+export default withTranslation<Props>(Namespaces.global)(CancelButton)

--- a/packages/mobile/src/components/CodeRow.tsx
+++ b/packages/mobile/src/components/CodeRow.tsx
@@ -152,4 +152,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.global)(CodeRow)
+export default withTranslation<Props>(Namespaces.global)(CodeRow)

--- a/packages/mobile/src/components/ErrorMessageInline.tsx
+++ b/packages/mobile/src/components/ErrorMessageInline.tsx
@@ -75,4 +75,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   (state: RootState) => mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.global)(ErrorMessageInline))
+)(withTranslation<Props>(Namespaces.global)(ErrorMessageInline))

--- a/packages/mobile/src/dappkit/DappKitAccountScreen.tsx
+++ b/packages/mobile/src/dappkit/DappKitAccountScreen.tsx
@@ -170,5 +170,5 @@ const styles = StyleSheet.create({
 })
 
 export default connect<StateProps, null, {}, RootState>(mapStateToProps)(
-  withTranslation(Namespaces.dappkit)(DappKitAccountAuthScreen)
+  withTranslation<Props>(Namespaces.dappkit)(DappKitAccountAuthScreen)
 )

--- a/packages/mobile/src/dappkit/DappKitSignTxScreen.tsx
+++ b/packages/mobile/src/dappkit/DappKitSignTxScreen.tsx
@@ -177,4 +177,4 @@ const styles = StyleSheet.create({
 export default connect<null, DispatchProps>(
   null,
   mapDispatchToProps
-)(withTranslation(Namespaces.dappkit)(DappKitSignTxScreen))
+)(withTranslation<Props>(Namespaces.dappkit)(DappKitSignTxScreen))

--- a/packages/mobile/src/dappkit/DappKitTxDataScreen.tsx
+++ b/packages/mobile/src/dappkit/DappKitTxDataScreen.tsx
@@ -53,4 +53,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.dappkit)(DappKitTxDataScreen)
+export default withTranslation<Props>(Namespaces.dappkit)(DappKitTxDataScreen)

--- a/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
@@ -126,4 +126,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.inviteFlow11)(EscrowedPaymentListItem)
+export default withTranslation<Props>(Namespaces.inviteFlow11)(EscrowedPaymentListItem)

--- a/packages/mobile/src/escrow/EscrowedPaymentListScreen.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListScreen.tsx
@@ -68,5 +68,5 @@ EscrowedPaymentListScreen.navigationOptions = titleWithBalanceNavigationOptions(
 )
 
 export default connect<StateProps, {}, {}, RootState>(mapStateToProps)(
-  withTranslation(Namespaces.global)(EscrowedPaymentListScreen)
+  withTranslation<Props>(Namespaces.global)(EscrowedPaymentListScreen)
 )

--- a/packages/mobile/src/escrow/EscrowedPaymentReminderSummaryNotification.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentReminderSummaryNotification.tsx
@@ -66,4 +66,6 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.walletFlow5)(EscrowedPaymentReminderSummaryNotification)
+export default withTranslation<Props>(Namespaces.walletFlow5)(
+  EscrowedPaymentReminderSummaryNotification
+)

--- a/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.tsx
+++ b/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.tsx
@@ -182,4 +182,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.sendFlow7)(ReclaimPaymentConfirmationScreen))
+)(withTranslation<Props>(Namespaces.sendFlow7)(ReclaimPaymentConfirmationScreen))

--- a/packages/mobile/src/exchange/CeloGoldHistoryChart.tsx
+++ b/packages/mobile/src/exchange/CeloGoldHistoryChart.tsx
@@ -287,4 +287,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.exchangeFlow9)(CeloGoldHistoryChart)
+export default withTranslation<Props>(Namespaces.exchangeFlow9)(CeloGoldHistoryChart)

--- a/packages/mobile/src/exchange/CeloGoldOverview.tsx
+++ b/packages/mobile/src/exchange/CeloGoldOverview.tsx
@@ -67,4 +67,4 @@ const styles = StyleSheet.create({
   code: {},
 })
 
-export default withTranslation(Namespaces.exchangeFlow9)(CeloGoldOverview)
+export default withTranslation<Props>(Namespaces.exchangeFlow9)(CeloGoldOverview)

--- a/packages/mobile/src/exchange/ExchangeReview.tsx
+++ b/packages/mobile/src/exchange/ExchangeReview.tsx
@@ -289,4 +289,4 @@ export default connect<StateProps, DispatchProps, OwnProps, RootState>(mapStateT
   exchangeTokens,
   fetchExchangeRate,
   fetchTobinTax,
-})(withTranslation(Namespaces.exchangeFlow9)(ExchangeReview))
+})(withTranslation<Props>(Namespaces.exchangeFlow9)(ExchangeReview))

--- a/packages/mobile/src/exchange/ExchangeTradeScreen.tsx
+++ b/packages/mobile/src/exchange/ExchangeTradeScreen.tsx
@@ -353,7 +353,7 @@ export default connect<StateProps, DispatchProps, OwnProps, RootState>(mapStateT
   fetchExchangeRate,
   showError,
   hideAlert,
-})(withTranslation(Namespaces.exchangeFlow9)(ExchangeTradeScreen))
+})(withTranslation<Props>(Namespaces.exchangeFlow9)(ExchangeTradeScreen))
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/exchange/FeeExchangeEducation.tsx
+++ b/packages/mobile/src/exchange/FeeExchangeEducation.tsx
@@ -56,4 +56,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.exchangeFlow9)(FeeExchangeEducation)
+export default withTranslation<Props>(Namespaces.exchangeFlow9)(FeeExchangeEducation)

--- a/packages/mobile/src/home/CeloDollarsOverview.tsx
+++ b/packages/mobile/src/home/CeloDollarsOverview.tsx
@@ -71,4 +71,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.walletFlow5)(CeloDollarsOverview)
+export default withTranslation<Props>(Namespaces.walletFlow5)(CeloDollarsOverview)

--- a/packages/mobile/src/home/NotificationBox.tsx
+++ b/packages/mobile/src/home/NotificationBox.tsx
@@ -324,4 +324,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.walletFlow5)(NotificationBox))
+)(withTranslation<Props>(Namespaces.walletFlow5)(NotificationBox))

--- a/packages/mobile/src/home/WalletHome.tsx
+++ b/packages/mobile/src/home/WalletHome.tsx
@@ -227,4 +227,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.walletFlow5)(WalletHome))
+)(withTranslation<Props>(Namespaces.walletFlow5)(WalletHome))

--- a/packages/mobile/src/i18n.ts
+++ b/packages/mobile/src/i18n.ts
@@ -6,7 +6,6 @@ import {
   initReactI18next,
   WithTranslation,
   withTranslation as withTranslationI18Next,
-  WithTranslationProps,
 } from 'react-i18next'
 import * as RNLocalize from 'react-native-localize'
 import Logger from 'src/utils/Logger'
@@ -102,10 +101,10 @@ RNLocalize.addEventListener('change', () => {
 
 // Create HOC wrapper that hoists statics
 // https://react.i18next.com/latest/withtranslation-hoc#hoist-non-react-statics
-export const withTranslation = (namespace: Namespaces) => <P extends WithTranslation>(
-  component: React.ComponentType<P>
-): React.ComponentType<Omit<P, keyof WithTranslation> & WithTranslationProps> =>
-  // cast as `any` here otherwise TypeScript complained
-  hoistStatics(withTranslationI18Next(namespace)(component), component as any)
+export const withTranslation = <P extends WithTranslation>(namespace: Namespaces) => <
+  C extends React.ComponentType<P>
+>(
+  component: C
+) => hoistStatics(withTranslationI18Next(namespace)(component), component)
 
 export default i18n

--- a/packages/mobile/src/import/ImportWallet.tsx
+++ b/packages/mobile/src/import/ImportWallet.tsx
@@ -188,4 +188,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(mapStateToProps, {
   importBackupPhrase,
   hideAlert,
-})(withTranslation(Namespaces.nuxRestoreWallet3)(ImportWallet))
+})(withTranslation<Props>(Namespaces.nuxRestoreWallet3)(ImportWallet))

--- a/packages/mobile/src/import/ImportWalletEmpty.tsx
+++ b/packages/mobile/src/import/ImportWalletEmpty.tsx
@@ -123,4 +123,4 @@ const styles = StyleSheet.create({
 
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   importBackupPhrase,
-})(withTranslation(Namespaces.nuxRestoreWallet3)(ImportWalletEmpty))
+})(withTranslation<Props>(Namespaces.nuxRestoreWallet3)(ImportWalletEmpty))

--- a/packages/mobile/src/import/ImportWalletSocial.tsx
+++ b/packages/mobile/src/import/ImportWalletSocial.tsx
@@ -180,4 +180,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   importBackupPhrase,
   hideAlert,
-})(withTranslation(Namespaces.nuxRestoreWallet3)(ImportWalletSocial))
+})(withTranslation<Props>(Namespaces.nuxRestoreWallet3)(ImportWalletSocial))

--- a/packages/mobile/src/invite/EnterInviteCode.tsx
+++ b/packages/mobile/src/invite/EnterInviteCode.tsx
@@ -238,4 +238,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.onboarding)(EnterInviteCode))
+)(withTranslation<Props>(Namespaces.onboarding)(EnterInviteCode))

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -211,7 +211,6 @@ const nuxScreens = (Navigator: typeof Stack) => (
     <Navigator.Screen
       name={Screens.EnterInviteCode}
       component={EnterInviteCode}
-      // @ts-ignore this is caused by withTranslation HOC
       options={EnterInviteCode.navigationOptions}
     />
     <Navigator.Screen

--- a/packages/mobile/src/onboarding/contacts/ImportContactsScreen.tsx
+++ b/packages/mobile/src/onboarding/contacts/ImportContactsScreen.tsx
@@ -252,4 +252,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.onboarding)(ImportContactScreen))
+)(withTranslation<Props>(Namespaces.onboarding)(ImportContactScreen))

--- a/packages/mobile/src/onboarding/registration/JoinCelo.tsx
+++ b/packages/mobile/src/onboarding/registration/JoinCelo.tsx
@@ -247,4 +247,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.nuxNamePin1)(JoinCelo))
+)(withTranslation<Props>(Namespaces.nuxNamePin1)(JoinCelo))

--- a/packages/mobile/src/onboarding/registration/RegulatoryTerms.tsx
+++ b/packages/mobile/src/onboarding/registration/RegulatoryTerms.tsx
@@ -98,7 +98,7 @@ export class RegulatoryTerms extends React.Component<Props> {
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.nuxNamePin1)(RegulatoryTerms))
+)(withTranslation<Props>(Namespaces.nuxNamePin1)(RegulatoryTerms))
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.tsx
+++ b/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.tsx
@@ -100,4 +100,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.paymentRequestFlow)(IncomingPaymentRequestListItem)
+export default withTranslation<Props>(Namespaces.paymentRequestFlow)(IncomingPaymentRequestListItem)

--- a/packages/mobile/src/paymentRequest/IncomingPaymentRequestListScreen.tsx
+++ b/packages/mobile/src/paymentRequest/IncomingPaymentRequestListScreen.tsx
@@ -136,4 +136,4 @@ class IncomingPaymentRequestListScreen extends React.Component<Props> {
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.paymentRequestFlow)(IncomingPaymentRequestListScreen))
+)(withTranslation<Props>(Namespaces.paymentRequestFlow)(IncomingPaymentRequestListScreen))

--- a/packages/mobile/src/paymentRequest/IncomingPaymentRequestSummaryNotification.tsx
+++ b/packages/mobile/src/paymentRequest/IncomingPaymentRequestSummaryNotification.tsx
@@ -101,4 +101,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.walletFlow5)(IncomingPaymentRequestSummaryNotification))
+)(withTranslation<Props>(Namespaces.walletFlow5)(IncomingPaymentRequestSummaryNotification))

--- a/packages/mobile/src/paymentRequest/OutgoingPaymentRequestListItem.tsx
+++ b/packages/mobile/src/paymentRequest/OutgoingPaymentRequestListItem.tsx
@@ -84,4 +84,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.paymentRequestFlow)(OutgoingPaymentRequestListItem)
+export default withTranslation<Props>(Namespaces.paymentRequestFlow)(OutgoingPaymentRequestListItem)

--- a/packages/mobile/src/paymentRequest/OutgoingPaymentRequestListScreen.tsx
+++ b/packages/mobile/src/paymentRequest/OutgoingPaymentRequestListScreen.tsx
@@ -86,4 +86,4 @@ OutgoingPaymentRequestListScreen.navigationOptions = titleWithBalanceNavigationO
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   cancelPaymentRequest,
   updatePaymentRequestNotified,
-})(withTranslation(Namespaces.paymentRequestFlow)(OutgoingPaymentRequestListScreen))
+})(withTranslation<Props>(Namespaces.paymentRequestFlow)(OutgoingPaymentRequestListScreen))

--- a/packages/mobile/src/paymentRequest/OutgoingPaymentRequestSummaryNotification.tsx
+++ b/packages/mobile/src/paymentRequest/OutgoingPaymentRequestSummaryNotification.tsx
@@ -101,4 +101,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(mapStateToProps, {
   cancelPaymentRequest,
   updatePaymentRequestNotified,
-})(withTranslation(Namespaces.walletFlow5)(OutgoingPaymentRequestSummaryNotification))
+})(withTranslation<Props>(Namespaces.walletFlow5)(OutgoingPaymentRequestSummaryNotification))

--- a/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
@@ -227,4 +227,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.paymentRequestFlow)(PaymentRequestConfirmation))
+)(withTranslation<Props>(Namespaces.paymentRequestFlow)(PaymentRequestConfirmation))

--- a/packages/mobile/src/pincode/PincodeEnter.tsx
+++ b/packages/mobile/src/pincode/PincodeEnter.tsx
@@ -96,4 +96,6 @@ const mapStateToProps = (state: RootState): StateProps => ({
   fornoMode: fornoSelector(state),
 })
 
-export default connect(mapStateToProps)(withTranslation(Namespaces.nuxNamePin1)(PincodeEnter))
+export default connect(mapStateToProps)(
+  withTranslation<Props>(Namespaces.nuxNamePin1)(PincodeEnter)
+)

--- a/packages/mobile/src/pincode/PincodeSet.tsx
+++ b/packages/mobile/src/pincode/PincodeSet.tsx
@@ -126,4 +126,4 @@ const style = StyleSheet.create({
 export default connect<{}, DispatchProps>(
   null,
   mapDispatchToProps
-)(withTranslation(Namespaces.onboarding)(PincodeSet))
+)(withTranslation<Props>(Namespaces.onboarding)(PincodeSet))

--- a/packages/mobile/src/recipients/RecipientPicker.tsx
+++ b/packages/mobile/src/recipients/RecipientPicker.tsx
@@ -244,4 +244,7 @@ const style = StyleSheet.create({
   },
 })
 
-export default connect(mapStateToProps, {})(withTranslation(Namespaces.sendFlow7)(RecipientPicker))
+export default connect(
+  mapStateToProps,
+  {}
+)(withTranslation<RecipientProps>(Namespaces.sendFlow7)(RecipientPicker))

--- a/packages/mobile/src/send/FeeEducation.tsx
+++ b/packages/mobile/src/send/FeeEducation.tsx
@@ -55,4 +55,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.sendFlow7)(FeeEducation)
+export default withTranslation<Props>(Namespaces.sendFlow7)(FeeEducation)

--- a/packages/mobile/src/send/Send.tsx
+++ b/packages/mobile/src/send/Send.tsx
@@ -335,4 +335,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.sendFlow7)(Send))
+)(withTranslation<Props>(Namespaces.sendFlow7)(Send))

--- a/packages/mobile/src/send/SendConfirmation.tsx
+++ b/packages/mobile/src/send/SendConfirmation.tsx
@@ -445,4 +445,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.sendFlow7)(SendConfirmation))
+)(withTranslation<Props>(Namespaces.sendFlow7)(SendConfirmation))

--- a/packages/mobile/src/send/ValidateRecipientAccount.tsx
+++ b/packages/mobile/src/send/ValidateRecipientAccount.tsx
@@ -336,4 +336,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, OwnProps, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.sendFlow7)(ValidateRecipientAccount))
+)(withTranslation<Props>(Namespaces.sendFlow7)(ValidateRecipientAccount))

--- a/packages/mobile/src/send/ValidateRecipientIntro.tsx
+++ b/packages/mobile/src/send/ValidateRecipientIntro.tsx
@@ -153,5 +153,5 @@ const styles = StyleSheet.create({
 })
 
 export default connect<StateProps, {}, OwnProps, RootState>(mapStateToProps)(
-  withTranslation(Namespaces.sendFlow7)(ValidateRecipientIntro)
+  withTranslation<Props>(Namespaces.sendFlow7)(ValidateRecipientIntro)
 )

--- a/packages/mobile/src/set-clock/SetClock.tsx
+++ b/packages/mobile/src/set-clock/SetClock.tsx
@@ -85,4 +85,4 @@ const style = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.global)(SetClock)
+export default withTranslation<WithTranslation>(Namespaces.global)(SetClock)

--- a/packages/mobile/src/shared/BackupPrompt.tsx
+++ b/packages/mobile/src/shared/BackupPrompt.tsx
@@ -51,5 +51,5 @@ export class BackupPrompt extends React.Component<Props> {
 }
 
 export default connect<StateProps, {}, {}, RootState>(mapStateToProps)(
-  withTranslation(Namespaces.backupKeyFlow6)(BackupPrompt)
+  withTranslation<Props>(Namespaces.backupKeyFlow6)(BackupPrompt)
 )

--- a/packages/mobile/src/shared/DisconnectBanner.tsx
+++ b/packages/mobile/src/shared/DisconnectBanner.tsx
@@ -90,5 +90,5 @@ const styles = StyleSheet.create({
 })
 
 export default connect<StateProps, {}, {}, RootState>(mapStateToProps)(
-  withTranslation(Namespaces.global)(DisconnectBanner)
+  withTranslation<Props>(Namespaces.global)(DisconnectBanner)
 )

--- a/packages/mobile/src/transactions/NoActivity.tsx
+++ b/packages/mobile/src/transactions/NoActivity.tsx
@@ -95,4 +95,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.walletFlow5)(NoActivity)
+export default withTranslation<Props>(Namespaces.walletFlow5)(NoActivity)

--- a/packages/mobile/src/verify/VerificationEducationScreen.tsx
+++ b/packages/mobile/src/verify/VerificationEducationScreen.tsx
@@ -202,4 +202,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.nuxVerification2)(VerificationEducationScreen))
+)(withTranslation<Props>(Namespaces.nuxVerification2)(VerificationEducationScreen))

--- a/packages/mobile/src/verify/VerificationInputScreen.tsx
+++ b/packages/mobile/src/verify/VerificationInputScreen.tsx
@@ -332,4 +332,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.nuxVerification2)(VerificationInputScreen))
+)(withTranslation<Props>(Namespaces.nuxVerification2)(VerificationInputScreen))

--- a/packages/mobile/src/verify/VerificationLearnMoreScreen.tsx
+++ b/packages/mobile/src/verify/VerificationLearnMoreScreen.tsx
@@ -53,4 +53,6 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation(Namespaces.nuxVerification2)(VerificationLearnMoreScreen)
+export default withTranslation<WithTranslation>(Namespaces.nuxVerification2)(
+  VerificationLearnMoreScreen
+)

--- a/packages/mobile/src/verify/VerificationLoadingScreen.tsx
+++ b/packages/mobile/src/verify/VerificationLoadingScreen.tsx
@@ -189,4 +189,4 @@ const styles = StyleSheet.create({
 export default connect<StateProps, DispatchProps, {}, RootState>(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation(Namespaces.nuxVerification2)(VerificationLoadingScreen))
+)(withTranslation<Props>(Namespaces.nuxVerification2)(VerificationLoadingScreen))


### PR DESCRIPTION
### Description

This PR fixes the typing of our `withTranslation` HOC.

This is so we can still call hoisted static methods from the original component in a type safe way and not causing a TypeScript error.

This is useful in `Navigator` when we want to access `MyComp.navigationOptions`.

The small inconvenience of this is we have to explicitly pass the component `Props` when calling `withTranslation<Props>(...)`.
This is very similar to the `connect` HOC we already use.

I tried to lift this requirement but couldn't. Maybe if one day TypeScript supports generics of generics it could be inferred automatically. But for now I think it's good enough.

Note: this PR depends on #4145, please merge that one first.

### Tested

TypeScript passes successfully.

### Backwards compatibility

Yes.