### PR TITLE
[Wallet] Instrument geth and contractkit initialization analytics 

### DIFF
--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -269,6 +269,11 @@ export enum GethEvents {
   geth_init_failure = 'geth_init_failure',
   geth_restart_to_fix_init = 'geth_restart_to_fix_init',
   prompt_forno = 'prompt_forno',
+  geth_init_start = 'geth_init_start',
+  create_geth_start = 'create_geth_start',
+  create_geth_finish = 'create_geth_finish',
+  start_geth_start = 'start_geth_start',
+  start_geth_finish = 'start_geth_finish',
 }
 
 export type AnalyticsEventType =

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -276,6 +276,18 @@ export enum GethEvents {
   start_geth_finish = 'start_geth_finish',
 }
 
+export enum ContractKitEvents {
+  init_contractkit_start = 'init_contractkit_start',
+  init_contractkit_geth_init_start = 'init_contractkit_geth_init_start',
+  init_contractkit_geth_init_finish = 'init_contractkit_geth_init_finish',
+  init_contractkit_get_ipc_start = 'init_contractkit_get_ipc_start',
+  init_contractkit_get_ipc_finish = 'init_contractkit_get_ipc_finish',
+  init_contractkit_get_wallet_start = 'init_contractkit_get_wallet_start',
+  init_contractkit_get_wallet_finish = 'init_contractkit_get_wallet_finish',
+  init_contractkit_init_wallet_finish = 'init_contractkit_init_wallet_finish',
+  init_contractkit_finish = 'init_contractkit_finish',
+}
+
 export type AnalyticsEventType =
   | AppEvents
   | HomeEvents

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -526,6 +526,13 @@ interface GethEventsProperties {
     error: string
     context: string
   }
+  [GethEvents.geth_init_start]: {
+    sync: boolean
+  }
+  [GethEvents.create_geth_start]: undefined
+  [GethEvents.create_geth_finish]: undefined
+  [GethEvents.start_geth_start]: undefined
+  [GethEvents.start_geth_finish]: undefined
 }
 
 export type AnalyticsPropertiesList = AppEventsProperties &

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -3,6 +3,7 @@ import { PincodeType } from 'src/account/reducer'
 import {
   AppEvents,
   CeloExchangeEvents,
+  ContractKitEvents,
   EscrowEvents,
   FeeEvents,
   GethEvents,
@@ -535,6 +536,20 @@ interface GethEventsProperties {
   [GethEvents.start_geth_finish]: undefined
 }
 
+interface ContractKitEventsProperties {
+  [ContractKitEvents.init_contractkit_start]: undefined
+  [ContractKitEvents.init_contractkit_geth_init_start]: {
+    retries: number
+  }
+  [ContractKitEvents.init_contractkit_geth_init_finish]: undefined
+  [ContractKitEvents.init_contractkit_get_ipc_start]: undefined
+  [ContractKitEvents.init_contractkit_get_ipc_finish]: undefined
+  [ContractKitEvents.init_contractkit_get_wallet_start]: undefined
+  [ContractKitEvents.init_contractkit_get_wallet_finish]: undefined
+  [ContractKitEvents.init_contractkit_init_wallet_finish]: undefined
+  [ContractKitEvents.init_contractkit_finish]: undefined
+}
+
 export type AnalyticsPropertiesList = AppEventsProperties &
   HomeEventsProperties &
   SettingsEventsProperties &
@@ -549,4 +564,5 @@ export type AnalyticsPropertiesList = AppEventsProperties &
   FeeEventsProperties &
   TransactionEventsProperties &
   CeloExchangeEventsProperties &
-  GethEventsProperties
+  GethEventsProperties &
+  ContractKitEventsProperties

--- a/packages/mobile/src/geth/geth.ts
+++ b/packages/mobile/src/geth/geth.ts
@@ -4,6 +4,8 @@ import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import * as RNFS from 'react-native-fs'
 import RNGeth from 'react-native-geth'
+import { GethEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { DEFAULT_TESTNET } from 'src/config'
 import { SYNCING_MAX_PEERS } from 'src/geth/consts'
 import networkConfig from 'src/geth/networkConfig'
@@ -111,6 +113,7 @@ async function createNewGeth(sync: boolean = true): Promise<typeof RNGeth> {
 }
 
 export async function initGeth(sync: boolean = true): Promise<typeof gethInstance> {
+  ValoraAnalytics.track(GethEvents.geth_init_start, { sync })
   Logger.info('Geth@init', `Create a new Geth instance with sync=${sync}`)
 
   if (gethLock) {
@@ -126,7 +129,9 @@ export async function initGeth(sync: boolean = true): Promise<typeof gethInstanc
     if (!(await ensureStaticNodesInitialized(sync))) {
       throw FailedToFetchStaticNodesError
     }
+    ValoraAnalytics.track(GethEvents.create_geth_start)
     const geth = await createNewGeth(sync)
+    ValoraAnalytics.track(GethEvents.create_geth_finish)
 
     if (!sync) {
       // chain data must be deleted to prevent geth from syncing with data saver on
@@ -136,7 +141,9 @@ export async function initGeth(sync: boolean = true): Promise<typeof gethInstanc
     }
 
     try {
+      ValoraAnalytics.track(GethEvents.start_geth_start)
       await geth.start()
+      ValoraAnalytics.track(GethEvents.start_geth_finish)
       gethInstance = geth
       if (sync) {
         geth.subscribeNewHead()


### PR DESCRIPTION
### Description

Adding events throughout geth and contractkit so that we can use timestamps to understand how long these processes are taking, particularly on low end devices

### Tested

I have not run these changes locally, but am simply adding events.  

### Related issues

- Partially addresses #4406 

### Backwards compatibility

Yes