### PR TITLE
[Wallet] Fix bug because of untyped yield take action

### DIFF
--- a/packages/mobile/src/geth/actions.ts
+++ b/packages/mobile/src/geth/actions.ts
@@ -6,7 +6,7 @@ export enum Actions {
   CANCEL_GETH_SAGA = 'GETH/CANCEL_GETH_SAGA',
 }
 
-interface SetInitStateAction {
+export interface SetInitStateAction {
   type: Actions.SET_INIT_STATE
   state: InitializationState
 }
@@ -20,7 +20,7 @@ export const cancelGethSaga = () => ({
   type: Actions.CANCEL_GETH_SAGA,
 })
 
-interface SetGethConnectedAction {
+export interface SetGethConnectedAction {
   type: Actions.SET_GETH_CONNECTED
   connected: boolean
 }

--- a/packages/mobile/src/geth/saga.ts
+++ b/packages/mobile/src/geth/saga.ts
@@ -5,7 +5,13 @@ import { setPromptForno } from 'src/account/actions'
 import { promptFornoIfNeededSelector } from 'src/account/selectors'
 import { GethEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { Actions, setGethConnected, setInitState } from 'src/geth/actions'
+import {
+  Actions,
+  setGethConnected,
+  SetGethConnectedAction,
+  setInitState,
+  SetInitStateAction,
+} from 'src/geth/actions'
 import {
   FailedToFetchGenesisBlockError,
   FailedToFetchStaticNodesError,
@@ -41,7 +47,7 @@ export function* waitForGethInitialized() {
     return
   }
   while (true) {
-    const action = yield take(Actions.SET_INIT_STATE)
+    const action: SetInitStateAction = yield take(Actions.SET_INIT_STATE)
     if (action.state === InitializationState.INITIALIZED) {
       return
     }
@@ -54,7 +60,7 @@ export function* waitForGethConnectivity() {
     return
   }
   while (true) {
-    const action = yield take(Actions.SET_GETH_CONNECTED)
+    const action: SetGethConnectedAction = yield take(Actions.SET_GETH_CONNECTED)
     if (action.connected) {
       return
     }

--- a/packages/mobile/src/qrcode/utils.ts
+++ b/packages/mobile/src/qrcode/utils.ts
@@ -61,22 +61,22 @@ function* handleSecureSend(
 
   const userScannedAddress = data.address.toLowerCase()
   const { e164PhoneNumber } = secureSendTxData.recipient
-  const possibleRecievingAddresses = e164NumberToAddress[e164PhoneNumber]
+  const possibleReceivingAddresses = e164NumberToAddress[e164PhoneNumber]
   // This should never happen. Secure Send is triggered when there are
-  // multiple addrresses for a given phone number
-  if (!possibleRecievingAddresses) {
+  // multiple addresses for a given phone number
+  if (!possibleReceivingAddresses) {
     throw Error("No addresses associated with recipient's phone number")
   }
 
   // Need to add the requester address to the option set in the event
   // a request is coming from an unverified account
-  if (requesterAddress && !possibleRecievingAddresses.includes(requesterAddress)) {
-    possibleRecievingAddresses.push(requesterAddress)
+  if (requesterAddress && !possibleReceivingAddresses.includes(requesterAddress)) {
+    possibleReceivingAddresses.push(requesterAddress)
   }
-  const possibleRecievingAddressesFormatted = possibleRecievingAddresses.map((address) =>
+  const possibleReceivingAddressesFormatted = possibleReceivingAddresses.map((address) =>
     address.toLowerCase()
   )
-  if (!possibleRecievingAddressesFormatted.includes(userScannedAddress)) {
+  if (!possibleReceivingAddressesFormatted.includes(userScannedAddress)) {
     const error = ErrorMessages.QR_FAILED_INVALID_RECIPIENT
     ValoraAnalytics.track(SendEvents.send_secure_incorrect, {
       confirmByScan: true,

--- a/packages/mobile/src/send/actions.ts
+++ b/packages/mobile/src/send/actions.ts
@@ -29,6 +29,11 @@ export interface HandleBarcodeDetectedAction {
   requesterAddress?: string
 }
 
+export interface ShareQRCodeAction {
+  type: Actions.QRCODE_SHARE
+  qrCodeSvg: SVG
+}
+
 export interface StoreLatestInRecentsAction {
   type: Actions.STORE_LATEST_IN_RECENTS
   recipient: Recipient
@@ -55,6 +60,7 @@ export interface SendPaymentOrInviteFailureAction {
 
 export type ActionTypes =
   | HandleBarcodeDetectedAction
+  | ShareQRCodeAction
   | StoreLatestInRecentsAction
   | SendPaymentOrInviteAction
   | SendPaymentOrInviteSuccessAction
@@ -80,7 +86,7 @@ export const handleBarcodeDetected = (
   requesterAddress,
 })
 
-export const shareQRCode = (qrCodeSvg: SVG) => ({
+export const shareQRCode = (qrCodeSvg: SVG): ShareQRCodeAction => ({
   type: Actions.QRCODE_SHARE,
   qrCodeSvg,
 })

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -17,9 +17,11 @@ import { handleBarcode, shareSVGImage } from 'src/qrcode/utils'
 import { recipientCacheSelector } from 'src/recipients/reducer'
 import {
   Actions,
+  HandleBarcodeDetectedAction,
   SendPaymentOrInviteAction,
   sendPaymentOrInviteFailure,
   sendPaymentOrInviteSuccess,
+  ShareQRCodeAction,
 } from 'src/send/actions'
 import { transferStableToken } from 'src/stableToken/actions'
 import {
@@ -66,7 +68,7 @@ export async function getSendFee(
 
 export function* watchQrCodeDetections() {
   while (true) {
-    const action = yield take(Actions.BARCODE_DETECTED)
+    const action: HandleBarcodeDetectedAction = yield take(Actions.BARCODE_DETECTED)
     Logger.debug(TAG, 'Barcode detected in watcher')
     const addressToE164Number = yield select(addressToE164NumberSelector)
     const recipientCache = yield select(recipientCacheSelector)
@@ -77,7 +79,7 @@ export function* watchQrCodeDetections() {
 
     if (action.scanIsForSecureSend) {
       secureSendTxData = action.transactionData
-      requesterAddress = action.requesterAddrress
+      requesterAddress = action.requesterAddress
     }
 
     try {
@@ -99,7 +101,7 @@ export function* watchQrCodeDetections() {
 
 export function* watchQrCodeShare() {
   while (true) {
-    const action = yield take(Actions.QRCODE_SHARE)
+    const action: ShareQRCodeAction = yield take(Actions.QRCODE_SHARE)
     try {
       yield call(shareSVGImage, action.qrCodeSvg)
     } catch (error) {

--- a/packages/mobile/src/web3/saga.ts
+++ b/packages/mobile/src/web3/saga.ts
@@ -26,6 +26,7 @@ import {
   Actions,
   completeWeb3Sync,
   setAccount,
+  SetAccountAction,
   setFornoMode,
   SetIsFornoAction,
   setPrivateCommentKey,
@@ -228,7 +229,7 @@ export function* getAccount() {
       return account
     }
 
-    const action = yield take(Actions.SET_ACCOUNT)
+    const action: SetAccountAction = yield take(Actions.SET_ACCOUNT)
     if (action.address) {
       // account exists
       return action.address


### PR DESCRIPTION
### Description

There was a typo in `requesterAddrress` in the code handling QR codes in secure send mode.
Not sure exactly of the exact problem it would cause, I'll let @tarikbellamine comment.

Long term fix is to find a solution for fully typed `redux-saga`.
As of today, there's no clear solution to this, see more discussion https://github.com/redux-saga/redux-saga/issues/1286

### Other changes

- Added manual types for `yield take(Actions...)`.

### Tested

TypeScript check succeeds.

### Backwards compatibility

Yes.