### PR TITLE
[Wallet] Fix user seeing the enter invite code screen after upgrading to 1.1.0

### DIFF
--- a/packages/mobile/src/invite/saga.test.ts
+++ b/packages/mobile/src/invite/saga.test.ts
@@ -20,6 +20,7 @@ import {
   sendInvite,
   SENTINEL_INVITE_COMMENT,
   skipInvite as skipInviteAction,
+  skipInviteSuccess,
   storeInviteeData,
 } from 'src/invite/actions'
 import {
@@ -281,7 +282,7 @@ describe(skipInvite, () => {
     await expectSaga(skipInvite)
       .provide([[call(getOrCreateAccount), mockAccount]])
       .withState(state)
-      .put(redeemInviteSuccess())
+      .put(skipInviteSuccess())
       .put(refreshAllBalances())
       .put(setHasSeenVerificationNux(true))
       .dispatch(skipInviteAction())

--- a/packages/mobile/src/invite/saga.test.ts
+++ b/packages/mobile/src/invite/saga.test.ts
@@ -10,7 +10,8 @@ import { PincodeType } from 'src/account/reducer'
 import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { generateShortInviteLink } from 'src/firebase/dynamicLinks'
-import { updateE164PhoneNumberAddresses } from 'src/identity/actions'
+import { refreshAllBalances } from 'src/home/actions'
+import { setHasSeenVerificationNux, updateE164PhoneNumberAddresses } from 'src/identity/actions'
 import {
   InviteBy,
   redeemInvite,
@@ -18,14 +19,17 @@ import {
   redeemInviteSuccess,
   sendInvite,
   SENTINEL_INVITE_COMMENT,
+  skipInvite as skipInviteAction,
   storeInviteeData,
 } from 'src/invite/actions'
 import {
   generateInviteLink,
   moveAllFundsFromAccount,
+  skipInvite,
   watchRedeemInvite,
   watchSendInvite,
 } from 'src/invite/saga'
+import { navigateHome } from 'src/navigator/NavigationService'
 import { getSendFee } from 'src/send/saga'
 import { fetchDollarBalance, transferStableToken } from 'src/stableToken/actions'
 import { transactionConfirmed } from 'src/transactions/actions'
@@ -265,5 +269,24 @@ describe(generateInviteLink, () => {
       appStoreId: '1482389446',
       bundleId: 'org.celo.mobile.alfajores',
     })
+  })
+})
+
+describe(skipInvite, () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('updates the state and navigates to the home screen', async () => {
+    await expectSaga(skipInvite)
+      .provide([[call(getOrCreateAccount), mockAccount]])
+      .withState(state)
+      .put(redeemInviteSuccess())
+      .put(refreshAllBalances())
+      .put(setHasSeenVerificationNux(true))
+      .dispatch(skipInviteAction())
+      .run()
+
+    expect(navigateHome).toHaveBeenCalledWith()
   })
 })

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -45,6 +45,8 @@ import {
   sendInviteFailure,
   sendInviteSuccess,
   SENTINEL_INVITE_COMMENT,
+  skipInviteFailure,
+  skipInviteSuccess,
   storeInviteeData,
 } from 'src/invite/actions'
 import { createInviteCode } from 'src/invite/utils'
@@ -383,19 +385,19 @@ export function* skipInvite() {
     ValoraAnalytics.track(OnboardingEvents.invite_redeem_skip_start)
     yield call(getOrCreateAccount)
     // TODO: refactor this, the multiple dispatch calls are somewhat confusing
-    // (`redeemInviteSuccess` though we're actually skipping and `setHasSeenVerificationNux` though the user hasn't seen it),
+    // (`setHasSeenVerificationNux` though the user hasn't seen it),
     // we should prefer a more atomic approach with a meaningful action type
-    // Set redeem invite complete so user isn't brought back into nux flow
-    yield put(redeemInviteSuccess())
     yield put(refreshAllBalances())
     yield put(setHasSeenVerificationNux(true))
     Logger.debug(TAG + '@skipInvite', 'Done skipping invite')
     ValoraAnalytics.track(OnboardingEvents.invite_redeem_skip_complete)
     navigateHome()
+    yield put(skipInviteSuccess())
   } catch (e) {
     Logger.error(TAG, 'Failed to skip invite', e)
     ValoraAnalytics.track(OnboardingEvents.invite_redeem_skip_error, { error: e.message })
     yield put(showError(ErrorMessages.ACCOUNT_SETUP_FAILED))
+    yield put(skipInviteFailure())
   }
 }
 

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -382,6 +382,11 @@ export function* skipInvite() {
   try {
     ValoraAnalytics.track(OnboardingEvents.invite_redeem_skip_start)
     yield call(getOrCreateAccount)
+    // TODO: refactor this, the multiple dispatch calls are somewhat confusing
+    // (`redeemInviteSuccess` though we're actually skipping and `setHasSeenVerificationNux` though the user hasn't seen it),
+    // we should prefer a more atomic approach with a meaningful action type
+    // Set redeem invite complete so user isn't brought back into nux flow
+    yield put(redeemInviteSuccess())
     yield put(refreshAllBalances())
     yield put(setHasSeenVerificationNux(true))
     Logger.debug(TAG + '@skipInvite', 'Done skipping invite')


### PR DESCRIPTION
### Description

There was a regression introduced by the change in https://github.com/celo-org/celo-monorepo/pull/4977/files#diff-55bba9805f8b51290d1be787ca2cbca6L507-R506

See details in #4997

Though it might looks confusing, `redeemComplete` needs to be set to true when skipping the invite code to avoid this problem.
This is similar to what is done when restoring an account from a seed phrase in https://github.com/celo-org/celo-monorepo/blob/910ab0a5218c05f712422b774dcff1aedf495289/packages/mobile/src/import/saga.ts#L79

Additional note: In the long term I think we would benefit from using more meaningful actions which update multiple parts of the state tree in an atomic manner.
Currently there are parts of the code which dispatch multiple actions sequentially, i.e. using actions as "glorified setters"
See description of the problem here: https://twitter.com/dan_abramov/status/800310164792414208?s=20

### Other changes

None.

### Tested

Added new test.

### Related issues

- Fixes #4997

### Backwards compatibility

Yes.