### PR TITLE
Add amount to Moonpay window

### DIFF
--- a/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
+++ b/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
@@ -60,10 +60,11 @@ export const fiatExchangesOptionsScreenOptions = ({
 }
 
 function FiatExchangeOptions({ route, navigation }: Props) {
-  function goToProvider(screen: keyof StackParamList) {
-    return () => navigation.navigate(screen)
+  const { amount } = route.params
+  const goToProvider = (screen: keyof StackParamList) => {
+    return () => navigation.navigate(screen, { amount })
   }
-  function onDismiss() {
+  const onDismiss = () => {
     navigation.setParams({ isExplanationOpen: false })
   }
 

--- a/packages/mobile/src/fiatExchanges/MoonPay.test.tsx
+++ b/packages/mobile/src/fiatExchanges/MoonPay.test.tsx
@@ -1,16 +1,23 @@
+import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import 'react-native'
 import { render } from 'react-native-testing-library'
 import { Provider } from 'react-redux'
 import MoonPay from 'src/fiatExchanges/MoonPay'
-import { createMockStore } from 'test/utils'
+import { Screens } from 'src/navigator/Screens'
+import { createMockStore, getMockStackScreenProps } from 'test/utils'
+
+const mockScreenProps = () =>
+  getMockStackScreenProps(Screens.MoonPay, {
+    amount: new BigNumber('1'),
+  })
 
 describe('MoonPay', () => {
   const store = createMockStore()
   it('renders correctly', () => {
     const { toJSON } = render(
       <Provider store={store}>
-        <MoonPay />
+        <MoonPay {...mockScreenProps()} />
       </Provider>
     )
     expect(toJSON()).toMatchSnapshot()

--- a/packages/mobile/src/fiatExchanges/MoonPay.tsx
+++ b/packages/mobile/src/fiatExchanges/MoonPay.tsx
@@ -52,7 +52,7 @@ function FiatExchangeWeb({ route }: Props) {
           currency: celoCurrencyCode,
           address: account,
           fiatCurrency: localCurrencyCode,
-          ...(localAmount && { fiatAmount: localAmount.toString() }),
+          fiatAmount: localAmount?.toString(),
         }),
       })
       const json = await response.json()

--- a/packages/mobile/src/fiatExchanges/MoonPay.tsx
+++ b/packages/mobile/src/fiatExchanges/MoonPay.tsx
@@ -10,9 +10,12 @@ import i18n from 'src/i18n'
 import { emptyHeader } from 'src/navigator/Headers.v2'
 import { navigate } from 'src/navigator/NavigationService'
 
-import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
+import { StackScreenProps } from '@react-navigation/stack'
+import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
+import { getLocalCurrencyCode, getLocalCurrencyExchangeRate } from 'src/localCurrency/selectors'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarTextButton } from 'src/navigator/TopBarButton.v2'
+import { StackParamList } from 'src/navigator/types'
 import { currentAccountSelector } from 'src/web3/selectors'
 
 const celoCurrencyCode = 'CUSD'
@@ -27,10 +30,16 @@ export const moonPayOptions = () => {
   }
 }
 
-function FiatExchangeWeb() {
+type RouteProps = StackScreenProps<StackParamList, Screens.MoonPay>
+type Props = RouteProps
+
+function FiatExchangeWeb({ route }: Props) {
   const [uri, setUri] = React.useState('')
+  const { amount } = route.params
   const account = useSelector(currentAccountSelector)
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
+  const localCurrencyExchangeRate = useSelector(getLocalCurrencyExchangeRate)
+  const localAmount = convertDollarsToLocalAmount(amount, localCurrencyExchangeRate)
   React.useEffect(() => {
     const getSignedUrl = async () => {
       const response = await fetch(config.signMoonpayUrl, {
@@ -39,11 +48,11 @@ function FiatExchangeWeb() {
           Accept: 'application/json',
           'Content-Type': 'application/json',
         },
-        // TODO: Add amount here
         body: JSON.stringify({
           currency: celoCurrencyCode,
           address: account,
           fiatCurrency: localCurrencyCode,
+          ...(localAmount && { fiatAmount: localAmount.toString() }),
         }),
       })
       const json = await response.json()

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -87,7 +87,9 @@ export type StackParamList = {
     currencyCode: LocalCurrencyCode
     isExplanationOpen?: boolean
   }
-  [Screens.MoonPay]: undefined
+  [Screens.MoonPay]: {
+    amount: BigNumber
+  }
   [Screens.GoldEducation]: undefined
   [Screens.ImportWallet]:
     | {

--- a/packages/moonpay-auth/src/index.ts
+++ b/packages/moonpay-auth/src/index.ts
@@ -13,7 +13,9 @@ export const signMoonpay = functions.https.onRequest((request, response) => {
     '&walletAddress=' +
     request.body.address +
     '&baseCurrencyCode=' +
-    request.body.fiatCurrency
+    request.body.fiatCurrency +
+    '&baseCurrencyAmount=' +
+    request.body.fiatAmount
   console.log(`Requested signature for: ${url}`)
 
   const signature = crypto


### PR DESCRIPTION
### Description

Add amount to Moonpay window

### Tested

iOS simulator (but to test it properly I need to redeploy `moonpay-auth`)

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/4230

### Backwards compatibility

Yes