### PR TITLE
oz-audit [L02] Parameter and input variable type mismatch celo-org/celo-labs#591

### DIFF
--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -748,7 +748,7 @@ contract Attestations is
   }
 
   // TODO(@i1skn): make this method external, so we can check it from outside
-  function isAttestationExpired(uint128 attestationRequestBlock) internal view returns (bool) {
+  function isAttestationExpired(uint32 attestationRequestBlock) internal view returns (bool) {
     return block.number >= uint256(attestationRequestBlock).add(attestationExpiryBlocks);
   }
 


### PR DESCRIPTION
### Description

Quick switch for parameter type `uint128` --> `uint32` to be consistent with structs

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

no test change needed. internal function.

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/591

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._