### PR TITLE
EpochRewards: Take out extra getVersionNumber

### DIFF
--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -534,8 +534,4 @@ contract EpochRewards is
         .fromFixed()
     );
   }
-
-  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
-  }
 }


### PR DESCRIPTION
### Description

Lack of rebase added the same function twice

### Other changes

n/a
### Tested

n/a

### Related issues

n/a

### Backwards compatibility

n/a