### PR TITLE
[Wallet] Fix push permission never asked on iOS

### DIFF
--- a/packages/mobile/src/firebase/firebase.test.ts
+++ b/packages/mobile/src/firebase/firebase.test.ts
@@ -1,3 +1,4 @@
+import firebase from '@react-native-firebase/app'
 import { expectSaga } from 'redux-saga-test-plan'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { call, select } from 'redux-saga/effects'
@@ -48,7 +49,10 @@ describe(initializeCloudMessaging, () => {
 
     await expectSaga(initializeCloudMessaging, app, address)
       .provide([
-        [call([app.messaging(), 'hasPermission']), false],
+        [
+          call([app.messaging(), 'hasPermission']),
+          firebase.messaging.AuthorizationStatus.NOT_DETERMINED,
+        ],
         [call([app.messaging(), 'requestPermission']), throwError(errorToRaise)],
         {
           spawn(effect, next) {

--- a/packages/mobile/src/utils/typescript.ts
+++ b/packages/mobile/src/utils/typescript.ts
@@ -21,7 +21,6 @@ export type ExtractProps<
  * Usage: array.filter(isPresent)
  * See https://github.com/microsoft/TypeScript/issues/16069#issuecomment-565658443
  */
-
 export function isPresent<T>(t: T | undefined | null | void): t is T {
   return t !== undefined && t !== null
 }
@@ -30,3 +29,10 @@ export function isPresent<T>(t: T | undefined | null | void): t is T {
 export function assertNever(x: never): never {
   throw new Error('Unexpected object: ' + x)
 }
+
+/**
+ * Unwrap type of promise.
+ * This can be removed once we switch to TypeScript 3.9 which directly supports the `awaited` keyword
+ * See https://github.com/microsoft/TypeScript/pull/35998
+ */
+export type Awaited<T> = T extends Promise<infer U> ? U : never


### PR DESCRIPTION
### Description

This broke in https://github.com/celo-org/celo-monorepo/pull/3650 with the upgrade of `react-native-firebase`
because `yield call(...)` return types are not inferred yet 😞 

Looks like the device I used when I worked on #3650 was already authorised for push that's why I missed that 2nd regression 🤦 

### Tested

Tested that push permission is being asked again on iOS.

### Backwards compatibility

Yes.