### PR TITLE
Expose owner in releasegold:show (#5066)

### DIFF
--- a/packages/cli/src/commands/releasegold/show.ts
+++ b/packages/cli/src/commands/releasegold/show.ts
@@ -31,6 +31,7 @@ export default class Show extends ReleaseGoldBaseCommand {
       releaseGoldWrapperAddress: this.releaseGoldWrapper.address,
       beneficiary: await this.releaseGoldWrapper.getBeneficiary(),
       releaseOwner: await this.releaseGoldWrapper.getReleaseOwner(),
+      owner: await this.releaseGoldWrapper.getOwner(),
       refundAddress: await this.releaseGoldWrapper.getRefundAddress(),
       liquidityProvisionMet: await this.releaseGoldWrapper.getLiquidityProvisionMet(),
       canValidate: await this.releaseGoldWrapper.getCanValidate(),

--- a/packages/contractkit/src/wrappers/ReleaseGold.ts
+++ b/packages/contractkit/src/wrappers/ReleaseGold.ts
@@ -33,6 +33,7 @@ export interface ReleaseGoldInfo {
   releaseGoldWrapperAddress: string
   beneficiary: string
   releaseOwner: string
+  owner: string
   refundAddress: string
   liquidityProvisionMet: boolean
   canValidate: boolean

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_releasegold_.releasegoldwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_releasegold_.releasegoldwrapper.md
@@ -101,7 +101,7 @@ Name | Type |
     tupleParser(valueToString, valueToString)
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:340](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L340)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:341](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L341)*
 
 Relocks gold that has been unlocked but not withdrawn.
 
@@ -126,7 +126,7 @@ ___
 
 • **createAccount**: *function* = proxySend(this.kit, this.contract.methods.createAccount)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:369](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L369)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:370](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L370)*
 
 Beneficiary creates an account on behalf of the ReleaseGold contract.
 
@@ -156,7 +156,7 @@ ___
 
 • **getBeneficiary**: *function* = proxyCall(this.contract.methods.beneficiary)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:85](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L85)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:86](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L86)*
 
 Returns the beneficiary of the ReleaseGold contract
 
@@ -172,7 +172,7 @@ ___
 
 • **getCanValidate**: *function* = proxyCall(this.contract.methods.canValidate)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:117](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L117)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:118](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L118)*
 
 Returns true if the contract can validate
 
@@ -188,7 +188,7 @@ ___
 
 • **getCanVote**: *function* = proxyCall(this.contract.methods.canVote)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:123](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L123)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:124](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L124)*
 
 Returns true if the contract can vote
 
@@ -208,7 +208,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:249](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L249)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:250](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L250)*
 
 Returns the total amount that has already released up to now
 
@@ -226,7 +226,7 @@ ___
     this.contract.methods.liquidityProvisionMet
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:109](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L109)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:110](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L110)*
 
 Returns true if the liquidity provision has been met for this contract
 
@@ -246,7 +246,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:140](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L140)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:141](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L141)*
 
 Returns the maximum amount of gold (regardless of release schedule)
 currently allowed for release.
@@ -263,7 +263,7 @@ ___
 
 • **getOwner**: *function* = proxyCall(this.contract.methods.owner)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:103](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L103)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:104](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L104)*
 
 Returns the owner's address of the ReleaseGold contract
 
@@ -279,7 +279,7 @@ ___
 
 • **getRefundAddress**: *function* = proxyCall(this.contract.methods.refundAddress)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:97](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L97)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:98](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L98)*
 
 Returns the refund address of the ReleaseGold contract
 
@@ -295,7 +295,7 @@ ___
 
 • **getReleaseOwner**: *function* = proxyCall(this.contract.methods.releaseOwner)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:91](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L91)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:92](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L92)*
 
 Returns the releaseOwner address of the ReleaseGold contract
 
@@ -315,7 +315,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:239](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L239)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:240](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L240)*
 
 Returns the remaining locked gold balance in the ReleaseGold instance
 
@@ -335,7 +335,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:219](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L219)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:220](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L220)*
 
 Returns the the sum of locked and unlocked gold in the ReleaseGold instance
 
@@ -355,7 +355,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:229](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L229)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:230](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L230)*
 
 Returns the remaining unlocked gold balance in the ReleaseGold instance
 
@@ -375,7 +375,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:209](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L209)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:210](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L210)*
 
 Returns the total balance of the ReleaseGold instance
 
@@ -395,7 +395,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:129](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L129)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L130)*
 
 Returns the total withdrawn amount from the ReleaseGold contract
 
@@ -411,7 +411,7 @@ ___
 
 • **isRevoked**: *function* = proxyCall(this.contract.methods.isRevoked)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:185](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L185)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:186](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L186)*
 
 Indicates if the release grant is revoked or not
 
@@ -431,7 +431,7 @@ ___
     tupleParser(valueToString)
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:275](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L275)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:276](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L276)*
 
 Locks gold to be used for voting.
 
@@ -453,7 +453,7 @@ ___
 
 • **setAccount**: *function* = proxySend(this.kit, this.contract.methods.setAccount)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:377](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L377)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:378](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L378)*
 
 Beneficiary creates an account on behalf of the ReleaseGold contract.
 
@@ -482,7 +482,7 @@ ___
     this.contract.methods.setAccountDataEncryptionKey
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:401](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L401)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:402](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L402)*
 
 Sets the data encryption of the account
 
@@ -504,7 +504,7 @@ ___
 
 • **setAccountMetadataURL**: *function* = proxySend(this.kit, this.contract.methods.setAccountMetadataURL)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:389](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L389)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:390](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L390)*
 
 Sets the metadataURL for the account
 
@@ -526,7 +526,7 @@ ___
 
 • **setAccountName**: *function* = proxySend(this.kit, this.contract.methods.setAccountName)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:383](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L383)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:384](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L384)*
 
 Sets the name for the account
 
@@ -548,7 +548,7 @@ ___
 
 • **setAccountWalletAddress**: *function* = proxySend(this.kit, this.contract.methods.setAccountWalletAddress)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:395](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L395)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:396](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L396)*
 
 Sets the wallet address for the account
 
@@ -570,7 +570,7 @@ ___
 
 • **setBeneficiary**: *function* = proxySend(this.kit, this.contract.methods.setBeneficiary)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:425](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L425)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:426](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L426)*
 
 Sets the contract's beneficiary
 
@@ -590,7 +590,7 @@ ___
 
 • **setCanExpire**: *function* = proxySend(this.kit, this.contract.methods.setCanExpire)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:415](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L415)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:416](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L416)*
 
 Sets the contract's `canExpire` field to `_canExpire`
 
@@ -612,7 +612,7 @@ ___
 
 • **setLiquidityProvision**: *function* = proxySend(this.kit, this.contract.methods.setLiquidityProvision)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:409](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L409)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:410](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L410)*
 
 Sets the contract's liquidity provision to true
 
@@ -632,7 +632,7 @@ ___
 
 • **setMaxDistribution**: *function* = proxySend(this.kit, this.contract.methods.setMaxDistribution)
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:420](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L420)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:421](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L421)*
 
 Sets the contract's max distribution
 
@@ -656,7 +656,7 @@ ___
     tupleParser(stringIdentity, valueToString)
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:281](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L281)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:282](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L282)*
 
 #### Type declaration:
 
@@ -679,7 +679,7 @@ ___
     tupleParser(valueToString)
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:291](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L291)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:292](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L292)*
 
 Unlocks gold that becomes withdrawable after the unlocking period.
 
@@ -705,7 +705,7 @@ ___
     tupleParser(valueToString)
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:360](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L360)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:361](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L361)*
 
 Transfer released gold from the ReleaseGold instance back to beneficiary.
 
@@ -731,7 +731,7 @@ ___
     tupleParser(valueToString)
   )
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:350](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L350)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:351](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L351)*
 
 Withdraw gold in the ReleaseGold instance that has been unlocked but not withdrawn.
 
@@ -767,7 +767,7 @@ Contract address
 
 ▸ **authorizeAttestationSigner**(`signer`: [Address](../modules/_base_.md#address), `proofOfSigningKeyPossession`: Signature): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:537](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L537)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:538](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L538)*
 
 Authorizes an address to sign attestation messages on behalf of the account.
 
@@ -788,7 +788,7 @@ ___
 
 ▸ **authorizeValidatorSigner**(`signer`: [Address](../modules/_base_.md#address), `proofOfSigningKeyPossession`: Signature): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:454](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L454)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:455](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L455)*
 
 Authorizes an address to sign validation messages on behalf of the account.
 
@@ -809,7 +809,7 @@ ___
 
 ▸ **authorizeValidatorSignerAndBls**(`signer`: [Address](../modules/_base_.md#address), `proofOfSigningKeyPossession`: Signature, `blsPublicKey`: string, `blsPop`: string): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:502](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L502)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:503](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L503)*
 
 Authorizes an address to sign consensus messages on behalf of the contract's account. Also switch BLS key at the same time.
 
@@ -832,7 +832,7 @@ ___
 
 ▸ **authorizeVoteSigner**(`signer`: [Address](../modules/_base_.md#address), `proofOfSigningKeyPossession`: Signature): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:433](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L433)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:434](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L434)*
 
 Authorizes an address to sign votes on behalf of the account.
 
@@ -874,7 +874,7 @@ ___
 
 ▸ **getReleaseSchedule**(): *Promise‹ReleaseSchedule›*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:69](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L69)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:70](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L70)*
 
 Returns the underlying Release schedule of the ReleaseGold contract
 
@@ -888,7 +888,7 @@ ___
 
 ▸ **getReleasedBalanceAtRevoke**(): *Promise‹string›*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:200](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L200)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:201](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L201)*
 
 Returns the balance of released gold when the grant was revoked
 
@@ -902,7 +902,7 @@ ___
 
 ▸ **getRevocationInfo**(): *Promise‹RevocationInfo›*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:150](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L150)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:151](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L151)*
 
 Returns the underlying Revocation Info of the ReleaseGold contract
 
@@ -916,7 +916,7 @@ ___
 
 ▸ **getRevokeTime**(): *Promise‹number›*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:191](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L191)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:192](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L192)*
 
 Returns the time at which the release schedule was revoked
 
@@ -930,7 +930,7 @@ ___
 
 ▸ **isRevocable**(): *Promise‹boolean›*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:176](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L176)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:177](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L177)*
 
 Indicates if the release grant is revocable or not
 
@@ -944,7 +944,7 @@ ___
 
 ▸ **refundAndFinalize**(): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:267](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L267)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:268](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L268)*
 
 Refund `refundAddress` and `beneficiary` after the ReleaseGold schedule has been revoked.
 
@@ -958,7 +958,7 @@ ___
 
 ▸ **relockGold**(`value`: BigNumber.Value): *Promise‹Array‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void›››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:302](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L302)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:303](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L303)*
 
 Relocks gold in the ReleaseGold instance that has been unlocked but not withdrawn.
 
@@ -976,7 +976,7 @@ ___
 
 ▸ **revoke**(`account`: [Address](../modules/_base_.md#address), `group`: [Address](../modules/_base_.md#address), `value`: BigNumber): *Promise‹Array‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void›››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:602](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L602)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:603](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L603)*
 
 **Parameters:**
 
@@ -994,7 +994,7 @@ ___
 
 ▸ **revokeActive**(`account`: [Address](../modules/_base_.md#address), `group`: [Address](../modules/_base_.md#address), `value`: BigNumber): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:583](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L583)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:584](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L584)*
 
 Revokes active votes
 
@@ -1014,7 +1014,7 @@ ___
 
 ▸ **revokePending**(`account`: [Address](../modules/_base_.md#address), `group`: [Address](../modules/_base_.md#address), `value`: BigNumber): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:558](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L558)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:559](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L559)*
 
 Revokes pending votes
 
@@ -1034,7 +1034,7 @@ ___
 
 ▸ **revokeReleasing**(): *Promise‹[CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹void››*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:259](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L259)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:260](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L260)*
 
 Revoke a Release schedule
 

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_releasegold_.releasegoldinfo.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_releasegold_.releasegoldinfo.md
@@ -14,6 +14,7 @@
 * [canVote](_wrappers_releasegold_.releasegoldinfo.md#canvote)
 * [isRevoked](_wrappers_releasegold_.releasegoldinfo.md#isrevoked)
 * [liquidityProvisionMet](_wrappers_releasegold_.releasegoldinfo.md#liquidityprovisionmet)
+* [owner](_wrappers_releasegold_.releasegoldinfo.md#owner)
 * [refundAddress](_wrappers_releasegold_.releasegoldinfo.md#refundaddress)
 * [releaseGoldWrapperAddress](_wrappers_releasegold_.releasegoldinfo.md#releasegoldwrapperaddress)
 * [releaseOwner](_wrappers_releasegold_.releasegoldinfo.md#releaseowner)
@@ -26,7 +27,7 @@
 
 • **balanceStateData**: *[BalanceState](_wrappers_releasegold_.balancestate.md)*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L43)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L44)*
 
 ___
 
@@ -42,7 +43,7 @@ ___
 
 • **canValidate**: *boolean*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:38](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L38)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:39](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L39)*
 
 ___
 
@@ -50,7 +51,7 @@ ___
 
 • **canVote**: *boolean*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:39](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L39)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:40](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L40)*
 
 ___
 
@@ -58,7 +59,7 @@ ___
 
 • **isRevoked**: *boolean*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L41)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L42)*
 
 ___
 
@@ -66,7 +67,15 @@ ___
 
 • **liquidityProvisionMet**: *boolean*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:37](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L37)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:38](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L38)*
+
+___
+
+###  owner
+
+• **owner**: *string*
+
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:36](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L36)*
 
 ___
 
@@ -74,7 +83,7 @@ ___
 
 • **refundAddress**: *string*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:36](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L36)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:37](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L37)*
 
 ___
 
@@ -98,7 +107,7 @@ ___
 
 • **releaseSchedule**: *ReleaseSchedule*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:40](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L40)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L41)*
 
 ___
 
@@ -106,4 +115,4 @@ ___
 
 • **revokedStateData**: *RevocationInfo*
 
-*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L42)*
+*Defined in [packages/contractkit/src/wrappers/ReleaseGold.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/ReleaseGold.ts#L43)*


### PR DESCRIPTION
### Description
Fixes #5066 .
This change displays the ReleaseGold contract `owner` when calling `celocli releasegold:show` (along with all the other parameters like `releaseOwner`, `refundAddress`...). The `getOwner` function had already been defined, so this only required including the field in `ReleaseGoldInfo`.

### Tested
Tested this locally on ReleaseGold addresses and ensured that outputs included the owner field.