### PR TITLE
Job page Buenos Aires vs Remote Fix

### DIFF
--- a/packages/web/src/jobs/version3/Jobs.tsx
+++ b/packages/web/src/jobs/version3/Jobs.tsx
@@ -46,7 +46,9 @@ const MAIN_LOCATIONS = [
 function getWorldWideLocations(jobs: LeverJob[]) {
   return jobs.reduce((collection, current) => {
     if (
-      ![Locations.SF.toString(), Locations.BER.toString()].includes(current.categories.location)
+      ![Locations.SF.toString(), Locations.BER.toString(), Locations.BA.toString()].includes(
+        current.categories.location
+      )
     ) {
       return collection.add(current.categories.location)
     } else {


### PR DESCRIPTION
### Description

Fixes Buenos Aires Jobs to be separate from general remote jobs. and not be selected when "remote" is chosen.  


### Related issues

- Fixes #3731 

