### PR TITLE
Change Test Faucet/ invite Link in App

### DIFF
--- a/packages/mobile/branding/celo/src/brandingConfig.ts
+++ b/packages/mobile/branding/celo/src/brandingConfig.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = 'Celo Wallet'
-export const CELO_FAUCET_LINK = 'https://celo.org/app'
+export const CELO_FAUCET_LINK = 'https://celo.org/developers/wallet'
 export const CELO_TERMS_LINK = 'https://celo.org/terms'
 export const TOS_LINK = 'https://celo.org/user-agreement'
 export const FAQ_LINK = 'https://celo.org/faq'

--- a/packages/mobile/locales/en-US/onboarding.json
+++ b/packages/mobile/locales/en-US/onboarding.json
@@ -28,7 +28,7 @@
     "label": "Invite Code",
     "codePlaceholder": "Enter invite code",
     "noCode": "Don’t have an Invite Code",
-    "nodeCodeInviteLink": "Don’t have an invite code? Request one at <0>celo.org/app</0> or <1>continue without</1>"
+    "nodeCodeInviteLink": "Don’t have an invite code? Request one at <0>celo.org/developers/wallet</0> or <1>continue without</1>"
   },
   "verificationEducation": {
     "title": "Confirm",

--- a/packages/mobile/locales/es-419/onboarding.json
+++ b/packages/mobile/locales/es-419/onboarding.json
@@ -28,7 +28,7 @@
     "label": "Codigo de invitacion",
     "codePlaceholder": "Ingrese el código de invitación",
     "noCode": "No tengo un código de invitación",
-    "nodeCodeInviteLink": "¿No tienes un código de invitación? Solicite uno en <0>celo.org/app</0> o <1>continúe sin</1>"
+    "nodeCodeInviteLink": "¿No tienes un código de invitación? Solicite uno en <0>celo.org/developers/wallet</0> o <1>continúe sin</1>"
   },
   "verificationEducation": {
     "title": "Confirmar",


### PR DESCRIPTION


### Description

Since we have a mainnet wallet it is now potentially ambiguous having celo.org/app go to a test wallet page. so it is being removed separately

in the wallet change the url to the canonical /developers/wallet

### Other changes


### Tested

ran the tests

