### PR TITLE
[Wallet] Payment requests must use lowercase addresses

### DIFF
--- a/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
@@ -117,7 +117,7 @@ class PaymentRequestConfirmation extends React.Component<Props> {
       timestamp: new Date(),
       requesterAddress: address,
       requesterE164Number: this.props.e164PhoneNumber ?? undefined,
-      requesteeAddress,
+      requesteeAddress: requesteeAddress.toLowerCase(),
       currency: currencyToShortMap[CURRENCY_ENUM.DOLLAR],
       status: PaymentRequestStatus.REQUESTED,
       notified: false,

--- a/packages/mobile/src/recipients/RecipientItem.tsx
+++ b/packages/mobile/src/recipients/RecipientItem.tsx
@@ -5,7 +5,7 @@ import fontStyles from '@celo/react-components/styles/fonts.v2'
 import variables from '@celo/react-components/styles/variables'
 import * as React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-import { getRecipientThumbnail, Recipient, RecipientKind } from 'src/recipients/recipient'
+import { getRecipientThumbnail, Recipient } from 'src/recipients/recipient'
 
 interface Props {
   recipient: Recipient
@@ -15,9 +15,7 @@ interface Props {
 class RecipientItem extends React.PureComponent<Props> {
   onPress = () => {
     const recipient = this.props.recipient
-    if (recipient.kind === RecipientKind.Address) {
-      recipient.address = recipient.address.toLowerCase()
-    }
+    recipient.address = recipient.address?.toLowerCase()
     this.props.onSelectRecipient(recipient)
   }
 

--- a/packages/mobile/src/recipients/RecipientItem.tsx
+++ b/packages/mobile/src/recipients/RecipientItem.tsx
@@ -5,7 +5,7 @@ import fontStyles from '@celo/react-components/styles/fonts.v2'
 import variables from '@celo/react-components/styles/variables'
 import * as React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-import { getRecipientThumbnail, Recipient } from 'src/recipients/recipient'
+import { getRecipientThumbnail, Recipient, RecipientKind } from 'src/recipients/recipient'
 
 interface Props {
   recipient: Recipient
@@ -14,7 +14,11 @@ interface Props {
 
 class RecipientItem extends React.PureComponent<Props> {
   onPress = () => {
-    this.props.onSelectRecipient(this.props.recipient)
+    const recipient = this.props.recipient
+    if (recipient.kind === RecipientKind.Address) {
+      recipient.address = recipient.address.toLowerCase()
+    }
+    this.props.onSelectRecipient(recipient)
   }
 
   render() {


### PR DESCRIPTION
### Description

When receiving a payment request, we look on Firebase for requests made to our address using lowercase letters. If the request was made using uppercase letters, we ignore that request. With this change, we are making sure requests are always made using lowercase addresses.

### Tested

Sent a payment request without this change, it didn't arrive. Made the change, made a new request, it arrived. 
Also did the same thing but manually changing from upper to lowercase on Firebase and the requests started showing up after doing so.

### Related issues

- Fixes #4886

### Backwards compatibility

Requests that failed in the past won't start working, new payment requests will need to be made. I think that's for the better though.