### PR TITLE
[Wallet] QR Request Bug + Android Activity Monitor Bug

### DIFF
--- a/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentListItem.test.tsx.snap
+++ b/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentListItem.test.tsx.snap
@@ -198,8 +198,10 @@ exports[`EscrowedPaymentReminderNotification renders correctly 1`] = `
               },
               Object {
                 "fontSize": 14,
+                "height": 16,
                 "lineHeight": 16,
                 "marginRight": 24,
+                "minWidth": 48,
               },
             ]
           }
@@ -236,8 +238,10 @@ exports[`EscrowedPaymentReminderNotification renders correctly 1`] = `
               },
               Object {
                 "fontSize": 14,
+                "height": 16,
                 "lineHeight": 16,
                 "marginRight": 24,
+                "minWidth": 48,
               },
             ]
           }

--- a/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentReminderSummaryNotification.test.tsx.snap
+++ b/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentReminderSummaryNotification.test.tsx.snap
@@ -127,8 +127,10 @@ exports[`EscrowedPaymentReminderSummaryNotification renders correctly 1`] = `
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -343,8 +345,10 @@ exports[`EscrowedPaymentReminderSummaryNotification when more 1 requests renders
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -381,8 +385,10 @@ exports[`EscrowedPaymentReminderSummaryNotification when more 1 requests renders
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -523,8 +529,10 @@ exports[`EscrowedPaymentReminderSummaryNotification when more than 2 requests re
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }

--- a/packages/mobile/src/home/SendOrRequestBar.tsx
+++ b/packages/mobile/src/home/SendOrRequestBar.tsx
@@ -15,12 +15,12 @@ import { Screens } from 'src/navigator/Screens'
 export default function SendOrRequestBar() {
   const onPressSend = () => {
     ValoraAnalytics.track(HomeEvents.home_send)
-    navigate(Screens.Send, { isRequest: false })
+    navigate(Screens.Send)
   }
 
   const onPressRequest = () => {
     ValoraAnalytics.track(HomeEvents.home_request)
-    navigate(Screens.Send, { isRequest: true })
+    navigate(Screens.Send, { isOutgoingPaymentRequest: true })
   }
 
   const onPressQrCode = () => {

--- a/packages/mobile/src/home/__snapshots__/NotificationBox.test.tsx.snap
+++ b/packages/mobile/src/home/__snapshots__/NotificationBox.test.tsx.snap
@@ -151,8 +151,10 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -270,8 +272,10 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -407,8 +411,10 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -445,8 +451,10 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -582,8 +590,10 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -620,8 +630,10 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -149,12 +149,12 @@ export type StackParamList = {
   [Screens.SelectLocalCurrency]: undefined
   [Screens.Send]:
     | {
-        isRequest?: boolean
+        isOutgoingPaymentRequest?: true
       }
     | undefined
   [Screens.SendAmount]: {
     recipient: Recipient
-    isRequest?: boolean
+    isOutgoingPaymentRequest?: true
     isFromScan?: boolean
   }
   [Screens.SendConfirmation]: {

--- a/packages/mobile/src/notifications/__snapshots__/SummaryNotification.test.tsx.snap
+++ b/packages/mobile/src/notifications/__snapshots__/SummaryNotification.test.tsx.snap
@@ -120,8 +120,10 @@ exports[`SummaryNotification renders correctly 1`] = `
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }

--- a/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.test.tsx
+++ b/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.test.tsx
@@ -69,6 +69,8 @@ describe('IncomingPaymentRequestListItem', () => {
       </Provider>
     )
 
+    fireEvent.press(tree.getByText('global:send'))
+
     const updatedStore = createMockStore({
       identity: {
         secureSendPhoneNumberMapping: {
@@ -108,6 +110,8 @@ describe('IncomingPaymentRequestListItem', () => {
         <IncomingPaymentRequestListItem {...props} />
       </Provider>
     )
+
+    fireEvent.press(tree.getByText('global:send'))
 
     const updatedStore = createMockStore({
       identity: {

--- a/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.tsx
+++ b/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.tsx
@@ -92,7 +92,7 @@ export default function IncomingPaymentRequestListItem({ id, amount, comment, re
   }
 
   React.useEffect(() => {
-    // Need this to make sure it's only triggered on clickyyyyy
+    // Need this to make sure it's only triggered on click
     if (!isLoading) {
       return
     }

--- a/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.tsx
+++ b/packages/mobile/src/paymentRequest/IncomingPaymentRequestListItem.tsx
@@ -92,6 +92,11 @@ export default function IncomingPaymentRequestListItem({ id, amount, comment, re
   }
 
   React.useEffect(() => {
+    // Need this to make sure it's only triggered on clickyyyyy
+    if (!isLoading) {
+      return
+    }
+
     const prevSecureSendDetails: SecureSendDetails | undefined = prevSecureSendDetailsRef.current
     prevSecureSendDetailsRef.current = secureSendDetails
     const wasFetchingAddresses = prevSecureSendDetails?.isFetchingAddresses

--- a/packages/mobile/src/paymentRequest/__snapshots__/IncomingPaymentRequestListItem.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/IncomingPaymentRequestListItem.test.tsx.snap
@@ -200,8 +200,10 @@ exports[`IncomingPaymentRequestListItem renders correctly 1`] = `
               },
               Object {
                 "fontSize": 14,
+                "height": 16,
                 "lineHeight": 16,
                 "marginRight": 24,
+                "minWidth": 48,
               },
             ]
           }
@@ -238,8 +240,10 @@ exports[`IncomingPaymentRequestListItem renders correctly 1`] = `
               },
               Object {
                 "fontSize": 14,
+                "height": 16,
                 "lineHeight": 16,
                 "marginRight": 24,
+                "minWidth": 48,
               },
             ]
           }

--- a/packages/mobile/src/paymentRequest/__snapshots__/IncomingPaymentRequestListScreen.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/IncomingPaymentRequestListScreen.test.tsx.snap
@@ -248,8 +248,10 @@ exports[`IncomingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -286,8 +288,10 @@ exports[`IncomingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -499,8 +503,10 @@ exports[`IncomingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -537,8 +543,10 @@ exports[`IncomingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -750,8 +758,10 @@ exports[`IncomingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -788,8 +798,10 @@ exports[`IncomingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }

--- a/packages/mobile/src/paymentRequest/__snapshots__/IncomingPaymentRequestSummaryNotification.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/IncomingPaymentRequestSummaryNotification.test.tsx.snap
@@ -201,8 +201,10 @@ exports[`IncomingPaymentRequestSummaryNotification renders a number when the add
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -239,8 +241,10 @@ exports[`IncomingPaymentRequestSummaryNotification renders a number when the add
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -455,8 +459,10 @@ exports[`IncomingPaymentRequestSummaryNotification renders correctly for just on
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -493,8 +499,10 @@ exports[`IncomingPaymentRequestSummaryNotification renders correctly for just on
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -635,8 +643,10 @@ exports[`IncomingPaymentRequestSummaryNotification renders correctly for more th
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }

--- a/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestListItem.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestListItem.test.tsx.snap
@@ -202,8 +202,10 @@ Array [
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -240,8 +242,10 @@ Array [
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }

--- a/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestListScreen.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestListScreen.test.tsx.snap
@@ -248,8 +248,10 @@ exports[`OutgoingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -286,8 +288,10 @@ exports[`OutgoingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -499,8 +503,10 @@ exports[`OutgoingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -537,8 +543,10 @@ exports[`OutgoingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -750,8 +758,10 @@ exports[`OutgoingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }
@@ -788,8 +798,10 @@ exports[`OutgoingPaymentRequestListScreen renders correctly with requests 1`] = 
                         },
                         Object {
                           "fontSize": 14,
+                          "height": 16,
                           "lineHeight": 16,
                           "marginRight": 24,
+                          "minWidth": 48,
                         },
                       ]
                     }

--- a/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestSummaryNotification.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestSummaryNotification.test.tsx.snap
@@ -201,8 +201,10 @@ exports[`OutgoingPaymentRequestSummaryNotification renders a number when the add
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -239,8 +241,10 @@ exports[`OutgoingPaymentRequestSummaryNotification renders a number when the add
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -455,8 +459,10 @@ exports[`OutgoingPaymentRequestSummaryNotification renders correctly for just on
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -493,8 +499,10 @@ exports[`OutgoingPaymentRequestSummaryNotification renders correctly for just on
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }
@@ -635,8 +643,10 @@ exports[`OutgoingPaymentRequestSummaryNotification renders correctly for multipl
                 },
                 Object {
                   "fontSize": 14,
+                  "height": 16,
                   "lineHeight": 16,
                   "marginRight": 24,
+                  "minWidth": 48,
                 },
               ]
             }

--- a/packages/mobile/src/qrcode/utils.ts
+++ b/packages/mobile/src/qrcode/utils.ts
@@ -153,6 +153,6 @@ export function* handleBarcode(
       addressJustValidated: true,
     })
   } else {
-    replace(Screens.SendAmount, { recipient, isFromScan: true })
+    replace(Screens.SendAmount, { recipient, isFromScan: true, isOutgoingPaymentRequest })
   }
 }

--- a/packages/mobile/src/send/Send.tsx
+++ b/packages/mobile/src/send/Send.tsx
@@ -100,8 +100,17 @@ export const sendScreenNavOptions = ({
 }: {
   route: RouteProp<StackParamList, Screens.Send>
 }) => {
-  const goQr = () => navigate(Screens.QRNavigator)
-  const title = route.params?.isRequest
+  const isOutgoingPaymentRequest = route.params?.isOutgoingPaymentRequest
+
+  const gotoQRScanner = () =>
+    navigate(Screens.QRNavigator, {
+      screen: Screens.QRScanner,
+      params: {
+        isOutgoingPaymentRequest,
+      },
+    })
+
+  const title = isOutgoingPaymentRequest
     ? i18n.t('paymentRequestFlow:request')
     : i18n.t('sendFlow7:send')
 
@@ -111,15 +120,15 @@ export const sendScreenNavOptions = ({
       <TopBarIconButton
         icon={<Times />}
         onPress={navigateBack}
-        eventName={route.params?.isRequest ? RequestEvents.request_cancel : SendEvents.send_cancel}
+        eventName={isOutgoingPaymentRequest ? RequestEvents.request_cancel : SendEvents.send_cancel}
       />
     ),
     headerLeftContainerStyle: styles.headerLeftContainer,
     headerRight: () => (
       <TopBarIconButton
         icon={<QRCodeBorderlessIcon height={32} color={colors.greenUI} />}
-        eventName={route.params?.isRequest ? RequestEvents.request_scan : SendEvents.send_scan}
-        onPress={goQr}
+        eventName={isOutgoingPaymentRequest ? RequestEvents.request_scan : SendEvents.send_scan}
+        onPress={gotoQRScanner}
       />
     ),
     headerRightContainerStyle: styles.headerRightContainer,
@@ -215,7 +224,7 @@ class Send extends React.Component<Props, State> {
 
   onSelectRecipient = (recipient: Recipient) => {
     this.props.hideAlert()
-    const isRequest = this.props.route.params?.isRequest ?? false
+    const isOutgoingPaymentRequest = this.props.route.params?.isOutgoingPaymentRequest
 
     if (!recipient.e164PhoneNumber && !recipient.address) {
       this.props.showError(ErrorMessages.CANT_SELECT_INVALID_PHONE)
@@ -225,14 +234,16 @@ class Send extends React.Component<Props, State> {
     this.props.storeLatestInRecents(recipient)
 
     ValoraAnalytics.track(
-      isRequest ? RequestEvents.request_select_recipient : SendEvents.send_select_recipient,
+      isOutgoingPaymentRequest
+        ? RequestEvents.request_select_recipient
+        : SendEvents.send_select_recipient,
       {
         recipientKind: recipient.kind,
         usedSearchBar: this.state.searchQuery.length > 0,
       }
     )
 
-    navigate(Screens.SendAmount, { recipient, isRequest })
+    navigate(Screens.SendAmount, { recipient, isOutgoingPaymentRequest })
   }
 
   onPressStartVerification = () => {

--- a/packages/mobile/src/send/Send.tsx
+++ b/packages/mobile/src/send/Send.tsx
@@ -102,7 +102,7 @@ export const sendScreenNavOptions = ({
 }) => {
   const isOutgoingPaymentRequest = route.params?.isOutgoingPaymentRequest
 
-  const gotoQRScanner = () =>
+  const goToQRScanner = () =>
     navigate(Screens.QRNavigator, {
       screen: Screens.QRScanner,
       params: {
@@ -128,7 +128,7 @@ export const sendScreenNavOptions = ({
       <TopBarIconButton
         icon={<QRCodeBorderlessIcon height={32} color={colors.greenUI} />}
         eventName={isOutgoingPaymentRequest ? RequestEvents.request_scan : SendEvents.send_scan}
-        onPress={gotoQRScanner}
+        onPress={goToQRScanner}
       />
     ),
     headerRightContainerStyle: styles.headerRightContainer,

--- a/packages/mobile/src/send/SendAmount.test.tsx
+++ b/packages/mobile/src/send/SendAmount.test.tsx
@@ -33,10 +33,10 @@ const storeData = {
   },
 }
 
-const mockScreenProps = (isRequest: boolean) =>
+const mockScreenProps = (isOutgoingPaymentRequest?: true) =>
   getMockStackScreenProps(Screens.SendAmount, {
     recipient: mockTransactionData.recipient,
-    isRequest,
+    isOutgoingPaymentRequest,
   })
 
 const enterAmount = (wrapper: RenderAPI, text: string) => {
@@ -56,7 +56,7 @@ describe('SendAmount', () => {
     const getWrapper = () =>
       render(
         <Provider store={store}>
-          <SendAmount {...mockScreenProps(false)} />
+          <SendAmount {...mockScreenProps()} />
         </Provider>
       )
 
@@ -92,7 +92,7 @@ describe('SendAmount', () => {
       const store = createMockStore(storeData)
       const wrapper = render(
         <Provider store={store}>
-          <SendAmount {...mockScreenProps(false)} />
+          <SendAmount {...mockScreenProps()} />
         </Provider>
       )
       enterAmount(wrapper, AMOUNT_TOO_MUCH)
@@ -120,7 +120,7 @@ describe('SendAmount', () => {
       const store = createMockStore(storeData)
       const wrapper = render(
         <Provider store={store}>
-          <SendAmount {...mockScreenProps(false)} />
+          <SendAmount {...mockScreenProps()} />
         </Provider>
       )
       enterAmount(wrapper, AMOUNT_ZERO)
@@ -157,7 +157,7 @@ describe('SendAmount', () => {
 
       const tree = render(
         <Provider store={store}>
-          <SendAmount {...mockScreenProps(false)} />
+          <SendAmount {...mockScreenProps()} />
         </Provider>
       )
       enterAmount(tree, AMOUNT_VALID)
@@ -183,7 +183,7 @@ describe('SendAmount', () => {
 
       const tree = render(
         <Provider store={store}>
-          <SendAmount {...mockScreenProps(false)} />
+          <SendAmount {...mockScreenProps()} />
         </Provider>
       )
       enterAmount(tree, AMOUNT_VALID)

--- a/packages/mobile/src/send/SendAmount.tsx
+++ b/packages/mobile/src/send/SendAmount.tsx
@@ -247,7 +247,11 @@ function SendAmount(props: Props) {
   const onRequest = React.useCallback(() => {
     const transactionData = getTransactionData(TokenTransactionType.PayRequest)
 
-    if (addressValidationType !== AddressValidationType.NONE) {
+    if (
+      addressValidationType !== AddressValidationType.NONE &&
+      recipient.kind !== RecipientKind.QrCode &&
+      recipient.kind !== RecipientKind.Address
+    ) {
       navigate(Screens.ValidateRecipientIntro, {
         transactionData,
         addressValidationType,

--- a/packages/mobile/src/send/SendAmount.tsx
+++ b/packages/mobile/src/send/SendAmount.tsx
@@ -70,11 +70,11 @@ export const sendAmountScreenNavOptions = ({
 }: {
   route: RouteProp<StackParamList, Screens.SendAmount>
 }) => {
-  const title = route.params?.isRequest
+  const title = route.params?.isOutgoingPaymentRequest
     ? i18n.t('paymentRequestFlow:request')
     : i18n.t('sendFlow7:send')
 
-  const eventName = route.params?.isRequest
+  const eventName = route.params?.isOutgoingPaymentRequest
     ? RequestEvents.request_amount_back
     : SendEvents.send_amount_back
 
@@ -88,8 +88,7 @@ export const sendAmountScreenNavOptions = ({
 function SendAmount(props: Props) {
   const dispatch = useDispatch()
 
-  const isRequest = props.route.params?.isRequest ?? false
-  const recipient = props.route.params.recipient
+  const { isOutgoingPaymentRequest, recipient } = props.route.params
 
   React.useEffect(() => {
     dispatch(fetchDollarBalance())
@@ -292,7 +291,7 @@ function SendAmount(props: Props) {
         size={BtnSizes.FULL}
         text={t('global:review')}
         type={BtnTypes.SECONDARY}
-        onPress={isRequest ? onRequest : onSend}
+        onPress={isOutgoingPaymentRequest ? onRequest : onSend}
         disabled={reviewBtnDisabled}
         testID="Review"
       />

--- a/packages/mobile/src/send/SendAmount.tsx
+++ b/packages/mobile/src/send/SendAmount.tsx
@@ -224,7 +224,11 @@ function SendAmount(props: Props) {
 
     dispatch(hideAlert())
 
-    if (addressValidationType !== AddressValidationType.NONE) {
+    if (
+      addressValidationType !== AddressValidationType.NONE &&
+      recipient.kind !== RecipientKind.QrCode &&
+      recipient.kind !== RecipientKind.Address
+    ) {
       navigate(Screens.ValidateRecipientIntro, {
         transactionData,
         addressValidationType,

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -71,12 +71,11 @@ export function* watchQrCodeDetections() {
     const addressToE164Number = yield select(addressToE164NumberSelector)
     const recipientCache = yield select(recipientCacheSelector)
     const e164NumberToAddress = yield select(e164NumberToAddressSelector)
+    const isOutgoingPaymentRequest = action.isOutgoingPaymentRequest
     let secureSendTxData
-    let isOutgoingPaymentRequest
 
     if (action.scanIsForSecureSend) {
       secureSendTxData = action.transactionData
-      isOutgoingPaymentRequest = action.isOutgoingPaymentRequest
     }
 
     try {

--- a/packages/react-components/components/CallToActionsBar.tsx
+++ b/packages/react-components/components/CallToActionsBar.tsx
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 16,
     marginRight: 24,
-    width: 50,
-    height: 18,
+    minWidth: 48,
+    height: 16,
   },
 })

--- a/packages/react-components/components/CallToActionsBar.tsx
+++ b/packages/react-components/components/CallToActionsBar.tsx
@@ -15,16 +15,25 @@ interface Props {
 export default function CallToActionsBar({ callToActions, testID }: Props) {
   return (
     <View style={styles.container} testID={testID}>
-      {callToActions.map((cta, i) => (
-        <TextButton
-          testID={`${testID}/${cta.text}/Button`}
-          key={i}
-          style={styles.action}
-          onPress={cta.onPress}
-        >
-          {cta.text}
-        </TextButton>
-      ))}
+      {callToActions.map((cta, i) => {
+        if (typeof cta.text === 'string') {
+          return (
+            <TextButton
+              testID={`${testID}/${cta.text}/Button`}
+              key={i}
+              style={styles.action}
+              onPress={cta.onPress}
+            >
+              {cta.text}
+            </TextButton>
+          )
+        }
+        return (
+          <View key={i} style={styles.action}>
+            {cta.text}
+          </View>
+        )
+      })}
     </View>
   )
 }
@@ -37,5 +46,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 16,
     marginRight: 24,
+    width: 50,
+    height: 18,
   },
 })


### PR DESCRIPTION
### Description
Fixed bug where clicking the QR icon from the request flow would send you into the send flow after a successful scan.

Also fixed two bugs regarding incoming payment requests:
- Android can't render non-text elements within a text element
- The lifecycle method on `IncomingPaymentRequestItem` would get inadvertently triggered when address fetches were done elsewhere in the app

### Other changes
No

### Tested
Yes

### Related issues
- Closes #4059 

### Backwards compatibility
Yes