### PR TITLE
[Wallet] Add BRL and CVE local currencies

### DIFF
--- a/packages/mobile/src/localCurrency/__snapshots__/SelectLocalCurrency.test.tsx.snap
+++ b/packages/mobile/src/localCurrency/__snapshots__/SelectLocalCurrency.test.tsx.snap
@@ -45,6 +45,8 @@ exports[`SelectLocalCurrency renders correctly 1`] = `
             "UGX",
             "GHS",
             "NGN",
+            "BRL",
+            "CVE",
           ]
         }
         disableVirtualization={false}

--- a/packages/mobile/src/localCurrency/consts.ts
+++ b/packages/mobile/src/localCurrency/consts.ts
@@ -12,6 +12,8 @@ export enum LocalCurrencyCode {
   UGX = 'UGX',
   GHS = 'GHS',
   NGN = 'NGN',
+  BRL = 'BRL',
+  CVE = 'CVE',
 }
 
 export enum LocalCurrencySymbol {
@@ -27,6 +29,8 @@ export enum LocalCurrencySymbol {
   UGX = 'USh',
   GHS = 'GH₵',
   NGN = '₦',
+  BRL = 'R$',
+  CVE = '$',
 }
 
 export const LOCAL_CURRENCY_CODES = Object.values(LocalCurrencyCode)


### PR DESCRIPTION
### Description

Add local currency for Brazil (BRL) and Republic of Cape Verde (CVE).

### Other changes

None.

### Tested

<img src="https://user-images.githubusercontent.com/57791/92733045-81a5b580-f377-11ea-9eb5-9c7b40f6b077.png" width="50%" />

### Related issues

Discussed on Slack.

### Backwards compatibility

Yes.