### PR TITLE
[M02] Data lengths alteration could lead to malicious transaction exe…

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -198,7 +198,7 @@ contract MetaTransactionWallet is
    * @notice Executes multiple transactions on behalf of the signer.`
    * @param destinations The address to which each transaction is to be sent.
    * @param values The CELO value to be sent with each transaction.
-   * @param data The concatenated data to be sent in each transaction.
+   * @param data The concatenated transaction data with their respective lengths <length+data>.
    * @param dataLengths The length of each transaction's data.
    */
   function executeTransactions(
@@ -213,8 +213,16 @@ contract MetaTransactionWallet is
     );
     uint256 dataPosition = 0;
     for (uint256 i = 0; i < destinations.length; i++) {
-      executeTransaction(destinations[i], values[i], sliceData(data, dataPosition, dataLengths[i]));
-      dataPosition = dataPosition.add(dataLengths[i]);
+      require(
+        uint8(data[dataPosition]) == dataLengths[i],
+        "Data length must match specified length"
+      );
+      executeTransaction(
+        destinations[i],
+        values[i],
+        sliceData(data, dataPosition.add(1), dataLengths[i])
+      );
+      dataPosition = dataPosition.add(dataLengths[i].add(1));
     }
   }
 
@@ -227,6 +235,7 @@ contract MetaTransactionWallet is
    */
   function sliceData(bytes memory data, uint256 start, uint256 length)
     internal
+    pure
     returns (bytes memory)
   {
     // When length == 0 bytes.slice does not seem to always return an empty byte array.

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -217,6 +217,8 @@ contract MetaTransactionWallet is
         uint8(data[dataPosition]) == dataLengths[i],
         "Data length must match specified length"
       );
+
+      // dataPositions.add(1) accounts for preceding 1 byte signifying length of following data
       executeTransaction(
         destinations[i],
         values[i],

--- a/packages/protocol/test/common/metatransactionwallet.ts
+++ b/packages/protocol/test/common/metatransactionwallet.ts
@@ -339,9 +339,9 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
                 ensureLeading0x(
                   transactions
                     .map((t) => {
-                      const data = trimLeading0x(t.data) // @ts-ignore
-                      const lengthHex = (data.length / 2).toString(16).padStart(2, '0')
-                      return `${lengthHex}${data}`
+                      const transactionData = trimLeading0x(t.data)
+                      const lengthHex = (transactionData.length / 2).toString(16).padStart(2, '0')
+                      return `${lengthHex}${transactionData}`
                     })
                     .join('')
                 ),
@@ -372,7 +372,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
         })
 
         describe('when lengths in length array do not match up with lengths in data', async () => {
-          it('reverts with correct message', async () => {
+          it('reverts', async () => {
             await assertRevert(
               wallet.executeTransactions(
                 transactions.map((t) => t.destination),
@@ -386,7 +386,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
                     })
                     .join('')
                 ),
-                // take length without dividing by 2 for invalid length
+                // take length without dividing by 2 (each byte is 2 characters) for invalid length mismatch
                 transactions.map((t) => trimLeading0x(t.data).length),
                 { from: signer }
               )


### PR DESCRIPTION
…cutions

### Description

oz audit fix:
MetaTransactionWallet.executeTransactions will include data length prepended to actual data in `data` parameter.

### Other changes

N/A

### Tested

Changed parameters in tests to account for data parameter update. And tested revert condition for update.

### Related issues

https://github.com/celo-org/celo-labs/issues/593

### Backwards compatibility

are not because of updated param in MetaTransactionWallet