### PR TITLE
[PGPNP] Add second combiner region and status endpoint

### DIFF
--- a/packages/phone-number-privacy/combiner/src/index.ts
+++ b/packages/phone-number-privacy/combiner/src/index.ts
@@ -4,7 +4,6 @@ import { VERSION } from './config'
 import { handleGetContactMatches } from './match-making/get-contact-matches'
 import { handleGetDistributedBlindedMessageForSalt } from './salt-generation/get-threshold-salt'
 
-
 // TODO fix example
 // EG. curl -v "http://localhost:5000/celo-phone-number-privacy/us-central1/getDistributedBlindedSalt" -H "Authorization: 0xfc2ee61c4d18b93374fdd525c9de09d01398f7d153d17340b9ae156f94a1eb3237207d9aacb42e7f2f4ee0cf2621ab6d5a0837211665a99e16e3367f5209a56b1b" -d '{"blindedQueryPhoneNumber":"+Dzuylsdcv1ZxbRcQwhQ29O0UJynTNYufjWc4jpw2Zr9FLu5gSU8bvvDJ3r/Nj+B","account":"0xdd18d08f1c2619ede729c26cc46da19af0a2aa7f", "hashedPhoneNumber":"0x8fb77f2aff2ef0343706535dc702fc99f61a5d1b8e46d7c144c80fd156826a77"}' -H 'Content-Type: application/json'
 export const getDistributedBlindedSalt = functions
@@ -12,20 +11,20 @@ export const getDistributedBlindedSalt = functions
   .https.onRequest(async (request, response) => {
     logger.info('Begin getDistributedBlindedSalt request')
     return handleGetDistributedBlindedMessageForSalt(request, response)
-})
+  })
 
 // EG. curl -v "http://localhost:5000/celo-phone-number-privacy/us-central1/getContactMatches" -H "Authorization: <SIGNED_BODY>" -d '{"userPhoneNumber": "+99999999999", "contactPhoneNumbers": ["+5555555555", "+3333333333"], "account": "0x117ea45d497ab022b85494ba3ab6f52969bf6812"}' -H 'Content-Type: application/json'
 export const getContactMatches = functions
-  .region('us-central1','europe-west3')
+  .region('us-central1', 'europe-west3')
   .https.onRequest(async (request, response) => {
     logger.info('Begin getContactMatches request')
     return handleGetContactMatches(request, response)
-})
+  })
 
 export const status = functions
-  .region('us-central1','europe-west3')
+  .region('us-central1', 'europe-west3')
   .https.onRequest(async (_request, response) => {
     response.status(200).json({
       version: VERSION,
     })
-})
+  })

--- a/packages/phone-number-privacy/combiner/src/index.ts
+++ b/packages/phone-number-privacy/combiner/src/index.ts
@@ -1,17 +1,31 @@
 import * as functions from 'firebase-functions'
 import logger from './common/logger'
+import { VERSION } from './config'
 import { handleGetContactMatches } from './match-making/get-contact-matches'
 import { handleGetDistributedBlindedMessageForSalt } from './salt-generation/get-threshold-salt'
 
+
 // TODO fix example
 // EG. curl -v "http://localhost:5000/celo-phone-number-privacy/us-central1/getDistributedBlindedSalt" -H "Authorization: 0xfc2ee61c4d18b93374fdd525c9de09d01398f7d153d17340b9ae156f94a1eb3237207d9aacb42e7f2f4ee0cf2621ab6d5a0837211665a99e16e3367f5209a56b1b" -d '{"blindedQueryPhoneNumber":"+Dzuylsdcv1ZxbRcQwhQ29O0UJynTNYufjWc4jpw2Zr9FLu5gSU8bvvDJ3r/Nj+B","account":"0xdd18d08f1c2619ede729c26cc46da19af0a2aa7f", "hashedPhoneNumber":"0x8fb77f2aff2ef0343706535dc702fc99f61a5d1b8e46d7c144c80fd156826a77"}' -H 'Content-Type: application/json'
-export const getDistributedBlindedSalt = functions.https.onRequest(async (request, response) => {
-  logger.info('Begin getDistributedBlindedSalt request')
-  return handleGetDistributedBlindedMessageForSalt(request, response)
+export const getDistributedBlindedSalt = functions
+  .region('us-central1', 'europe-west3')
+  .https.onRequest(async (request, response) => {
+    logger.info('Begin getDistributedBlindedSalt request')
+    return handleGetDistributedBlindedMessageForSalt(request, response)
 })
 
 // EG. curl -v "http://localhost:5000/celo-phone-number-privacy/us-central1/getContactMatches" -H "Authorization: <SIGNED_BODY>" -d '{"userPhoneNumber": "+99999999999", "contactPhoneNumbers": ["+5555555555", "+3333333333"], "account": "0x117ea45d497ab022b85494ba3ab6f52969bf6812"}' -H 'Content-Type: application/json'
-export const getContactMatches = functions.https.onRequest(async (request, response) => {
-  logger.info('Begin getContactMatches request')
-  return handleGetContactMatches(request, response)
+export const getContactMatches = functions
+  .region('us-central1','europe-west3')
+  .https.onRequest(async (request, response) => {
+    logger.info('Begin getContactMatches request')
+    return handleGetContactMatches(request, response)
+})
+
+export const status = functions
+  .region('us-central1','europe-west3')
+  .https.onRequest(async (_request, response) => {
+    response.status(200).json({
+      version: VERSION,
+    })
 })


### PR DESCRIPTION
### Description

- Add second combiner region for firebase function so that we have live two functions
- Using Azure Front Door to load balance between the two regions to increase SLA (firebase SLA is 99.5% whereas AFD 99.99%)
- Note they share the same DB still with SLA 99.95%
- Added a status function since Azure Front Door requires it for knowing whether to route traffic away from a service.  This isn't foolproof since it is a separate function but it will indicate if that region is experiencing down time.

### Other changes

NA

### Tested

Set up staging environment.

### Related issues

NA

### Backwards compatibility

Yes -- the old endpoints still remain.  Wallet will just switch to the azure front door endpoint when ready.