### PR TITLE
[Wallet] Witdraw CELO QR scan fixes

### DIFF
--- a/packages/mobile/src/exchange/WithdrawCeloQrScannerScreen.tsx
+++ b/packages/mobile/src/exchange/WithdrawCeloQrScannerScreen.tsx
@@ -6,13 +6,18 @@ import { componentStyles } from '@celo/react-components/styles/styles'
 import { StackScreenProps } from '@react-navigation/stack'
 import { memoize } from 'lodash'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
+import { showMessage } from 'src/alert/actions'
+import { ErrorMessages } from 'src/app/ErrorMessages'
 import BackButton from 'src/components/BackButton.v2'
-import i18n from 'src/i18n'
+import i18n, { Namespaces } from 'src/i18n'
 import { nuxNavigationOptions } from 'src/navigator/Headers.v2'
 import { navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import QRScanner from 'src/qrcode/QRScanner'
+import { uriDataFromUrl } from 'src/qrcode/schema'
 import { QrCode } from 'src/send/actions'
 import Logger from 'src/utils/Logger'
 
@@ -22,7 +27,7 @@ type Props = StackScreenProps<StackParamList, Screens.WithdrawCeloQrScannerScree
 
 function fetchAddressFromQrData(data: string): string | null {
   try {
-    return JSON.parse(data).address
+    return uriDataFromUrl(data).address
   } catch (error) {
     return null
   }
@@ -31,13 +36,20 @@ function fetchAddressFromQrData(data: string): string | null {
 function WithdrawCeloQrScannerScreen({ route }: Props) {
   const { onAddressScanned } = route.params
 
+  const { t } = useTranslation(Namespaces.global)
+  const dispatch = useDispatch()
+
   const onBarCodeDetected = memoize(
     (qrCode: QrCode) => {
       const qrData = qrCode.data
       Logger.debug(TAG, 'Bar code detected: ' + qrData)
       const address = fetchAddressFromQrData(qrData) || qrData
-      onAddressScanned(address)
-      navigateBack()
+      if (address.startsWith('0x') && address.length === 42) {
+        onAddressScanned(address)
+        navigateBack()
+      } else {
+        dispatch(showMessage(t(ErrorMessages.QR_FAILED_INVALID_ADDRESS)))
+      }
     },
     (qrCode) => qrCode.data
   )

--- a/packages/mobile/src/exchange/WithdrawCeloQrScannerScreen.tsx
+++ b/packages/mobile/src/exchange/WithdrawCeloQrScannerScreen.tsx
@@ -6,12 +6,12 @@ import { componentStyles } from '@celo/react-components/styles/styles'
 import { StackScreenProps } from '@react-navigation/stack'
 import { memoize } from 'lodash'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
-import { showMessage } from 'src/alert/actions'
+import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import BackButton from 'src/components/BackButton.v2'
-import i18n, { Namespaces } from 'src/i18n'
+import { ADDRESS_LENGTH } from 'src/exchange/reducer'
+import i18n from 'src/i18n'
 import { nuxNavigationOptions } from 'src/navigator/Headers.v2'
 import { navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -35,8 +35,6 @@ function fetchAddressFromQrData(data: string): string | null {
 
 function WithdrawCeloQrScannerScreen({ route }: Props) {
   const { onAddressScanned } = route.params
-
-  const { t } = useTranslation(Namespaces.global)
   const dispatch = useDispatch()
 
   const onBarCodeDetected = memoize(
@@ -44,11 +42,11 @@ function WithdrawCeloQrScannerScreen({ route }: Props) {
       const qrData = qrCode.data
       Logger.debug(TAG, 'Bar code detected: ' + qrData)
       const address = fetchAddressFromQrData(qrData) || qrData
-      if (address.startsWith('0x') && address.length === 42) {
+      if (address.startsWith('0x') && address.length === ADDRESS_LENGTH) {
         onAddressScanned(address)
         navigateBack()
       } else {
-        dispatch(showMessage(t(ErrorMessages.QR_FAILED_INVALID_ADDRESS)))
+        dispatch(showError(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
       }
     },
     (qrCode) => qrCode.data

--- a/packages/mobile/src/exchange/WithdrawCeloScreen.tsx
+++ b/packages/mobile/src/exchange/WithdrawCeloScreen.tsx
@@ -17,6 +17,7 @@ import { CeloExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import AccountAddressInput from 'src/components/AccountAddressInput'
 import CeloAmountInput from 'src/components/CeloAmountInput'
+import { ADDRESS_LENGTH } from 'src/exchange/reducer'
 import { CURRENCY_ENUM } from 'src/geth/consts'
 import i18n, { Namespaces } from 'src/i18n'
 import { HeaderTitleWithBalance, headerWithBackButton } from 'src/navigator/Headers.v2'
@@ -38,7 +39,7 @@ function WithdrawCeloScreen({ navigation }: Props) {
   const celoToTransferNumber = new BigNumber(celoToTransfer)
   const readyToReview =
     accountAddress.startsWith('0x') &&
-    accountAddress.length === 42 &&
+    accountAddress.length === ADDRESS_LENGTH &&
     celoToTransferNumber.isGreaterThan(0) &&
     celoToTransferNumber.isLessThanOrEqualTo(goldBalanceNumber)
 

--- a/packages/mobile/src/exchange/reducer.ts
+++ b/packages/mobile/src/exchange/reducer.ts
@@ -4,6 +4,7 @@ import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persi
 import { RootState } from 'src/redux/reducers'
 
 export const MAX_HISTORY_RETENTION = 30 * 24 * 3600 * 1000 // (ms) ~ 180 days
+export const ADDRESS_LENGTH = 42
 
 export interface ExchangeRatePair {
   goldMaker: string // number of dollarTokens received for one goldToken

--- a/packages/mobile/src/qrcode/utils.ts
+++ b/packages/mobile/src/qrcode/utils.ts
@@ -1,11 +1,10 @@
 import * as RNFS from 'react-native-fs'
 import Share from 'react-native-share'
 import { call, put } from 'redux-saga/effects'
-import { showMessage } from 'src/alert/actions'
+import { showError, showMessage } from 'src/alert/actions'
 import { SendEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import i18n from 'src/i18n'
 import { validateRecipientAddressSuccess } from 'src/identity/actions'
 import { AddressToE164NumberType, E164NumberToAddressType } from 'src/identity/reducer'
 import { replace } from 'src/navigator/NavigationService'
@@ -104,7 +103,7 @@ export function* handleBarcode(
   try {
     qrData = uriDataFromUrl(barcode.data)
   } catch (e) {
-    yield put(showMessage(i18n.t(`global:${ErrorMessages.QR_FAILED_INVALID_ADDRESS}`)))
+    yield put(showError(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
     Logger.error(TAG, 'qr scan failed', e)
     return
   }

--- a/packages/mobile/src/qrcode/utils.ts
+++ b/packages/mobile/src/qrcode/utils.ts
@@ -5,6 +5,7 @@ import { showMessage } from 'src/alert/actions'
 import { SendEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import i18n from 'src/i18n'
 import { validateRecipientAddressSuccess } from 'src/identity/actions'
 import { AddressToE164NumberType, E164NumberToAddressType } from 'src/identity/reducer'
 import { replace } from 'src/navigator/NavigationService'
@@ -103,7 +104,7 @@ export function* handleBarcode(
   try {
     qrData = uriDataFromUrl(barcode.data)
   } catch (e) {
-    yield put(showMessage(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
+    yield put(showMessage(i18n.t(`global:${ErrorMessages.QR_FAILED_INVALID_ADDRESS}`)))
     Logger.error(TAG, 'qr scan failed', e)
     return
   }

--- a/packages/mobile/src/send/saga.test.ts
+++ b/packages/mobile/src/send/saga.test.ts
@@ -146,7 +146,7 @@ describe(watchQrCodeDetections, () => {
         [select(e164NumberToAddressSelector), {}],
       ])
       .dispatch({ type: Actions.BARCODE_DETECTED, data })
-      .put(showMessage(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
+      .put(showMessage(`global:${ErrorMessages.QR_FAILED_INVALID_ADDRESS}`))
       .silentRun()
     expect(navigate).not.toHaveBeenCalled()
   })
@@ -166,7 +166,7 @@ describe(watchQrCodeDetections, () => {
         [select(e164NumberToAddressSelector), {}],
       ])
       .dispatch({ type: Actions.BARCODE_DETECTED, data })
-      .put(showMessage(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
+      .put(showMessage(`global:${ErrorMessages.QR_FAILED_INVALID_ADDRESS}`))
       .silentRun()
     expect(navigate).not.toHaveBeenCalled()
   })

--- a/packages/mobile/src/send/saga.test.ts
+++ b/packages/mobile/src/send/saga.test.ts
@@ -1,6 +1,6 @@
 import { expectSaga } from 'redux-saga-test-plan'
 import { select } from 'redux-saga/effects'
-import { showMessage } from 'src/alert/actions'
+import { showError, showMessage } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { validateRecipientAddressSuccess } from 'src/identity/actions'
 import {
@@ -146,7 +146,7 @@ describe(watchQrCodeDetections, () => {
         [select(e164NumberToAddressSelector), {}],
       ])
       .dispatch({ type: Actions.BARCODE_DETECTED, data })
-      .put(showMessage(`global:${ErrorMessages.QR_FAILED_INVALID_ADDRESS}`))
+      .put(showError(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
       .silentRun()
     expect(navigate).not.toHaveBeenCalled()
   })
@@ -166,7 +166,7 @@ describe(watchQrCodeDetections, () => {
         [select(e164NumberToAddressSelector), {}],
       ])
       .dispatch({ type: Actions.BARCODE_DETECTED, data })
-      .put(showMessage(`global:${ErrorMessages.QR_FAILED_INVALID_ADDRESS}`))
+      .put(showError(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
       .silentRun()
     expect(navigate).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
### Description

The withdraw CELO PR (https://github.com/celo-org/celo-monorepo/pull/4646) used the old QR format that was modified by another PR (https://github.com/celo-org/celo-monorepo/pull/4536/files). With the new format, scanning a QR is not returning the correct address. This PR fixes that and adds an error message if an invalid QR is scanned

### Tested

On an Android physical phone.

### Related issues

- Fixes #4732 and #4731