### PR TITLE
revert trying modern. came across some breakages that i missed before

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -4,7 +4,7 @@ const serverEnvConfig = require('./server-env-config')
 
 module.exports = withImages({
   experimental: {
-    modern: true,
+    modern: false,
   },
   publicRuntimeConfig: envConfig,
   serverRuntimeConfig: serverEnvConfig,


### PR DESCRIPTION
### Description

reverts serving modern JS

deploying to stage no longer breaks about page with `Math.seedrandom` error

reverts: https://github.com/celo-org/celo-monorepo/issues/4659