### PR TITLE
[Wallet] Skip revoke verification if account is not verified

### DIFF
--- a/packages/mobile/src/identity/revoke.ts
+++ b/packages/mobile/src/identity/revoke.ts
@@ -31,11 +31,11 @@ export function* revokePhoneMapping(e164Number: string, account: string) {
       phoneHash
     )
 
-    if (status.total < 1) {
-      throw new Error('No attestations associated with identifier')
+    if (status.isVerified) {
+      yield call([attestationsWrapper, attestationsWrapper.revoke], phoneHash, account)
+    } else {
+      Logger.debug(TAG + '@revokeVerification', 'Account not verified, skipping actual revoke call')
     }
-
-    yield call([attestationsWrapper, attestationsWrapper.revoke], phoneHash, account)
     yield put(resetVerification())
     yield put(setNumberVerified(false))
 


### PR DESCRIPTION
### Description

Follow up from https://github.com/celo-org/celo-monorepo/pull/4339 to fix migration error if account is not yet verified.

This is the error I got when trying the migration with an unverified account:
```
Debug [2020-07-08T11:01:44.328Z] identity/revoke@revokeVerification/Revoking previous verification
Info [2020-07-08T11:01:44.329Z] ValoraAnalytics/Tracking event verification_revoke_start with properties: {"timestamp":1594206104328,"sessionId":"87367a43cc6ef85dcf67b61e7c1f78af4b92f148841860abb035138fe156ee","userAddress":"0xfb3f13b23037991002fe14b1a3f3bd2561a7555a"}
Debug [2020-07-08T11:01:45.518Z] web3/saga@unlockAccount/Unlocking account: 0xfb3f13b23037991002fe14b1a3f3bd2561a7555a
Debug [2020-07-08T11:01:45.519Z] identity/privateHashing@fetchPrivatePhoneHash/Fetching phone hash details
Debug [2020-07-08T11:01:45.519Z] identity/privateHashing@fetchPrivatePhoneHash/Salt was cached
Debug [2020-07-08T11:01:45.520Z] identity/verification@getAttestationsStatus/Getting verification status from contract
Debug [2020-07-08T11:01:46.125Z] transactions/TransactionsList/onTxsFetched handler triggered
Debug [2020-07-08T11:01:46.270Z] identity/verification@getAttestationsStatus/3 verifications remaining. Total of 4 requested.
Info [2020-07-08T11:01:46.915Z] identity/revoke@revokeVerification :: Error revoking verification :: Account not found in identifier's accounts in /private/var/containers/Bundle/Application/548E2B9D-4D4E-4D4D-B056-2D6E58CDFD78/celo.app/main.jsbund
Info [2020-07-08T11:01:46.917Z] ValoraAnalytics/Tracking event verification_revoke_error with properties: {"timestamp":1594206106916,"sessionId":"87367a43cc6ef85dcf67b61e7c1f78af4b92f148841860abb035138fe156ee","userAddress":"0xfb3f13b23037991002fe14b1a3f3bd2561a7555a","error":"Account not found in identifier's accounts"}
Error [2020-07-08T11:01:46.924Z] The above error occurred in task x
    created by R
    created by G
```

### Other changes

N/A

### Tested

Not yet.

### Related issues

Discussed on Slack.

### Backwards compatibility

Yes