### PR TITLE
[Wallet] Fix escrow failing randomly with local currency

### DIFF
--- a/packages/mobile/.env
+++ b/packages/mobile/.env
@@ -16,7 +16,7 @@ APP_BUNDLE_ID=org.celo.mobile.dev
 APP_STORE_ID=1482389446
 APP_DISPLAY_NAME=Celo (dev)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.dev.plist
-DYNAMIC_LINK_DOMAIN=http://l.celo.org
+DYNAMIC_LINK_DOMAIN=https://l.celo.org
 GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution

--- a/packages/mobile/.env.alfajores
+++ b/packages/mobile/.env.alfajores
@@ -14,7 +14,7 @@ APP_BUNDLE_ID=org.celo.mobile.alfajores
 APP_STORE_ID=1482389446
 APP_DISPLAY_NAME=Celo
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.alfajores.plist
-DYNAMIC_LINK_DOMAIN=http://l.celo.org
+DYNAMIC_LINK_DOMAIN=https://l.celo.org
 GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution

--- a/packages/mobile/src/localCurrency/convert.test.ts
+++ b/packages/mobile/src/localCurrency/convert.test.ts
@@ -22,4 +22,11 @@ describe(convertDollarsToMaxSupportedPrecision, () => {
     const dollarsResult = convertDollarsToMaxSupportedPrecision(new BigNumber('2.99'))
     expect(dollarsResult.toString()).toEqual('2.99')
   })
+
+  it('should round amounts with more than 18 decimals to 18 decimals (the max precision)', () => {
+    const dollarsResult = convertDollarsToMaxSupportedPrecision(
+      new BigNumber('0.01183102924038876762')
+    )
+    expect(dollarsResult.toString()).toEqual('0.011831029240388768')
+  })
 })

--- a/packages/mobile/src/localCurrency/convert.ts
+++ b/packages/mobile/src/localCurrency/convert.ts
@@ -48,5 +48,5 @@ export function convertLocalAmountToDollars(
 //   If the user enters `2.99` cUSD, this function has no impact
 //   and `2.99` is still displayed in the confirmation screen.
 export function convertDollarsToMaxSupportedPrecision(amount: BigNumber) {
-  return new BigNumber(amount.toPrecision(18, BigNumber.ROUND_UP))
+  return new BigNumber(amount.toFixed(18, BigNumber.ROUND_UP))
 }

--- a/packages/mobile/src/send/SendAmount.test.tsx
+++ b/packages/mobile/src/send/SendAmount.test.tsx
@@ -45,7 +45,7 @@ const mockE164NumberToAddress: E164NumberToAddressType = {
 const mockTransactionData2 = {
   type: mockTransactionData.type,
   recipient: mockTransactionData.recipient,
-  amount: new BigNumber('3.70676691729323309'),
+  amount: new BigNumber('3.706766917293233083'),
   reason: '',
 }
 


### PR DESCRIPTION
### Description

This PR fixes sending an invite with an escrowed payment failing randomly when using a local currency.

See details in #3000

### Other changes

- Fixed dynamic link generation never returning and leaving the UI in loading state indefinitely (underlying error was `Invalid domainURIPrefix scheme. Scheme needs to be https`)

### Tested

Added new test. Invite with escrow works.

### Related issues

- Fixes #3000

### Backwards compatibility

Yes