### PR TITLE
L06: Lack of Validation

### DIFF
--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -145,6 +145,7 @@ contract GoldToken is Initializable, CalledByVm, Freezable, IERC20, ICeloToken {
       return true;
     }
 
+    require(to != address(0), "mint attempted to reserved address 0x0");
     totalSupply_ = totalSupply_.add(value);
 
     bool success;

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -7,8 +7,16 @@ import "./CalledByVm.sol";
 import "./Freezable.sol";
 import "./Initializable.sol";
 import "./interfaces/ICeloToken.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 
-contract GoldToken is Initializable, CalledByVm, Freezable, IERC20, ICeloToken {
+contract GoldToken is
+  Initializable,
+  CalledByVm,
+  Freezable,
+  IERC20,
+  ICeloToken,
+  ICeloVersionedContract
+{
   using SafeMath for uint256;
 
   // Address of the TRANSFER precompiled contract.
@@ -27,6 +35,14 @@ contract GoldToken is Initializable, CalledByVm, Freezable, IERC20, ICeloToken {
   event TransferComment(string comment);
 
   event Approval(address indexed owner, address indexed spender, uint256 value);
+
+  /**
+   * @notice Returns the storage, major, minor, and patch version of the contract.
+   * @return The storage, major, minor, and patch version of the contract.
+   */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
+  }
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -70,6 +70,7 @@ contract MetaTransactionWallet is
    * @param _signer The address authorized to execute transactions via this wallet.
    */
   function setSigner(address _signer) public onlyOwner {
+    require(_signer != address(0), "cannot assign zero address as signer");
     signer = _signer;
     emit SignerSet(signer);
   }

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -179,6 +179,7 @@ contract EpochRewards is
    * @return True upon success.
    */
   function setCarbonOffsettingFund(address partner, uint256 value) public onlyOwner returns (bool) {
+    require(partner != address(0), "partner cannot be null address");
     require(partner != carbonOffsettingPartner || value != carbonOffsettingFraction.unwrap());
     require(value < FixidityLib.fixed1().unwrap());
     carbonOffsettingPartner = partner;

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -189,7 +189,6 @@ contract EpochRewards is
    * @return True upon success.
    */
   function setCarbonOffsettingFund(address partner, uint256 value) public onlyOwner returns (bool) {
-    require(partner != address(0), "partner cannot be null address");
     require(partner != carbonOffsettingPartner || value != carbonOffsettingFraction.unwrap());
     require(value < FixidityLib.fixed1().unwrap());
     carbonOffsettingPartner = partner;

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -9,6 +9,7 @@ import "../common/Freezable.sol";
 import "../common/Initializable.sol";
 import "../common/UsingRegistry.sol";
 import "../common/UsingPrecompiles.sol";
+import "../common/interfaces/ICeloVersionedContract.sol";
 
 /**
  * @title Contract for calculating epoch rewards.
@@ -19,7 +20,8 @@ contract EpochRewards is
   UsingPrecompiles,
   UsingRegistry,
   Freezable,
-  CalledByVm
+  CalledByVm,
+  ICeloVersionedContract
 {
   using FixidityLib for FixidityLib.Fraction;
   using SafeMath for uint256;
@@ -81,6 +83,14 @@ contract EpochRewards is
   );
 
   event TargetVotingYieldUpdated(uint256 fraction);
+
+  /*
+   * @notice Returns the storage, major, minor, and patch version of the contract.
+   * @return The storage, major, minor, and patch version of the contract.
+   */
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
+    return (1, 1, 1, 0);
+  }
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -108,7 +108,6 @@ contract LockedGold is
    */
   function lock() external payable nonReentrant {
     require(getAccounts().isAccount(msg.sender), "not account");
-    require(msg.value > 0, "no value");
     _incrementNonvotingAccountBalance(msg.sender, msg.value);
     emit GoldLocked(msg.sender, msg.value);
   }

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -712,7 +712,7 @@ contract Attestations is
     if (status && transferApprovals[other][key]) {
       _transfer(identifier, index, from, to);
       transferApprovals[other][key] = false;
-    } else if (transferApprovals[msg.sender][key] != status) {
+    } else {
       transferApprovals[msg.sender][key] = status;
       emit TransferApproval(msg.sender, identifier, from, to, status);
     }

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -712,7 +712,7 @@ contract Attestations is
     if (status && transferApprovals[other][key]) {
       _transfer(identifier, index, from, to);
       transferApprovals[other][key] = false;
-    } else {
+    } else if (transferApprovals[msg.sender][key] != status) {
       transferApprovals[msg.sender][key] = status;
       emit TransferApproval(msg.sender, identifier, from, to, status);
     }

--- a/packages/protocol/test/governance/lockedgold.ts
+++ b/packages/protocol/test/governance/lockedgold.ts
@@ -178,11 +178,6 @@ contract('LockedGold', (accounts: string[]) => {
       })
     })
 
-    it('should revert when the specified value is 0', async () => {
-      // @ts-ignore: TODO(mcortesi) fix typings for TransactionDetails
-      await assertRevert(lockedGold.lock({ value: 0 }))
-    })
-
     it('should revert when the account does not exist', async () => {
       await assertRevert(lockedGold.lock({ value, from: accounts[1] }))
     })


### PR DESCRIPTION
### Description

Added some extra validation such as protecting against address(0) assignments.

### Other changes

Took out a check for 0 value in locked gold to start setting a precedent that no-op operations should be checked for by the client to save the user gas, not on-chain. no-op checks can also start to become a pandoras box. for consistency, we'll relegate that to the client.

### Tested

everything should continue working as before

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/590

### Backwards compatibility

yes