### PR TITLE
[Wallet] Add migration to set redeemComplete to true if account exists

### DIFF
--- a/packages/mobile/src/redux/migrations.test.ts
+++ b/packages/mobile/src/redux/migrations.test.ts
@@ -90,4 +90,17 @@ describe('Redux persist migrations', () => {
     expect(migratedSchema.web3.dataEncryptionKey).toBe('key')
     expect(migratedSchema.web3.commentKey).toBe(undefined)
   })
+
+  it('works for v5 to v6', () => {
+    const v5Stub = {
+      invite: {
+        redeemComplete: false,
+      },
+      web3: {
+        account: 'some_account',
+      },
+    }
+    const migratedSchema = migrations[6](v5Stub)
+    expect(migratedSchema.invite.redeemComplete).toBe(true)
+  })
 })

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -82,4 +82,13 @@ export const migrations = {
       },
     }
   },
+  6: (state: any) => {
+    return {
+      ...state,
+      invite: {
+        ...state.invite,
+        redeemComplete: !!state.web3.account,
+      },
+    }
+  },
 }

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -9,7 +9,7 @@ import { rootSaga } from 'src/redux/sagas'
 
 const persistConfig: any = {
   key: 'root',
-  version: 5, // default is -1, increment as we make migrations
+  version: 6, // default is -1, increment as we make migrations
   storage: AsyncStorage,
   blacklist: ['home', 'geth', 'networkInfo', 'alert', 'fees', 'recipients', 'imports'],
   stateReconciler: autoMergeLevel2,


### PR DESCRIPTION
### Description

Added a migration for the Redux store that sets `redeemComplete` to `true` if there is an account saved on the store.

### Tested

1- Manually set `redeemComplete` to false in the store and opened the app. 
2- I saw the invite screen even though I had an account. 
3- Add the migrations in the PR and opened the app again. 
4- Saw on the logs that migrations run and I appeared on the Home screen.

### Related issues

- Fixes #4997

### Backwards compatibility

That's the point of the PR :D