### PR TITLE
Remove /app redirect

### DIFF
--- a/packages/web/server/index.ts
+++ b/packages/web/server/index.ts
@@ -87,7 +87,7 @@ function wwwRedirect(req: express.Request, res: express.Response, nextAction: ()
   server.get('/build/*', (req, res) => {
     res.redirect(`/developers/${req.params[0]}`)
   })
-  ;['/app', '/test-wallet', '/mobile-app', 'build/download'].forEach((route) => {
+  ;['/test-wallet', 'build/download'].forEach((route) => {
     server.get(route, (_, res) => {
       res.redirect('/developers/wallet')
     })
@@ -196,8 +196,8 @@ function wwwRedirect(req: express.Request, res: express.Response, nextAction: ()
 
   server.post('/ecosystem/:table', rateLimit, async (req, res) => {
     try {
-      const record = await ecoFundSubmission(req.body, req.params.table as Tables)
-      res.status(CREATED).json({ id: record.id })
+      await ecoFundSubmission(req.body, req.params.table as Tables)
+      res.sendStatus(CREATED)
     } catch (e) {
       Sentry.withScope((scope) => {
         scope.setTag('Service', 'Airtable')


### PR DESCRIPTION
### Description

Now that we have a main-net wallet  launching having celo.org/app go to the alfajores testnet wallet is confusing.

### Other changes

dont return the ID when submitting form as its not useful. 

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/547

