### PR TITLE
Changing libphonenumber to libphonenumber-js

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,7 +30,7 @@
     "crypto-js": "^3.1.9-1",
     "elliptic": "^6.5.3",
     "ethereumjs-util": "^5.2.0",
-    "google-libphonenumber": "^3.2.4",
+    "libphonenumber-js": "^1.7.50",
     "keccak256": "^1.0.0",
     "lodash": "^4.17.14",
     "numeral": "^2.0.6",

--- a/packages/utils/src/phoneNumbers.ts
+++ b/packages/utils/src/phoneNumbers.ts
@@ -2,6 +2,7 @@ import CountryData from 'country-data'
 import {
   CountryCode,
   getCountries,
+  getCountryCallingCode,
   getExampleNumber as libGetExampleNumber,
   parsePhoneNumber as libParsePhoneNumber,
   parsePhoneNumberFromString,
@@ -85,13 +86,19 @@ export function getRegionCode(e164PhoneNumber: string) {
   }
 }
 
-function _getRegionCodeFromCountryCode(countryCode: string | undefined): CountryCode | null {
+function _getRegionCodeFromCountryCode(countryCode: string | undefined): CountryCode | undefined {
   if (!countryCode) {
-    return null
+    return undefined
   }
   const countries = getCountries()
-  const regionCode = countries[parseInt(countryCode, 10)]
-  return regionCode
+  const asNumber = parseInt(countryCode, 10)
+  // TODO: precalculate a dictionary country calling code => country iso code
+  // to avoid this iteration
+  return countries.find((country) => {
+    const cc = getCountryCallingCode(country) as string
+    const ccAsNumber = parseInt(cc, 10)
+    return ccAsNumber === asNumber
+  })
 }
 
 export function getRegionCodeFromCountryCode(countryCode: string) {

--- a/packages/utils/src/phoneNumbers.ts
+++ b/packages/utils/src/phoneNumbers.ts
@@ -1,10 +1,19 @@
 import CountryData from 'country-data'
+// import {
+//   PhoneNumber,
+//   PhoneNumberFormat,
+//   PhoneNumberType,
+//   PhoneNumberUtil,
+// } from 'google-libphonenumber'
 import {
+  CountryCode,
+  getCountries,
+  getExampleNumber as libGetExampleNumber,
+  parsePhoneNumber as libParsePhoneNumber,
+  parsePhoneNumberFromString,
   PhoneNumber,
-  PhoneNumberFormat,
-  PhoneNumberType,
-  PhoneNumberUtil,
-} from 'google-libphonenumber'
+} from 'libphonenumber-js'
+import examples from 'libphonenumber-js/examples.mobile.json'
 import * as Web3Utils from 'web3-utils'
 import { getIdentifierPrefix, IdentifierType } from './attestations'
 
@@ -16,7 +25,6 @@ export interface ParsedPhoneNumber {
   regionCode?: string
 }
 
-const phoneUtil = PhoneNumberUtil.getInstance()
 const MIN_PHONE_LENGTH = 4
 const PHONE_SALT_SEPARATOR = '__'
 const E164_REGEX = /^\+[1-9][0-9]{1,14}$/
@@ -56,9 +64,13 @@ export function getCountryCode(e164PhoneNumber: string) {
     return null
   }
   try {
-    return phoneUtil.parse(e164PhoneNumber).getCountryCode()
+    // type CountryCallingCode is an extension of String, but
+    // type checks fail when attempting to pass it as a parameter for parseInt,
+    // so here we force the string representation, and then parse it to a number
+    const callingCode = parsePhoneNumberFromString(e164PhoneNumber)?.countryCallingCode
+    return parseInt(callingCode as string, 10)
   } catch (error) {
-    console.debug(`getCountryCode, number: ${e164PhoneNumber}, error: ${error}`)
+    console.debug(`countryCallingCode, number: ${e164PhoneNumber}, error: ${error}`)
     return null
   }
 }
@@ -68,21 +80,38 @@ export function getRegionCode(e164PhoneNumber: string) {
     return null
   }
   try {
-    return phoneUtil.getRegionCodeForNumber(phoneUtil.parse(e164PhoneNumber))
+    const country = parsePhoneNumberFromString(e164PhoneNumber)?.country
+    // type CountryCode is an extension of String, but
+    // type checks fail when attempting to pass it as a parameter for parseInt,
+    // so here we force the string representation
+    return country as string
   } catch (error) {
-    console.debug(`getRegionCodeForNumber, number: ${e164PhoneNumber}, error: ${error}`)
+    console.debug(`country, number: ${e164PhoneNumber}, error: ${error}`)
     return null
   }
 }
 
-export function getRegionCodeFromCountryCode(countryCode: string) {
+function _getRegionCodeFromCountryCode(countryCode: string | undefined): CountryCode | null {
   if (!countryCode) {
     return null
   }
+  const countries = getCountries()
+  const regionCode = countries[parseInt(countryCode, 10)]
+  return regionCode
+}
+
+export function getRegionCodeFromCountryCode(countryCode: string) {
   try {
-    return phoneUtil.getRegionCodeForCountryCode(parseInt(countryCode, 10))
+    const cc = _getRegionCodeFromCountryCode(countryCode)
+    if (!cc) {
+      return null
+    }
+    // type CountryCode is an extension of String, but
+    // type checks fail when attempting to pass it as a parameter for parseInt,
+    // so here we force the string representation
+    return cc as string
   } catch (error) {
-    console.debug(`getRegionCodeFromCountryCode, countrycode: ${countryCode}, error: ${error}`)
+    console.debug(`getCountries, countrycode: ${countryCode}, error: ${error}`)
     return null
   }
 }
@@ -128,11 +157,11 @@ export function isE164Number(phoneNumber: string) {
 
 // Actually runs through the parsing instead of using a regex
 export function isE164NumberStrict(phoneNumber: string) {
-  const parsedPhoneNumber = phoneUtil.parse(phoneNumber)
-  if (!phoneUtil.isValidNumber(parsedPhoneNumber)) {
+  const parsedPhoneNumber = parsePhoneNumberFromString(phoneNumber)
+  if (!parsedPhoneNumber?.isValid()) {
     return false
   }
-  return phoneUtil.format(parsedPhoneNumber, PhoneNumberFormat.E164) === phoneNumber
+  return parsedPhoneNumber.format('E.164') === phoneNumber
 }
 
 export function parsePhoneNumber(
@@ -144,12 +173,13 @@ export function parsePhoneNumber(
       return null
     }
 
-    const defaultRegionCode = defaultCountryCode
-      ? getRegionCodeFromCountryCode(defaultCountryCode)
-      : null
-    const parsedNumberUnfixed = phoneUtil.parse(phoneNumberRaw, defaultRegionCode || undefined)
-    const parsedCountryCode = parsedNumberUnfixed.getCountryCode()
-    const parsedRegionCode = phoneUtil.getRegionCodeForNumber(parsedNumberUnfixed)
+    const defaultRegionCode = _getRegionCodeFromCountryCode(defaultCountryCode)
+    const parsedNumberUnfixed = libParsePhoneNumber(phoneNumberRaw, defaultRegionCode || undefined)
+    const strParsedCountryCode = parsedNumberUnfixed?.countryCallingCode
+    const parsedCountryCode = strParsedCountryCode
+      ? parseInt(strParsedCountryCode as string, 10)
+      : undefined
+    const parsedRegionCode = parsedNumberUnfixed?.country
     const parsedNumber = handleSpecialCasesForParsing(
       parsedNumberUnfixed,
       parsedCountryCode,
@@ -159,21 +189,16 @@ export function parsePhoneNumber(
     if (!parsedNumber) {
       return null
     }
-
-    const isValid = phoneUtil.isValidNumberForRegion(parsedNumber, parsedRegionCode)
-
-    return isValid
-      ? {
-          e164Number: phoneUtil.format(parsedNumber, PhoneNumberFormat.E164),
-          displayNumber: handleSpecialCasesForDisplay(parsedNumber, parsedCountryCode),
-          displayNumberInternational: phoneUtil.format(
-            parsedNumber,
-            PhoneNumberFormat.INTERNATIONAL
-          ),
-          countryCode: parsedCountryCode,
-          regionCode: parsedRegionCode,
-        }
-      : null
+    if (!parsedNumber.isValid()) {
+      return null
+    }
+    return {
+      e164Number: parsedNumber.format('E.164'),
+      displayNumber: handleSpecialCasesForDisplay(parsedNumber, parsedCountryCode),
+      displayNumberInternational: parsedNumber.format('INTERNATIONAL'),
+      countryCode: parsedCountryCode,
+      regionCode: parsedRegionCode as string,
+    }
   } catch (error) {
     console.debug(`phoneNumbers/parsePhoneNumber/Failed to parse phone number, error: ${error}`)
     return null
@@ -183,7 +208,7 @@ export function parsePhoneNumber(
 function handleSpecialCasesForParsing(
   parsedNumber: PhoneNumber,
   countryCode?: number,
-  regionCode?: string
+  regionCode?: CountryCode
 ) {
   if (!countryCode || !regionCode) {
     return parsedNumber
@@ -203,22 +228,20 @@ function handleSpecialCasesForParsing(
 
 // TODO(Rossy) Given the inconsistencies of numbers around the world, we should
 // display e164 everywhere to ensure users knows exactly who their sending money to
-function handleSpecialCasesForDisplay(parsedNumber: PhoneNumber, countryCode?: number) {
+function handleSpecialCasesForDisplay(parsedNumber: PhoneNumber, countryCode?: number): string {
   switch (countryCode) {
     // Argentina
     // The Google lib formatter incorretly adds '15' to the nationally formatted number for Argentina
     // However '15' is only needed when calling a mobile from a landline
     case 54:
-      return phoneUtil
-        .format(parsedNumber, PhoneNumberFormat.INTERNATIONAL)
-        .replace(/\+54(\s)?/, '')
+      return parsedNumber.format('INTERNATIONAL').replace(/\+54(\s)?/, '')
 
     case 231:
-      const formatted = phoneUtil.format(parsedNumber, PhoneNumberFormat.NATIONAL)
+      const formatted = parsedNumber.format('NATIONAL')
       return formatted && formatted[0] === '0' ? formatted.slice(1) : formatted
 
     default:
-      return phoneUtil.format(parsedNumber, PhoneNumberFormat.NATIONAL)
+      return parsedNumber.format('NATIONAL')
   }
 }
 
@@ -228,14 +251,14 @@ function handleSpecialCasesForDisplay(parsedNumber: PhoneNumber, countryCode?: n
  */
 function prependToFormMobilePhoneNumber(
   parsedNumber: PhoneNumber,
-  regionCode: string,
+  regionCode: CountryCode,
   prefix: string
 ) {
-  if (phoneUtil.getNumberType(parsedNumber) === PhoneNumberType.MOBILE) {
+  if (parsedNumber.getType() === 'MOBILE') {
     return parsedNumber
   }
 
-  let nationalNumber = phoneUtil.format(parsedNumber, PhoneNumberFormat.NATIONAL)
+  let nationalNumber = parsedNumber.format('NATIONAL')
   // Nationally formatted numbers sometimes contain leading 0
   if (nationalNumber.charAt(0) === '0') {
     nationalNumber = nationalNumber.slice(1)
@@ -245,8 +268,8 @@ function prependToFormMobilePhoneNumber(
     return null
   }
 
-  const adjustedNumber = phoneUtil.parse(prefix + nationalNumber, regionCode)
-  return phoneUtil.getNumberType(adjustedNumber) === PhoneNumberType.MOBILE ? adjustedNumber : null
+  const adjustedNumber = libParsePhoneNumber(prefix + nationalNumber, regionCode)
+  return adjustedNumber.getType() === 'MOBILE' ? adjustedNumber : null
 }
 
 export function anonymizedPhone(phoneNumber: string) {
@@ -258,18 +281,17 @@ export function getExampleNumber(
   useOnlyZeroes: boolean = true,
   isInternational: boolean = false
 ) {
-  const examplePhone = phoneUtil.getExampleNumber(
-    getRegionCodeFromCountryCode(regionCode) as string
-  )
+  const cc = _getRegionCodeFromCountryCode(regionCode)
+  if (!cc) {
+    return
+  }
+  const examplePhone = libGetExampleNumber(cc, examples)
 
   if (!examplePhone) {
     return
   }
 
-  const formatedExample = phoneUtil.format(
-    examplePhone,
-    isInternational ? PhoneNumberFormat.INTERNATIONAL : PhoneNumberFormat.NATIONAL
-  )
+  const formatedExample = examplePhone.format(isInternational ? 'INTERNATIONAL' : 'NATIONAL')
 
   if (useOnlyZeroes) {
     if (isInternational) {

--- a/packages/utils/src/phoneNumbers.ts
+++ b/packages/utils/src/phoneNumbers.ts
@@ -1,10 +1,4 @@
 import CountryData from 'country-data'
-// import {
-//   PhoneNumber,
-//   PhoneNumberFormat,
-//   PhoneNumberType,
-//   PhoneNumberUtil,
-// } from 'google-libphonenumber'
 import {
   CountryCode,
   getCountries,

--- a/packages/utils/src/types.d.ts
+++ b/packages/utils/src/types.d.ts
@@ -3,3 +3,5 @@ declare module '@umpirsky/country-list/data/es_AR/country.json' {
   const value: { [countryCode: string]: string }
   export default value
 }
+
+declare module 'libphonenumber-js/examples.mobile.json'

--- a/yarn.lock
+++ b/yarn.lock
@@ -22348,6 +22348,14 @@ libphonenumber-js@^1.7.22:
     minimist "^1.2.0"
     xml2js "^0.4.17"
 
+libphonenumber-js@^1.7.50:
+  version "1.7.56"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.7.56.tgz#1f206c69acb112a43134141e2331a737cdfcb8a0"
+  integrity sha512-7ArN9sSVs9bzX72+HeryCrmI68w1ry3Sd67+BmbPxbaCU+ZpuB2R9YT/YTsTUFYbxkp933vpQUP5E/1TJ9WvTQ==
+  dependencies:
+    minimist "^1.2.5"
+    xml2js "^0.4.17"
+
 liftoff@3.1.0, liftoff@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-3.1.0.tgz#c9ba6081f908670607ee79062d700df062c52ed3"


### PR DESCRIPTION
Since google libphonenumber weights ~ 700kb, in this PR we attempt to change it to libphonenumber-js, which is supposedly much smaller