### PR TITLE
[L04] BitmapSetForInterval event does not broadcast caller information

### DIFF
--- a/packages/protocol/contracts/governance/DowntimeSlasher.sol
+++ b/packages/protocol/contracts/governance/DowntimeSlasher.sol
@@ -24,7 +24,12 @@ contract DowntimeSlasher is ICeloVersionedContract, SlasherUtil {
     uint256 indexed startBlock,
     uint256 indexed endBlock
   );
-  event BitmapSetForInterval(uint256 indexed startBlock, uint256 indexed endBlock, bytes32 bitmap);
+  event BitmapSetForInterval(
+    address indexed sender,
+    uint256 indexed startBlock,
+    uint256 indexed endBlock,
+    bytes32 bitmap
+  );
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
@@ -120,7 +125,7 @@ contract DowntimeSlasher is ICeloVersionedContract, SlasherUtil {
     bytes32 bitmap = getBitmapForInterval(startBlock, endBlock);
     bitmaps[msg.sender][startBlock][endBlock] = bitmap;
 
-    emit BitmapSetForInterval(startBlock, endBlock, bitmap);
+    emit BitmapSetForInterval(msg.sender, startBlock, endBlock, bitmap);
 
     return bitmap;
   }

--- a/packages/protocol/test/governance/downtimeslasher.ts
+++ b/packages/protocol/test/governance/downtimeslasher.ts
@@ -282,6 +282,7 @@ contract('DowntimeSlasher', (accounts: string[]) => {
       assertLogMatches2(resp.logs[0], {
         event: 'BitmapSetForInterval',
         args: {
+          sender: accounts[0],
           startBlock: blockNumber,
           endBlock: blockNumber + 1,
           bitmap: '0x0000000000000000000000000000000000000000000000000000000000000003',


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/592

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._