### PR TITLE
Correct documentation on the validator and validator group deregister

### DIFF
--- a/packages/cli/src/commands/validator/deregister.ts
+++ b/packages/cli/src/commands/validator/deregister.ts
@@ -5,7 +5,7 @@ import { Flags } from '../../utils/command'
 
 export default class ValidatorDeregister extends BaseCommand {
   static description =
-    'Deregister a Validator. Approximately 60 days after deregistration, the 10,000 Gold locked up to register the Validator will become possible to unlock. Note that deregistering a Validator will also deaffiliate and remove the Validator from any Group it may be an affiliate or member of.'
+    "Deregister a Validator. Approximately 60 days after the validator is no longer part of any group, it will be possible to deregister the validator and start unlocking the CELO. If you wish to deregister your validator, you must first remove it from it's group, such as by deaffiliating it, then wait the required 60 days before running this command."
 
   static flags = {
     ...BaseCommand.flags,

--- a/packages/cli/src/commands/validatorgroup/deregister.ts
+++ b/packages/cli/src/commands/validatorgroup/deregister.ts
@@ -5,7 +5,7 @@ import { Flags } from '../../utils/command'
 
 export default class ValidatorGroupDeRegister extends BaseCommand {
   static description =
-    'Deregister a Validator Group. Approximately 60 days after deregistration, the 10,000 Gold locked up to register the Validator Group will become possible to unlock. Note that the Group must be empty (i.e. no members) before deregistering.'
+    'Deregister a Validator Group. Approximately 180 days after the validator group is empty, it will be possible to deregister it start unlocking the CELO. If you wish to deregister your validator group, you must first remove all members, then wait the required 180 days before running this command.'
 
   static flags = {
     ...BaseCommand.flags,

--- a/packages/docs/command-line-interface/validator.md
+++ b/packages/docs/command-line-interface/validator.md
@@ -75,7 +75,7 @@ _See code: [packages/cli/src/commands/validator/deaffiliate.ts](https://github.c
 
 ### Deregister
 
-Deregister a Validator. Approximately 60 days after deregistration, the 10,000 Gold locked up to register the Validator will become possible to unlock. Note that deregistering a Validator will also deaffiliate and remove the Validator from any Group it may be an affiliate or member of.
+Deregister a Validator. Approximately 60 days after the validator is no longer part of any group, it will be possible to deregister the validator and start unlocking the CELO. If you wish to deregister your validator, you must first remove it from it's group, such as by deaffiliating it, then wait the required 60 days before running this command.
 
 ```
 USAGE

--- a/packages/docs/command-line-interface/validatorgroup.md
+++ b/packages/docs/command-line-interface/validatorgroup.md
@@ -46,7 +46,7 @@ _See code: [packages/cli/src/commands/validatorgroup/commission.ts](https://gith
 
 ### Deregister
 
-Deregister a Validator Group. Approximately 60 days after deregistration, the 10,000 Gold locked up to register the Validator Group will become possible to unlock. Note that the Group must be empty (i.e. no members) before deregistering.
+Deregister a Validator Group. Approximately 180 days after the validator group is empty, it will be possible to deregister it start unlocking the CELO. If you wish to deregister your validator group, you must first remove all members, then wait the required 180 days before running this command.
 
 ```
 USAGE


### PR DESCRIPTION
### Description

The documentation on the `celocli validator:deregister` and `celocli validatorgroup:deregister` describe an outdated version of the Valdiator contract code. It's current implementation requires validators to leave their groups before attempting to deregister, whereas the waiting period was attached to withdrawing locked gold before.

This PR updates the doc string on these commands to correct the descriptions.

https://discordapp.com/channels/600834479145353243/601046166620078100/758486506075324437

_Brief explanation of why these changes are/are not backwards compatible._