### PR TITLE
[Wallet] Payment limit bug fix

### DIFF
--- a/packages/mobile/locales/en-US/global.json
+++ b/packages/mobile/locales/en-US/global.json
@@ -121,7 +121,7 @@
   "saltFetchFailure": "Failed to retrieve phone number secret",
   "saltQuotaExceededError": "Your phone number lookup quota is used up",
   "matchmakingQuotaExceededError": "Matchmaking can be done only once",
-  "paymentLimitReached": "The daily limit is {{dailyLimitcUSD}}CUSD ({{currencySymbol}}{{dailyLimit}})\n{{dailyRemainingcUSD}}CUSD ({{currencySymbol}}{{dailyRemaining}}) remaining",
+  "paymentLimitReached": "The daily limit is {{dailyLimitcUSD}} cUSD ({{currencySymbol}}{{dailyLimit}})\n{{dailyRemainingcUSD}} cUSD ({{currencySymbol}}{{dailyRemaining}}) remaining",
   "ordinals": [
     "zeroth",
     "first",

--- a/packages/mobile/locales/es-419/global.json
+++ b/packages/mobile/locales/es-419/global.json
@@ -121,7 +121,7 @@
   "saltFetchFailure": "Error al recuperar el secreto del número de teléfono",
   "saltQuotaExceededError": "Su cuota de búsqueda de número de teléfono está agotada",
   "matchmakingQuotaExceededError": "El emparejamiento solo se puede hacer una vez",
-  "paymentLimitReached": "El límite diario es {{dailyLimitcUSD}}CUSD ({{currencySymbol}}{{dailyLimit}})\n{{dailyRemainingcUSD}}CUSD ({{currencySymbol}}{{dailyRemaining}}) restante",
+  "paymentLimitReached": "El límite diario es {{dailyLimitcUSD}} cUSD ({{currencySymbol}}{{dailyLimit}})\n{{dailyRemainingcUSD}} cUSD ({{currencySymbol}}{{dailyRemaining}}) restante",
   "ordinals": [
     "cero",
     "primera",

--- a/packages/mobile/src/fiatExchanges/FiatExchangeAmount.test.tsx
+++ b/packages/mobile/src/fiatExchanges/FiatExchangeAmount.test.tsx
@@ -42,7 +42,7 @@ describe('FiatExchangeAmount', () => {
     fireEvent.changeText(getByTestId('FiatExchangeInput'), '750')
     expect(getByTestId('FiatExchangeNextButton').props.disabled).toBe(false)
     fireEvent.press(getByTestId('FiatExchangeNextButton'))
-    expect(store.getActions()).toContainEqual(showError(ErrorMessages.PAYMENT_LIMIT_REACHED, null))
+    expect(store.getActions()).toContainEqual(showError(ErrorMessages.PAYMENT_LIMIT_REACHED, 5000))
   })
 
   it('validates the amount when adding funds', () => {
@@ -59,6 +59,6 @@ describe('FiatExchangeAmount', () => {
     fireEvent.changeText(getByTestId('FiatExchangeInput'), '750')
     expect(getByTestId('FiatExchangeNextButton').props.disabled).toBe(false)
     fireEvent.press(getByTestId('FiatExchangeNextButton'))
-    expect(store.getActions()).toContainEqual(showError(ErrorMessages.PAYMENT_LIMIT_REACHED, null))
+    expect(store.getActions()).toContainEqual(showError(ErrorMessages.PAYMENT_LIMIT_REACHED, 5000))
   })
 })

--- a/packages/mobile/src/fiatExchanges/FiatExchangeAmount.test.tsx
+++ b/packages/mobile/src/fiatExchanges/FiatExchangeAmount.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render } from 'react-native-testing-library'
 import { Provider } from 'react-redux'
 import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { ALERT_BANNER_DURATION } from 'src/config'
 import FiatExchangeAmount from 'src/fiatExchanges/FiatExchangeAmount'
 import { Screens } from 'src/navigator/Screens'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
@@ -42,7 +43,9 @@ describe('FiatExchangeAmount', () => {
     fireEvent.changeText(getByTestId('FiatExchangeInput'), '750')
     expect(getByTestId('FiatExchangeNextButton').props.disabled).toBe(false)
     fireEvent.press(getByTestId('FiatExchangeNextButton'))
-    expect(store.getActions()).toContainEqual(showError(ErrorMessages.PAYMENT_LIMIT_REACHED, 5000))
+    expect(store.getActions()).toContainEqual(
+      showError(ErrorMessages.PAYMENT_LIMIT_REACHED, ALERT_BANNER_DURATION)
+    )
   })
 
   it('validates the amount when adding funds', () => {
@@ -59,6 +62,8 @@ describe('FiatExchangeAmount', () => {
     fireEvent.changeText(getByTestId('FiatExchangeInput'), '750')
     expect(getByTestId('FiatExchangeNextButton').props.disabled).toBe(false)
     fireEvent.press(getByTestId('FiatExchangeNextButton'))
-    expect(store.getActions()).toContainEqual(showError(ErrorMessages.PAYMENT_LIMIT_REACHED, 5000))
+    expect(store.getActions()).toContainEqual(
+      showError(ErrorMessages.PAYMENT_LIMIT_REACHED, ALERT_BANNER_DURATION)
+    )
   })
 })

--- a/packages/mobile/src/redux/migrations.test.ts
+++ b/packages/mobile/src/redux/migrations.test.ts
@@ -1,5 +1,5 @@
 import { migrations } from 'src/redux/migrations'
-import { v0Schema, v1Schema, vNeg1Schema } from 'test/schemas'
+import { v0Schema, v1Schema, v2Schema, vNeg1Schema } from 'test/schemas'
 
 describe('Redux persist migrations', () => {
   it('works for v-1 to v0', () => {
@@ -42,5 +42,17 @@ describe('Redux persist migrations', () => {
     }
     const migratedSchema = migrations[2](v1Stub)
     expect(migratedSchema.app.numberVerified).toEqual(false)
+  })
+
+  it('works for v2 to v3', () => {
+    const v2Stub = {
+      ...v2Schema,
+      send: {
+        ...v2Schema.send,
+        recentPayments: [{ timestamp: Date.now(), amount: '100' }],
+      },
+    }
+    const migratedSchema = migrations[3](v2Stub)
+    expect(migratedSchema.send.recentPayments.length).toEqual(0)
   })
 })

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -42,18 +42,11 @@ export const migrations = {
     }
   },
   3: (state: any) => {
-    const recentPayments = state.send.recentPayments.map(
-      (paymentDetails: { timestamp: number; amount: string }) => ({
-        amount: Number(paymentDetails.amount),
-        timestamp: paymentDetails.timestamp,
-      })
-    )
-
     return {
       ...state,
       send: {
         ...state.send,
-        recentPayments,
+        recentPayments: [],
       },
     }
   },

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -41,4 +41,20 @@ export const migrations = {
       },
     }
   },
+  3: (state: any) => {
+    const recentPayments = state.send.recentPayments.map(
+      (paymentDetails: { timestamp: number; amount: string }) => ({
+        amount: Number(paymentDetails.amount),
+        timestamp: paymentDetails.timestamp,
+      })
+    )
+
+    return {
+      ...state,
+      send: {
+        ...state.send,
+        recentPayments,
+      },
+    }
+  },
 }

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -9,7 +9,7 @@ import { rootSaga } from 'src/redux/sagas'
 
 const persistConfig: any = {
   key: 'root',
-  version: 2, // default is -1, increment as we make migrations
+  version: 3, // default is -1, increment as we make migrations
   storage: AsyncStorage,
   blacklist: ['home', 'geth', 'networkInfo', 'alert', 'fees', 'recipients', 'imports'],
   stateReconciler: autoMergeLevel2,

--- a/packages/mobile/src/send/SendAmount.tsx
+++ b/packages/mobile/src/send/SendAmount.tsx
@@ -152,15 +152,12 @@ function SendAmount(props: Props) {
     }
   }, [amount, setAmount])
 
-  const getDollarAmount = React.useCallback(
-    (localAmount: BigNumber.Value) => {
-      const dollarsAmount =
-        convertLocalAmountToDollars(localAmount, localCurrencyExchangeRate) || new BigNumber('')
+  const getDollarAmount = (localAmount: BigNumber.Value) => {
+    const dollarsAmount =
+      convertLocalAmountToDollars(localAmount, localCurrencyExchangeRate) || new BigNumber('')
 
-      return convertDollarsToMaxSupportedPrecision(dollarsAmount)
-    },
-    [localCurrencyExchangeRate]
-  )
+    return convertDollarsToMaxSupportedPrecision(dollarsAmount)
+  }
 
   const parsedLocalAmount = parseInputAmount(amount, decimalSeparator)
   const dollarAmount = getDollarAmount(parsedLocalAmount)

--- a/packages/mobile/src/send/SendConfirmation.tsx
+++ b/packages/mobile/src/send/SendConfirmation.tsx
@@ -162,7 +162,6 @@ export class SendConfirmation extends React.Component<Props, State> {
     } = this.props.confirmationInput
     const { comment } = this.state
 
-    const timestamp = Date.now()
     const localCurrencyAmount = convertDollarsToLocalAmount(
       amount,
       this.props.localCurrencyExchangeRate
@@ -181,7 +180,6 @@ export class SendConfirmation extends React.Component<Props, State> {
 
     this.props.sendPaymentOrInvite(
       amount,
-      timestamp,
       comment,
       recipient,
       recipientAddress,

--- a/packages/mobile/src/send/actions.ts
+++ b/packages/mobile/src/send/actions.ts
@@ -35,7 +35,6 @@ export interface StoreLatestInRecentsAction {
 export interface SendPaymentOrInviteAction {
   type: Actions.SEND_PAYMENT_OR_INVITE
   amount: BigNumber
-  timestamp: number
   comment: string
   recipient: Recipient
   recipientAddress?: string | null
@@ -45,6 +44,7 @@ export interface SendPaymentOrInviteAction {
 
 export interface SendPaymentOrInviteSuccessAction {
   type: Actions.SEND_PAYMENT_OR_INVITE_SUCCESS
+  amount: BigNumber
 }
 
 export interface SendPaymentOrInviteFailureAction {
@@ -81,7 +81,6 @@ export const shareQRCode = (qrCodeSvg: SVG) => ({
 
 export const sendPaymentOrInvite = (
   amount: BigNumber,
-  timestamp: number,
   comment: string,
   recipient: Recipient,
   recipientAddress: string | null | undefined,
@@ -90,7 +89,6 @@ export const sendPaymentOrInvite = (
 ): SendPaymentOrInviteAction => ({
   type: Actions.SEND_PAYMENT_OR_INVITE,
   amount,
-  timestamp,
   comment,
   recipient,
   recipientAddress,
@@ -98,8 +96,11 @@ export const sendPaymentOrInvite = (
   firebasePendingRequestUid,
 })
 
-export const sendPaymentOrInviteSuccess = (): SendPaymentOrInviteSuccessAction => ({
+export const sendPaymentOrInviteSuccess = (
+  amount: BigNumber
+): SendPaymentOrInviteSuccessAction => ({
   type: Actions.SEND_PAYMENT_OR_INVITE_SUCCESS,
+  amount,
 })
 
 export const sendPaymentOrInviteFailure = (): SendPaymentOrInviteFailureAction => ({

--- a/packages/mobile/src/send/reducers.ts
+++ b/packages/mobile/src/send/reducers.ts
@@ -53,9 +53,9 @@ export const sendReducer = (
       const latestPayment: PaymentInfo = { amount: action.amount.toNumber(), timestamp: now }
       return {
         ...state,
+        isSending: false,
         recentPayments: [...paymentsLast24Hours, latestPayment],
       }
-
     case Actions.SEND_PAYMENT_OR_INVITE_FAILURE:
       return {
         ...state,

--- a/packages/mobile/src/send/reducers.ts
+++ b/packages/mobile/src/send/reducers.ts
@@ -10,14 +10,13 @@ const RECENT_RECIPIENTS_TO_STORE = 8
 // We need to know the last 24 hours of payments (for compliance reasons)
 export interface PaymentInfo {
   timestamp: number
-  amount: number
+  amount: BigNumber
 }
 
 export interface State {
   isSending: boolean
   recentRecipients: Recipient[]
-  // keep a list of recent (last 24 hours) payments
-  // TODO(erdal) when do we clean this up?
+  // Keep a list of recent (last 24 hours) payments
   recentPayments: PaymentInfo[]
 }
 
@@ -59,17 +58,15 @@ export const sendReducer = (
 const sendPaymentOrInvite = (state: State, amount: BigNumber, timestamp: number) => {
   const latestPayment = { timestamp, amount }
 
-  // keep only the last 24 hours
+  // Keep only the last 24 hours
   const paymentsLast24Hours = state.recentPayments.filter(
     (p: PaymentInfo) => timeDeltaInHours(timestamp, p.timestamp) < 24
   )
 
-  const recentPayments = [...paymentsLast24Hours, latestPayment]
-
   return {
     ...state,
     isSending: true,
-    recentPayments,
+    recentPayments: [...paymentsLast24Hours, latestPayment],
   }
 }
 

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -186,7 +186,7 @@ function* sendPaymentOrInviteSaga({
     }
 
     navigateHome()
-    yield put(sendPaymentOrInviteSuccess())
+    yield put(sendPaymentOrInviteSuccess(amount))
   } catch (e) {
     yield put(showError(ErrorMessages.SEND_PAYMENT_FAILED))
     yield put(sendPaymentOrInviteFailure())

--- a/packages/mobile/src/send/utils.ts
+++ b/packages/mobile/src/send/utils.ts
@@ -14,6 +14,8 @@ import { PaymentInfo } from 'src/send/reducers'
 import { TransactionDataInput } from 'src/send/SendAmount'
 import { timeDeltaInHours } from 'src/utils/time'
 
+const DISMISS_SPEND_LIMIT_BANNER_TIMER = 5000
+
 export interface ConfirmationInput {
   recipient: Recipient
   amount: BigNumber
@@ -101,6 +103,10 @@ export function showLimitReachedError(
     dailyRemainingcUSD,
     dailyLimitcUSD: DAILY_PAYMENT_LIMIT_CUSD,
   }
-  const dismissAfterInMilliSecs = 5000
-  return showError(ErrorMessages.PAYMENT_LIMIT_REACHED, dismissAfterInMilliSecs, translationParams)
+
+  return showError(
+    ErrorMessages.PAYMENT_LIMIT_REACHED,
+    DISMISS_SPEND_LIMIT_BANNER_TIMER,
+    translationParams
+  )
 }

--- a/packages/mobile/src/send/utils.ts
+++ b/packages/mobile/src/send/utils.ts
@@ -68,7 +68,10 @@ function dailySpent(now: number, recentPayments: PaymentInfo[]) {
     (p: PaymentInfo) => timeDeltaInHours(now, p.timestamp) < 24
   )
 
-  const amount: number = paymentsLast24Hours.reduce((sum, p: PaymentInfo) => sum + p.amount, 0)
+  const amount: number = paymentsLast24Hours.reduce(
+    (sum, p: PaymentInfo) => sum + p.amount.toNumber(),
+    0
+  )
   return amount
 }
 

--- a/packages/mobile/src/send/utils.ts
+++ b/packages/mobile/src/send/utils.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import { showError } from 'src/alert/actions'
 import { TokenTransactionType } from 'src/apollo/types'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { DAILY_PAYMENT_LIMIT_CUSD } from 'src/config'
+import { ALERT_BANNER_DURATION, DAILY_PAYMENT_LIMIT_CUSD } from 'src/config'
 import { FeeType } from 'src/fees/actions'
 import { getAddressFromPhoneNumber } from 'src/identity/contactMapping'
 import { E164NumberToAddressType, SecureSendPhoneNumberMapping } from 'src/identity/reducer'
@@ -13,8 +13,6 @@ import { Recipient, RecipientKind } from 'src/recipients/recipient'
 import { PaymentInfo } from 'src/send/reducers'
 import { TransactionDataInput } from 'src/send/SendAmount'
 import { timeDeltaInHours } from 'src/utils/time'
-
-const DISMISS_SPEND_LIMIT_BANNER_TIMER = 5000
 
 export interface ConfirmationInput {
   recipient: Recipient
@@ -104,9 +102,5 @@ export function showLimitReachedError(
     dailyLimitcUSD: DAILY_PAYMENT_LIMIT_CUSD,
   }
 
-  return showError(
-    ErrorMessages.PAYMENT_LIMIT_REACHED,
-    DISMISS_SPEND_LIMIT_BANNER_TIMER,
-    translationParams
-  )
+  return showError(ErrorMessages.PAYMENT_LIMIT_REACHED, ALERT_BANNER_DURATION, translationParams)
 }

--- a/packages/mobile/src/send/utils.ts
+++ b/packages/mobile/src/send/utils.ts
@@ -63,15 +63,12 @@ export function dailyAmountRemaining(now: number, recentPayments: PaymentInfo[])
 }
 
 function dailySpent(now: number, recentPayments: PaymentInfo[]) {
-  // we are only interested in the last 24 hours
+  // We are only interested in the last 24 hours
   const paymentsLast24Hours = recentPayments.filter(
     (p: PaymentInfo) => timeDeltaInHours(now, p.timestamp) < 24
   )
 
-  const amount: number = paymentsLast24Hours.reduce(
-    (sum, p: PaymentInfo) => sum + p.amount.toNumber(),
-    0
-  )
+  const amount: number = paymentsLast24Hours.reduce((sum, p: PaymentInfo) => sum + p.amount, 0)
   return amount
 }
 
@@ -104,5 +101,6 @@ export function showLimitReachedError(
     dailyRemainingcUSD,
     dailyLimitcUSD: DAILY_PAYMENT_LIMIT_CUSD,
   }
-  return showError(ErrorMessages.PAYMENT_LIMIT_REACHED, null, translationParams)
+  const dismissAfterInMilliSecs = 5000
+  return showError(ErrorMessages.PAYMENT_LIMIT_REACHED, dismissAfterInMilliSecs, translationParams)
 }


### PR DESCRIPTION
### Description
Fixed bug that resulted in false errors regarding users being over the daily transaction limit. This was caused for two reasons:
- Amount was being incorrectly stored in redux as a non-primitive data type (BigNumber) yet the created interface was defining it as a number, which resulted in some faulty math
- Payments were being stored on transaction initiation, not success, which would mean failed transactions would incorrectly count against the daily limit

### Other changes
Minor cleanup

### Tested
Yes

### Related issues

- Part of #3988 

### Backwards compatibility
Created redux store migration.