### PR TITLE
[Phone Number Privacy] Include celo utils as explicit dependency

### DIFF
--- a/dependency-graph.json
+++ b/dependency-graph.json
@@ -163,7 +163,9 @@
   },
   "@celo/phone-number-privacy-common": {
     "location": "packages/phone-number-privacy/common",
-    "dependencies": []
+    "dependencies": [
+      "@celo/utils"
+    ]
   },
   "@celo/phone-number-privacy-signer": {
     "location": "packages/phone-number-privacy/signer",

--- a/packages/phone-number-privacy/common/package.json
+++ b/packages/phone-number-privacy/common/package.json
@@ -16,6 +16,7 @@
     "lib/**/*"
   ],
   "dependencies": {
+    "@celo/utils": "^0.1.17-dev",
     "bignumber.js": "^9.0.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
### Description

Adding @celo/utils as explicit dependency in `phone-number-privacy/common` as it is used in input-validation.ts

Was seeing "src/utils/input-validation.ts(1,47): error TS2307: Cannot find module '@celo/utils/lib/address'." when running `yarn build`

### Tested

Ran yarn build

### Backwards compatibility

Yes