### PR TITLE
Add usdGas flag to base command

### DIFF
--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -1,4 +1,4 @@
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { CeloContract, ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { stopProvider } from '@celo/contractkit/lib/utils/provider-utils'
 import { AzureHSMWallet } from '@celo/contractkit/lib/wallets/azure-hsm-wallet'
 import {
@@ -43,6 +43,10 @@ export abstract class BaseCommand extends LocalCommand {
     ...LocalCommand.flags,
     privateKey: flags.string({ hidden: true }),
     node: flags.string({ char: 'n', hidden: true }),
+    usdGas: flags.boolean({
+      default: false,
+      description: 'If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD',
+    }),
     useLedger: flags.boolean({
       default: false,
       hidden: false,
@@ -162,15 +166,18 @@ export abstract class BaseCommand extends LocalCommand {
       }
     } else if (res.flags.useAKV) {
       try {
-        const akvWallet = await new AzureHSMWallet(res.flags.azureVaultName)
+        const akvWallet = new AzureHSMWallet(res.flags.azureVaultName)
         await akvWallet.init()
-        console.log(`Found addresses: ${await akvWallet.getAccounts()}`)
+        console.log(`Found addresses: ${akvWallet.getAccounts()}`)
         this._wallet = akvWallet
       } catch (err) {
         console.log(`Failed to connect to AKV ${err}`)
         throw err
       }
     }
+    await this.kit.setFeeCurrency(
+      res.flags.usdGas ? CeloContract.StableToken : CeloContract.GoldToken
+    )
   }
 
   finally(arg: Error | undefined): Promise<any> {

--- a/packages/contractkit/src/kit.test.ts
+++ b/packages/contractkit/src/kit.test.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'bignumber.js'
 import { PromiEvent, TransactionReceipt, Tx } from 'web3-core'
 import { TransactionObject } from 'web3-eth'
 import { newKit } from './kit'
@@ -70,13 +71,29 @@ describe('kit.sendTransactionObject()', () => {
     )
   })
 
+  test('should retrieve currency gasPrice with feeCurrency', async () => {
+    const txo = txoStub()
+    const gasPrice = 100
+    const getGasPriceMin = jest.fn().mockImplementation(() => ({
+      getGasPriceMinimum() {
+        return new BigNumber(gasPrice)
+      },
+    }))
+    kit.contracts.getGasPriceMinimum = getGasPriceMin.bind(kit.contracts)
+    const options: Tx = { gas: 555, feeCurrency: 'XXX', from: '0xAAFFF' }
+    await kit.sendTransactionObject(txo, options)
+    expect(txo.send).toBeCalledWith({
+      gasPrice: `${gasPrice * 5}`,
+      ...options,
+    })
+  })
+
   test('should forward txoptions to txo.send()', async () => {
     const txo = txoStub()
-    await kit.sendTransactionObject(txo, { gas: 555, feeCurrency: 'XXX', from: '0xAAFFF' })
+    await kit.sendTransactionObject(txo, { gas: 555, from: '0xAAFFF' })
     expect(txo.send).toBeCalledWith({
       gasPrice: '0',
       gas: 555,
-      feeCurrency: 'XXX',
       from: '0xAAFFF',
     })
   })

--- a/packages/contractkit/src/kit.ts
+++ b/packages/contractkit/src/kit.ts
@@ -75,6 +75,7 @@ export interface NetworkConfig {
 export interface KitOptions {
   gasInflationFactor: number
   gasPrice: string
+  gasPriceSuggestionMultiplier: number
   feeCurrency?: Address
   from?: Address
 }
@@ -100,6 +101,7 @@ export class ContractKit {
       gasInflationFactor: 1.3,
       // gasPrice:0 means the node will compute gasPrice on its own
       gasPrice: '0',
+      gasPriceSuggestionMultiplier: 3,
     }
     if (!(web3.currentProvider instanceof CeloProvider)) {
       const celoProviderInstance = new CeloProvider(web3.currentProvider, wallet)
@@ -302,6 +304,13 @@ export class ContractKit {
   ): Promise<TransactionResult> {
     tx = this.fillTxDefaults(tx)
 
+    // TODO: remove once cUSD gasPrice is available on minimumClientVersion node rpc
+    if (tx.feeCurrency && tx.gasPrice === '0') {
+      const gasPriceMinimum = await this.contracts.getGasPriceMinimum()
+      const rawGasPrice = await gasPriceMinimum.getGasPriceMinimum(tx.feeCurrency)
+      tx.gasPrice = rawGasPrice.multipliedBy(this.config.gasPriceSuggestionMultiplier).toFixed()
+    }
+
     let gas = tx.gas
     if (gas == null) {
       const gasEstimator = (_tx: Tx) => txObj.estimateGas({ ..._tx })
@@ -333,10 +342,6 @@ export class ContractKit {
       from: this.config.from,
       feeCurrency: this.config.feeCurrency,
       gasPrice: this.config.gasPrice,
-    }
-
-    if (this.config.feeCurrency) {
-      defaultTx.feeCurrency = this.config.feeCurrency
     }
 
     return {

--- a/packages/contractkit/src/kit.ts
+++ b/packages/contractkit/src/kit.ts
@@ -102,7 +102,7 @@ export class ContractKit {
       gasInflationFactor: 1.3,
       // gasPrice:0 means the node will compute gasPrice on its own
       gasPrice: '0',
-      gasPriceSuggestionMultiplier: 3,
+      gasPriceSuggestionMultiplier: 5,
     }
     if (!(web3.currentProvider instanceof CeloProvider)) {
       const celoProviderInstance = new CeloProvider(web3.currentProvider, wallet)

--- a/packages/contractkit/src/kit.ts
+++ b/packages/contractkit/src/kit.ts
@@ -75,6 +75,7 @@ export interface NetworkConfig {
 export interface KitOptions {
   gasInflationFactor: number
   gasPrice: string
+  // TODO: remove once cUSD gasPrice is available on minimumClientVersion node rpc
   gasPriceSuggestionMultiplier: number
   feeCurrency?: Address
   from?: Address

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -38,6 +38,9 @@ OPTIONS
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
 
+  --usdGas                                             If --usdGas is set, the transaction is paid for with a
+                                                       feeCurrency of cUSD
+
   --useLedger                                          Set it to use a ledger wallet
 
 EXAMPLES
@@ -63,6 +66,9 @@ View Celo Dollar and Gold balances for an address
 ```
 USAGE
   $ celocli account:balance ADDRESS
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   balance 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -100,6 +106,9 @@ OPTIONS
   --publicKey=publicKey                              The public key of the account that others may use to send you
                                                      encrypted messages
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -135,6 +144,9 @@ OPTIONS
                                                      "[4,99]"
 
   --url=https://www.celo.org                         (required) The url you want to claim
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -172,6 +184,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -204,6 +219,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -242,6 +260,9 @@ OPTIONS
 
   --name=name                                        (required) The name you want to claim
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -277,6 +298,9 @@ OPTIONS
 
   --url=https://www.celo.org                         (required) The URL of the storage root you want to claim
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -310,6 +334,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -338,6 +365,9 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -368,6 +398,9 @@ OPTIONS
   --[no-]local                                   If set, only show local and hardware wallet accounts. Use no-local to
                                                  only show keystore addresses.
 
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
+
   --useLedger                                    Set it to use a ledger wallet
 ```
 
@@ -383,6 +416,9 @@ USAGE
 
 ARGUMENTS
   ACCOUNT  Account address
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   lock 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -456,6 +492,9 @@ OPTIONS
                                                         --ledgerCustomAddresses "[4,99]"
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer key to prove possession of.
+
+  --usdGas                                              If --usdGas is set, the transaction is paid for with a
+                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 
@@ -534,6 +573,9 @@ OPTIONS
 
   --name=name
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLES
@@ -567,6 +609,9 @@ OPTIONS
 
   --url=https://www.celo.org                         (required) The url to the metadata you want to register
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -598,6 +643,9 @@ OPTIONS
 
   --name=name                                           (required)
 
+  --usdGas                                              If --usdGas is set, the transaction is paid for with a
+                                                        feeCurrency of cUSD
+
   --useLedger                                           Set it to use a ledger wallet
 
 EXAMPLE
@@ -624,6 +672,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
+
   --useLedger                                    Set it to use a ledger wallet
 
 EXAMPLE
@@ -649,6 +700,9 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -679,6 +733,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
+
   --useLedger                                    Set it to use a ledger wallet
 
 EXAMPLE
@@ -701,6 +758,7 @@ ARGUMENTS
 OPTIONS
   --duration=duration  Duration in seconds to leave the account unlocked. Unlocks until the node exits by default.
   --password=password  Password used to unlock the account. If not specified, you will be prompted for a password.
+  --usdGas             If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLES
   unlock 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -736,6 +794,9 @@ OPTIONS
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer key to verify proof of
                                                         possession.
+
+  --usdGas                                              If --usdGas is set, the transaction is paid for with a
+                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/dkg.md
+++ b/packages/docs/command-line-interface/dkg.md
@@ -29,6 +29,9 @@ OPTIONS
 
   --threshold=threshold                              (required) The threshold to use for the DKG
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 ```
 
@@ -56,6 +59,9 @@ OPTIONS
                                                                        signing. Example --ledgerCustomAddresses "[4,99]"
 
   --method=(shares|responses|justifications|participants|phase|group)  (required) Getter method to call
+
+  --usdGas                                                             If --usdGas is set, the transaction is paid for
+                                                                       with a feeCurrency of cUSD
 
   --useLedger                                                          Set it to use a ledger wallet
 ```
@@ -85,6 +91,9 @@ OPTIONS
                                                         index addresses for local signing. Example
                                                         --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                              If --usdGas is set, the transaction is paid for with a
+                                                        feeCurrency of cUSD
+
   --useLedger                                           Set it to use a ledger wallet
 ```
 
@@ -113,6 +122,9 @@ OPTIONS
                                                         index addresses for local signing. Example
                                                         --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                              If --usdGas is set, the transaction is paid for with a
+                                                        feeCurrency of cUSD
+
   --useLedger                                           Set it to use a ledger wallet
 ```
 
@@ -139,6 +151,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses         [default: [0]] If --useLedger is set, this will get the array of
                                                         index addresses for local signing. Example
                                                         --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                              If --usdGas is set, the transaction is paid for with a
+                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 ```
@@ -168,6 +183,9 @@ OPTIONS
                                                         --ledgerCustomAddresses "[4,99]"
 
   --participantAddress=participantAddress               (required) Address of the participant to whitelist
+
+  --usdGas                                              If --usdGas is set, the transaction is paid for with a
+                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 ```

--- a/packages/docs/command-line-interface/election.md
+++ b/packages/docs/command-line-interface/election.md
@@ -25,6 +25,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --wait                                             Wait until all pending votes can be activated
@@ -45,6 +48,8 @@ USAGE
   $ celocli election:current
 
 OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+
   --valset  Show currently used signers from valset (by default the authorized validator signers are shown). Useful for
             checking if keys have been rotated.
 ```
@@ -58,6 +63,9 @@ Prints the list of validator groups, the number of votes they have received, the
 ```
 USAGE
   $ celocli election:list
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   list
@@ -87,6 +95,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --value=value                                      (required) Value of votes to revoke
@@ -105,6 +116,9 @@ Runs a "mock" election and prints out the validators that would be elected if th
 ```
 USAGE
   $ celocli election:run
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 ```
 
 _See code: [packages/cli/src/commands/election/run.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/election/run.ts)_
@@ -121,8 +135,9 @@ ARGUMENTS
   ADDRESS  Voter or Validator Groups's address
 
 OPTIONS
-  --group  Show information about a group running in Validator elections
-  --voter  Show information about an account voting in Validator elections
+  --group   Show information about a group running in Validator elections
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --voter   Show information about an account voting in Validator elections
 
 EXAMPLES
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3 --voter
@@ -152,6 +167,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/exchange.md
+++ b/packages/docs/command-line-interface/exchange.md
@@ -28,6 +28,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --value=10000000000000000000000                    (required) The value of CELO to exchange for Celo Dollars
@@ -62,6 +65,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -98,6 +104,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --value=10000000000000000000000                    (required) The value of CELO to exchange for Celo Dollars
@@ -119,6 +128,7 @@ USAGE
 
 OPTIONS
   --amount=amount  [default: 1000000000000000000] Amount of the token being exchanged to report rates for
+  --usdGas         If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   list

--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -25,6 +25,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -55,6 +58,9 @@ OPTIONS
                                                      "[4,99]"
 
   --proposalID=proposalID                            (required) UUID of proposal to execute
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -88,6 +94,9 @@ OPTIONS
 
   --salt=salt                                        (required) Secret salt associated with hotfix
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -119,6 +128,9 @@ OPTIONS
 
   --salt=salt                                    (required) Secret salt associated with hotfix
 
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
+
   --useLedger                                    Set it to use a ledger wallet
 
 EXAMPLE
@@ -135,6 +147,9 @@ List live governance proposals (queued and ongoing)
 ```
 USAGE
   $ celocli governance:list
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   list
@@ -163,6 +178,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -201,6 +219,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -231,6 +252,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -254,6 +278,7 @@ OPTIONS
   --notwhitelisted         List validators who have not whitelisted the specified hotfix
   --proposalID=proposalID  UUID of proposal to view
   --raw                    Display proposal in raw bytes format
+  --usdGas                 If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
   --whitelisters           If set, displays validators that have whitelisted the hotfix.
 
 EXAMPLES
@@ -290,6 +315,9 @@ OPTIONS
 
   --proposalID=proposalID                            (required) UUID of proposal to upvote
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -309,6 +337,7 @@ USAGE
 OPTIONS
   --proposalID=proposalID  (required) UUID of proposal to view
   --raw                    Display proposal in raw bytes format
+  --usdGas                 If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLES
   view --proposalID 99
@@ -328,6 +357,7 @@ USAGE
 OPTIONS
   --hash=hash        (required) Hash of hotfix transactions
   --nonwhitelisters  If set, displays validators that have not whitelisted the hotfix.
+  --usdGas           If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
   --whitelisters     If set, displays validators that have whitelisted the hotfix.
 
 EXAMPLES
@@ -361,6 +391,9 @@ OPTIONS
 
   --proposalID=proposalID                            (required) UUID of proposal to vote on
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --value=(Abstain|No|Yes)                           (required) Vote
@@ -393,6 +426,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -422,6 +458,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/identity.md
+++ b/packages/docs/command-line-interface/identity.md
@@ -11,6 +11,9 @@ Outputs the set of validators currently participating in BFT and which ones are 
 ```
 USAGE
   $ celocli identity:current-attestation-services
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 ```
 
 _See code: [packages/cli/src/commands/identity/current-attestation-services.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/identity/current-attestation-services.ts)_
@@ -39,6 +42,9 @@ OPTIONS
   --message=message                                  (required) The message of the SMS
 
   --phoneNumber=+14152223333                         (required) The phone number to send the test message to
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/lockedgold.md
+++ b/packages/docs/command-line-interface/lockedgold.md
@@ -24,6 +24,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
+
   --useLedger                                    Set it to use a ledger wallet
 
   --value=value                                  (required) The unit amount of CELO
@@ -41,6 +44,9 @@ Show Locked Gold information for a given account. This includes the total amount
 ```
 USAGE
   $ celocli lockedgold:show ACCOUNT
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -68,6 +74,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -99,6 +108,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/multisig.md
+++ b/packages/docs/command-line-interface/multisig.md
@@ -13,9 +13,10 @@ USAGE
   $ celocli multisig:show ADDRESS
 
 OPTIONS
-  --all    Show info about all transactions
-  --raw    Do not attempt to parse transactions
-  --tx=tx  Show info for a transaction
+  --all     Show info about all transactions
+  --raw     Do not attempt to parse transactions
+  --tx=tx   Show info for a transaction
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLES
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631

--- a/packages/docs/command-line-interface/network.md
+++ b/packages/docs/command-line-interface/network.md
@@ -11,6 +11,9 @@ Prints Celo contract addesses.
 ```
 USAGE
   $ celocli network:contracts
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 ```
 
 _See code: [packages/cli/src/commands/network/contracts.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/contracts.ts)_
@@ -22,6 +25,9 @@ View parameters of the network, including but not limited to configuration for t
 ```
 USAGE
   $ celocli network:parameters
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 ```
 
 _See code: [packages/cli/src/commands/network/parameters.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/parameters.ts)_

--- a/packages/docs/command-line-interface/node.md
+++ b/packages/docs/command-line-interface/node.md
@@ -22,6 +22,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
+
   --useLedger                                    Set it to use a ledger wallet
 ```
 
@@ -36,6 +39,7 @@ USAGE
   $ celocli node:synced
 
 OPTIONS
+  --usdGas   If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
   --verbose  output the full status if syncing
 ```
 

--- a/packages/docs/command-line-interface/oracle.md
+++ b/packages/docs/command-line-interface/oracle.md
@@ -15,6 +15,9 @@ USAGE
 ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to list the oracles for
 
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+
 EXAMPLES
   list StableToken
   list
@@ -45,6 +48,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -79,6 +85,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --value=value                                      (required) Amount of the specified token equal to 1 CELO
@@ -100,6 +109,9 @@ USAGE
 
 ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to list the reports for
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLES
   reports StableToken

--- a/packages/docs/command-line-interface/releasegold.md
+++ b/packages/docs/command-line-interface/releasegold.md
@@ -39,6 +39,9 @@ OPTIONS
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) The signer key that is to be used for voting through
                                                          the ReleaseGold instance
 
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
+
   --useLedger                                            Set it to use a ledger wallet
 
 EXAMPLES
@@ -79,6 +82,9 @@ OPTIONS
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
+
   --useLedger                                            Set it to use a ledger wallet
 
 EXAMPLE
@@ -108,6 +114,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -144,6 +153,9 @@ OPTIONS
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
+
   --useLedger                                            Set it to use a ledger wallet
 
 EXAMPLE
@@ -171,6 +183,9 @@ OPTIONS
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
+
   --useLedger                                            Set it to use a ledger wallet
 ```
 
@@ -196,6 +211,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -228,6 +246,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -263,6 +284,9 @@ OPTIONS
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
+
   --useLedger                                            Set it to use a ledger wallet
 
 EXAMPLES
@@ -297,6 +321,9 @@ OPTIONS
                                                               --ledgerCustomAddresses "[4,99]"
 
   --pop=pop                                                   ECDSA PoP for signer over contract's account
+
+  --usdGas                                                    If --usdGas is set, the transaction is paid for with a
+                                                              feeCurrency of cUSD
 
   --useLedger                                                 Set it to use a ledger wallet
 
@@ -338,6 +365,9 @@ OPTIONS
                                                             array of index addresses for local signing. Example
                                                             --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                                  If --usdGas is set, the transaction is paid for with a
+                                                            feeCurrency of cUSD
+
   --useLedger                                               Set it to use a ledger wallet
 
   --yesreally                                               Override prompt to set new beneficiary (be careful!)
@@ -369,6 +399,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -402,6 +435,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -437,6 +473,9 @@ OPTIONS
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
+
   --useLedger                                            Set it to use a ledger wallet
 
   --yesreally                                            Override prompt to set new maximum distribution (be careful!)
@@ -467,6 +506,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -499,6 +541,9 @@ OPTIONS
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d        (required) Address of the recipient of Celo Dollars transfer
 
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
+
   --useLedger                                            Set it to use a ledger wallet
 
   --value=10000000000000000000000                        (required) Value (in Wei) of Celo Dollars to transfer
@@ -530,6 +575,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
+
+  --usdGas                                               If --usdGas is set, the transaction is paid for with a
+                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/reserve.md
+++ b/packages/docs/command-line-interface/reserve.md
@@ -12,6 +12,9 @@ Shows information about reserve
 USAGE
   $ celocli reserve:status
 
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+
 EXAMPLE
   status
 ```
@@ -40,6 +43,9 @@ OPTIONS
                                                      "[4,99]"
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Receiving address
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/rewards.md
+++ b/packages/docs/command-line-interface/rewards.md
@@ -17,7 +17,12 @@ OPTIONS
   --estimate                                              Estimate voter rewards from current votes
   --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show rewards for
   --slashing                                              Show rewards for slashing
+
+  --usdGas                                                If --usdGas is set, the transaction is paid for with a
+                                                          feeCurrency of cUSD
+
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Validator to show rewards for
+
   --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Voter to show rewards for
 
 EXAMPLE

--- a/packages/docs/command-line-interface/transfer.md
+++ b/packages/docs/command-line-interface/transfer.md
@@ -28,6 +28,9 @@ OPTIONS
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --value=value                                      (required) Amount to transfer (in wei)
@@ -63,6 +66,9 @@ OPTIONS
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --value=value                                      (required) Amount to transfer (in wei)
@@ -97,6 +103,9 @@ OPTIONS
                                                      "[4,99]"
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/validator.md
+++ b/packages/docs/command-line-interface/validator.md
@@ -28,6 +28,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --yes                                              Answer yes to prompt
@@ -59,6 +62,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -87,6 +93,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -117,6 +126,9 @@ OPTIONS
                                                           of index addresses for local signing. Example
                                                           --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                                If --usdGas is set, the transaction is paid for with a
+                                                          feeCurrency of cUSD
+
   --useLedger                                             Set it to use a ledger wallet
 
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Validator's address
@@ -135,6 +147,9 @@ List registered Validators, their name (if provided), affiliation, uptime score,
 ```
 USAGE
   $ celocli validator:list
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   list
@@ -166,6 +181,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --yes                                              Answer yes to prompt
@@ -189,6 +207,9 @@ List the Locked Gold requirements for registering a Validator. This consists of 
 USAGE
   $ celocli validator:requirements
 
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+
 EXAMPLE
   requirements
 ```
@@ -205,6 +226,9 @@ USAGE
 
 ARGUMENTS
   VALIDATORADDRESS  Validator's address
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3
@@ -224,6 +248,10 @@ OPTIONS
   --at-block=at-block                                  latest block to examine for signer activity
   --lookback=lookback                                  [default: 120] how many blocks to look back for signer activity
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) address of the signer to check for signatures
+
+  --usdGas                                             If --usdGas is set, the transaction is paid for with a
+                                                       feeCurrency of cUSD
+
   --width=width                                        [default: 40] line width for printing marks
 
 EXAMPLES
@@ -251,6 +279,9 @@ OPTIONS
                                                           activity
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     address of the signer to check if elected and validating
+
+  --usdGas                                                If --usdGas is set, the transaction is paid for with a
+                                                          feeCurrency of cUSD
 
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  address of the validator to check if elected and validating
 
@@ -283,6 +314,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/validatorgroup.md
+++ b/packages/docs/command-line-interface/validatorgroup.md
@@ -32,6 +32,9 @@ OPTIONS
   --queue-update=queue-update                        Queues an update to the commission, which can be applied after the
                                                      update delay.
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLES
@@ -62,6 +65,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
@@ -77,6 +83,9 @@ List registered Validator Groups, their names (if provided), commission, and mem
 ```
 USAGE
   $ celocli validatorgroup:list
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   list
@@ -112,6 +121,9 @@ OPTIONS
   --remove                                           Remove a validator from the members list
 
   --reorder=reorder                                  Reorder a validator within the members list. Indices are 0 based
+
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -149,6 +161,9 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
+  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
+                                                     of cUSD
+
   --useLedger                                        Set it to use a ledger wallet
 
   --yes                                              Answer yes to prompt
@@ -180,6 +195,9 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
 
+  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
+                                                 cUSD
+
   --useLedger                                    Set it to use a ledger wallet
 
 EXAMPLE
@@ -198,6 +216,9 @@ USAGE
 
 ARGUMENTS
   GROUPADDRESS  ValidatorGroup's address
+
+OPTIONS
+  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
 
 EXAMPLE
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3

--- a/packages/docs/developer-resources/contractkit/reference/classes/_contractkit_src_kit_.contractkit.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_contractkit_src_kit_.contractkit.md
@@ -46,7 +46,7 @@
 
 \+ **new ContractKit**(`web3`: Web3, `wallet?`: [Wallet](../interfaces/_contractkit_src_wallets_wallet_.wallet.md)): *[ContractKit](_contractkit_src_kit_.contractkit.md)*
 
-*Defined in [contractkit/src/kit.ts:97](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L97)*
+*Defined in [contractkit/src/kit.ts:99](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L99)*
 
 **Parameters:**
 
@@ -63,7 +63,7 @@ Name | Type |
 
 • **_web3Contracts**: *[Web3ContractCache](_contractkit_src_web3_contract_cache_.web3contractcache.md)*
 
-*Defined in [contractkit/src/kit.ts:93](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L93)*
+*Defined in [contractkit/src/kit.ts:95](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L95)*
 
 factory for core contract's native web3 wrappers
 
@@ -73,7 +73,7 @@ ___
 
 • **contracts**: *[WrapperCache](_contractkit_src_contract_cache_.wrappercache.md)*
 
-*Defined in [contractkit/src/kit.ts:95](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L95)*
+*Defined in [contractkit/src/kit.ts:97](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L97)*
 
 factory for core contract's kit wrappers
 
@@ -83,7 +83,7 @@ ___
 
 • **registry**: *[AddressRegistry](_contractkit_src_address_registry_.addressregistry.md)*
 
-*Defined in [contractkit/src/kit.ts:91](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L91)*
+*Defined in [contractkit/src/kit.ts:93](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L93)*
 
 core contract's address registry
 
@@ -93,7 +93,7 @@ ___
 
 • **web3**: *Web3*
 
-*Defined in [contractkit/src/kit.ts:98](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L98)*
+*Defined in [contractkit/src/kit.ts:100](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L100)*
 
 ## Accessors
 
@@ -101,7 +101,7 @@ ___
 
 • **get defaultAccount**(): *[Address](../modules/_contractkit_src_base_.md#address) | undefined*
 
-*Defined in [contractkit/src/kit.ts:210](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L210)*
+*Defined in [contractkit/src/kit.ts:213](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L213)*
 
 Default account for generated transactions (eg. tx.from)
 
@@ -109,7 +109,7 @@ Default account for generated transactions (eg. tx.from)
 
 • **set defaultAccount**(`address`: [Address](../modules/_contractkit_src_base_.md#address) | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:202](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L202)*
+*Defined in [contractkit/src/kit.ts:205](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L205)*
 
 Set default account for generated transactions (eg. tx.from )
 
@@ -127,7 +127,7 @@ ___
 
 • **get defaultFeeCurrency**(): *undefined | string*
 
-*Defined in [contractkit/src/kit.ts:243](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L243)*
+*Defined in [contractkit/src/kit.ts:246](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L246)*
 
 Set the ERC20 address for the token to use to pay for transaction fees.
 The ERC20 must be whitelisted for gas.
@@ -138,7 +138,7 @@ Set to `null` to use CELO
 
 • **set defaultFeeCurrency**(`address`: [Address](../modules/_contractkit_src_base_.md#address) | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:239](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L239)*
+*Defined in [contractkit/src/kit.ts:242](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L242)*
 
 Set the ERC20 address for the token to use to pay for transaction fees.
 The ERC20 must be whitelisted for gas.
@@ -159,13 +159,13 @@ ___
 
 • **get gasInflationFactor**(): *number*
 
-*Defined in [contractkit/src/kit.ts:219](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L219)*
+*Defined in [contractkit/src/kit.ts:222](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L222)*
 
 **Returns:** *number*
 
 • **set gasInflationFactor**(`factor`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:215](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L215)*
+*Defined in [contractkit/src/kit.ts:218](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L218)*
 
 **Parameters:**
 
@@ -181,13 +181,13 @@ ___
 
 • **get gasPrice**(): *number*
 
-*Defined in [contractkit/src/kit.ts:227](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L227)*
+*Defined in [contractkit/src/kit.ts:230](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L230)*
 
 **Returns:** *number*
 
 • **set gasPrice**(`price`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:223](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L223)*
+*Defined in [contractkit/src/kit.ts:226](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L226)*
 
 **Parameters:**
 
@@ -203,7 +203,7 @@ Name | Type |
 
 ▸ **addAccount**(`privateKey`: string): *void*
 
-*Defined in [contractkit/src/kit.ts:194](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L194)*
+*Defined in [contractkit/src/kit.ts:197](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L197)*
 
 **Parameters:**
 
@@ -219,7 +219,7 @@ ___
 
 ▸ **getEpochNumberOfBlock**(`blockNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:375](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L375)*
+*Defined in [contractkit/src/kit.ts:381](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L381)*
 
 **Parameters:**
 
@@ -235,7 +235,7 @@ ___
 
 ▸ **getEpochSize**(): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:348](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L348)*
+*Defined in [contractkit/src/kit.ts:354](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L354)*
 
 **Returns:** *Promise‹number›*
 
@@ -245,7 +245,7 @@ ___
 
 ▸ **getFirstBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:355](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L355)*
+*Defined in [contractkit/src/kit.ts:361](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L361)*
 
 **Parameters:**
 
@@ -261,7 +261,7 @@ ___
 
 ▸ **getLastBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:365](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L365)*
+*Defined in [contractkit/src/kit.ts:371](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L371)*
 
 **Parameters:**
 
@@ -277,7 +277,7 @@ ___
 
 ▸ **getNetworkConfig**(): *Promise‹[NetworkConfig](../interfaces/_contractkit_src_kit_.networkconfig.md)›*
 
-*Defined in [contractkit/src/kit.ts:137](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L137)*
+*Defined in [contractkit/src/kit.ts:140](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L140)*
 
 **Returns:** *Promise‹[NetworkConfig](../interfaces/_contractkit_src_kit_.networkconfig.md)›*
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **getTotalBalance**(`address`: string): *Promise‹AccountBalance›*
 
-*Defined in [contractkit/src/kit.ts:115](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L115)*
+*Defined in [contractkit/src/kit.ts:118](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L118)*
 
 **Parameters:**
 
@@ -303,7 +303,7 @@ ___
 
 ▸ **isListening**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:247](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L247)*
+*Defined in [contractkit/src/kit.ts:250](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L250)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -313,7 +313,7 @@ ___
 
 ▸ **isSyncing**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:251](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L251)*
+*Defined in [contractkit/src/kit.ts:254](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L254)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **sendTransaction**(`tx`: Tx): *Promise‹[TransactionResult](_contractkit_src_utils_tx_result_.transactionresult.md)›*
 
-*Defined in [contractkit/src/kit.ts:275](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L275)*
+*Defined in [contractkit/src/kit.ts:278](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L278)*
 
 Send a transaction to celo-blockchain.
 
@@ -346,7 +346,7 @@ ___
 
 ▸ **sendTransactionObject**(`txObj`: TransactionObject‹any›, `tx?`: Omit‹Tx, "data"›): *Promise‹[TransactionResult](_contractkit_src_utils_tx_result_.transactionresult.md)›*
 
-*Defined in [contractkit/src/kit.ts:299](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L299)*
+*Defined in [contractkit/src/kit.ts:302](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L302)*
 
 **Parameters:**
 
@@ -363,7 +363,7 @@ ___
 
 ▸ **setFeeCurrency**(`token`: [CeloToken](../modules/_contractkit_src_base_.md#celotoken)): *Promise‹void›*
 
-*Defined in [contractkit/src/kit.ts:189](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L189)*
+*Defined in [contractkit/src/kit.ts:192](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L192)*
 
 Set CeloToken to use to pay for gas fees
 
@@ -381,6 +381,6 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [contractkit/src/kit.ts:386](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L386)*
+*Defined in [contractkit/src/kit.ts:392](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L392)*
 
 **Returns:** *void*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_contractkit_src_kit_.kitoptions.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_contractkit_src_kit_.kitoptions.md
@@ -12,6 +12,7 @@
 * [from](_contractkit_src_kit_.kitoptions.md#optional-from)
 * [gasInflationFactor](_contractkit_src_kit_.kitoptions.md#gasinflationfactor)
 * [gasPrice](_contractkit_src_kit_.kitoptions.md#gasprice)
+* [gasPriceSuggestionMultiplier](_contractkit_src_kit_.kitoptions.md#gaspricesuggestionmultiplier)
 
 ## Properties
 
@@ -19,7 +20,7 @@
 
 • **feeCurrency**? : *[Address](../modules/_contractkit_src_base_.md#address)*
 
-*Defined in [contractkit/src/kit.ts:78](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L78)*
+*Defined in [contractkit/src/kit.ts:80](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L80)*
 
 ___
 
@@ -27,7 +28,7 @@ ___
 
 • **from**? : *[Address](../modules/_contractkit_src_base_.md#address)*
 
-*Defined in [contractkit/src/kit.ts:79](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L79)*
+*Defined in [contractkit/src/kit.ts:81](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L81)*
 
 ___
 
@@ -44,3 +45,11 @@ ___
 • **gasPrice**: *string*
 
 *Defined in [contractkit/src/kit.ts:77](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L77)*
+
+___
+
+###  gasPriceSuggestionMultiplier
+
+• **gasPriceSuggestionMultiplier**: *number*
+
+*Defined in [contractkit/src/kit.ts:79](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/kit.ts#L79)*


### PR DESCRIPTION
### Description

Should work seamlessly with `tx-params-normalizer` for locally signed transactions by populating `tx.feeCurrency`

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #4544

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._