### PR TITLE
Add check to CI deps audit for deps changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,28 +93,7 @@ commands:
       - run:
           name: Fail if generated dependency graph doesn't match committed
           command: ./scripts/ci_check_dependency_graph_changed.sh
-      - run:
-          name: Fail if there are vulnerabilities in packages
-          command: |
-            generate_post_data()
-            {
-              cat <<EOF
-            {
-              "summary": "Vulnerability found in CI during yarn audit",
-              "details": "$REPORT",
-              "targets": [{
-                "type": "EscalationPolicy",
-                "slug": "pol-bu0pGzGe3mMQ1W8D",
-              }]
-            }
-            EOF
-            }
-            REPORT=$(yarn audit --groups dependencies --level high)
-            if [[ $? -ge 8 ]]; then
-              curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
-              --header "X-VO-Api-Id: $VICTOROPS_API_ID" --header "X-VO-Api-Key: $VICTOROPS_API_KEY" \
-              -d "$(generate_post_data)" 'https://api.victorops.com/api-public/v1/incidents'
-            fi
+
       # Workaround save_cache not supporting globbing for the paths key
       # see note in https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching and https://ideas.circleci.com/ideas/CCI-I-239
       - run:
@@ -411,7 +390,14 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/app
-      - run: ./scripts/ci_check_vulnerabilities.sh
+      - run:
+          name: audit when dependencies have changed
+          command: /
+            if [ ! -e ~/.tmp/yarn_deps_have_changed ]; then
+              echo "Skipping dependency audit, dependencies haven't changed"
+              exit 0
+            fi
+            ./scripts/ci_check_vulnerabilities.sh
 
   general-test:
     <<: *defaults
@@ -967,6 +953,34 @@ jobs:
             cd packages/protocol
             certoraRun specs/harnesses/AccountsHarness.sol --verify AccountsHarness:specs/accounts.spec --settings -assumeUnwindCond
 
+  yarn-audit-vulnerabilities:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/app
+      - run:
+          name: Fail if there are vulnerabilities in packages
+          command: |
+            alert_vulnerabilities_oncall()
+            {
+              cat <<EOF
+            {
+              "summary": "Vulnerability found in CI during yarn audit",
+              "details": "$1",
+              "targets": [{
+                "type": "EscalationPolicy",
+                "slug": "pol-bu0pGzGe3mMQ1W8D",
+              }]
+            }
+            EOF
+            }
+
+            ./scripts/ci_check_vulnerabilities.sh
+            if [ $? -ne 0 ]
+            then
+              alert_vulnerabilities_oncall() $CIRCLE_BUILD_URL
+            fi
+
   flakey-test-summary:
     <<: *defaults
     steps:
@@ -1096,6 +1110,17 @@ workflows:
       - test-utils-npm-package-install
       - test-contractkit-npm-package-install
       - test-celocli-npm-package-install
+  yarn-audit-cron-workflow:
+    triggers:
+      - schedule:
+          # every 4 hours (6 times a day)
+          cron: '0 0,4,8,12,16,20 * * *'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - yarn-audit-vulnerabilities
   protocol-testing-with-code-coverage-cron-workflow:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -963,7 +963,7 @@ jobs:
           command: |
             alert_vulnerabilities_oncall()
             {
-              cat <<EOF
+              cat \<\<EOF
             {
               "summary": "Vulnerability found in CI during yarn audit",
               "details": "$1",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -961,24 +961,26 @@ jobs:
       - run:
           name: Fail if there are vulnerabilities in packages
           command: |
-            alert_vulnerabilities_oncall()
-            {
-              cat \<\<EOF
+            generate_post_data() {
+              cat <<EOF
             {
               "summary": "Vulnerability found in CI during yarn audit",
-              "details": "$1",
+              "details": "Please see CircleCI output:\n $1",
+              "userName": "yorhodes",
               "targets": [{
                 "type": "EscalationPolicy",
-                "slug": "pol-bu0pGzGe3mMQ1W8D",
+                "slug": "pol-bu0pGzGe3mMQ1W8D"
               }]
             }
             EOF
             }
 
             ./scripts/ci_check_vulnerabilities.sh
-            if [ $? -ne 0 ]
-            then
-              alert_vulnerabilities_oncall() $CIRCLE_BUILD_URL
+            if [ $? -ne 0 ]; then
+              echo "Posting new incident to VictorOps"
+              curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
+                --header "X-VO-Api-Id: $VICTOROPS_API_ID" --header "X-VO-Api-Key: $VICTOROPS_API_KEY" \
+                -d "$(generate_post_data $CIRCLE_BUILD_URL)" 'https://api.victorops.com/api-public/v1/incidents'
             fi
 
   flakey-test-summary:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,28 @@ commands:
       - run:
           name: Fail if generated dependency graph doesn't match committed
           command: ./scripts/ci_check_dependency_graph_changed.sh
+      - run:
+          name: Fail if there are vulnerabilities in packages
+          command: |
+            generate_post_data()
+            {
+              cat <<EOF
+            {
+              "summary": "Vulnerability found in CI during yarn audit",
+              "details": "$REPORT",
+              "targets": [{
+                "type": "EscalationPolicy",
+                "slug": "pol-bu0pGzGe3mMQ1W8D",
+              }]
+            }
+            EOF
+            }
+            REPORT=$(yarn audit --groups dependencies --level high)
+            if [[ $? -ge 8 ]]; then
+              curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
+              --header "X-VO-Api-Id: $VICTOROPS_API_ID" --header "X-VO-Api-Key: $VICTOROPS_API_KEY" \
+              -d "$(generate_post_data)" 'https://api.victorops.com/api-public/v1/incidents'
+            fi
       # Workaround save_cache not supporting globbing for the paths key
       # see note in https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching and https://ideas.circleci.com/ideas/CCI-I-239
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ commands:
       - run:
           name: Fail if generated dependency graph doesn't match committed
           command: ./scripts/ci_check_dependency_graph_changed.sh
-
       # Workaround save_cache not supporting globbing for the paths key
       # see note in https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching and https://ideas.circleci.com/ideas/CCI-I-239
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -962,7 +962,7 @@ jobs:
           name: Fail if there are vulnerabilities in packages
           command: |
             generate_post_data() {
-              cat <<EOF
+              cat \<\<EOF
             {
               "summary": "Vulnerability found in CI during yarn audit",
               "details": "Please see CircleCI output:\n $1",

--- a/scripts/ci_check_vulnerabilities.sh
+++ b/scripts/ci_check_vulnerabilities.sh
@@ -23,7 +23,9 @@ if [ -f yarn-audit-known-issues ] && echo "$json_output" | grep auditAdvisory | 
 fi
 
 echo
-echo Security vulnerabilities were found that were not ignored
+echo "$readable_output"
+echo 
+echo Security vulnerabilities were found that are not ignored
 echo
 echo Check to see if these vulnerabilities apply to production
 echo and/or if they have fixes available. If they do not have
@@ -35,6 +37,5 @@ echo "yarn audit --json --groups dependencies --level high | grep auditAdvisory 
 echo
 echo and commit the yarn-audit-known-issues file
 echo
-echo "$readable_output"
 
-exit "$result"
+exit $result

--- a/scripts/ci_check_vulnerabilities.sh
+++ b/scripts/ci_check_vulnerabilities.sh
@@ -6,7 +6,8 @@
 set -u
 
 set +e
-output=$(yarn audit --json --groups dependencies --level high)
+readable_output=$(yarn audit --groups dependencies --level high)
+json_output=$(yarn audit --json --groups dependencies --level high)
 result=$?
 set -e
 
@@ -15,9 +16,9 @@ if [ $result -eq 0 ]; then
 	exit 0
 fi
 
-if [ -f yarn-audit-known-issues ] && echo "$output" | grep auditAdvisory | diff -q yarn-audit-known-issues - > /dev/null 2>&1; then
+if [ -f yarn-audit-known-issues ] && echo "$json_output" | grep auditAdvisory | diff -q yarn-audit-known-issues - > /dev/null 2>&1; then
 	echo
-	echo Ignorning known vulnerabilities
+	echo Ignoring known vulnerabilities
 	exit 0
 fi
 
@@ -34,6 +35,6 @@ echo "yarn audit --json --groups dependencies --level high | grep auditAdvisory 
 echo
 echo and commit the yarn-audit-known-issues file
 echo
-echo "$output" | grep auditAdvisory | python -mjson.tool
+echo "$readable_output"
 
 exit "$result"


### PR DESCRIPTION
### Description

- Moves `yarn audit` vulnerabilities check from blocking CI to cronjob
- Makes `yarn audit` run in CI when dependencies have changed

### Other changes

- outputs yarn audit results in human readable format in CI

### Tested

![Screen Shot 2020-10-08 at 4 19 20 PM](https://user-images.githubusercontent.com/3020995/95522876-1f45d200-0982-11eb-96b5-9bed784eb457.png)

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._