### PR TITLE
Require transfer approver to be one of the two parties

### DIFF
--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -689,6 +689,7 @@ contract Attestations is
   function approveTransfer(bytes32 identifier, uint256 index, address from, address to, bool status)
     external
   {
+    require(msg.sender == from || msg.sender == to);
     bytes32 key = keccak256(abi.encodePacked(identifier, from, to));
     address other = msg.sender == from ? to : from;
     if (status && transferApprovals[other][key]) {

--- a/packages/protocol/test/identity/attestations.ts
+++ b/packages/protocol/test/identity/attestations.ts
@@ -64,7 +64,6 @@ contract('Attestations', (accounts: string[]) => {
   const web3: Web3 = new Web3Class(provider)
   const phoneNumber: string = '+18005551212'
   const caller: string = accounts[0]
-  const replacementAddress: string = accounts[1]
   // Private keys of each of the 10 miners, in the same order as their addresses in 'accounts'.
   const accountPrivateKeys: string[] = [
     '0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d',
@@ -194,14 +193,12 @@ contract('Attestations', (accounts: string[]) => {
 
   describe('#initialize()', () => {
     it('should have set attestationExpiryBlocks', async () => {
-      const actualAttestationExpiryBlocks: number = await attestations.attestationExpiryBlocks.call(
-        this
-      )
-      assert.equal(actualAttestationExpiryBlocks, attestationExpiryBlocks)
+      const actualAttestationExpiryBlocks = await attestations.attestationExpiryBlocks()
+      assertEqualBN(actualAttestationExpiryBlocks, attestationExpiryBlocks)
     })
 
     it('should have set the fee', async () => {
-      const fee = await attestations.getAttestationRequestFee.call(mockStableToken.address)
+      const fee = await attestations.getAttestationRequestFee(mockStableToken.address)
       assert.equal(fee.toString(), attestationFee.toString())
     })
 
@@ -224,8 +221,8 @@ contract('Attestations', (accounts: string[]) => {
 
     it('should set attestationExpiryBlocks', async () => {
       await attestations.setAttestationExpiryBlocks(newMaxNumBlocksPerAttestation)
-      const actualAttestationExpiryBlocks = await attestations.attestationExpiryBlocks.call(this)
-      assert.equal(actualAttestationExpiryBlocks, newMaxNumBlocksPerAttestation)
+      const actualAttestationExpiryBlocks = await attestations.attestationExpiryBlocks()
+      assertEqualBN(actualAttestationExpiryBlocks, newMaxNumBlocksPerAttestation)
     })
 
     it('should emit the AttestationExpiryBlocksSet event', async () => {
@@ -252,7 +249,7 @@ contract('Attestations', (accounts: string[]) => {
 
     it('should set the fee', async () => {
       await attestations.setAttestationRequestFee(mockStableToken.address, newAttestationFee)
-      const fee = await attestations.getAttestationRequestFee.call(mockStableToken.address)
+      const fee = await attestations.getAttestationRequestFee(mockStableToken.address)
       assert.equal(fee.toString(), newAttestationFee.toString())
     })
 
@@ -290,8 +287,8 @@ contract('Attestations', (accounts: string[]) => {
 
     it('should set selectIssuersWaitBlocks', async () => {
       await attestations.setSelectIssuersWaitBlocks(newSelectIssuersWaitBlocks)
-      const actualAttestationExpiryBlocks = await attestations.selectIssuersWaitBlocks.call(this)
-      assert.equal(actualAttestationExpiryBlocks, newSelectIssuersWaitBlocks)
+      const actualAttestationExpiryBlocks = await attestations.selectIssuersWaitBlocks()
+      assertEqualBN(actualAttestationExpiryBlocks, newSelectIssuersWaitBlocks)
     })
 
     it('should emit the SelectIssuersWaitBlocksSet event', async () => {
@@ -318,7 +315,7 @@ contract('Attestations', (accounts: string[]) => {
 
     it('should set maxAttestations', async () => {
       await attestations.setMaxAttestations(newMaxAttestations)
-      assert.equal(await attestations.maxAttestations.call(this), newMaxAttestations)
+      assertEqualBN(await attestations.maxAttestations(), newMaxAttestations)
     })
 
     it('should emit the MaxAttestationsSet event', async () => {
@@ -689,7 +686,7 @@ contract('Attestations', (accounts: string[]) => {
 
     it('should increment pendingWithdrawals for the rewards recipient', async () => {
       await attestations.complete(phoneHash, v, r, s)
-      const pendingWithdrawals = await attestations.pendingWithdrawals.call(
+      const pendingWithdrawals = await attestations.pendingWithdrawals(
         mockStableToken.address,
         issuer
       )
@@ -751,11 +748,11 @@ contract('Attestations', (accounts: string[]) => {
       await attestations.withdraw(mockStableToken.address, {
         from: issuer,
       })
-      const pendingWithdrawals: number = await attestations.pendingWithdrawals.call(
+      const pendingWithdrawals = await attestations.pendingWithdrawals(
         mockStableToken.address,
         issuer
       )
-      assert.equal(pendingWithdrawals, 0)
+      assertEqualBN(pendingWithdrawals, 0)
     })
 
     it('should remove the balance of available rewards for the issuer from attestation signer', async () => {
@@ -763,11 +760,11 @@ contract('Attestations', (accounts: string[]) => {
       await attestations.withdraw(mockStableToken.address, {
         from: signer,
       })
-      const pendingWithdrawals: number = await attestations.pendingWithdrawals.call(
+      const pendingWithdrawals = await attestations.pendingWithdrawals(
         mockStableToken.address,
         issuer
       )
-      assert.equal(pendingWithdrawals, 0)
+      assertEqualBN(pendingWithdrawals, 0)
     })
 
     it('should revert from non-attestation signer or issuer account', async () => {
@@ -823,7 +820,7 @@ contract('Attestations', (accounts: string[]) => {
       })
 
       it("does not return the user's account", async () => {
-        const attestedAccounts = await attestations.lookupAccountsForIdentifier.call(phoneHash)
+        const attestedAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
         assert.isEmpty(attestedAccounts)
       })
     })
@@ -835,7 +832,7 @@ contract('Attestations', (accounts: string[]) => {
 
       describe('when the account has no walletAddress mapped', () => {
         it('should allow a user to lookup the attested account of a phone number', async () => {
-          const attestedAccounts = await attestations.lookupAccountsForIdentifier.call(phoneHash)
+          const attestedAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
           assert.deepEqual(attestedAccounts, [caller])
         })
       })
@@ -844,7 +841,7 @@ contract('Attestations', (accounts: string[]) => {
         beforeEach(setAccountWalletAddress)
 
         it('should allow a user to lookup the attested account of a phone number', async () => {
-          const attestedAccounts = await attestations.lookupAccountsForIdentifier.call(phoneHash)
+          const attestedAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
           assert.deepEqual(attestedAccounts, [caller])
         })
       })
@@ -852,7 +849,7 @@ contract('Attestations', (accounts: string[]) => {
 
     describe('when an account is not attested', () => {
       it('should return an empty array for the phone number', async () => {
-        const attestedAccounts = await attestations.lookupAccountsForIdentifier.call(phoneHash)
+        const attestedAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
         assert.isEmpty(attestedAccounts)
       })
     })
@@ -871,7 +868,7 @@ contract('Attestations', (accounts: string[]) => {
           string[],
           BigNumber[],
           BigNumber[]
-        ] = await attestations.batchGetAttestationStats.call([phoneHash])
+        ] = await attestations.batchGetAttestationStats([phoneHash])
         assert.lengthOf(matches, 1)
         assert.lengthOf(addresses, 0)
         assert.lengthOf(completed, 0)
@@ -894,7 +891,7 @@ contract('Attestations', (accounts: string[]) => {
             string[],
             BigNumber[],
             BigNumber[]
-          ] = await attestations.batchGetAttestationStats.call([phoneHash])
+          ] = await attestations.batchGetAttestationStats([phoneHash])
           assert.lengthOf(matches, 1)
           assert.lengthOf(addresses, 1)
           assert.lengthOf(completed, 1)
@@ -931,7 +928,7 @@ contract('Attestations', (accounts: string[]) => {
               string[],
               BigNumber[],
               BigNumber[]
-            ] = await attestations.batchGetAttestationStats.call([phoneHash])
+            ] = await attestations.batchGetAttestationStats([phoneHash])
             assert.lengthOf(matches, 1)
             assert.lengthOf(addresses, 2)
             assert.lengthOf(completed, 2)
@@ -955,7 +952,7 @@ contract('Attestations', (accounts: string[]) => {
             string[],
             BigNumber[],
             BigNumber[]
-          ] = await attestations.batchGetAttestationStats.call([phoneHash])
+          ] = await attestations.batchGetAttestationStats([phoneHash])
           assert.lengthOf(matches, 1)
           assert.lengthOf(addresses, 1)
           assert.lengthOf(completed, 1)
@@ -976,7 +973,7 @@ contract('Attestations', (accounts: string[]) => {
           string[],
           BigNumber[],
           BigNumber[]
-        ] = await attestations.batchGetAttestationStats.call([phoneHash])
+        ] = await attestations.batchGetAttestationStats([phoneHash])
         assert.lengthOf(matches, 1)
         assert.lengthOf(addresses, 0)
         assert.lengthOf(completed, 0)
@@ -993,14 +990,14 @@ contract('Attestations', (accounts: string[]) => {
 
     it('should allow a user to revoke their account for a phone number', async () => {
       await attestations.revoke(phoneHash, 0)
-      const attestedAccounts = await attestations.lookupAccountsForIdentifier.call(phoneHash)
+      const attestedAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
       assert.isEmpty(attestedAccounts)
       const [matches, addresses, completed, total]: [
         BigNumber[],
         string[],
         BigNumber[],
         BigNumber[]
-      ] = await attestations.batchGetAttestationStats.call([phoneHash])
+      ] = await attestations.batchGetAttestationStats([phoneHash])
       assert.lengthOf(matches, 1)
       assert.lengthOf(addresses, 0)
       assert.lengthOf(completed, 0)
@@ -1009,6 +1006,7 @@ contract('Attestations', (accounts: string[]) => {
   })
 
   describe('#approveTransfer()', () => {
+    const replacementAddress: string = accounts[1]
     describe('when the attestation exists', () => {
       beforeEach(async () => {
         await requestAndCompleteAttestations()
@@ -1020,12 +1018,12 @@ contract('Attestations', (accounts: string[]) => {
         await attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, true, {
           from: caller,
         })
-        const attestedAccounts = await attestations.lookupAccountsForIdentifier.call(phoneHash)
+        const attestedAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
         await assert.deepEqual(attestedAccounts, [caller])
         await attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, true, {
           from: replacementAddress,
         })
-        const attestedAccountsAfterApproval = await attestations.lookupAccountsForIdentifier.call(
+        const attestedAccountsAfterApproval = await attestations.lookupAccountsForIdentifier(
           phoneHash
         )
         assert.deepEqual(attestedAccountsAfterApproval, [replacementAddress])
@@ -1047,12 +1045,12 @@ contract('Attestations', (accounts: string[]) => {
         await attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, true, {
           from: replacementAddress,
         })
-        const attestedAccounts = await attestations.lookupAccountsForIdentifier.call(phoneHash)
+        const attestedAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
         await assert.deepEqual(attestedAccounts, [caller])
         await attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, true, {
           from: caller,
         })
-        const attestedAccountsAfterApproval = await attestations.lookupAccountsForIdentifier.call(
+        const attestedAccountsAfterApproval = await attestations.lookupAccountsForIdentifier(
           phoneHash
         )
         assert.deepEqual(attestedAccountsAfterApproval, [replacementAddress])
@@ -1068,7 +1066,34 @@ contract('Attestations', (accounts: string[]) => {
         assert.deepEqual(originalUnselectedRequest, newUnselectedRequest)
       })
 
-      it('fails when the `to` address has attestations existing', async () => {
+      it('should allow a user to revoke their approval', async () => {
+        await attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, true, {
+          from: caller,
+        })
+        await attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, false, {
+          from: caller,
+        })
+        await attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, true, {
+          from: replacementAddress,
+        })
+        const [completed, requested] = await attestations.getAttestationStats(
+          phoneHash,
+          replacementAddress
+        )
+        assertEqualBN(completed, 0)
+        assertEqualBN(requested, 0)
+      })
+
+      it('should revert if the caller is not one of the two parties', async () => {
+        const otherAddress: string = accounts[2]
+        await assertRevert(
+          attestations.approveTransfer(phoneHash, 0, caller, replacementAddress, true, {
+            from: otherAddress,
+          })
+        )
+      })
+
+      it('should revert when the `to` address has attestations existing', async () => {
         await attestations.request(phoneHash, attestationsRequested, mockStableToken.address, {
           from: replacementAddress,
         })


### PR DESCRIPTION
### Description

This PR fixes a bug introduced in https://github.com/celo-org/celo-monorepo/pull/4583 which would allow attestations to be transferred with an approval from only one party. 

### Other changes

- Remove unnecessary `.call`s from attestations tests.
- Add test the users can revoke attestations transfer approval.

### Tested

Unit tests
### Related issues

None
### Backwards compatibility

Yes