### PR TITLE
[Wallet] Fix for measuring app load time

### DIFF
--- a/packages/mobile/android/app/src/main/java/org/celo/mobile/MainActivity.java
+++ b/packages/mobile/android/app/src/main/java/org/celo/mobile/MainActivity.java
@@ -18,7 +18,7 @@ import org.devio.rn.splashscreen.SplashScreen;
 public class MainActivity
   extends ReactFragmentActivity
   implements ReactInstanceManager.ReactInstanceEventListener {
-  Date appStartTimestamp;
+  long appStartedMillis;
 
   /**
    * Returns the name of the main component registered from JavaScript. This is
@@ -40,7 +40,7 @@ public class MainActivity
         View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
       );
 
-    appStartTimestamp = new Date();
+    appStartedMillis = System.currentTimeMillis();
     SplashScreen.show(this, R.style.SplashTheme);
     super.onCreate(null);
   }
@@ -64,7 +64,7 @@ public class MainActivity
   public void onReactContextInitialized(ReactContext context) {
     context
       .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-      .emit("AppStartedLoading", appStartTimestamp.toString());
+      .emit("AppStartedLoading", "" + appStartedMillis);
   }
 
   @Override

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -54,15 +54,15 @@ BigNumber.config({
 export class App extends React.Component {
   async componentDidMount() {
     await ValoraAnalytics.init()
-    const appLoadedAt: Date = new Date()
+    const appLoadedMillis: number = Date.now()
     const { width, height } = Dimensions.get('window')
 
     if (Platform.OS === 'android') {
       const appStartListener = DeviceEventEmitter.addListener(
         'AppStartedLoading',
-        (appInitializedAtString: string) => {
-          const appInitializedAt = new Date(appInitializedAtString)
-          const loadingDuration = appLoadedAt.getTime() - appInitializedAt.getTime()
+        (appStartedMillisStr: string) => {
+          const appStartedMillis: number = +appStartedMillisStr
+          const loadingDuration = appLoadedMillis - appStartedMillis
           ValoraAnalytics.startSession(AppEvents.app_launched, {
             loadingDuration,
             deviceHeight: height,


### PR DESCRIPTION
### Description

Just a small fix for logging the app start time.

The problem was the conversion from a Date object in Java to a date object in typescript. When passing data through the emitter everything is encoded as strings and toString of Date in Java printed a nice string which was not parseable on the other side. Instead, I switched both sides to unix timestamps, a number type on the TS side and a long primitive in Java, which is pretty common for measuring intervals.

### Tested

Just logged the parameters and the difference.

### Backwards compatibility

This change is backwards compatible since the data is all in memory.
