### PR TITLE
Add function to verify the number of attestation requests matches expectations

### DIFF
--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -586,12 +586,12 @@ contract Attestations is
    * @dev It can be used when batching meta-transactions to validate
    * attestation are requested as expected in untrusted scenarios
    */
-  function requireNAttestationRequests(bytes32 identifier, address account, uint32 expected)
+  function requireNAttestationsRequested(bytes32 identifier, address account, uint32 expected)
     external
     view
   {
     uint256 requested = identifiers[identifier].attestations[account].requested;
-    require(requested == expected, "number of requests does not match expectations");
+    require(requested == expected, "requested attestations does not match expected");
   }
 
   /**

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -578,6 +578,23 @@ contract Attestations is
   }
 
   /**
+   * @notice Require that a given identifier/address pair has
+   * requested a specific number of attestations.
+   * @param identifier Hash of the identifier.
+   * @param account Address of the account.
+   * @param expected Number of expected attestations
+   * @dev It can be used when batching meta-transactions to validate
+   * attestation are requested as expected in untrusted scenarios
+   */
+  function requireNAttestationRequests(bytes32 identifier, address account, uint32 expected)
+    external
+    view
+  {
+    uint256 requested = identifiers[identifier].attestations[account].requested;
+    require(requested == expected, "number of requests does not match expectations");
+  }
+
+  /**
    * @notice Helper function for batchGetAttestationStats to calculate the
              total number of addresses that have >0 complete attestations for the identifiers.
    * @param identifiersToLookup Array of n identifiers.

--- a/packages/protocol/contracts/identity/interfaces/IAttestations.sol
+++ b/packages/protocol/contracts/identity/interfaces/IAttestations.sol
@@ -28,5 +28,5 @@ interface IAttestations {
     view
     returns (uint32[] memory, address[] memory, uint256[] memory, bytes memory);
 
-  function requireNAttestationRequests(bytes32, address, uint32) external view;
+  function requireNAttestationsRequested(bytes32, address, uint32) external view;
 }

--- a/packages/protocol/contracts/identity/interfaces/IAttestations.sol
+++ b/packages/protocol/contracts/identity/interfaces/IAttestations.sol
@@ -27,4 +27,6 @@ interface IAttestations {
     external
     view
     returns (uint32[] memory, address[] memory, uint256[] memory, bytes memory);
+
+  function requireNAttestationRequests(bytes32, address, uint32) external view;
 }

--- a/packages/protocol/test/identity/attestations.ts
+++ b/packages/protocol/test/identity/attestations.ts
@@ -1006,4 +1006,36 @@ contract('Attestations', (accounts: string[]) => {
       assert.lengthOf(total, 0)
     })
   })
+
+  describe.only('#requireNAttestationRequests()', () => {
+    describe('with none requested', () => {
+      it('does not revert when called with 0', async () => {
+        await attestations.requireNAttestationRequests(phoneHash, caller, 0)
+      })
+
+      it('does revert when called with something else', async () => {
+        await assertRevert(
+          attestations.requireNAttestationRequests(phoneHash, caller, 2),
+          'number of requests does not match expectations'
+        )
+      })
+    })
+
+    describe('with some requested', () => {
+      beforeEach(async () => {
+        await requestAttestations()
+      })
+
+      it('does revert when called with 0', async () => {
+        await assertRevert(
+          attestations.requireNAttestationRequests(phoneHash, caller, 0),
+          'number of requests does not match expectations'
+        )
+      })
+
+      it('does not revert when called with the correct number', async () => {
+        await attestations.requireNAttestationRequests(phoneHash, caller, attestationsRequested)
+      })
+    })
+  })
 })

--- a/packages/protocol/test/identity/attestations.ts
+++ b/packages/protocol/test/identity/attestations.ts
@@ -1007,16 +1007,18 @@ contract('Attestations', (accounts: string[]) => {
     })
   })
 
-  describe.only('#requireNAttestationRequests()', () => {
+  describe('#requireNAttestationRequests()', () => {
+    const requestNError = 'requested attestations does not match expected'
+
     describe('with none requested', () => {
       it('does not revert when called with 0', async () => {
-        await attestations.requireNAttestationRequests(phoneHash, caller, 0)
+        await attestations.requireNAttestationsRequested(phoneHash, caller, 0)
       })
 
       it('does revert when called with something else', async () => {
         await assertRevert(
-          attestations.requireNAttestationRequests(phoneHash, caller, 2),
-          'number of requests does not match expectations'
+          attestations.requireNAttestationsRequested(phoneHash, caller, 2),
+          requestNError
         )
       })
     })
@@ -1028,13 +1030,13 @@ contract('Attestations', (accounts: string[]) => {
 
       it('does revert when called with 0', async () => {
         await assertRevert(
-          attestations.requireNAttestationRequests(phoneHash, caller, 0),
-          'number of requests does not match expectations'
+          attestations.requireNAttestationsRequested(phoneHash, caller, 0),
+          requestNError
         )
       })
 
       it('does not revert when called with the correct number', async () => {
-        await attestations.requireNAttestationRequests(phoneHash, caller, attestationsRequested)
+        await attestations.requireNAttestationsRequested(phoneHash, caller, attestationsRequested)
       })
     })
   })


### PR DESCRIPTION
### Description

During the development of [the fee-less attestation subsidy](https://docs.google.com/document/d/1wBFX6c1Tu4Dyxrx9JdKhmXPXXaFmVpHmP5bAAzmX6EU/edit) we came across a solution of implementing the subsidy as a [MetaTransactionWallet](https://github.com/celo-org/celo-monorepo/pull/4587) that also supports a function that receives an array of transactions to execute as a batch.

This way our subsidy could essentially work like:
```
subsidy.executeTransactions([
   cUSD.transfer(beneficiary, fee), // subsidy -> beneficiary
   beneficiary.executeMetaTransaction(cUSD.approve(attestations, fee)),
   beneficiary.executeMetaTransaction(attestations.request(identifier, attestationsRequested, cUSD))
]);
```

However this is exploitable because the beneficiary can upgrade his MetaTransactionWallet to run no-ops and keep the cUSD transfer. This can be mitigated if we have a function that reverts based on the number of attestation requests in state:

```solidity
function requireNAttestationsRequested(bytes32 identifier, address account, uint32 expected)
```

This way the flow above changes into:
```
subsidy.executeTransactions([
   attestations.requireNAttestationRequests(identifier, beneficiary, currentRequests),
   cUSD.transfer(beneficiary, fee), // subsidy -> beneficiary
   beneficiary.executeMetaTransaction(cUSD.approve(attestations, fee)),
   beneficiary.executeMetaTransaction(attestations.request(identifier, attestationsRequested, cUSD)),
   attestations.requireNAttestationRequests(identifier, beneficiary, currentRequests + attestationsRequested)
]);
```

### Tested

Straightforward tests ✅ 

### Related issues

- Related to #4587 
