### PR TITLE
Enable usdGas + useLedger and refactor usdGas to gasCurrency

### DIFF
--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -107,7 +107,6 @@ export abstract class BaseCommand extends LocalCommand {
   // to its definition:
   //   requireSynced = false
   public requireSynced: boolean = true
-  protected gasCurrencyConfig?: GasOptions | undefined
 
   private _web3: Web3 | null = null
   private _kit: ContractKit | null = null
@@ -191,19 +190,17 @@ export abstract class BaseCommand extends LocalCommand {
       this.kit.defaultAccount = res.flags.from
     }
 
-    this.gasCurrencyConfig = res.flags.gasCurrency
+    const gasCurrencyConfig = res.flags.gasCurrency
       ? GasOptions[res.flags.gasCurrency as keyof typeof GasOptions]
       : getGasCurrency(this.config.configDir)
 
-    if (this.gasCurrencyConfig) {
-      const setUsd = () => this.kit.setFeeCurrency(CeloContract.StableToken)
-      if (this.gasCurrencyConfig === GasOptions.cUSD) {
-        await setUsd()
-      } else if (this.gasCurrencyConfig === GasOptions.auto && this.kit.defaultAccount) {
-        const balances = await this.kit.getTotalBalance(this.kit.defaultAccount)
-        if (balances.CELO.isZero()) {
-          await setUsd()
-        }
+    const setUsdGas = () => this.kit.setFeeCurrency(CeloContract.StableToken)
+    if (gasCurrencyConfig === GasOptions.cUSD) {
+      await setUsdGas()
+    } else if (gasCurrencyConfig === GasOptions.auto && this.kit.defaultAccount) {
+      const balances = await this.kit.getTotalBalance(this.kit.defaultAccount)
+      if (balances.CELO.isZero()) {
+        await setUsdGas()
       }
     }
   }

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -55,7 +55,7 @@ export abstract class BaseCommand extends LocalCommand {
     gasCurrency: flags.enum({
       options: Object.keys(GasOptions),
       description:
-        "Use a specific gas currency for transaction fees ('auto' defaults to denomination of transfer or whatever is available)",
+        "Use a specific gas currency for transaction fees (defaults to 'auto' which uses whatever feeCurrency is available)",
     }),
     useLedger: flags.boolean({
       default: false,

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -187,6 +187,10 @@ export abstract class BaseCommand extends LocalCommand {
       }
     }
 
+    if (res.flags.from) {
+      this.kit.defaultAccount = res.flags.from
+    }
+
     this.gasCurrencyConfig = res.flags.gasCurrency
       ? GasOptions[res.flags.gasCurrency as keyof typeof GasOptions]
       : getGasCurrency(this.config.configDir)

--- a/packages/cli/src/commands/account/authorize.ts
+++ b/packages/cli/src/commands/account/authorize.ts
@@ -41,7 +41,7 @@ export default class Authorize extends BaseCommand {
 
   async run() {
     const res = this.parse(Authorize)
-    this.kit.defaultAccount = res.flags.from
+
     const accounts = await this.kit.contracts.getAccounts()
     const sig = accounts.parseSignatureOfAddress(
       res.flags.from,

--- a/packages/cli/src/commands/account/register-metadata.ts
+++ b/packages/cli/src/commands/account/register-metadata.ts
@@ -29,7 +29,6 @@ export default class RegisterMetadata extends BaseCommand {
 
   async run() {
     const res = this.parse(RegisterMetadata)
-    this.kit.defaultAccount = res.flags.from
 
     await newCheckBuilder(this)
       .isAccount(res.flags.from)

--- a/packages/cli/src/commands/account/register.ts
+++ b/packages/cli/src/commands/account/register.ts
@@ -23,7 +23,7 @@ export default class Register extends BaseCommand {
 
   async run() {
     const res = this.parse(Register)
-    this.kit.defaultAccount = res.flags.from
+
     const accounts = await this.kit.contracts.getAccounts()
 
     await newCheckBuilder(this)

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -19,6 +19,7 @@ export default class Set extends LocalCommand {
     'set  --node ws://localhost:2500',
     'set  --node <geth-location>/geth.ipc',
     'set --gasCurrency cUSD',
+    'set --gasCurrency CELO',
   ]
 
   async run() {

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -10,14 +10,16 @@ export default class Set extends LocalCommand {
     // Overrides base command node flag.
     node: flags.string({
       char: 'n',
-      required: false,
       description: 'URL of the node to run commands against',
-      default: 'http://localhost:8545',
     }),
     gasCurrency: BaseCommand.flags.gasCurrency,
   }
 
-  static examples = ['set  --node ws://localhost:2500', 'set  --node <geth-location>/geth.ipc']
+  static examples = [
+    'set  --node ws://localhost:2500',
+    'set  --node <geth-location>/geth.ipc',
+    'set --gasCurrency cUSD',
+  ]
 
   async run() {
     const res = this.parse(Set)

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -10,7 +10,7 @@ export default class Set extends LocalCommand {
     // Overrides base command node flag.
     node: flags.string({
       char: 'n',
-      description: 'URL of the node to run commands against',
+      description: "URL of the node to run commands against (defaults to 'http://localhost:8545')",
     }),
     gasCurrency: BaseCommand.flags.gasCurrency,
   }

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -1,6 +1,6 @@
 import { flags } from '@oclif/command'
-import { LocalCommand } from '../../base'
-import { CeloConfig, writeConfig } from '../../utils/config'
+import { BaseCommand, GasOptions, LocalCommand } from '../../base'
+import { readConfig, writeConfig } from '../../utils/config'
 
 export default class Set extends LocalCommand {
   static description = 'Configure running node information for propogating transactions to network'
@@ -10,19 +10,25 @@ export default class Set extends LocalCommand {
     // Overrides base command node flag.
     node: flags.string({
       char: 'n',
-      required: true,
+      required: false,
       description: 'URL of the node to run commands against',
       default: 'http://localhost:8545',
     }),
+    gasCurrency: BaseCommand.flags.gasCurrency,
   }
 
   static examples = ['set  --node ws://localhost:2500', 'set  --node <geth-location>/geth.ipc']
 
   async run() {
     const res = this.parse(Set)
-    const config: CeloConfig = {
-      nodeUrl: res.flags.node,
-    }
-    await writeConfig(this.config.configDir, config)
+    const curr = readConfig(this.config.configDir)
+    const node = res.flags.node ?? curr.node
+    const gasCurrency = res.flags.gasCurrency
+      ? GasOptions[res.flags.gasCurrency as keyof typeof GasOptions]
+      : curr.gasCurrency
+    writeConfig(this.config.configDir, {
+      node,
+      gasCurrency,
+    })
   }
 }

--- a/packages/cli/src/commands/election/activate.ts
+++ b/packages/cli/src/commands/election/activate.ts
@@ -23,7 +23,6 @@ export default class ElectionVote extends BaseCommand {
   async run() {
     const res = this.parse(ElectionVote)
 
-    this.kit.defaultAccount = res.flags.from
     await newCheckBuilder(this, res.flags.from)
       .isSignerOrAccount()
       .runChecks()

--- a/packages/cli/src/commands/election/revoke.ts
+++ b/packages/cli/src/commands/election/revoke.ts
@@ -24,7 +24,6 @@ export default class ElectionRevoke extends BaseCommand {
   async run() {
     const res = this.parse(ElectionRevoke)
 
-    this.kit.defaultAccount = res.flags.from
     await newCheckBuilder(this, res.flags.from)
       .isSignerOrAccount()
       .isValidatorGroup(res.flags.for)

--- a/packages/cli/src/commands/election/vote.ts
+++ b/packages/cli/src/commands/election/vote.ts
@@ -25,7 +25,6 @@ export default class ElectionVote extends BaseCommand {
     const res = this.parse(ElectionVote)
     const value = new BigNumber(res.flags.value)
 
-    this.kit.defaultAccount = res.flags.from
     await newCheckBuilder(this, res.flags.from)
       .isSignerOrAccount()
       .isValidatorGroup(res.flags.for)

--- a/packages/cli/src/commands/exchange/celo.ts
+++ b/packages/cli/src/commands/exchange/celo.ts
@@ -51,7 +51,6 @@ export default class ExchangeCelo extends BaseCommand {
       }
     }
 
-    this.kit.defaultAccount = res.flags.from
     const celoToken = await this.kit.contracts.getGoldToken()
     const exchange = await this.kit.contracts.getExchange()
 

--- a/packages/cli/src/commands/exchange/dollars.ts
+++ b/packages/cli/src/commands/exchange/dollars.ts
@@ -51,7 +51,7 @@ export default class ExchangeDollars extends BaseCommand {
         return
       }
     }
-    this.kit.defaultAccount = res.flags.from
+
     const stableToken = await this.kit.contracts.getStableToken()
     const exchange = await this.kit.contracts.getExchange()
 

--- a/packages/cli/src/commands/governance/withdraw.ts
+++ b/packages/cli/src/commands/governance/withdraw.ts
@@ -15,7 +15,7 @@ export default class Withdraw extends BaseCommand {
 
   async run() {
     const res = this.parse(Withdraw)
-    this.kit.defaultAccount = res.flags.from
+
     await newCheckBuilder(this, res.flags.from)
       .hasRefundedDeposits(res.flags.from)
       .runChecks()

--- a/packages/cli/src/commands/lockedgold/unlock.ts
+++ b/packages/cli/src/commands/lockedgold/unlock.ts
@@ -22,7 +22,7 @@ export default class Unlock extends BaseCommand {
 
   async run() {
     const res = this.parse(Unlock)
-    this.kit.defaultAccount = res.flags.from
+
     const lockedgold = await this.kit.contracts.getLockedGold()
     const value = new BigNumber(res.flags.value)
 

--- a/packages/cli/src/commands/oracle/remove-expired-reports.ts
+++ b/packages/cli/src/commands/oracle/remove-expired-reports.ts
@@ -31,7 +31,7 @@ export default class RemoveExpiredReports extends BaseCommand {
 
   async run() {
     const res = this.parse(RemoveExpiredReports)
-    this.kit.defaultAccount = res.flags.from
+
     const sortedOracles = await this.kit.contracts.getSortedOracles()
     const txo = await sortedOracles.removeExpiredReports(res.args.token)
     await displaySendTx('removeExpiredReports', txo)

--- a/packages/cli/src/commands/transfer/dollars.ts
+++ b/packages/cli/src/commands/transfer/dollars.ts
@@ -49,7 +49,7 @@ export default class TransferDollars extends BaseCommand {
           const balance = await stableToken.balanceOf(from)
           return balance.gte(value.plus(gasValue))
         },
-        `Cannot afford transfer with cUSD gasCurrency; try using gasCurrency=CELO or reducing value slightly`
+        `Cannot afford transfer with cUSD gasCurrency; try reducing value slightly or using gasCurrency=CELO`
       )
       .runChecks()
 

--- a/packages/cli/src/commands/transfer/dollars.ts
+++ b/packages/cli/src/commands/transfer/dollars.ts
@@ -28,7 +28,6 @@ export default class TransferDollars extends BaseCommand {
     const to: string = res.flags.to
     const value = new BigNumber(res.flags.value)
 
-    this.kit.defaultAccount = from
     const stableToken = await this.kit.contracts.getStableToken()
 
     const tx = res.flags.comment

--- a/packages/cli/src/commands/validator/affiliate.ts
+++ b/packages/cli/src/commands/validator/affiliate.ts
@@ -26,7 +26,7 @@ export default class ValidatorAffiliate extends BaseCommand {
 
   async run() {
     const res = this.parse(ValidatorAffiliate)
-    this.kit.defaultAccount = res.flags.from
+
     const validators = await this.kit.contracts.getValidators()
 
     await newCheckBuilder(this, res.flags.from)

--- a/packages/cli/src/commands/validator/deaffiliate.ts
+++ b/packages/cli/src/commands/validator/deaffiliate.ts
@@ -16,7 +16,7 @@ export default class ValidatorDeAffiliate extends BaseCommand {
 
   async run() {
     const res = this.parse(ValidatorDeAffiliate)
-    this.kit.defaultAccount = res.flags.from
+
     const validators = await this.kit.contracts.getValidators()
 
     await newCheckBuilder(this, res.flags.from)

--- a/packages/cli/src/commands/validator/deregister.ts
+++ b/packages/cli/src/commands/validator/deregister.ts
@@ -17,7 +17,6 @@ export default class ValidatorDeregister extends BaseCommand {
   async run() {
     const res = this.parse(ValidatorDeregister)
 
-    this.kit.defaultAccount = res.flags.from
     const validators = await this.kit.contracts.getValidators()
 
     await newCheckBuilder(this, res.flags.from)

--- a/packages/cli/src/commands/validator/force-deaffiliate.ts
+++ b/packages/cli/src/commands/validator/force-deaffiliate.ts
@@ -19,7 +19,7 @@ export default class ValidatorForceDeaffiliate extends BaseCommand {
 
   async run() {
     const res = this.parse(ValidatorForceDeaffiliate)
-    this.kit.defaultAccount = res.flags.from
+
     const validators = await this.kit.contracts.getValidators()
 
     await newCheckBuilder(this, res.flags.validator)

--- a/packages/cli/src/commands/validator/register.ts
+++ b/packages/cli/src/commands/validator/register.ts
@@ -24,7 +24,6 @@ export default class ValidatorRegister extends BaseCommand {
 
   async run() {
     const res = this.parse(ValidatorRegister)
-    this.kit.defaultAccount = res.flags.from
 
     const validators = await this.kit.contracts.getValidators()
     const accounts = await this.kit.contracts.getAccounts()

--- a/packages/cli/src/commands/validator/update-bls-public-key.ts
+++ b/packages/cli/src/commands/validator/update-bls-public-key.ts
@@ -19,7 +19,7 @@ export default class ValidatorUpdateBlsPublicKey extends BaseCommand {
   ]
   async run() {
     const res = this.parse(ValidatorUpdateBlsPublicKey)
-    this.kit.defaultAccount = res.flags.from
+
     const validators = await this.kit.contracts.getValidators()
     await newCheckBuilder(this, res.flags.from)
       .isSignerOrAccount()

--- a/packages/cli/src/commands/validatorgroup/commission.ts
+++ b/packages/cli/src/commands/validatorgroup/commission.ts
@@ -39,7 +39,6 @@ export default class ValidatorGroupCommission extends BaseCommand {
       return
     }
 
-    this.kit.defaultAccount = res.flags.from
     const validators = await this.kit.contracts.getValidators()
 
     if (res.flags['queue-update']) {

--- a/packages/cli/src/commands/validatorgroup/deregister.ts
+++ b/packages/cli/src/commands/validatorgroup/deregister.ts
@@ -17,7 +17,6 @@ export default class ValidatorGroupDeRegister extends BaseCommand {
   async run() {
     const res = this.parse(ValidatorGroupDeRegister)
 
-    this.kit.defaultAccount = res.flags.from
     const validators = await this.kit.contracts.getValidators()
 
     const account = await validators.signerToAccount(res.flags.from)

--- a/packages/cli/src/commands/validatorgroup/member.ts
+++ b/packages/cli/src/commands/validatorgroup/member.ts
@@ -43,7 +43,6 @@ export default class ValidatorGroupMembers extends BaseCommand {
       return
     }
 
-    this.kit.defaultAccount = res.flags.from
     const validators = await this.kit.contracts.getValidators()
 
     await newCheckBuilder(this, res.flags.from)

--- a/packages/cli/src/commands/validatorgroup/register.ts
+++ b/packages/cli/src/commands/validatorgroup/register.ts
@@ -25,7 +25,6 @@ export default class ValidatorGroupRegister extends BaseCommand {
   async run() {
     const res = this.parse(ValidatorGroupRegister)
 
-    this.kit.defaultAccount = res.flags.from
     const validators = await this.kit.contracts.getValidators()
     const commission = new BigNumber(res.flags.commission)
 

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -6,11 +6,12 @@ import { GasOptions } from '../base'
 
 export interface CeloConfig {
   node: string
-  gasCurrency?: GasOptions
+  gasCurrency: GasOptions
 }
 
 export const localGeth: CeloConfig = {
   node: 'http://localhost:8545',
+  gasCurrency: GasOptions.auto,
 }
 
 const configFile = 'config.json'
@@ -31,7 +32,7 @@ export function getNodeUrl(configDir: string): string {
   return readConfig(configDir).node
 }
 
-export function getGasCurrency(configDir: string): GasOptions | undefined {
+export function getGasCurrency(configDir: string): GasOptions {
   return readConfig(configDir).gasCurrency
 }
 

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -9,7 +9,7 @@ export interface CeloConfig {
   gasCurrency: GasOptions
 }
 
-export const localGeth: CeloConfig = {
+export const defaultConfig: CeloConfig = {
   node: 'http://localhost:8545',
   gasCurrency: GasOptions.auto,
 }
@@ -24,7 +24,7 @@ export function readConfig(configDir: string): CeloConfig {
   if (fs.pathExistsSync(configPath(configDir))) {
     return fs.readJSONSync(configPath(configDir))
   } else {
-    return localGeth
+    return defaultConfig
   }
 }
 

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -11,7 +11,7 @@ export interface CeloConfig {
 
 export const defaultConfig: CeloConfig = {
   node: 'http://localhost:8545',
-  gasCurrency: GasOptions.auto,
+  gasCurrency: 'auto' as GasOptions,
 }
 
 const configFile = 'config.json'

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -2,13 +2,15 @@
 // TODO: investigate tslint issues
 import * as fs from 'fs-extra'
 import * as path from 'path'
+import { GasOptions } from '../base'
 
 export interface CeloConfig {
-  nodeUrl: string
+  node: string
+  gasCurrency?: GasOptions
 }
 
 export const localGeth: CeloConfig = {
-  nodeUrl: 'http://localhost:8545',
+  node: 'http://localhost:8545',
 }
 
 const configFile = 'config.json'
@@ -26,7 +28,11 @@ export function readConfig(configDir: string): CeloConfig {
 }
 
 export function getNodeUrl(configDir: string): string {
-  return readConfig(configDir).nodeUrl
+  return readConfig(configDir).node
+}
+
+export function getGasCurrency(configDir: string): GasOptions | undefined {
+  return readConfig(configDir).gasCurrency
 }
 
 export function writeConfig(configDir: string, configObj: CeloConfig) {

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -23,6 +23,9 @@ OPTIONS
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Account Address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)        Use a specific gas currency for transaction fees (defaults to
+                                                       'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                    [default: 1] If --useLedger is set, this will get the first N
                                                        addresses for local signing
 
@@ -37,9 +40,6 @@ OPTIONS
                                                        key
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-
-  --usdGas                                             If --usdGas is set, the transaction is paid for with a
-                                                       feeCurrency of cUSD
 
   --useLedger                                          Set it to use a ledger wallet
 
@@ -68,7 +68,8 @@ USAGE
   $ celocli account:balance ADDRESS
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   balance 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -93,6 +94,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -105,9 +109,6 @@ OPTIONS
 
   --publicKey=publicKey                              The public key of the account that others may use to send you
                                                      encrypted messages
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -133,6 +134,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -144,9 +148,6 @@ OPTIONS
                                                      "[4,99]"
 
   --url=https://www.celo.org                         (required) The url you want to claim
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -174,6 +175,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -183,9 +187,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -210,6 +211,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -219,9 +223,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -248,6 +249,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -259,9 +263,6 @@ OPTIONS
                                                      "[4,99]"
 
   --name=name                                        (required) The name you want to claim
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -286,6 +287,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -297,9 +301,6 @@ OPTIONS
                                                      "[4,99]"
 
   --url=https://www.celo.org                         (required) The URL of the storage root you want to claim
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -324,6 +325,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -333,9 +337,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -357,6 +358,9 @@ ARGUMENTS
   ADDRESS  Address to get metadata for
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -365,9 +369,6 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -386,6 +387,9 @@ USAGE
   $ celocli account:list
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -397,9 +401,6 @@ OPTIONS
 
   --[no-]local                                   If set, only show local and hardware wallet accounts. Use no-local to
                                                  only show keystore addresses.
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 ```
@@ -418,7 +419,8 @@ ARGUMENTS
   ACCOUNT  Account address
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   lock 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -481,6 +483,9 @@ OPTIONS
   --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account that needs to prove possession
                                                         of the signer key.
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
+                                                        'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
 
@@ -492,9 +497,6 @@ OPTIONS
                                                         --ledgerCustomAddresses "[4,99]"
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer key to prove possession of.
-
-  --usdGas                                              If --usdGas is set, the transaction is paid for with a
-                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 
@@ -561,6 +563,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -572,9 +577,6 @@ OPTIONS
                                                      "[4,99]"
 
   --name=name
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -597,6 +599,9 @@ OPTIONS
   --force                                            Ignore metadata validity checks
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Addess of the account to set metadata for
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -608,9 +613,6 @@ OPTIONS
                                                      "[4,99]"
 
   --url=https://www.celo.org                         (required) The url to the metadata you want to register
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -631,6 +633,9 @@ USAGE
 OPTIONS
   --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
+                                                        'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
 
@@ -642,9 +647,6 @@ OPTIONS
                                                         --ledgerCustomAddresses "[4,99]"
 
   --name=name                                           (required)
-
-  --usdGas                                              If --usdGas is set, the transaction is paid for with a
-                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 
@@ -663,6 +665,9 @@ USAGE
   $ celocli account:show ADDRESS
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -671,9 +676,6 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -692,6 +694,9 @@ USAGE
   $ celocli account:show-claimed-accounts ADDRESS
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -700,9 +705,6 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -724,6 +726,9 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -732,9 +737,6 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -756,9 +758,14 @@ ARGUMENTS
   ACCOUNT  Account address
 
 OPTIONS
-  --duration=duration  Duration in seconds to leave the account unlocked. Unlocks until the node exits by default.
-  --password=password  Password used to unlock the account. If not specified, you will be prompted for a password.
-  --usdGas             If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --duration=duration                            Duration in seconds to leave the account unlocked. Unlocks until the
+                                                 node exits by default.
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
+  --password=password                            Password used to unlock the account. If not specified, you will be
+                                                 prompted for a password.
 
 EXAMPLES
   unlock 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -779,6 +786,9 @@ OPTIONS
   --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account that needs to prove possession
                                                         of the signer key.
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
+                                                        'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
 
@@ -794,9 +804,6 @@ OPTIONS
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer key to verify proof of
                                                         possession.
-
-  --usdGas                                              If --usdGas is set, the transaction is paid for with a
-                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/config.md
+++ b/packages/docs/command-line-interface/config.md
@@ -24,11 +24,17 @@ USAGE
   $ celocli config:set
 
 OPTIONS
-  -n, --node=node  (required) [default: http://localhost:8545] URL of the node to run commands against
+  -n, --node=node                                URL of the node to run commands against (defaults to
+                                                 'http://localhost:8545')
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLES
   set  --node ws://localhost:2500
   set  --node <geth-location>/geth.ipc
+  set --gasCurrency cUSD
+  set --gasCurrency CELO
 ```
 
 _See code: [packages/cli/src/commands/config/set.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/config/set.ts)_

--- a/packages/docs/command-line-interface/dkg.md
+++ b/packages/docs/command-line-interface/dkg.md
@@ -15,6 +15,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -28,9 +31,6 @@ OPTIONS
   --phaseDuration=phaseDuration                      (required) Duration of each DKG phase in blocks
 
   --threshold=threshold                              (required) The threshold to use for the DKG
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 ```
@@ -48,6 +48,10 @@ USAGE
 OPTIONS
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d                 (required) DKG Contract Address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)                        Use a specific gas currency for transaction fees
+                                                                       (defaults to 'auto' which uses whatever
+                                                                       feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                                    [default: 1] If --useLedger is set, this will get
                                                                        the first N addresses for local signing
 
@@ -59,9 +63,6 @@ OPTIONS
                                                                        signing. Example --ledgerCustomAddresses "[4,99]"
 
   --method=(shares|responses|justifications|participants|phase|group)  (required) Getter method to call
-
-  --usdGas                                                             If --usdGas is set, the transaction is paid for
-                                                                       with a feeCurrency of cUSD
 
   --useLedger                                                          Set it to use a ledger wallet
 ```
@@ -81,6 +82,9 @@ OPTIONS
   --data=data                                           (required) Path to the data being published
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
+                                                        'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
 
@@ -90,9 +94,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses         [default: [0]] If --useLedger is set, this will get the array of
                                                         index addresses for local signing. Example
                                                         --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                              If --usdGas is set, the transaction is paid for with a
-                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 ```
@@ -112,6 +113,9 @@ OPTIONS
   --blsKey=blsKey                                       (required)
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
+                                                        'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
 
@@ -121,9 +125,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses         [default: [0]] If --useLedger is set, this will get the array of
                                                         index addresses for local signing. Example
                                                         --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                              If --usdGas is set, the transaction is paid for with a
-                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 ```
@@ -142,6 +143,9 @@ OPTIONS
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
+                                                        'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
 
@@ -151,9 +155,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses         [default: [0]] If --useLedger is set, this will get the array of
                                                         index addresses for local signing. Example
                                                         --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                              If --usdGas is set, the transaction is paid for with a
-                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 ```
@@ -172,6 +173,9 @@ OPTIONS
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
+                                                        'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
 
@@ -183,9 +187,6 @@ OPTIONS
                                                         --ledgerCustomAddresses "[4,99]"
 
   --participantAddress=participantAddress               (required) Address of the participant to whitelist
-
-  --usdGas                                              If --usdGas is set, the transaction is paid for with a
-                                                        feeCurrency of cUSD
 
   --useLedger                                           Set it to use a ledger wallet
 ```

--- a/packages/docs/command-line-interface/election.md
+++ b/packages/docs/command-line-interface/election.md
@@ -15,6 +15,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -24,9 +27,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -48,10 +48,12 @@ USAGE
   $ celocli election:current
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
-  --valset  Show currently used signers from valset (by default the authorized validator signers are shown). Useful for
-            checking if keys have been rotated.
+  --valset                                       Show currently used signers from valset (by default the authorized
+                                                 validator signers are shown). Useful for checking if keys have been
+                                                 rotated.
 ```
 
 _See code: [packages/cli/src/commands/election/current.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/election/current.ts)_
@@ -65,7 +67,8 @@ USAGE
   $ celocli election:list
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   list
@@ -85,6 +88,9 @@ OPTIONS
   --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) ValidatorGroup's address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -94,9 +100,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -118,7 +121,8 @@ USAGE
   $ celocli election:run
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 ```
 
 _See code: [packages/cli/src/commands/election/run.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/election/run.ts)_
@@ -135,9 +139,12 @@ ARGUMENTS
   ADDRESS  Voter or Validator Groups's address
 
 OPTIONS
-  --group   Show information about a group running in Validator elections
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
-  --voter   Show information about an account voting in Validator elections
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
+  --group                                        Show information about a group running in Validator elections
+
+  --voter                                        Show information about an account voting in Validator elections
 
 EXAMPLES
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3 --voter
@@ -158,6 +165,9 @@ OPTIONS
   --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) ValidatorGroup's address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -167,9 +177,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/exchange.md
+++ b/packages/docs/command-line-interface/exchange.md
@@ -18,6 +18,9 @@ OPTIONS
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with CELO to exchange
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -27,9 +30,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -56,6 +56,9 @@ OPTIONS
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with Celo Dollars to exchange
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -65,9 +68,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -94,6 +94,9 @@ OPTIONS
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with CELO to exchange
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -103,9 +106,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -127,8 +127,11 @@ USAGE
   $ celocli exchange:show
 
 OPTIONS
-  --amount=amount  [default: 1000000000000000000] Amount of the token being exchanged to report rates for
-  --usdGas         If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --amount=amount                                [default: 1000000000000000000] Amount of the token being exchanged to
+                                                 report rates for
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   list

--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -15,6 +15,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) From address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -24,9 +27,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -47,6 +47,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Executor's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -58,9 +61,6 @@ OPTIONS
                                                      "[4,99]"
 
   --proposalID=proposalID                            (required) UUID of proposal to execute
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -80,6 +80,10 @@ USAGE
 
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Executors's address
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --jsonTransactions=jsonTransactions                (required) Path to json transactions
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
@@ -93,9 +97,6 @@ OPTIONS
                                                      "[4,99]"
 
   --salt=salt                                        (required) Secret salt associated with hotfix
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -115,6 +116,9 @@ USAGE
   $ celocli governance:hashhotfix
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --jsonTransactions=jsonTransactions            (required) Path to json transactions of the hotfix
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
@@ -127,9 +131,6 @@ OPTIONS
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
 
   --salt=salt                                    (required) Secret salt associated with hotfix
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -149,7 +150,8 @@ USAGE
   $ celocli governance:list
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   list
@@ -167,6 +169,10 @@ USAGE
 
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Preparer's address
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --hash=hash                                        (required) Hash of hotfix transactions
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
@@ -178,9 +184,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -207,6 +210,9 @@ OPTIONS
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Proposer's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --jsonTransactions=jsonTransactions                (required) Path to json transactions
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
@@ -218,9 +224,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -242,6 +245,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Upvoter's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -251,9 +257,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -272,14 +275,22 @@ USAGE
   $ celocli governance:show
 
 OPTIONS
-  --account=account        Address of account or voter
-  --hotfix=hotfix          Hash of hotfix proposal
-  --nonwhitelisters        If set, displays validators that have not whitelisted the hotfix.
-  --notwhitelisted         List validators who have not whitelisted the specified hotfix
-  --proposalID=proposalID  UUID of proposal to view
-  --raw                    Display proposal in raw bytes format
-  --usdGas                 If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
-  --whitelisters           If set, displays validators that have whitelisted the hotfix.
+  --account=account                              Address of account or voter
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
+  --hotfix=hotfix                                Hash of hotfix proposal
+
+  --nonwhitelisters                              If set, displays validators that have not whitelisted the hotfix.
+
+  --notwhitelisted                               List validators who have not whitelisted the specified hotfix
+
+  --proposalID=proposalID                        UUID of proposal to view
+
+  --raw                                          Display proposal in raw bytes format
+
+  --whitelisters                                 If set, displays validators that have whitelisted the hotfix.
 
 EXAMPLES
   show --proposalID 99
@@ -303,6 +314,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Upvoter's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -314,9 +328,6 @@ OPTIONS
                                                      "[4,99]"
 
   --proposalID=proposalID                            (required) UUID of proposal to upvote
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -335,9 +346,12 @@ USAGE
   $ celocli governance:view
 
 OPTIONS
-  --proposalID=proposalID  (required) UUID of proposal to view
-  --raw                    Display proposal in raw bytes format
-  --usdGas                 If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
+  --proposalID=proposalID                        (required) UUID of proposal to view
+
+  --raw                                          Display proposal in raw bytes format
 
 EXAMPLES
   view --proposalID 99
@@ -355,10 +369,14 @@ USAGE
   $ celocli governance:viewhotfix
 
 OPTIONS
-  --hash=hash        (required) Hash of hotfix transactions
-  --nonwhitelisters  If set, displays validators that have not whitelisted the hotfix.
-  --usdGas           If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
-  --whitelisters     If set, displays validators that have whitelisted the hotfix.
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
+  --hash=hash                                    (required) Hash of hotfix transactions
+
+  --nonwhitelisters                              If set, displays validators that have not whitelisted the hotfix.
+
+  --whitelisters                                 If set, displays validators that have whitelisted the hotfix.
 
 EXAMPLES
   viewhotfix --hash 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658
@@ -379,6 +397,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -390,9 +411,6 @@ OPTIONS
                                                      "[4,99]"
 
   --proposalID=proposalID                            (required) UUID of proposal to vote on
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -414,6 +432,10 @@ USAGE
 
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Whitelister's address
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --hash=hash                                        (required) Hash of hotfix transactions
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
@@ -425,9 +447,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -449,6 +468,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Proposer's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -458,9 +480,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/identity.md
+++ b/packages/docs/command-line-interface/identity.md
@@ -13,7 +13,8 @@ USAGE
   $ celocli identity:current-attestation-services
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 ```
 
 _See code: [packages/cli/src/commands/identity/current-attestation-services.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/identity/current-attestation-services.ts)_
@@ -29,6 +30,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Your validator's signer or account address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -42,9 +46,6 @@ OPTIONS
   --message=message                                  (required) The message of the SMS
 
   --phoneNumber=+14152223333                         (required) The phone number to send the test message to
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/lockedgold.md
+++ b/packages/docs/command-line-interface/lockedgold.md
@@ -15,6 +15,9 @@ USAGE
 OPTIONS
   --from=from                                    (required)
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -23,9 +26,6 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -46,7 +46,8 @@ USAGE
   $ celocli lockedgold:show ACCOUNT
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -65,6 +66,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -74,9 +78,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -99,6 +100,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -108,9 +112,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/multisig.md
+++ b/packages/docs/command-line-interface/multisig.md
@@ -13,10 +13,14 @@ USAGE
   $ celocli multisig:show ADDRESS
 
 OPTIONS
-  --all     Show info about all transactions
-  --raw     Do not attempt to parse transactions
-  --tx=tx   Show info for a transaction
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --all                                          Show info about all transactions
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
+  --raw                                          Do not attempt to parse transactions
+
+  --tx=tx                                        Show info for a transaction
 
 EXAMPLES
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631

--- a/packages/docs/command-line-interface/network.md
+++ b/packages/docs/command-line-interface/network.md
@@ -13,7 +13,8 @@ USAGE
   $ celocli network:contracts
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 ```
 
 _See code: [packages/cli/src/commands/network/contracts.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/contracts.ts)_
@@ -27,7 +28,8 @@ USAGE
   $ celocli network:parameters
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 ```
 
 _See code: [packages/cli/src/commands/network/parameters.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/parameters.ts)_

--- a/packages/docs/command-line-interface/node.md
+++ b/packages/docs/command-line-interface/node.md
@@ -13,6 +13,9 @@ USAGE
   $ celocli node:accounts
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -21,9 +24,6 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 ```
@@ -39,8 +39,10 @@ USAGE
   $ celocli node:synced
 
 OPTIONS
-  --usdGas   If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
-  --verbose  output the full status if syncing
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
+  --verbose                                      output the full status if syncing
 ```
 
 _See code: [packages/cli/src/commands/node/synced.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/node/synced.ts)_

--- a/packages/docs/command-line-interface/oracle.md
+++ b/packages/docs/command-line-interface/oracle.md
@@ -16,7 +16,8 @@ ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to list the oracles for
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLES
   list StableToken
@@ -39,6 +40,9 @@ ARGUMENTS
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account removing oracle reports
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -48,9 +52,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -75,6 +76,9 @@ ARGUMENTS
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the oracle account
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -84,9 +88,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -111,7 +112,8 @@ ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to list the reports for
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLES
   reports StableToken

--- a/packages/docs/command-line-interface/releasegold.md
+++ b/packages/docs/command-line-interface/releasegold.md
@@ -21,6 +21,9 @@ OPTIONS
 
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -38,9 +41,6 @@ OPTIONS
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) The signer key that is to be used for voting through
                                                          the ReleaseGold instance
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -72,6 +72,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -81,9 +84,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -105,6 +105,9 @@ OPTIONS
   -a, --action=lock|unlock|withdraw                      (required) Action to perform on contract's gold
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -114,9 +117,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -143,6 +143,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -152,9 +155,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -175,6 +175,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -184,9 +187,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -208,6 +208,10 @@ USAGE
 
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the group to revoke votes from
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
@@ -219,9 +223,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -247,6 +248,9 @@ OPTIONS
   -v, --value=value                                      (required) Property value to set
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -256,9 +260,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -283,6 +284,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)               Use a specific gas currency for transaction fees (defaults
+                                                              to 'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                           [default: 1] If --useLedger is set, this will get the
                                                               first N addresses for local signing
 
@@ -294,9 +298,6 @@ OPTIONS
                                                               --ledgerCustomAddresses "[4,99]"
 
   --pop=pop                                                   ECDSA PoP for signer over contract's account
-
-  --usdGas                                                    If --usdGas is set, the transaction is paid for with a
-                                                              feeCurrency of cUSD
 
   --useLedger                                                 Set it to use a ledger wallet
 
@@ -328,6 +329,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address to submit multisig transaction from (one
                                                             of the owners)
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)             Use a specific gas currency for transaction fees (defaults
+                                                            to 'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                         [default: 1] If --useLedger is set, this will get the first
                                                             N addresses for local signing
 
@@ -337,9 +341,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses             [default: [0]] If --useLedger is set, this will get the
                                                             array of index addresses for local signing. Example
                                                             --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                                  If --usdGas is set, the transaction is paid for with a
-                                                            feeCurrency of cUSD
 
   --useLedger                                               Set it to use a ledger wallet
 
@@ -363,6 +364,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -372,9 +376,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -399,6 +400,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -408,9 +412,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -436,6 +437,9 @@ OPTIONS
   --distributionRatio=distributionRatio                  (required) Amount in range [0, 1000] (3 significant figures)
                                                          indicating % of total balance available for distribution.
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -445,9 +449,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -470,6 +471,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -479,9 +483,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -502,6 +503,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -513,9 +517,6 @@ OPTIONS
                                                          --ledgerCustomAddresses "[4,99]"
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d        (required) Address of the recipient of Celo Dollars transfer
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 
@@ -539,6 +540,9 @@ USAGE
 OPTIONS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
+                                                         'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
 
@@ -548,9 +552,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses          [default: [0]] If --useLedger is set, this will get the array
                                                          of index addresses for local signing. Example
                                                          --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                               If --usdGas is set, the transaction is paid for with a
-                                                         feeCurrency of cUSD
 
   --useLedger                                            Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/reserve.md
+++ b/packages/docs/command-line-interface/reserve.md
@@ -13,7 +13,8 @@ USAGE
   $ celocli reserve:status
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   status
@@ -32,6 +33,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Spender's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -43,9 +47,6 @@ OPTIONS
                                                      "[4,99]"
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Receiving address
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/rewards.md
+++ b/packages/docs/command-line-interface/rewards.md
@@ -15,11 +15,13 @@ USAGE
 OPTIONS
   --epochs=epochs                                         [default: 1] Show results for the last N epochs
   --estimate                                              Estimate voter rewards from current votes
-  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show rewards for
-  --slashing                                              Show rewards for slashing
 
-  --usdGas                                                If --usdGas is set, the transaction is paid for with a
-                                                          feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)           Use a specific gas currency for transaction fees (defaults to
+                                                          'auto' which uses whatever feeCurrency is available)
+
+  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show rewards for
+
+  --slashing                                              Show rewards for slashing
 
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Validator to show rewards for
 

--- a/packages/docs/command-line-interface/transfer.md
+++ b/packages/docs/command-line-interface/transfer.md
@@ -16,6 +16,9 @@ OPTIONS
   --comment=comment                                  Transfer comment
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -27,9 +30,6 @@ OPTIONS
                                                      "[4,99]"
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -54,6 +54,9 @@ OPTIONS
   --comment=comment                                  Transfer comment
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -65,9 +68,6 @@ OPTIONS
                                                      "[4,99]"
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -92,6 +92,9 @@ OPTIONS
   --comment=comment                                  Transfer comment
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -103,9 +106,6 @@ OPTIONS
                                                      "[4,99]"
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/validator.md
+++ b/packages/docs/command-line-interface/validator.md
@@ -18,6 +18,9 @@ ARGUMENTS
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -27,9 +30,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -52,6 +52,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -61,9 +64,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -84,6 +84,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -93,9 +96,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -116,6 +116,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Initiator
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)           Use a specific gas currency for transaction fees (defaults to
+                                                          'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                       [default: 1] If --useLedger is set, this will get the first N
                                                           addresses for local signing
 
@@ -125,9 +128,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses           [default: [0]] If --useLedger is set, this will get the array
                                                           of index addresses for local signing. Example
                                                           --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                                If --usdGas is set, the transaction is paid for with a
-                                                          feeCurrency of cUSD
 
   --useLedger                                             Set it to use a ledger wallet
 
@@ -149,7 +149,8 @@ USAGE
   $ celocli validator:list
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   list
@@ -171,6 +172,9 @@ OPTIONS
   --ecdsaKey=0x                                      (required) ECDSA Public Key
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the Validator
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -180,9 +184,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -208,7 +209,8 @@ USAGE
   $ celocli validator:requirements
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   requirements
@@ -228,7 +230,8 @@ ARGUMENTS
   VALIDATORADDRESS  Validator's address
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3
@@ -246,11 +249,13 @@ USAGE
 
 OPTIONS
   --at-block=at-block                                  latest block to examine for signer activity
-  --lookback=lookback                                  [default: 120] how many blocks to look back for signer activity
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) address of the signer to check for signatures
 
-  --usdGas                                             If --usdGas is set, the transaction is paid for with a
-                                                       feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)        Use a specific gas currency for transaction fees (defaults to
+                                                       'auto' which uses whatever feeCurrency is available)
+
+  --lookback=lookback                                  [default: 120] how many blocks to look back for signer activity
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) address of the signer to check for signatures
 
   --width=width                                        [default: 40] line width for printing marks
 
@@ -278,13 +283,13 @@ OPTIONS
   --end=end                                               [default: -1] what block to end at when looking at signer
                                                           activity. defaults to the latest block
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)           Use a specific gas currency for transaction fees (defaults to
+                                                          'auto' which uses whatever feeCurrency is available)
+
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     address of the signer to check if elected and validating
 
   --start=start                                           [default: -1] what block to start at when looking at signer
                                                           activity. defaults to the last 100 blocks
-
-  --usdGas                                                If --usdGas is set, the transaction is paid for with a
-                                                          feeCurrency of cUSD
 
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  address of the validator to check if elected and validating
 
@@ -309,6 +314,9 @@ OPTIONS
   --blsPop=0x                                        (required) BLS Proof-of-Possession
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Validator's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -318,9 +326,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 

--- a/packages/docs/command-line-interface/validatorgroup.md
+++ b/packages/docs/command-line-interface/validatorgroup.md
@@ -19,6 +19,9 @@ OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the Validator Group or Validator Group
                                                      validator signer
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -31,9 +34,6 @@ OPTIONS
 
   --queue-update=queue-update                        Queues an update to the commission, which can be applied after the
                                                      update delay.
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -55,6 +55,9 @@ USAGE
 OPTIONS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or ValidatorGroup's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -64,9 +67,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -85,7 +85,8 @@ USAGE
   $ celocli validatorgroup:list
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   list
@@ -108,6 +109,9 @@ OPTIONS
   --accept                                           Accept a validator whose affiliation is already set to the group
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) ValidatorGroup's address
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -121,9 +125,6 @@ OPTIONS
   --remove                                           Remove a validator from the members list
 
   --reorder=reorder                                  Reorder a validator within the members list. Indices are 0 based
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -151,6 +152,9 @@ OPTIONS
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the Validator Group
 
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
+                                                     'auto' which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
 
@@ -160,9 +164,6 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
-
-  --usdGas                                           If --usdGas is set, the transaction is paid for with a feeCurrency
-                                                     of cUSD
 
   --useLedger                                        Set it to use a ledger wallet
 
@@ -186,6 +187,9 @@ ARGUMENTS
   GROUPADDRESS  ValidatorGroup's address
 
 OPTIONS
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
+
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
 
@@ -194,9 +198,6 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
-
-  --usdGas                                       If --usdGas is set, the transaction is paid for with a feeCurrency of
-                                                 cUSD
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -218,7 +219,8 @@ ARGUMENTS
   GROUPADDRESS  ValidatorGroup's address
 
 OPTIONS
-  --usdGas  If --usdGas is set, the transaction is paid for with a feeCurrency of cUSD
+  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
+                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3


### PR DESCRIPTION
### Description

Add base `gasCurrency` flag and config for use with `cUSD` and `CELO` fee currencies
Also supports an `auto` mode which defaults to whatever is available on the sender's balance
Config `gasCurrency` defaults to `auto` before being set by the user

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._