### PR TITLE
[ Attestation Service] Fix Twilio callback auth when behind proxies. Bump version to 1.0.3.

### DIFF
--- a/packages/attestation-service/package.json
+++ b/packages/attestation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/attestation-service",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Issues attestation messages for Celo's identity protocol",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/attestation-service/src/requestHandlers/liveness.ts
+++ b/packages/attestation-service/src/requestHandlers/liveness.ts
@@ -11,11 +11,13 @@ export async function handleLivenessRequest(_req: express.Request, res: express.
 
     if (await isNodeSyncing()) {
       respondWithError(res, 504, ErrorMessages.NODE_IS_SYNCING)
+      return
     }
 
     const { ageOfLatestBlock } = await getAgeOfLatestBlock()
     if (ageOfLatestBlock > 30) {
       respondWithError(res, 504, ErrorMessages.NODE_IS_STUCK)
+      return
     }
 
     try {

--- a/packages/attestation-service/src/sms/twilio.ts
+++ b/packages/attestation-service/src/sms/twilio.ts
@@ -64,7 +64,10 @@ export class TwilioSmsProvider extends SmsProvider {
 
   supportsDeliveryStatus = () => true
 
-  deliveryStatusHandlers = () => [bodyParser.urlencoded({ extended: false }), twilio.webhook()]
+  deliveryStatusHandlers() {
+    const host = new URL(this.deliveryStatusURL!).host
+    return [bodyParser.urlencoded({ extended: false }), twilio.webhook({ host })]
+  }
 
   async initialize(deliveryStatusURL: string) {
     // Ensure the messaging service exists

--- a/packages/attestation-service/src/sms/twilio.ts
+++ b/packages/attestation-service/src/sms/twilio.ts
@@ -65,8 +65,10 @@ export class TwilioSmsProvider extends SmsProvider {
   supportsDeliveryStatus = () => true
 
   deliveryStatusHandlers() {
-    const host = new URL(this.deliveryStatusURL!).host
-    return [bodyParser.urlencoded({ extended: false }), twilio.webhook({ host })]
+    return [
+      bodyParser.urlencoded({ extended: false }),
+      twilio.webhook({ url: this.deliveryStatusURL! }),
+    ]
   }
 
   async initialize(deliveryStatusURL: string) {


### PR DESCRIPTION
### Description

* Pass hostname of external endpoint through to Twilio callback auth so that setups where Attestation Service runs behind services like CloudFlare can successfully validate Twilio-provided signatures

### Other changes

* Bump version to 1.0.3 in anticipation of release
* Fix issue where response already sent in failing health check

### Tested

Locally to ensure no regressions. <s>Awaiting testing in a CloudFlare proxy setup</s>

### Backwards compatibility

Yes