### PR TITLE
Fix certora rules broken by #4523

### DIFF
--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -44,7 +44,7 @@ contract Accounts is IAccounts, Ownable, ReentrancyGuard, Initializable, UsingRe
     string metadataURL;
   }
 
-  mapping(address => Account) private accounts;
+  mapping(address => Account) internal accounts;
   // Maps authorized signers to the account that provided the authorization.
   mapping(address => address) public authorizedBy;
 


### PR DESCRIPTION
### Description

#4523 broke certora rules by making an internal mapping private, to prevent the compatibility tool detecting a version change. However, now that bytecode metadata is being stripped, no change is being detected and this mapping can be made internal with no versioning implications

### Other changes

None

### Tested

No
### Related issues

None
### Backwards compatibility

Yes