### PR TITLE
Update setup guide

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -161,7 +161,7 @@ npm install lerna
 # install dependencies and run post-install script
 yarn
 # build all packages
-yarn build
+yarn build --ignore docs
 ```
 
 > Note that if you do your checkouts with a different method, Yarn will fail if
@@ -172,6 +172,9 @@ yarn build
 > When removing a dependency via `yarn remove some-package`, be sure to also run `yarn postinstall` so
 > you aren't left with freshly unpackaged modules. This is because we use `patch-package`
 > and the `postinstall` step which uses it is not automatically run after using `yarn remove`.
+
+> The docs package relies on gitbook which has problems off of a fresh install. Running
+> `yarn build --ignore docs` is a known workaround. 
 
 
 ## Running the mobile wallet


### PR DESCRIPTION
Fixes issues with docs

### Description

Gitbook is borked on a fresh install. Note, I've personally be able to fix this is by running `npm install` in `~/.gitbook/versions/3.2.3`. Not sure if that's a recommended fix.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._