### PR TITLE
Do not let a ReleaseGold contract self-destruct with a cUSD balance

### DIFF
--- a/packages/cli/src/commands/releasegold/withdraw.test.ts
+++ b/packages/cli/src/commands/releasegold/withdraw.test.ts
@@ -5,6 +5,7 @@ import { getContractFromEvent, testWithGanache, timeTravel } from '@celo/dev-uti
 import Web3 from 'web3'
 import CreateAccount from './create-account'
 import SetLiquidityProvision from './set-liquidity-provision'
+import RGTransferDollars from './transfer-dollars'
 import Withdraw from './withdraw'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -34,5 +35,41 @@ testWithGanache('releasegold:withdraw cmd', (web3: Web3) => {
     await Withdraw.run(['--contract', contractAddress, '--value', '10000000000000000000000'])
     const balanceAfter = await kit.getTotalBalance(beneficiary)
     await expect(balanceBefore.gold.toNumber()).toBeLessThan(balanceAfter.gold.toNumber())
+  })
+
+  test('cant withdraw the whole balance if there is a cUSD balance', async () => {
+    await SetLiquidityProvision.run(['--contract', contractAddress, '--yesreally'])
+    // ReleasePeriod of default contract
+    await timeTravel(100000000, web3)
+    const releaseGoldWrapper = new ReleaseGoldWrapper(kit, newReleaseGold(web3, contractAddress))
+    const beneficiary = await releaseGoldWrapper.getBeneficiary()
+    const balanceBefore = await kit.getTotalBalance(beneficiary)
+    const remainingBalance = await releaseGoldWrapper.getRemainingUnlockedBalance()
+
+    const stableToken = await kit.contracts.getStableToken()
+
+    await stableToken.transfer(contractAddress, 100).sendAndWaitForReceipt({ from: beneficiary })
+
+    // Can't withdraw since there is cUSD balance still
+    await expect(
+      Withdraw.run(['--contract', contractAddress, '--value', remainingBalance.toString()])
+    ).rejects.toThrow()
+
+    // Move out the cUSD balance
+    await await RGTransferDollars.run([
+      '--contract',
+      contractAddress,
+      '--to',
+      beneficiary,
+      '--value',
+      '100',
+    ])
+
+    await Withdraw.run(['--contract', contractAddress, '--value', remainingBalance.toString()])
+    const balanceAfter = await kit.getTotalBalance(beneficiary)
+    await expect(balanceBefore.gold.toNumber()).toBeLessThan(balanceAfter.gold.toNumber())
+
+    // Contract should self-destruct now
+    await expect(releaseGoldWrapper.getRemainingUnlockedBalance()).rejects.toThrow()
   })
 })

--- a/packages/cli/src/commands/releasegold/withdraw.test.ts
+++ b/packages/cli/src/commands/releasegold/withdraw.test.ts
@@ -37,7 +37,7 @@ testWithGanache('releasegold:withdraw cmd', (web3: Web3) => {
     await expect(balanceBefore.gold.toNumber()).toBeLessThan(balanceAfter.gold.toNumber())
   })
 
-  test('cant withdraw the whole balance if there is a cUSD balance', async () => {
+  test("can't withdraw the whole balance if there is a cUSD balance", async () => {
     await SetLiquidityProvision.run(['--contract', contractAddress, '--yesreally'])
     // ReleasePeriod of default contract
     await timeTravel(100000000, web3)

--- a/packages/cli/src/commands/releasegold/withdraw.ts
+++ b/packages/cli/src/commands/releasegold/withdraw.ts
@@ -39,6 +39,20 @@ export default class Withdraw extends ReleaseGoldCommand {
       .addCheck('Contract has met liquidity provision if applicable', () =>
         this.releaseGoldWrapper.getLiquidityProvisionMet()
       )
+      .addCheck(
+        'Contract does not self-distruct with cUSD left when withdrawing the whole balance',
+        async () => {
+          if (value.eq(remainingUnlockedBalance)) {
+            const stableToken = await this.kit.contracts.getStableToken()
+            const stableBalance = await stableToken.balanceOf(this.releaseGoldWrapper.address)
+            if (stableBalance.gt(0)) {
+              return false
+            }
+          }
+
+          return true
+        }
+      )
       .runChecks()
 
     this.kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()

--- a/packages/cli/src/commands/releasegold/withdraw.ts
+++ b/packages/cli/src/commands/releasegold/withdraw.ts
@@ -40,7 +40,7 @@ export default class Withdraw extends ReleaseGoldCommand {
         this.releaseGoldWrapper.getLiquidityProvisionMet()
       )
       .addCheck(
-        'Contract does not self-distruct with cUSD left when withdrawing the whole balance',
+        'Contract would self-destruct with cUSD left when withdrawing the whole balance',
         async () => {
           if (value.eq(remainingUnlockedBalance)) {
             const stableToken = await this.kit.contracts.getStableToken()


### PR DESCRIPTION
### Description

This PR prevents CLI users from withdrawing their remaining balance if they have a cUSD balance to avoid loss of funds when the contract self-destructs


### Tested

- Unit test

### Related issues

- Fixes #4571 
