### PR TITLE
fix: hash the raw transaction to get txhash not rlpencoded tx

### DIFF
--- a/packages/contractkit/src/utils/signing-utils.ts
+++ b/packages/contractkit/src/utils/signing-utils.ts
@@ -121,8 +121,6 @@ export async function encodeTransaction(
   rlpEncoded: RLPEncodedTx,
   signature: { v: number; r: Buffer; s: Buffer }
 ): Promise<EncodedTransaction> {
-  const hash = getHashFromEncoded(rlpEncoded.rlpEncode)
-
   const sanitizedSignature = signatureFormatter(signature)
   const v = sanitizedSignature.v
   const r = sanitizedSignature.r
@@ -132,6 +130,7 @@ export async function encodeTransaction(
     .concat([v, r, s])
 
   const rawTransaction = RLP.encode(rawTx)
+  const hash = getHashFromEncoded(rawTransaction)
 
   const result: EncodedTransaction = {
     tx: {

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
@@ -39,7 +39,7 @@ ___
 
 ▸ **decodeSig**(`sig`: any): *object*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:209](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L209)*
+*Defined in [contractkit/src/utils/signing-utils.ts:208](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L208)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **recoverMessageSigner**(`signingDataHex`: string, `signedData`: string): *string*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:188](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L188)*
+*Defined in [contractkit/src/utils/signing-utils.ts:187](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L187)*
 
 **Parameters:**
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **recoverTransaction**(`rawTx`: string): *[Tx, string]*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:156](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L156)*
+*Defined in [contractkit/src/utils/signing-utils.ts:155](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L155)*
 
 **Parameters:**
 
@@ -148,7 +148,7 @@ ___
 
 ▸ **verifyEIP712TypedDataSigner**(`typedData`: EIP712TypedData, `signedData`: string, `expectedAddress`: string): *boolean*
 
-*Defined in [contractkit/src/utils/signing-utils.ts:198](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L198)*
+*Defined in [contractkit/src/utils/signing-utils.ts:197](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L197)*
 
 **Parameters:**
 


### PR DESCRIPTION
### Description

The transaction hash we generate in ContractKit doesn't match what we generate in geth.

### Other changes

N/A

### Tested

This script will show the issue, try it with this branch and then current master:

```
import { newKit, CeloContract } from "@celo/contractkit"
import { LocalWallet } from "@celo/contractkit/lib/wallets/local-wallet"

const privateKey =
  "0xc5be16549e8c9a53e07a8a40515f581883feb93dad3083c9a271cbdb769f864d"

async function main() {
  const wallet = new LocalWallet()
  wallet.addAccount(privateKey)
  const [from] = wallet.getAccounts()

  const kit = newKit("https://alfajores-forno.celo-testnet.org", wallet)

  const nonce = await kit.web3.eth.getTransactionCount(from)
  const value = kit.web3.utils.toWei("1", "ether")
  const chainId = await kit.web3.eth.getChainId()
  const goldToken = await kit.contracts.getGoldToken()
  const gasPriceMinimumContract = await kit.contracts.getGasPriceMinimum()
  const goldTokenAddress = await kit.registry.addressFor(
    CeloContract.GoldToken,
  )
  const gasPriceMinimum = await gasPriceMinimumContract.getGasPriceMinimum(
    goldTokenAddress,
  )

  const to = "0xf9405fd0af7c5cb71ff68a01238730bd79041502"
  const txo = goldToken.transfer(to, value).txo
  const estimatedGas = await txo.estimateGas({ from })
  const data = txo.encodeABI()
  const params = {
    to,
    from,
    // todo: figure out proper numbers here
    gasPrice: gasPriceMinimum.toNumber() * 1.3,
    gas: Math.ceil(estimatedGas * 1.3),
    data,
    chainId,
    nonce,
    value,
    feeCurrency: "0x",
    gatewayFeeRecipient: "0x",
    gatewayFee: "0x0",
    common: "0x",
    chain: "0x",
    hardfork: "0x",
  }
  const walletSignedTx = await wallet.signTransaction(params)
  console.log("locally generated hash", walletSignedTx.tx.hash)

  const a = await kit.web3.eth.sendSignedTransaction(walletSignedTx.raw)
  console.log("hash from blockchain", a.transactionHash)
}

main()
```

### Related issues

N/A

### Backwards compatibility

It's currently broken so people are depending on incorrect hashes.