### PR TITLE
[Wallet] SetClock bugfix

### DIFF
--- a/packages/mobile/src/set-clock/SetClock.tsx
+++ b/packages/mobile/src/set-clock/SetClock.tsx
@@ -18,8 +18,11 @@ export class SetClock extends React.Component<WithTranslation> {
     if (Platform.OS === 'android') {
       return AndroidOpenSettings.dateSettings()
     } else {
-      // TODO: Implement Date Setting on iOS
       navigateHome()
+      // With the following line we would be able to direct to the correct screen in
+      // settings, but it looks like this is a private API and using it risks getting
+      // the app rejected by Apple: https://stackoverflow.com/a/34024467
+      // return Linking.openURL('App-prefs:General&path=DATE_AND_TIME')
     }
   }
 

--- a/packages/mobile/src/utils/time.ts
+++ b/packages/mobile/src/utils/time.ts
@@ -288,7 +288,7 @@ export const getLocalTimezone = () => {
   const timezoneGuess = momentTimezone.tz(momentTimezone.tz.guess())
   momentTimezone.fn.zoneName = function() {
     const abbr = this.zoneAbbr()
-    if (!i18n.language.includes('en')) {
+    if (!i18n.language?.includes('en')) {
       return abbr
     }
     return (


### PR DESCRIPTION
### Description

When the clock is not synced with the real time, we redirect users to the `SetClock` screen. In that screen, we have a button to go to the date settings and show the user's timezone. 
- When fetching the device's timezone, we were accessing `i18n.language` which might not be initialized yet, added a null check just in case.
- Tried to make iOS go to the settings page as well, but it risks getting the app rejected by the App Store, so I left it commented out.

### Related issues

- Fixes Sentry crash https://sentry.io/organizations/celo/issues/1816186985