### PR TITLE
[docs] Git is required to install some cli dependencies

### DIFF
--- a/packages/docs/command-line-interface/introduction.md
+++ b/packages/docs/command-line-interface/introduction.md
@@ -14,7 +14,7 @@ description: >-
 
 ### NPM Package
 
-The Celo CLI is published as a node module on NPM. Assuming you have [npm installed](https://www.npmjs.com/get-npm), you can install the Celo CLI using the following command:
+The Celo CLI is published as a node module on NPM. Assuming you have [npm](https://www.npmjs.com/get-npm) and [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) both installed, you can install the Celo CLI using the following command:
 
 ```bash
 npm install -g @celo/celocli


### PR DESCRIPTION
### Description

Due to how we import some dependencies, having `git` installed is required to install the `cli`

### Note

This is just a patch to unlock some users following the guide that cannot use the `cli`. For the actual fix, this #4622 issue was created