### PR TITLE
Salt was renamed to pepper in the PhoneNumberHashDetails

### DIFF
--- a/packages/mobile/src/identity/privateHashing.ts
+++ b/packages/mobile/src/identity/privateHashing.ts
@@ -66,7 +66,8 @@ function* doFetchPhoneHashPrivate(e164Number: string) {
   if (cachedSalt) {
     Logger.debug(`${TAG}@fetchPrivatePhoneHash`, 'Salt was cached')
     const phoneHash = getPhoneHash(e164Number, cachedSalt)
-    return { e164Number, phoneHash, salt: cachedSalt }
+    const cachedDetails: PhoneNumberHashDetails = { e164Number, phoneHash, pepper: cachedSalt }
+    return cachedDetails
   }
 
   Logger.debug(`${TAG}@fetchPrivatePhoneHash`, 'Salt was not cached, fetching')


### PR DESCRIPTION
### Description

Looks like there's a leftover `salt` -> `pepper` here that wasn't caught because our generators aren't strictly typed. This feels dangerous and should be treated more broadly, but I know generators are notoriously hard to type because of the yield typing semantics.

For now I introduced a typed const to ensure correct typing -- feels like this should be a pattern instead of directly returning objects from generators as that will never complain about structure.

### Tested

Curious why tests didn't flag this - we don't have cached pepper related tests?