### PR TITLE
[Wallet] Fix invite flow and i18n texts

### DIFF
--- a/packages/mobile/locales/en-US/onboarding.json
+++ b/packages/mobile/locales/en-US/onboarding.json
@@ -61,8 +61,8 @@
   },
   "verificationPrematureRevealMessage": "Please wait one minute before resending",
   "verificationLearnMoreDialog": {
-    "title": "Phone Numbers and Valora",
-    "body": "Confirming makes it easy to connect with our friends by allowing you to send and receive funds to your phone number.\n\n<0>Can I do this later?</0>\n\nYes, but unconfirmed accounts can only send payments with QR codes or account numbers (addresses).\n\n<1>Secure and Private</1>\n\nValora uses state of the art cryptography to keep your phone number private.",
+    "title": "Phone Numbers and {{appName}}",
+    "body": "Confirming makes it easy to connect with your friends by allowing you to send and receive funds to your phone number.\n\n<0>Can I do this later?</0>\n\nYes, but unconfirmed accounts can only send payments with QR codes or account numbers (addresses).\n\n<1>Secure and Private</1>\n\nValora uses state of the art cryptography to keep your phone number private.",
     "dismiss": "Dismiss"
   },
   "importExistingKey": {

--- a/packages/mobile/locales/es-419/onboarding.json
+++ b/packages/mobile/locales/es-419/onboarding.json
@@ -61,8 +61,8 @@
   },
   "verificationPrematureRevealMessage": "Por favor espera 1 minuto antes de volver a enviar",
   "verificationLearnMoreDialog": {
-    "title": "Confirmación de número de teléfono",
-    "body": "La confirmación del número de teléfono funciona asociando tu cuenta con tu número de teléfono.\n\n<0>¿Necesito completar esto?</0>\n\nNo se requiere confirmación, sin embargo, las cuentas no confirmadas solo pueden enviar pagos utilizando direcciones Celo o códigos QR.\n\n<1>Seguridad y privacidad</1>\n\nPara proteger tu privacidad, solo una versión ofuscada de tu número de teléfono se almacena en la cadena de bloques de Celo.",
+    "title": "Números de teléfono y {{appName}}",
+    "body": "Confirmar facilita conectar con tus amigos al permitir enviar y recibir dinero usando tu número de teléfono.\n\n<0>¿Puedo hacerlo más tarde?</0>\n\nSi, pero cuentas sin confirmar solo pueden enviar dinero usando códigos QR o números de cuenta (direcciones).\n\n<1>Seguro y Privado</1>\n\nValora usa criptografía de vanguardia para mantener tu número de teléfono privado.",
     "dismiss": "Descartar"
   },
   "importExistingKey": {

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -315,6 +315,7 @@ export function* redeemInviteSaga({ tempAccountPrivateKey }: RedeemInviteAction)
   if (result?.success === true) {
     Logger.debug(TAG, 'Redeem Invite completed successfully')
     yield put(redeemInviteSuccess())
+    yield put(refreshAllBalances())
     navigate(Screens.VerificationEducationScreen)
     // Note: We are ok with this succeeding or failing silently in the background,
     // user will have another chance to register DEK when sending their first tx


### PR DESCRIPTION
### Description

Fix to the issue reported in Slack:
> I found an issue on the invite redemption flow: After redeeming an invite code, if I try to verify my number I get a "Verification Failed" error immediately. If I skip verification but then verify by tapping on the notification box or the settings menu verification works well.
Attaching logs, the relevant line seems to be identity/verification :: Error occured during verification flow :: invalid bytes32 value (arg="identifier", coderType="bytes32", value="") in throwError@http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:299691:26
This is reproduced 100% on iOS emulator, trying now on Android device.

### Other changes

Address Jean's comments in https://github.com/celo-org/celo-monorepo/pull/5134

### Related Issues
- Closes #5228

### Tested

iOS simulator

### Backwards compatibility

Yes