### PR TITLE
Add alliance member names under logo

### DIFF
--- a/packages/web/src/alliance/Members.tsx
+++ b/packages/web/src/alliance/Members.tsx
@@ -150,14 +150,19 @@ const Member = React.memo(function _Member({ logo, name, url }: Ally) {
       {(onLoad: () => void) => (
         <View style={styles.member}>
           <a target={'_blank'} href={href}>
-            <Image
-              resizeMode="contain"
-              resizeMethod="resize"
-              onLoad={onLoad}
-              source={{ uri: logo.uri }}
-              accessibilityLabel={name}
-              style={[styles.logo, { width: logo.width / divisor }]}
-            />
+            <View style={styles.memberName}>
+              <Image
+                resizeMode="contain"
+                resizeMethod="resize"
+                onLoad={onLoad}
+                source={{ uri: logo.uri }}
+                accessibilityLabel={name}
+                style={[styles.logo, { width: logo.width / divisor }]}
+              />
+              <Text style={[fonts.mini, textStyles.italic, textStyles.center, textStyles.caption]}>
+                {name}
+              </Text>
+            </View>
           </a>
           {href && <Outbound url={href} />}
         </View>
@@ -187,6 +192,7 @@ const styles = StyleSheet.create({
   selectionArea: { maxWidth: 220 },
   membersArea: { minHeight: 650 },
   memberTitle: { marginBottom: 5 },
+  memberName: { flexDirection: 'column' },
   grayLine: {
     marginTop: 2,
     borderBottomColor: colors.gray,


### PR DESCRIPTION
### Description

Names of alliance members are added under their logos

### Other changes

I think my linter made a lot of formatting changes in the file

### Tested

<img width="913" alt="Screen Shot 2020-09-01 at 3 23 14 PM" src="https://user-images.githubusercontent.com/15326838/91897080-c2ab1500-ec67-11ea-942b-b9467575f0ca.png">

### Related issues

- Fixes #4864 
