### PR TITLE
Adding script to revoke set of contracts

### DIFF
--- a/packages/protocol/scripts/bash/revoke_contracts.sh
+++ b/packages/protocol/scripts/bash/revoke_contracts.sh
@@ -43,16 +43,16 @@ for contract in $(<"$1"); do
   fi
 
   contractExists=1
-  celocli releasegold:revoke --contract "$contract" --yesreally > /dev/null || contractExists=0
+  celocli releasegold:revoke --contract "$contract" --yesreally --useLedger > /dev/null || contractExists=0
   if [ "$contractExists" -eq 0 ]; then
     echo "Contract doesn't exist, rejecting $contract"
     rejects+=( $contract )
     continue
   fi
   if [ "$accountCreated" -ne 0 ]; then
-    celocli releasegold:locked-gold --contract "$contract" --action withdraw --value "$total" --yes 
+    celocli releasegold:locked-gold --contract "$contract" --action withdraw --value "$total" --yes --useLedger > /dev/null
   fi
-  celocli releasegold:refund-and-finalize --contract "$contract" > /dev/null
+  celocli releasegold:refund-and-finalize --contract "$contract" --useLedger > /dev/null
 
 done
 

--- a/packages/protocol/scripts/bash/revoke_contracts.sh
+++ b/packages/protocol/scripts/bash/revoke_contracts.sh
@@ -1,0 +1,68 @@
+#! /usr/bin/env bash
+set -euo pipefail
+rejects=()
+
+if [ "$#" -ne 1 ]; then
+  echo "Expected usage: ./revoke_contracts.sh contracts.txt"
+  echo "contracts.txt should include contracts you'd like to revoke and refund, one address per line"
+  exit 1
+fi
+
+for contract in $(<"$1"); do
+  echo "Contract $contract"
+
+  # Check that account has been created
+  accountExists=1
+  celocli lockedgold:show "$contract" > /dev/null 2>&1 || accountExists=0
+  if [ $accountExists -eq 0 ]; then
+    echo "Account not created, rejecting $contract"
+    rejects+=( $contract )
+    continue
+  fi
+
+  # Check that CELO has been unlocked
+  lockedgold=$(celocli lockedgold:show "$contract")
+  total=$(echo "$lockedgold" | grep -o "total: [0-9]*" | cut -f2 -d : | tr -d '[:space:]')
+  if [ "$total" != "0" ]; then
+    echo "Reject $contract"
+    rejects+=( $contract )
+    continue
+  fi
+
+  # Check that withdrawals are available
+  if [ -z $(echo "$lockedgold" | grep -o "time: [0-9]*" | cut -f2 -d :) ]; then
+    echo "No pending withdrawals"
+  else 
+    pendingTimes=$(echo "$lockedgold" | grep -o "time: [0-9]*" | cut -f2 -d :)
+    now=$(date +%s)
+    while IFS= read -r line
+    do 
+      if [ "$line" -ge "$now" ]; then
+        echo "Pending withdrawal not ready, rejecting $contract"
+        rejects+=( $contract )
+        continue 2
+      fi
+    done < <(printf '%s\n' "$pendingTimes")
+  fi
+
+  contractExists=1
+  celocli releasegold:revoke --contract "$contract" --yesreally > /dev/null || contractExists=0
+  if [ "$contractExists" -eq 0 ]; then
+    echo "Contract doesn't exist, rejecting $contract"
+    rejects+=( $contract )
+    continue
+  fi
+  celocli releasegold:locked-gold --contract "$contract" --action withdraw --value "$total" --yes 
+  celocli releasegold:refund-and-finalize --contract "$contract" > /dev/null
+
+done
+
+echo ""
+echo "-----------------------------------"
+echo "-----------------------------------"
+echo "-----------------------------------"
+echo ""
+echo "Rejects:"
+for reject in ${rejects[@]}; do
+  echo "$reject"
+done

--- a/packages/protocol/scripts/bash/revoke_contracts.sh
+++ b/packages/protocol/scripts/bash/revoke_contracts.sh
@@ -20,7 +20,7 @@ for contract in $(<"$1"); do
     lockedgold=$(celocli lockedgold:show "$contract")
     total=$(echo "$lockedgold" | grep -o "total: [0-9]*" | cut -f2 -d : | tr -d '[:space:]')
     if [ "$total" != "0" ]; then
-      echo "Reject $contract"
+      echo "Reject $contract: locked CELO > 0"
       rejects+=( $contract )
       continue
     fi

--- a/packages/protocol/scripts/bash/revoke_contracts.sh
+++ b/packages/protocol/scripts/bash/revoke_contracts.sh
@@ -12,37 +12,34 @@ for contract in $(<"$1"); do
   echo "Contract $contract"
 
   # Check that account has been created
-  accountExists=1
-  celocli lockedgold:show "$contract" > /dev/null 2>&1 || accountExists=0
-  if [ $accountExists -eq 0 ]; then
-    echo "Account not created, rejecting $contract"
-    rejects+=( $contract )
-    continue
-  fi
+  accountCreated=1
+  celocli lockedgold:show "$contract" > /dev/null 2>&1 || accountCreated=0
+  if [ $accountCreated -ne 0 ]; then
 
-  # Check that CELO has been unlocked
-  lockedgold=$(celocli lockedgold:show "$contract")
-  total=$(echo "$lockedgold" | grep -o "total: [0-9]*" | cut -f2 -d : | tr -d '[:space:]')
-  if [ "$total" != "0" ]; then
-    echo "Reject $contract"
-    rejects+=( $contract )
-    continue
-  fi
+    # Check that CELO has been unlocked
+    lockedgold=$(celocli lockedgold:show "$contract")
+    total=$(echo "$lockedgold" | grep -o "total: [0-9]*" | cut -f2 -d : | tr -d '[:space:]')
+    if [ "$total" != "0" ]; then
+      echo "Reject $contract"
+      rejects+=( $contract )
+      continue
+    fi
 
-  # Check that withdrawals are available
-  if [ -z $(echo "$lockedgold" | grep -o "time: [0-9]*" | cut -f2 -d :) ]; then
-    echo "No pending withdrawals"
-  else 
-    pendingTimes=$(echo "$lockedgold" | grep -o "time: [0-9]*" | cut -f2 -d :)
-    now=$(date +%s)
-    while IFS= read -r line
-    do 
-      if [ "$line" -ge "$now" ]; then
-        echo "Pending withdrawal not ready, rejecting $contract"
-        rejects+=( $contract )
-        continue 2
-      fi
-    done < <(printf '%s\n' "$pendingTimes")
+    # Check that withdrawals are available
+    if [ -z $(echo "$lockedgold" | grep -o "time: [0-9]*" | cut -f2 -d :) ]; then
+      echo "No pending withdrawals"
+    else 
+      pendingTimes=$(echo "$lockedgold" | grep -o "time: [0-9]*" | cut -f2 -d :)
+      now=$(date +%s)
+      while IFS= read -r line
+      do 
+        if [ "$line" -ge "$now" ]; then
+          echo "Pending withdrawal not ready, rejecting $contract"
+          rejects+=( $contract )
+          continue 2
+        fi
+      done < <(printf '%s\n' "$pendingTimes")
+    fi
   fi
 
   contractExists=1
@@ -52,7 +49,9 @@ for contract in $(<"$1"); do
     rejects+=( $contract )
     continue
   fi
-  celocli releasegold:locked-gold --contract "$contract" --action withdraw --value "$total" --yes 
+  if [ "$accountCreated" -ne 0 ]; then
+    celocli releasegold:locked-gold --contract "$contract" --action withdraw --value "$total" --yes 
+  fi
   celocli releasegold:refund-and-finalize --contract "$contract" > /dev/null
 
 done


### PR DESCRIPTION
### Description

Adds bash script that consumes a list of contracts to revoke, withdraw, and refund/destroy the contracts.

Script also checks for things like: that the contract exists, it has created an account, the contract has unlocked all of its gold, and that the contract's gold has passed the unlocking period.

Example contract file:
`contract_file.txt`:
```
0x34BCf674AD932711AE791BD17371395281B79C32
0x6bB206ffdDe4b7f7744B01B1437F57E621E8426c
```

### Tested

Tested on local testnets and ganache