### PR TITLE
Fix QR scan for requests

### DIFF
--- a/packages/mobile/src/qrcode/utils.ts
+++ b/packages/mobile/src/qrcode/utils.ts
@@ -131,6 +131,8 @@ export function* handleBarcode(
         addressJustValidated: true,
       })
     }
+
+    return
   }
 
   const cachedRecipient = getRecipientFromAddress(
@@ -139,5 +141,5 @@ export function* handleBarcode(
     recipientCache
   )
 
-  yield call(handleSendPaymentData, qrData, cachedRecipient)
+  yield call(handleSendPaymentData, qrData, cachedRecipient, isOutgoingPaymentRequest)
 }

--- a/packages/mobile/src/send/utils.ts
+++ b/packages/mobile/src/send/utils.ts
@@ -126,7 +126,11 @@ export function showLimitReachedError(
   return showError(ErrorMessages.PAYMENT_LIMIT_REACHED, ALERT_BANNER_DURATION, translationParams)
 }
 
-export function* handleSendPaymentData(data: UriData, cachedRecipient?: RecipientWithContact) {
+export function* handleSendPaymentData(
+  data: UriData,
+  cachedRecipient?: RecipientWithContact,
+  isOutgoingPaymentRequest?: true
+) {
   const recipient: RecipientWithQrCode = {
     kind: RecipientKind.QrCode,
     address: data.address,
@@ -168,7 +172,7 @@ export function* handleSendPaymentData(data: UriData, cachedRecipient?: Recipien
     }
     navigate(Screens.SendConfirmation, { transactionData, isFromScan: true })
   } else {
-    navigate(Screens.SendAmount, { recipient, isFromScan: true })
+    navigate(Screens.SendAmount, { recipient, isFromScan: true, isOutgoingPaymentRequest })
   }
 }
 


### PR DESCRIPTION
### Description
Fixed bug where QR scan for a request would take you into the send flow.

### Other changes
None

### Tested
On device

### Related issues
- Closes #4059 

### Backwards compatibility
Yes