### PR TITLE
Add note to @celo/utils Lock about reentrancy and reject on throw error

### DIFF
--- a/packages/utils/src/lock.ts
+++ b/packages/utils/src/lock.ts
@@ -15,8 +15,8 @@ export class Lock {
     this.emitter = new EventEmitter()
   }
 
-  // Attempt to aquire the lock without blocking.
-  // @returns {boolean} True if the lock was aquired.
+  // Attempt to acquire the lock without blocking.
+  // @returns {boolean} True if the lock was acquired.
   tryAcquire(): boolean {
     if (!this.locked) {
       this.locked = true
@@ -25,7 +25,7 @@ export class Lock {
     return false
   }
 
-  // Aquire the lock, blocking until the lock is available.
+  // Acquire the lock, blocking until the lock is available.
   acquire(): Promise<void> {
     return new Promise((resolve) => {
       // Attempt to grab the lock without waiting.
@@ -45,7 +45,7 @@ export class Lock {
     })
   }
 
-  // Release the lock such that another caller can aquire it.
+  // Release the lock such that another caller can acquire it.
   // If not locked, calling this method has no effect.
   release() {
     if (this.locked) {

--- a/packages/utils/src/lock.ts
+++ b/packages/utils/src/lock.ts
@@ -5,6 +5,8 @@ enum LockEvent {
 }
 
 // Lock which can be used to ensure mutual exclusion in concurrent code.
+//
+// This lock is non-reentrant, and attempting to acquire it while holding the lock will result in a deadlock.
 export class Lock {
   private locked: boolean = false
   private emitter: EventEmitter
@@ -14,7 +16,6 @@ export class Lock {
   }
 
   // Attempt to aquire the lock without blocking.
-  //
   // @returns {boolean} True if the lock was aquired.
   tryAcquire(): boolean {
     if (!this.locked) {
@@ -45,6 +46,7 @@ export class Lock {
   }
 
   // Release the lock such that another caller can aquire it.
+  // If not locked, calling this method has no effect.
   release() {
     if (this.locked) {
       this.locked = false

--- a/packages/utils/src/lock.ts
+++ b/packages/utils/src/lock.ts
@@ -27,7 +27,7 @@ export class Lock {
 
   // Acquire the lock, blocking until the lock is available.
   acquire(): Promise<void> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       // Attempt to grab the lock without waiting.
       if (this.tryAcquire()) {
         resolve()
@@ -36,9 +36,13 @@ export class Lock {
 
       // Wait for an event emitted when releasing the lock.
       const callback = () => {
-        if (this.tryAcquire()) {
-          this.emitter.removeListener(LockEvent.Unlock, callback)
-          resolve()
+        try {
+          if (this.tryAcquire()) {
+            this.emitter.removeListener(LockEvent.Unlock, callback)
+            resolve()
+          }
+        } catch (error) {
+          reject(error)
         }
       }
       this.emitter.on(LockEvent.Unlock, callback)


### PR DESCRIPTION
### Description

Followup to https://github.com/celo-org/celo-monorepo/pull/4678 (which was merged with `automerge` before I responded to @timmoreton comments), this PR adds a comment about reentrancy and rejects the acquire promise if an error is thrown.

### Backwards compatibility

100%