### PR TITLE
[Wallet] Add retry logic to verification reveal failure

### DIFF
--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -174,12 +174,14 @@ interface VerificationEventsProperties {
     issuer: any
   }
   [VerificationEvents.verification_revealed_attestation]: {
+    retryRequired: boolean
     issuer: any
     duration: number
   }
   [VerificationEvents.verification_reveal_error]: {
     issuer: any
     statusCode: any
+    error: any
   }
   [VerificationEvents.verification_wait_for_attestation_code]: {
     issuer: any


### PR DESCRIPTION
### Description

Add retry logic to verification reveal failure when `No incomplete attestation found` error returned by attestation service

Currently, when a reveal fails, we assume that either it was already revealed in the past (Verification Failure modal shown with option to enter codes) or it is an irrecoverable failure (Verification Failure modal with no option to enter codes). However @nambrot pointed out that a reveal can fail if an attestation service has not yet received the block where it is made responsible for the attestation, in which case the reveal should retry, as time will have passed for the attestation service to receive the relevant block. 

More context: https://celo-org.slack.com/archives/CJXJ1EV0D/p1593590635047500

### Other changes

Add reveal error message to analytics

### Tested

Not yet tested

### Backwards compatibility

Yes