### PR TITLE
Fix getting languages on Press page for client side

### DIFF
--- a/packages/web/src/press/PressPage.tsx
+++ b/packages/web/src/press/PressPage.tsx
@@ -39,7 +39,7 @@ class PressPage extends React.PureComponent<I18nProps & Props> {
       } else {
         const res = await fetch(`/api/press`)
         press = await res.json()
-        languages = navigator.languages.map((s) => s.substr(0, 2))
+        languages = navigator.languages ? navigator.languages.map((s) => s.substr(0, 2)) : []
       }
       return { press, languages }
     } catch {

--- a/packages/web/src/press/PressPage.tsx
+++ b/packages/web/src/press/PressPage.tsx
@@ -26,17 +26,20 @@ interface Props {
 class PressPage extends React.PureComponent<I18nProps & Props> {
   static async getInitialProps(context) {
     let press = []
-    let languages
+    let languages = []
     try {
       // when run on server import fetching code and run. on client send req to api
       if (context.req) {
         const getpress = await import('src/../server/fetchPress')
         press = await getpress.default()
         languages = context.req.headers['accept-language']
+          .toLowerCase()
+          .split(',')
+          .map((s) => s.substr(0, 2))
       } else {
         const res = await fetch(`/api/press`)
         press = await res.json()
-        languages = res.headers.get('accept-language')
+        languages = navigator.languages.map((s) => s.substr(0, 2))
       }
       return { press, languages }
     } catch {
@@ -45,12 +48,7 @@ class PressPage extends React.PureComponent<I18nProps & Props> {
   }
   render() {
     const { t, press, languages, i18n } = this.props
-    const langList = new Set(
-      languages
-        .toLowerCase()
-        .split(',')
-        .map((s) => s.substr(0, 2))
-    )
+    const langList = new Set(languages)
 
     const formated = press
       .filter(


### PR DESCRIPTION
### Description

When on client side, `languages` was a null object, it now fetches the correct data.

### Tested

navigated to press page from other page

### Related issues

- Fixes #5015 

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._