### PR TITLE
OZ Audit Phase 4: M02 + M03

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -198,7 +198,7 @@ contract MetaTransactionWallet is
    * @notice Executes multiple transactions on behalf of the signer.`
    * @param destinations The address to which each transaction is to be sent.
    * @param values The CELO value to be sent with each transaction.
-   * @param data The concatenated data to be sent in each transaction.
+   * @param data The concatenated transaction data with their respective lengths <length+data>.
    * @param dataLengths The length of each transaction's data.
    */
   function executeTransactions(
@@ -213,8 +213,16 @@ contract MetaTransactionWallet is
     );
     uint256 dataPosition = 0;
     for (uint256 i = 0; i < destinations.length; i++) {
-      executeTransaction(destinations[i], values[i], sliceData(data, dataPosition, dataLengths[i]));
-      dataPosition = dataPosition.add(dataLengths[i]);
+      require(
+        uint8(data[dataPosition]) == dataLengths[i],
+        "Data length must match specified length"
+      );
+      executeTransaction(
+        destinations[i],
+        values[i],
+        sliceData(data, dataPosition.add(1), dataLengths[i])
+      );
+      dataPosition = dataPosition.add(dataLengths[i].add(1));
     }
   }
 
@@ -227,6 +235,7 @@ contract MetaTransactionWallet is
    */
   function sliceData(bytes memory data, uint256 start, uint256 length)
     internal
+    pure
     returns (bytes memory)
   {
     // When length == 0 bytes.slice does not seem to always return an empty byte array.

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -217,6 +217,8 @@ contract MetaTransactionWallet is
         uint8(data[dataPosition]) == dataLengths[i],
         "Data length must match specified length"
       );
+
+      // dataPositions.add(1) accounts for preceding 1 byte signifying length of following data
       executeTransaction(
         destinations[i],
         values[i],

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -199,33 +199,26 @@ contract MetaTransactionWallet is
    * @param destinations The address to which each transaction is to be sent.
    * @param values The CELO value to be sent with each transaction.
    * @param data The concatenated transaction data with their respective lengths <length+data>.
-   * @param dataLengths The length of each transaction's data.
    */
   function executeTransactions(
     address[] calldata destinations,
     uint256[] calldata values,
-    bytes calldata data,
-    uint256[] calldata dataLengths
+    bytes calldata data
   ) external {
-    require(
-      destinations.length == values.length && values.length == dataLengths.length,
-      "Input arrays must be same length"
-    );
+    require(destinations.length == values.length, "Input arrays must be same length");
+
     uint256 dataPosition = 0;
     for (uint256 i = 0; i < destinations.length; i++) {
-      require(
-        uint8(data[dataPosition]) == dataLengths[i],
-        "Data length must match specified length"
-      );
-
+      uint256 dataLength = uint256(uint8(data[dataPosition]));
       // dataPositions.add(1) accounts for preceding 1 byte signifying length of following data
       executeTransaction(
         destinations[i],
         values[i],
-        sliceData(data, dataPosition.add(1), dataLengths[i])
+        sliceData(data, dataPosition.add(1), dataLength)
       );
-      dataPosition = dataPosition.add(dataLengths[i].add(1));
+      dataPosition = dataPosition.add(dataLength).add(1);
     }
+    require(dataPosition == data.length, "data parameter length too large");
   }
 
   /**

--- a/packages/protocol/contracts/common/interfaces/IMetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/interfaces/IMetaTransactionWallet.sol
@@ -4,12 +4,7 @@ interface IMetaTransactionWallet {
   function setSigner(address) external;
   function setEip712DomainSeparator() external;
   function executeTransaction(address, uint256, bytes calldata) external returns (bytes memory);
-  function executeTransactions(
-    address[] calldata,
-    uint256[] calldata,
-    bytes calldata,
-    uint256[] calldata
-  ) external;
+  function executeTransactions(address[] calldata, uint256[] calldata, bytes calldata) external;
   function executeMetaTransaction(address, uint256, bytes calldata, uint8, bytes32, bytes32)
     external
     returns (bytes memory);

--- a/packages/protocol/test/common/metatransactionwallet.ts
+++ b/packages/protocol/test/common/metatransactionwallet.ts
@@ -294,7 +294,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
         await web3.eth.sendTransaction({
           from: accounts[0],
           to: wallet.address,
-          value: value * 2,
+          value: value * 4,
         })
       })
 
@@ -313,7 +313,6 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
                   })
                   .join('')
               ),
-              transactions.map((t) => trimLeading0x(t.data).length / 2),
               { from: signer }
             )
           })
@@ -344,8 +343,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
                       return `${lengthHex}${transactionData}`
                     })
                     .join('')
-                ),
-                transactions.map((t) => trimLeading0x(t.data).length / 2)
+                )
               )
               .encodeABI()
             const digest = constructMetaTransactionExecutionDigest(wallet.address, {
@@ -371,7 +369,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
           })
         })
 
-        describe('when lengths in length array do not match up with lengths in data', async () => {
+        describe('when data parameter has extra unused data appened to the end', async () => {
           it('reverts', async () => {
             await assertRevert(
               wallet.executeTransactions(
@@ -385,9 +383,8 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
                       return `${lengthHex}${data}`
                     })
                     .join('')
+                    .concat('abc123')
                 ),
-                // take length without dividing by 2 (each byte is 2 characters) for invalid length mismatch
-                transactions.map((t) => trimLeading0x(t.data).length),
                 { from: signer }
               )
             )

--- a/packages/protocol/test/common/metatransactionwallet.ts
+++ b/packages/protocol/test/common/metatransactionwallet.ts
@@ -339,9 +339,9 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
                 ensureLeading0x(
                   transactions
                     .map((t) => {
-                      const data = trimLeading0x(t.data) // @ts-ignore
-                      const lengthHex = (data.length / 2).toString(16).padStart(2, '0')
-                      return `${lengthHex}${data}`
+                      const transactionData = trimLeading0x(t.data)
+                      const lengthHex = (transactionData.length / 2).toString(16).padStart(2, '0')
+                      return `${lengthHex}${transactionData}`
                     })
                     .join('')
                 ),
@@ -372,7 +372,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
         })
 
         describe('when lengths in length array do not match up with lengths in data', async () => {
-          it('reverts with correct message', async () => {
+          it('reverts', async () => {
             await assertRevert(
               wallet.executeTransactions(
                 transactions.map((t) => t.destination),
@@ -386,7 +386,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
                     })
                     .join('')
                 ),
-                // take length without dividing by 2 for invalid length
+                // take length without dividing by 2 (each byte is 2 characters) for invalid length mismatch
                 transactions.map((t) => trimLeading0x(t.data).length),
                 { from: signer }
               )


### PR DESCRIPTION
### Description

M02: Instead of having extra `dataLength` parameter in `MetaTransactionWallet.executeTransactions()`, `data` contains lengths internally to guarantee matchup.
M03: function reverts if data has extra unused bytes appended at the end

### Other changes

N/A

### Tested

Test added for revert, otherwise everything should perform as expected.
### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/597 
https://github.com/celo-org/celo-labs/issues/593

### Backwards compatibility

Parameters changed on MetaTransactionWallet.executeTransactions() but we haven't officially published an initial version, so I don't think this matters