### PR TITLE
Alternative proposal for error semantics

### DIFF
--- a/packages/base/src/result.ts
+++ b/packages/base/src/result.ts
@@ -28,9 +28,9 @@ export function isError<TResult, TError extends Error>(
   return result.status === ResultStatus.Error
 }
 export function isOk<TResult, TError extends Error>(
-  task: Result<TResult, TError>
-): task is OkResult<TResult> {
-  return task.status === ResultStatus.Ok
+  result: Result<TResult, TError>
+): result is OkResult<TResult> {
+  return result.status === ResultStatus.Ok
 }
 
 export function throwIfError<TResult, TError extends Error, TModifiedError extends Error>(

--- a/packages/contractkit/src/identity/offchain/schema-utils.ts
+++ b/packages/contractkit/src/identity/offchain/schema-utils.ts
@@ -9,22 +9,19 @@ export enum SchemaErrorTypes {
   OffchainError = 'OffchainError',
 }
 
-export interface InvalidDataError extends Error {
-  errorType: SchemaErrorTypes.InvalidDataError
-}
-export interface IOffchainError extends Error {
-  errorType: SchemaErrorTypes.OffchainError
-  error: OffchainErrors
+export class InvalidDataError extends RootError<SchemaErrorTypes.InvalidDataError> {
+  constructor() {
+    super(SchemaErrorTypes.InvalidDataError)
+  }
 }
 
-export class OffchainError extends RootError<SchemaErrorTypes.OffchainError>
-  implements IOffchainError {
+export class OffchainError extends RootError<SchemaErrorTypes.OffchainError> {
   constructor(readonly error: OffchainErrors) {
     super(SchemaErrorTypes.OffchainError)
   }
 }
 
-type SchemaErrors = InvalidDataError | IOffchainError
+type SchemaErrors = InvalidDataError | OffchainError
 
 export class SingleSchema<T> {
   constructor(

--- a/packages/contractkit/src/identity/offchain/schemas.ts
+++ b/packages/contractkit/src/identity/offchain/schemas.ts
@@ -28,7 +28,6 @@ export class AuthorizedSignerAccessor {
   constructor(readonly wrapper: OffchainDataWrapper) {}
 
   async readAsResult(account: Address, signer: Address) {
-    console.log(this)
     return readWithSchemaAsResult(
       this.wrapper,
       AuthorizedSignerSchema,


### PR DESCRIPTION
I'm not in love with the way the errors are initialised in the proposal I think it makes it harder to understand what's going on because we define those `interfaces` that act as the error types that the RootError can implement, so that we can have an union type of errors, but when we actually throw an error we instantiate a RootError with the enum type. 

All of that I think is a bit complicated especially when you take into account that we can also have error types that actually extend the RootError in order to contain more data / wrap other errors inside. I'd suggest going down the route of declaring Error classes all the time, even if that increases some of the JS footprint (the interface approach would melt away during typescript compilation). But it makes the semantics a bit more clear and the also nicer to work with:

```typescript
return Err(new NoStorageRootProvidedData())
// vs
return Err(new RootError(OffchainErrorTypes.FetchError))
```