### PR TITLE
Make Election.revokeAllActive callable by removing prohibitive reentrancy check

### DIFF
--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -333,7 +333,6 @@ contract Election is
    */
   function revokeAllActive(address group, address lesser, address greater, uint256 index)
     external
-    nonReentrant
     returns (bool)
   {
     address account = getAccounts().voteSignerToAccount(msg.sender);

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -333,11 +333,12 @@ contract Election is
    */
   function revokeAllActive(address group, address lesser, address greater, uint256 index)
     external
+    nonReentrant
     returns (bool)
   {
     address account = getAccounts().voteSignerToAccount(msg.sender);
     uint256 value = getActiveVotesForGroupByAccount(group, account);
-    return revokeActive(group, value, lesser, greater, index);
+    return _revokeActive(group, value, lesser, greater, index);
   }
 
   /**
@@ -358,7 +359,17 @@ contract Election is
     address lesser,
     address greater,
     uint256 index
-  ) public nonReentrant returns (bool) {
+  ) external nonReentrant returns (bool) {
+    return _revokeActive(group, value, lesser, greater, index);
+  }
+
+  function _revokeActive(
+    address group,
+    uint256 value,
+    address lesser,
+    address greater,
+    uint256 index
+  ) internal returns (bool) {
     // TODO(asa): Dedup with revokePending.
     require(group != address(0), "Group address zero");
     address account = getAccounts().voteSignerToAccount(msg.sender);

--- a/packages/protocol/test/governance/election.ts
+++ b/packages/protocol/test/governance/election.ts
@@ -833,6 +833,21 @@ contract('Election', (accounts: string[]) => {
       })
 
       describe('when the revoked value is equal to the active votes', () => {
+        describe.only('#revokeAllActive', () => {
+          const index = 0
+          beforeEach(async () => {
+            await election.revokeAllActive(group, NULL_ADDRESS, NULL_ADDRESS, index)
+          })
+
+          it('should be consistent', async () => {
+            await assertConsistentSums()
+          })
+
+          it("should decrement all of the account's active votes for the group", async () => {
+            assertEqualBN(await election.getActiveVotesForGroupByAccount(group, voter0), 0)
+          })
+        })
+
         describe('when the correct index is provided', () => {
           const index = 0
           const revokedValue = voteValue0 + reward0

--- a/packages/protocol/test/governance/election.ts
+++ b/packages/protocol/test/governance/election.ts
@@ -833,7 +833,7 @@ contract('Election', (accounts: string[]) => {
       })
 
       describe('when the revoked value is equal to the active votes', () => {
-        describe.only('#revokeAllActive', () => {
+        describe('#revokeAllActive', () => {
           const index = 0
           beforeEach(async () => {
             await election.revokeAllActive(group, NULL_ADDRESS, NULL_ADDRESS, index)


### PR DESCRIPTION
### Description

`nonReentrant` functions cannot call each other per the [OpenZeppelin docs ](https://docs.openzeppelin.com/contracts/2.x/api/utils#ReentrancyGuard-nonReentrant--)

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

Added unit tests for all active value being revoked

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Network upgrade necessary