### PR TITLE
[Wallet] Currency representation consistency and fix Gold Education

### DIFF
--- a/packages/mobile/src/account/Education.tsx
+++ b/packages/mobile/src/account/Education.tsx
@@ -11,6 +11,7 @@ import Swiper from 'react-native-swiper'
 import { AnalyticsEventType } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { placeholder } from 'src/images/Images'
+import DrawerTopBar from 'src/navigator/DrawerTopBar'
 import { navigateBack } from 'src/navigator/NavigationService'
 import { TopBarIconButton } from 'src/navigator/TopBarButton.v2'
 
@@ -80,15 +81,15 @@ export default class Education extends React.Component<Props, State> {
     const isLastStep = this.state.step === stepInfo.length - 1
     return (
       <SafeAreaView style={styles.root}>
-        <View style={styles.top} testID="Education/top">
-          {isClosable && (
+        {(isClosable && (
+          <View style={styles.top} testID="Education/top">
             <TopBarIconButton
               testID="Education/CloseIcon"
               onPress={this.goBack}
               icon={this.state.step === 0 ? <Times /> : <BackChevron color={colors.dark} />}
             />
-          )}
-        </View>
+          </View>
+        )) || <DrawerTopBar testID="DrawerTopBar" />}
         <View style={styles.container}>
           <Swiper
             ref={this.swiper}
@@ -123,12 +124,12 @@ export default class Education extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
+    backgroundColor: colors.background,
   },
   container: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: 'white',
     paddingBottom: 24,
   },
   heading: {

--- a/packages/mobile/src/account/FiatExchange.tsx
+++ b/packages/mobile/src/account/FiatExchange.tsx
@@ -5,15 +5,12 @@ import variables from '@celo/react-components/styles/variables'
 import { CURRENCIES, CURRENCY_ENUM } from '@celo/utils/src'
 import { useNavigation } from '@react-navigation/native'
 import * as React from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useSelector } from 'react-redux'
 import CurrencyDisplay from 'src/components/CurrencyDisplay'
 import { SHOW_CASH_OUT } from 'src/config'
-import { Namespaces } from 'src/i18n'
-import { LocalCurrencyCode } from 'src/localCurrency/consts'
-import { useLocalCurrencyCode } from 'src/localCurrency/hooks'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
 import { Screens } from 'src/navigator/Screens'
 import { stableTokenBalanceSelector } from 'src/stableToken/reducer'
@@ -29,8 +26,6 @@ function FiatExchange() {
 
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const localCurrencyCode = useLocalCurrencyCode()
-  const isUsdLocalCurrency = localCurrencyCode === LocalCurrencyCode.USD
   const dollarBalance = useSelector(stableTokenBalanceSelector)
   const dollarAmount = {
     value: dollarBalance ?? '0',
@@ -43,19 +38,14 @@ function FiatExchange() {
       <View style={styles.image} />
       <View style={styles.balanceSheet}>
         <Text style={styles.currentBalance}>{t('global:currentBalance')}</Text>
+        <CurrencyDisplay style={styles.localBalance} amount={dollarAmount} />
         <CurrencyDisplay
-          style={styles.localBalance}
+          style={styles.dollarBalance}
           amount={dollarAmount}
-          showLocalAmount={!isUsdLocalCurrency}
+          showLocalAmount={false}
+          hideFullCurrencyName={false}
+          hideSymbol={true}
         />
-        {!isUsdLocalCurrency && (
-          <Text style={styles.dollarBalance}>
-            <Trans i18nKey="dollarBalance" ns={Namespaces.walletFlow5}>
-              <CurrencyDisplay showLocalAmount={false} hideSymbol={true} amount={dollarAmount} />{' '}
-              Celo Dollars
-            </Trans>
-          </Text>
-        )}
       </View>
       <View>
         <ListItem onPress={goToAddFunds}>

--- a/packages/mobile/src/account/GoldEducation.test.tsx
+++ b/packages/mobile/src/account/GoldEducation.test.tsx
@@ -23,7 +23,7 @@ describe('when first time (!goldToken.educationCompleted)', () => {
       </Provider>
     )
 
-    expect(getByTestId('Education/top').props.children).toEqual(false)
+    expect(getByTestId('DrawerTopBar')).toBeTruthy()
   })
 })
 

--- a/packages/mobile/src/account/__snapshots__/AccountKeyEducation.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/AccountKeyEducation.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
 <RNCSafeAreaView
   style={
     Object {
+      "backgroundColor": "#FFFFFF",
       "flex": 1,
     }
   }
@@ -75,7 +76,6 @@ exports[`AccountKeyEducation renders correctly 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "white",
         "flex": 1,
         "justifyContent": "center",
         "paddingBottom": 24,

--- a/packages/mobile/src/account/__snapshots__/Education.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Education.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Education renders correctly 1`] = `
 <RNCSafeAreaView
   style={
     Object {
+      "backgroundColor": "#FFFFFF",
       "flex": 1,
     }
   }
@@ -75,7 +76,6 @@ exports[`Education renders correctly 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "white",
         "flex": 1,
         "justifyContent": "center",
         "paddingBottom": 24,

--- a/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
@@ -142,31 +142,24 @@ exports[`FiatExchange renders correctly 1`] = `
       0.00
     </Text>
     <Text
+      numberOfLines={1}
       style={
-        Object {
-          "color": "#9CA4A9",
-          "fontFamily": "Inter-Regular",
-          "fontSize": 14,
-          "lineHeight": 18,
-        }
+        Array [
+          Object {
+            "color": "#9CA4A9",
+            "fontFamily": "Inter-Regular",
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          Object {
+            "color": "#9CA4A9",
+          },
+        ]
       }
     >
-      <Text
-        numberOfLines={1}
-        style={
-          Array [
-            undefined,
-            Object {
-              "color": undefined,
-            },
-          ]
-        }
-      >
-        
-        0.00
-      </Text>
-       
-      Celo Dollars
+      
+      0.00
+       global:celoDollars
     </Text>
   </View>
   <View>

--- a/packages/mobile/src/account/__snapshots__/GoldEducation.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/GoldEducation.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders correctly 1`] = `
 <RNCSafeAreaView
   style={
     Object {
+      "backgroundColor": "#FFFFFF",
       "flex": 1,
     }
   }
@@ -11,19 +12,85 @@ exports[`renders correctly 1`] = `
   <View
     style={
       Object {
+        "alignItems": "center",
+        "backgroundColor": "transparent",
+        "borderBottomColor": AnimatedValue {
+          " __value": NaN,
+        },
+        "borderBottomWidth": 1,
         "flexDirection": "row",
-        "paddingLeft": 24,
-        "paddingVertical": 16,
-        "width": "100%",
+        "height": 62,
+        "justifyContent": "space-between",
       }
     }
-    testID="Education/top"
-  />
+    testID="DrawerTopBar"
+  >
+    <View
+      accessible={true}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "marginBottom": 0,
+          "marginLeft": 4,
+          "opacity": 1,
+          "padding": 8,
+        }
+      }
+    >
+      <svg
+        fill="none"
+        height="32"
+        viewBox="0 0 32 32"
+        width="32"
+      >
+        <line
+          stroke="#2E3338"
+          strokeLinecap="round"
+          strokeWidth="2.5"
+          x1="7.25"
+          x2="24.75"
+          y1="9.75"
+          y2="9.75"
+        />
+        <line
+          stroke="#2E3338"
+          strokeLinecap="round"
+          strokeWidth="2.5"
+          x1="7.25"
+          x2="24.75"
+          y1="15.75"
+          y2="15.75"
+        />
+        <line
+          stroke="#2E3338"
+          strokeLinecap="round"
+          strokeWidth="2.5"
+          x1="7.25"
+          x2="24.75"
+          y1="21.75"
+          y2="21.75"
+        />
+      </svg>
+    </View>
+    <View
+      style={
+        Object {
+          "width": 45,
+        }
+      }
+    />
+  </View>
   <View
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "white",
         "flex": 1,
         "justifyContent": "center",
         "paddingBottom": 24,

--- a/packages/mobile/src/components/CurrencyDisplay.tsx
+++ b/packages/mobile/src/components/CurrencyDisplay.tsx
@@ -6,6 +6,7 @@ import { StyleProp, StyleSheet, Text, TextStyle, View } from 'react-native'
 import { MoneyAmount } from 'src/apollo/types'
 import { useExchangeRate as useGoldToDollarRate } from 'src/exchange/hooks'
 import { CURRENCIES, CURRENCY_ENUM } from 'src/geth/consts'
+import i18n from 'src/i18n'
 import { LocalCurrencyCode, LocalCurrencySymbol } from 'src/localCurrency/consts'
 import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
 import {
@@ -46,6 +47,7 @@ interface Props {
   showLocalAmount?: boolean
   showExplicitPositiveSign: boolean // shows '+' for a positive amount when true (default is false)
   formatType: FormatType
+  hideFullCurrencyName: boolean
   style?: StyleProp<TextStyle>
 }
 
@@ -127,6 +129,7 @@ export default function CurrencyDisplay({
   showExplicitPositiveSign,
   amount,
   formatType,
+  hideFullCurrencyName,
   style,
 }: Props) {
   const localCurrencyCode = useLocalCurrencyCode()
@@ -208,6 +211,9 @@ export default function CurrencyDisplay({
       {!hideSymbol && currencySymbol}
       {formattedValue}
       {!hideCode && !!code && ` ${code}`}
+      {!hideFullCurrencyName &&
+        code === CURRENCIES[CURRENCY_ENUM.DOLLAR].code &&
+        ` ${i18n.t('global:celoDollars')}`}
     </Text>
   )
 }
@@ -221,6 +227,7 @@ CurrencyDisplay.defaultProps = {
   hideCode: true,
   showExplicitPositiveSign: false,
   formatType: FormatType.Default,
+  hideFullCurrencyName: true,
 }
 
 const styles = StyleSheet.create({

--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -2,6 +2,7 @@ import ContactCircle from '@celo/react-components/components/ContactCircle'
 import PhoneNumberWithFlag from '@celo/react-components/components/PhoneNumberWithFlag'
 import colorsV2 from '@celo/react-components/styles/colors.v2'
 import fontStyles from '@celo/react-components/styles/fonts.v2'
+import { CURRENCIES, CURRENCY_ENUM } from '@celo/utils/src'
 import {
   createDrawerNavigator,
   DrawerContentComponentProps,
@@ -19,7 +20,6 @@ import {
   DrawerNavigationState,
   useLinkBuilder,
 } from '@react-navigation/native'
-import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
@@ -36,6 +36,7 @@ import SettingsScreen from 'src/account/Settings'
 import Support from 'src/account/Support'
 import BackupIntroduction from 'src/backup/BackupIntroduction'
 import AccountNumber from 'src/components/AccountNumber'
+import CurrencyDisplay from 'src/components/CurrencyDisplay'
 import ExchangeHomeScreen from 'src/exchange/ExchangeHomeScreen'
 import WalletHome from 'src/home/WalletHome'
 import { Namespaces } from 'src/i18n'
@@ -45,7 +46,6 @@ import { Gold } from 'src/icons/navigator/Gold'
 import { Help } from 'src/icons/navigator/Help'
 import { Home } from 'src/icons/navigator/Home'
 import { Settings } from 'src/icons/navigator/Settings'
-import { useDollarsToLocalAmount, useLocalCurrencySymbol } from 'src/localCurrency/hooks'
 import { ensurePincode } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import useSelector from 'src/redux/useSelector'
@@ -118,11 +118,11 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
   const e164PhoneNumber = useSelector(e164NumberSelector)
   const contactDetails = useSelector(userContactDetailsSelector)
   const defaultCountryCode = useSelector(defaultCountryCodeSelector)
-  const balance = useSelector(stableTokenBalanceSelector)
-  const bigNumBalance = balance ? new BigNumber(balance) : undefined
-  const localBalance = useDollarsToLocalAmount(balance)
-  const symbol = useLocalCurrencySymbol()
-  const { t } = useTranslation(Namespaces.global)
+  const dollarBalance = useSelector(stableTokenBalanceSelector)
+  const dollarAmount = {
+    value: dollarBalance ?? '0',
+    currencyCode: CURRENCIES[CURRENCY_ENUM.DOLLAR].code,
+  }
   const account = useSelector(currentAccountSelector)
   const appVersion = deviceInfoModule.getVersion()
 
@@ -138,10 +138,18 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
           />
         )}
         <View style={styles.border} />
-        <Text style={fontStyles.regular500}>{`${symbol} ${localBalance?.toFixed(2)}`}</Text>
-        <Text style={[styles.smallLabel, styles.dollarsLabel]}>{`${bigNumBalance?.toFixed(2)} ${t(
-          'celoDollars'
-        )}`}</Text>
+        <CurrencyDisplay
+          style={fontStyles.regular500}
+          amount={dollarAmount}
+          showLocalAmount={true}
+        />
+        <CurrencyDisplay
+          style={styles.dollarsLabel}
+          amount={dollarAmount}
+          showLocalAmount={false}
+          hideFullCurrencyName={false}
+          hideSymbol={true}
+        />
         <View style={styles.borderBottom} />
       </View>
       <CustomDrawerItemList {...props} protectedRoutes={[Screens.BackupIntroduction]} />
@@ -181,11 +189,19 @@ export default function DrawerNavigator() {
         component={WalletHome}
         options={{ title: t('home'), drawerIcon: Home }}
       />
-      <Drawer.Screen
-        name={isCeloEducationComplete ? Screens.ExchangeHomeScreen : Screens.GoldEducation}
-        component={isCeloEducationComplete ? ExchangeHomeScreen : GoldEducation}
-        options={{ title: t('celoGold'), drawerIcon: Gold }}
-      />
+      {(isCeloEducationComplete && (
+        <Drawer.Screen
+          name={Screens.ExchangeHomeScreen}
+          component={ExchangeHomeScreen}
+          options={{ title: t('celoGold'), drawerIcon: Gold }}
+        />
+      )) || (
+        <Drawer.Screen
+          name={Screens.GoldEducation}
+          component={GoldEducation}
+          options={{ title: t('celoGold'), drawerIcon: Gold }}
+        />
+      )}
       <Drawer.Screen
         name={Screens.BackupIntroduction}
         component={BackupIntroduction}
@@ -229,6 +245,8 @@ const styles = StyleSheet.create({
     alignSelf: 'stretch',
   },
   dollarsLabel: {
+    ...fontStyles.small,
+    color: colorsV2.gray4,
     marginTop: 2,
   },
   borderBottom: {

--- a/packages/mobile/src/navigator/DrawerTopBar.tsx
+++ b/packages/mobile/src/navigator/DrawerTopBar.tsx
@@ -9,9 +9,10 @@ import Hamburger from 'src/icons/Hamburger'
 interface Props {
   middleElement?: React.ReactNode
   scrollPosition?: Animated.Value<number>
+  testID?: string
 }
 
-function DrawerTopBar({ middleElement, scrollPosition }: Props) {
+function DrawerTopBar({ middleElement, scrollPosition, testID }: Props) {
   const navigation = useNavigation()
   const viewStyle = React.useMemo(
     () => ({
@@ -26,7 +27,7 @@ function DrawerTopBar({ middleElement, scrollPosition }: Props) {
   )
 
   return (
-    <Animated.View style={viewStyle}>
+    <Animated.View testID={testID} style={viewStyle}>
       {/*
       // @ts-ignore Only used in a drawer */}
       <TouchableOpacity style={styles.hamburger} onPress={navigation.toggleDrawer}>


### PR DESCRIPTION
### Description

* Currency representation consistency in Drawer and Cash In/Out screen
* Add hamburger icon to the Gold Education, when user lands on it from Drawer, so it is possible to go away without finishing the whole tutorial.

### Tested

iOS and Android

### Backwards compatibility

Yes

### Screenshots
![RhwQWEtRtShdMmL5PXMbBfsUac6bf5nD](https://user-images.githubusercontent.com/6160124/86253471-e1802300-bbb4-11ea-97f4-f7a4fc846300.png)
