### PR TITLE
[L13] Not using the SafeMath library

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -212,7 +212,7 @@ contract MetaTransactionWallet is
       "Input arrays must be same length"
     );
     uint256 dataPosition = 0;
-    for (uint256 i = 0; i < destinations.length; i++) {
+    for (uint256 i = 0; i < destinations.length; i.add(1)) {
       executeTransaction(destinations[i], values[i], sliceData(data, dataPosition, dataLengths[i]));
       dataPosition = dataPosition.add(dataLengths[i]);
     }

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -212,7 +212,7 @@ contract MetaTransactionWallet is
       "Input arrays must be same length"
     );
     uint256 dataPosition = 0;
-    for (uint256 i = 0; i < destinations.length; i.add(1)) {
+    for (uint256 i = 0; i < destinations.length; i = i.add(1)) {
       executeTransaction(destinations[i], values[i], sliceData(data, dataPosition, dataLengths[i]));
       dataPosition = dataPosition.add(dataLengths[i]);
     }

--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -93,7 +93,7 @@ contract UsingPrecompiles {
     if (blockNumber % epochSize == 0) {
       return epochNumber;
     } else {
-      return epochNumber + 1;
+      return epochNumber.add(1);
     }
   }
 
@@ -243,7 +243,7 @@ contract UsingPrecompiles {
    * @return bytes32 data
    */
   function getBytes32FromBytes(bytes memory bs, uint256 start) internal pure returns (bytes32) {
-    require(bs.length >= start + 32, "slicing out of range");
+    require(bs.length >= start.add(32), "slicing out of range");
     bytes32 x;
     assembly {
       x := mload(add(bs, add(start, 32)))

--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.5.3;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 
-contract UsingPrecompiles {
+contract UsingPrecompiles is ICeloVersionedContract {
   using SafeMath for uint256;
 
   address constant TRANSFER = address(0xff - 2);
@@ -15,6 +16,14 @@ contract UsingPrecompiles {
   address constant HASH_HEADER = address(0xff - 9);
   address constant GET_PARENT_SEAL_BITMAP = address(0xff - 10);
   address constant GET_VERIFIED_SEAL_BITMAP = address(0xff - 11);
+
+  /**
+  * @notice Returns the storage, major, minor, and patch version of the contract.
+  * @return The storage, major, minor, and patch version of the contract.
+  */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
+  }
 
   /**
    * @notice calculate a * b^x for fractions a, b to `decimals` precision

--- a/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
+++ b/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
@@ -5,7 +5,7 @@ import "../common/interfaces/ICeloVersionedContract.sol";
 
 import "./SlasherUtil.sol";
 
-contract DoubleSigningSlasher is SlasherUtil, ICeloVersionedContract {
+contract DoubleSigningSlasher is ICeloVersionedContract, SlasherUtil {
   using SafeMath for uint256;
 
   // For each signer address, check if a block header has already been slashed

--- a/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
+++ b/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
@@ -1,10 +1,11 @@
 pragma solidity ^0.5.3;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 
 import "./SlasherUtil.sol";
 
-contract DoubleSigningSlasher is SlasherUtil {
+contract DoubleSigningSlasher is SlasherUtil, ICeloVersionedContract {
   using SafeMath for uint256;
 
   // For each signer address, check if a block header has already been slashed
@@ -12,6 +13,14 @@ contract DoubleSigningSlasher is SlasherUtil {
 
   event SlashingIncentivesSet(uint256 penalty, uint256 reward);
   event DoubleSigningSlashPerformed(address indexed validator, uint256 indexed blockNumber);
+
+  /**
+  * @notice Returns the storage, major, minor, and patch version of the contract.
+  * @return The storage, major, minor, and patch version of the contract.
+  */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
+  }
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts/governance/DowntimeSlasher.sol
+++ b/packages/protocol/contracts/governance/DowntimeSlasher.sol
@@ -99,7 +99,7 @@ contract DowntimeSlasher is ICeloVersionedContract, SlasherUtil {
     );
 
     bytes32 bitmap;
-    for (uint256 blockNumber = startBlock; blockNumber <= endBlock; blockNumber++) {
+    for (uint256 blockNumber = startBlock; blockNumber <= endBlock; blockNumber.add(1)) {
       // The canonical signatures for block N are stored in the parent seal bitmap for block N+1.
       bitmap |= getParentSealBitmap(blockNumber.add(1));
     }

--- a/packages/protocol/contracts/governance/DowntimeSlasher.sol
+++ b/packages/protocol/contracts/governance/DowntimeSlasher.sol
@@ -99,7 +99,11 @@ contract DowntimeSlasher is ICeloVersionedContract, SlasherUtil {
     );
 
     bytes32 bitmap;
-    for (uint256 blockNumber = startBlock; blockNumber <= endBlock; blockNumber.add(1)) {
+    for (
+      uint256 blockNumber = startBlock;
+      blockNumber <= endBlock;
+      blockNumber = blockNumber.add(1)
+    ) {
       // The canonical signatures for block N are stored in the parent seal bitmap for block N+1.
       bitmap |= getParentSealBitmap(blockNumber.add(1));
     }

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -962,7 +962,7 @@ contract Election is
     FixidityLib.Fraction[] memory votesForNextMember = new FixidityLib.Fraction[](
       electionGroups.length
     );
-    for (uint256 i = 0; i < electionGroups.length; i++) {
+    for (uint256 i = 0; i < electionGroups.length; i.add(1)) {
       keys[i] = i;
       votesForNextMember[i] = FixidityLib.newFixed(
         votes.total.eligible.getValue(electionGroups[i])

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -962,7 +962,7 @@ contract Election is
     FixidityLib.Fraction[] memory votesForNextMember = new FixidityLib.Fraction[](
       electionGroups.length
     );
-    for (uint256 i = 0; i < electionGroups.length; i.add(1)) {
+    for (uint256 i = 0; i < electionGroups.length; i = i.add(1)) {
       keys[i] = i;
       votesForNextMember[i] = FixidityLib.newFixed(
         votes.total.eligible.getValue(electionGroups[i])

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -9,6 +9,7 @@ import "../common/Freezable.sol";
 import "../common/Initializable.sol";
 import "../common/UsingRegistry.sol";
 import "../common/UsingPrecompiles.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 
 /**
  * @title Contract for calculating epoch rewards.
@@ -16,6 +17,7 @@ import "../common/UsingPrecompiles.sol";
 contract EpochRewards is
   Ownable,
   Initializable,
+  ICeloVersionedContract,
   UsingPrecompiles,
   UsingRegistry,
   Freezable,
@@ -81,6 +83,14 @@ contract EpochRewards is
   );
 
   event TargetVotingYieldUpdated(uint256 fraction);
+
+  /**
+  * @notice Returns the storage, major, minor, and patch version of the contract.
+  * @return The storage, major, minor, and patch version of the contract.
+  */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
+  }
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -15,14 +15,13 @@ import "../common/interfaces/ICeloVersionedContract.sol";
  * @title Contract for calculating epoch rewards.
  */
 contract EpochRewards is
+  ICeloVersionedContract,
   Ownable,
   Initializable,
-  ICeloVersionedContract,
   UsingPrecompiles,
   UsingRegistry,
   Freezable,
-  CalledByVm,
-  ICeloVersionedContract
+  CalledByVm
 {
   using FixidityLib for FixidityLib.Fraction;
   using SafeMath for uint256;

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -75,9 +75,9 @@ contract LockedGold is
   );
 
   /**
-   * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
-   */
+  * @notice Returns the storage, major, minor, and patch version of the contract.
+  * @return The storage, major, minor, and patch version of the contract.
+  */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);
   }

--- a/packages/protocol/contracts/governance/SlasherUtil.sol
+++ b/packages/protocol/contracts/governance/SlasherUtil.sol
@@ -6,8 +6,15 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "../common/Initializable.sol";
 import "../common/UsingRegistry.sol";
 import "../common/UsingPrecompiles.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 
-contract SlasherUtil is Ownable, Initializable, UsingRegistry, UsingPrecompiles {
+contract SlasherUtil is
+  ICeloVersionedContract,
+  Ownable,
+  Initializable,
+  UsingRegistry,
+  UsingPrecompiles
+{
   using SafeMath for uint256;
 
   struct SlashingIncentives {
@@ -20,6 +27,14 @@ contract SlasherUtil is Ownable, Initializable, UsingRegistry, UsingPrecompiles 
   SlashingIncentives public slashingIncentives;
 
   event SlashingIncentivesSet(uint256 penalty, uint256 reward);
+
+  /**
+  * @notice Returns the storage, major, minor, and patch version of the contract.
+  * @return The storage, major, minor, and patch version of the contract.
+  */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
+  }
 
   /**
    * @notice Sets slashing incentives.

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -629,7 +629,7 @@ contract Attestations is
     for (uint256 i = 0; i < identifiersToLookup.length; i = i.add(1)) {
       uint256 count = identifiers[identifiersToLookup[i]].accounts.length;
 
-      totalAddresses = totalAddresses + count;
+      totalAddresses = totalAddresses.add(count);
       matches[i] = count;
     }
 
@@ -651,7 +651,7 @@ contract Attestations is
     IAccounts accounts = getAccounts();
     uint256 issuersLength = numberValidatorsInCurrentSet();
     uint256[] memory issuers = new uint256[](issuersLength);
-    for (uint256 i = 0; i < issuersLength; i++) issuers[i] = i;
+    for (uint256 i = 0; i < issuersLength; i.add(1)) issuers[i] = i;
 
     require(unselectedRequest.attestationsRequested <= issuersLength, "not enough issuers");
 

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -651,7 +651,7 @@ contract Attestations is
     IAccounts accounts = getAccounts();
     uint256 issuersLength = numberValidatorsInCurrentSet();
     uint256[] memory issuers = new uint256[](issuersLength);
-    for (uint256 i = 0; i < issuersLength; i.add(1)) issuers[i] = i;
+    for (uint256 i = 0; i < issuersLength; i = i.add(1)) issuers[i] = i;
 
     require(unselectedRequest.attestationsRequested <= issuersLength, "not enough issuers");
 

--- a/packages/protocol/contracts/identity/Random.sol
+++ b/packages/protocol/contracts/identity/Random.sol
@@ -7,11 +7,19 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "../common/CalledByVm.sol";
 import "../common/Initializable.sol";
 import "../common/UsingPrecompiles.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 
 /**
  * @title Provides randomness for verifier selection
  */
-contract Random is IRandom, Ownable, Initializable, UsingPrecompiles, CalledByVm {
+contract Random is
+  IRandom,
+  ICeloVersionedContract,
+  Ownable,
+  Initializable,
+  UsingPrecompiles,
+  CalledByVm
+{
   using SafeMath for uint256;
 
   /* Stores most recent commitment per address */
@@ -25,6 +33,14 @@ contract Random is IRandom, Ownable, Initializable, UsingPrecompiles, CalledByVm
   uint256 private lastEpochBlock;
 
   event RandomnessBlockRetentionWindowSet(uint256 value);
+
+  /**
+  * @notice Returns the storage, major, minor, and patch version of the contract.
+  * @return The storage, major, minor, and patch version of the contract.
+  */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
+  }
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -6,6 +6,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 import "./interfaces/IStableToken.sol";
 import "../common/interfaces/ICeloToken.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 import "../common/CalledByVm.sol";
 import "../common/Initializable.sol";
 import "../common/FixidityLib.sol";
@@ -25,6 +26,7 @@ contract StableToken is
   Freezable,
   CalledByVm,
   IStableToken,
+  ICeloVersionedContract,
   IERC20,
   ICeloToken
 {
@@ -81,6 +83,14 @@ contract StableToken is
       emit InflationFactorUpdated(inflationState.factor.unwrap(), inflationState.factorLastUpdated);
     }
     _;
+  }
+
+  /**
+  * @notice Returns the storage, major, minor, and patch version of the contract.
+  * @return The storage, major, minor, and patch version of the contract.
+  */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
   }
 
   /**

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -19,6 +19,7 @@ import "../common/UsingPrecompiles.sol";
  */
 // solhint-disable-next-line max-line-length
 contract StableToken is
+  ICeloVersionedContract,
   Ownable,
   Initializable,
   UsingRegistry,
@@ -26,7 +27,6 @@ contract StableToken is
   Freezable,
   CalledByVm,
   IStableToken,
-  ICeloVersionedContract,
   IERC20,
   ICeloToken
 {

--- a/packages/protocol/specs/harnesses/LockedGoldHarness.sol
+++ b/packages/protocol/specs/harnesses/LockedGoldHarness.sol
@@ -1,10 +1,13 @@
 pragma solidity ^0.5.8;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "contracts/governance/LockedGold.sol";
 import "./GoldTokenHarness.sol";
 
 contract LockedGoldHarness is LockedGold {
+  using SafeMath for uint256;
+
   GoldTokenHarness goldToken;
 
   /* solhint-disable-next-line no-empty-blocks */
@@ -31,16 +34,16 @@ contract LockedGoldHarness is LockedGold {
     require(getAccounts().isAccount(account), "Unknown account");
     uint256 length = balances[account].pendingWithdrawals.length;
     uint256 total = 0;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i = 0; i < length; i.add(1)) {
       uint256 pendingValue = balances[account].pendingWithdrawals[i].value;
-      require(total + pendingValue >= total, "Pending value must be greater than 0");
-      total = total + pendingValue;
+      require(total.add(pendingValue) >= total, "Pending value must be greater than 0");
+      total = total.add(pendingValue);
     }
     return total;
   }
 
   function pendingWithdrawalsNotFull(address account) public view returns (bool) {
-    return balances[account].pendingWithdrawals.length + 2 >= 2; // we can add 2 more additional elements
+    return balances[account].pendingWithdrawals.length.add(2) >= 2; // we can add 2 more additional elements
   }
 
   function getPendingWithdrawalsLength(address account) external view returns (uint256) {

--- a/packages/protocol/specs/harnesses/LockedGoldHarness.sol
+++ b/packages/protocol/specs/harnesses/LockedGoldHarness.sol
@@ -34,7 +34,7 @@ contract LockedGoldHarness is LockedGold {
     require(getAccounts().isAccount(account), "Unknown account");
     uint256 length = balances[account].pendingWithdrawals.length;
     uint256 total = 0;
-    for (uint256 i = 0; i < length; i.add(1)) {
+    for (uint256 i = 0; i < length; i = i.add(1)) {
       uint256 pendingValue = balances[account].pendingWithdrawals[i].value;
       require(total.add(pendingValue) >= total, "Pending value must be greater than 0");
       total = total.add(pendingValue);

--- a/packages/protocol/specs/harnesses/RegistryHarness.sol
+++ b/packages/protocol/specs/harnesses/RegistryHarness.sol
@@ -1,8 +1,11 @@
 pragma solidity ^0.5.8;
 
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./IRegistryExtended.sol";
 
 contract RegistryHarness is IRegistryExtended {
+  using SafeMath for uint256;
+
   bytes32 constant ATTESTATIONS_REGISTRY_ID = keccak256(abi.encodePacked("Attestations"));
   bytes32 constant LOCKED_GOLD_REGISTRY_ID = keccak256(abi.encodePacked("LockedGold"));
   bytes32 constant GAS_CURRENCY_WHITELIST_REGISTRY_ID = keccak256(
@@ -123,23 +126,23 @@ contract RegistryHarness is IRegistryExtended {
   }
 
   function transfer(address recipient, uint256 value) external returns (bool) {
-    goldToken_balanceOf[msg.sender] = getRandomUInt256() - value;
-    goldToken_balanceOf[recipient] = getRandomUInt256() + value;
+    goldToken_balanceOf[msg.sender] = getRandomUInt256().sub(value);
+    goldToken_balanceOf[recipient] = getRandomUInt256().add(value);
     return getRandomBool();
   }
 
   function getRandomBool() public returns (bool) {
-    randomIndex++;
+    randomIndex.add(1);
     return randomBoolMap[randomIndex];
   }
 
   function getRandomUInt256() public returns (uint256) {
-    randomIndex++;
+    randomIndex.add(1);
     return randomUInt256Map[randomIndex];
   }
 
   function getRandomAddress() public returns (address) {
-    randomIndex++;
+    randomIndex.add(1);
     return randomAddressMap[randomIndex];
   }
 

--- a/packages/protocol/specs/harnesses/RegistryHarness.sol
+++ b/packages/protocol/specs/harnesses/RegistryHarness.sol
@@ -132,17 +132,17 @@ contract RegistryHarness is IRegistryExtended {
   }
 
   function getRandomBool() public returns (bool) {
-    randomIndex.add(1);
+    randomIndex = randomIndex.add(1);
     return randomBoolMap[randomIndex];
   }
 
   function getRandomUInt256() public returns (uint256) {
-    randomIndex.add(1);
+    randomIndex = randomIndex.add(1);
     return randomUInt256Map[randomIndex];
   }
 
   function getRandomAddress() public returns (address) {
-    randomIndex.add(1);
+    randomIndex = randomIndex.add(1);
     return randomAddressMap[randomIndex];
   }
 


### PR DESCRIPTION
### Description

Add safemath where possible

### Other changes

Added `ICeloVersionedContract` interface to `UsingPrecompiles`

### Tested

N/A should remain working as expected

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/603
### Backwards compatibility

N/A should remain working as expected