### PR TITLE
Fix e2e mobile test on iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,11 @@ jobs:
       - yarn_install
 
       - run:
+          # This has to be run after `yarn install` since it uses js dependencies
+          name: Check if the test should run
+          command: ./scripts/ci_check_if_test_should_run_v2.sh @celo/mobile
+
+      - run:
           name: Build mobile dependencies
           command: |
             set -euo pipefail
@@ -277,20 +282,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install node 10 and dependencies
-          command: |
-            brew uninstall --ignore-dependencies node icu4c
-            brew install node@10
-            brew link --overwrite --force node@10
-            yarn
-      - run:
-          name: Fail if generated dependency graph doesn't match committed
-          command: ./scripts/ci_check_dependency_graph_changed.sh
-      - run:
-          name: Check if the test should run
-          command: ./scripts/ci_check_if_test_should_run_v2.sh @celo/mobile
-
-      - run:
           name: Configure environment variables
           command: |
             echo 'export PATH=/usr/local/opt/node@10/bin:$PATH' >> $BASH_ENV
@@ -307,6 +298,10 @@ jobs:
       # Not using a workspace here as Node and Yarn versions
       # differ between our macOS executor image and the Docker containers
       - yarn_install
+      - run:
+          # This has to be run after `yarn install` since it uses js dependencies
+          name: Check if the test should run
+          command: ./scripts/ci_check_if_test_should_run_v2.sh @celo/mobile
       - run:
           name: Build mobile dependencies
           command: |


### PR DESCRIPTION
### Description

Fix e2e mobile test on iOS.
Exampe: https://app.circleci.com/pipelines/github/celo-org/celo-monorepo/21678/workflows/81e5cddd-1455-42b5-9a8e-b16d5c02a9aa/jobs/232406/steps

Also:
- Fix running `yarn install` in a non cached/optimized way for the e2e mobile test for iOS (regression introduced in https://github.com/celo-org/celo-monorepo/pull/3761)
- Also skip android e2e test if unnecessary

### Tested

CircleCI is green again.

### Related issues

Discussed on Slack.

### Backwards compatibility

Yes.