### PR TITLE
Implement signTypedData across all different wallets/signers

### DIFF
--- a/packages/contractkit/src/utils/signing-utils.ts
+++ b/packages/contractkit/src/utils/signing-utils.ts
@@ -1,6 +1,6 @@
 import { Address, ensureLeading0x, trimLeading0x } from '@celo/base/lib/address'
 import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
-import { verifySignature } from '@celo/utils/lib/signatureUtils'
+import { parseSignatureWithoutPrefix } from '@celo/utils/lib/signatureUtils'
 import { BigNumber } from 'bignumber.js'
 import debugFactory from 'debug'
 // @ts-ignore-next-line
@@ -226,8 +226,20 @@ export function verifyEIP712TypedDataSigner(
 ): boolean {
   const dataBuff = generateTypedDataHash(typedData)
   const trimmedData = dataBuff.toString('hex')
-  const valid = verifySignature(ensureLeading0x(trimmedData), signedData, expectedAddress)
-  return valid
+  return verifySignatureWithoutPrefix(ensureLeading0x(trimmedData), signedData, expectedAddress)
+}
+
+export function verifySignatureWithoutPrefix(
+  messageHash: string,
+  signature: string,
+  signer: string
+) {
+  try {
+    parseSignatureWithoutPrefix(messageHash, signature, signer)
+    return true
+  } catch (error) {
+    return false
+  }
 }
 
 export function decodeSig(sig: any) {

--- a/packages/contractkit/src/wallets/ledger-wallet.test.ts
+++ b/packages/contractkit/src/wallets/ledger-wallet.test.ts
@@ -142,6 +142,24 @@ function mockLedger(wallet: LedgerWallet, mockForceValidation: () => void) {
         }
         throw new Error('Invalid Path')
       },
+      signEIP712HashedMessage: async (
+        derivationPath: string,
+        domainSeparator: Buffer,
+        structHash: Buffer
+      ) => {
+        const messageHash = ethUtil.sha3(
+          Buffer.concat([Buffer.from('1901', 'hex'), domainSeparator, structHash])
+        ) as Buffer
+
+        const trimmedKey = trimLeading0x(ledgerAddresses[derivationPath].privateKey)
+        const pkBuffer = Buffer.from(trimmedKey, 'hex')
+        const signature = ethUtil.ecsign(messageHash, pkBuffer)
+        return {
+          v: signature.v,
+          r: signature.r.toString('hex'),
+          s: signature.s.toString('hex'),
+        }
+      },
       getAppConfiguration: async () => {
         return { arbitraryDataEnabled: 1, version: '0.0.0' }
       },

--- a/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts
+++ b/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts
@@ -1,4 +1,5 @@
 import { ensureLeading0x, trimLeading0x } from '@celo/utils/lib/address'
+import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
 import { KMS } from 'aws-sdk'
 import { BigNumber } from 'bignumber.js'
 import * as ethUtil from 'ethereumjs-util'
@@ -85,6 +86,17 @@ export default class AwsHsmSigner implements Signer {
     const dataBuff = ethUtil.toBuffer(ensureLeading0x(data))
     const msgHashBuff = ethUtil.hashPersonalMessage(dataBuff) as Buffer
     const { v, r, s } = await this.sign(msgHashBuff)
+
+    return {
+      v: v + 27,
+      r,
+      s,
+    }
+  }
+
+  async signTypedData(typedData: EIP712TypedData): Promise<Signature> {
+    const typedDataHashBuff = generateTypedDataHash(typedData)
+    const { v, r, s } = await this.sign(typedDataHashBuff)
 
     return {
       v: v + 27,

--- a/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts
+++ b/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts
@@ -1,4 +1,5 @@
 import { ensureLeading0x, trimLeading0x } from '@celo/base/lib/address'
+import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
 import * as ethUtil from 'ethereumjs-util'
 import { AzureKeyVaultClient } from '../../utils/azure-key-vault-client'
 import { getHashFromEncoded, RLPEncodedTx } from '../../utils/signing-utils'
@@ -46,6 +47,20 @@ export class AzureHSMSigner implements Signer {
     // https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v
     const sigV = signature.v + 27
 
+    return {
+      v: sigV,
+      r: signature.r,
+      s: signature.s,
+    }
+  }
+
+  async signTypedData(typedData: EIP712TypedData): Promise<{ v: number; r: Buffer; s: Buffer }> {
+    const dataBuff = generateTypedDataHash(typedData)
+    const signature = await AzureHSMSigner.keyVaultClient.signMessage(dataBuff, this.keyName)
+
+    // Recovery ID should be a byte prefix
+    // https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v
+    const sigV = signature.v + 27
     return {
       v: sigV,
       r: signature.r,

--- a/packages/contractkit/src/wallets/signers/ledger-signer.ts
+++ b/packages/contractkit/src/wallets/signers/ledger-signer.ts
@@ -1,5 +1,5 @@
 import { ensureLeading0x, trimLeading0x } from '@celo/base/lib/address'
-import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
+import { EIP712TypedData, structHash } from '@celo/utils/lib/sign-typed-data-utils'
 import { TransportStatusError } from '@ledgerhq/errors'
 import debugFactory from 'debug'
 import * as ethUtil from 'ethereumjs-util'
@@ -103,11 +103,17 @@ export class LedgerSigner implements Signer {
 
   async signTypedData(typedData: EIP712TypedData): Promise<{ v: number; r: Buffer; s: Buffer }> {
     try {
-      const dataBuff = generateTypedDataHash(typedData)
-      const trimmedData = trimLeading0x(dataBuff.toString('hex'))
-      const sig = await this.ledger!.signPersonalMessage(
+      const domainSeparator = structHash('EIP712Domain', typedData.domain, typedData.types)
+      const hashStructMessage = structHash(
+        typedData.primaryType,
+        typedData.message,
+        typedData.types
+      )
+
+      const sig = await this.ledger!.signEIP712HashedMessage(
         await this.getValidatedDerivationPath(),
-        trimmedData
+        domainSeparator,
+        hashStructMessage
       )
 
       return {

--- a/packages/contractkit/src/wallets/signers/local-signer.ts
+++ b/packages/contractkit/src/wallets/signers/local-signer.ts
@@ -1,5 +1,6 @@
 import { ensureLeading0x, trimLeading0x } from '@celo/base/lib/address'
 import { Decrypt } from '@celo/utils/lib/ecies'
+import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
 // @ts-ignore-next-line
 import { account as Account } from 'eth-lib'
 import * as ethUtil from 'ethereumjs-util'
@@ -38,6 +39,19 @@ export class LocalSigner implements Signer {
     const msgHashBuff = ethUtil.hashPersonalMessage(dataBuff)
 
     const sig = ethUtil.ecsign(msgHashBuff, pkBuffer)
+    return {
+      v: parseInt(sig.v, 10),
+      r: Buffer.from(sig.r),
+      s: Buffer.from(sig.s),
+    }
+  }
+
+  async signTypedData(typedData: EIP712TypedData): Promise<{ v: number; r: Buffer; s: Buffer }> {
+    const dataBuff = generateTypedDataHash(typedData)
+    const trimmedKey = trimLeading0x(this.privateKey)
+    const pkBuffer = Buffer.from(trimmedKey, 'hex')
+
+    const sig = ethUtil.ecsign(dataBuff, pkBuffer)
     return {
       v: parseInt(sig.v, 10),
       r: Buffer.from(sig.r),

--- a/packages/contractkit/src/wallets/signers/rpc-signer.ts
+++ b/packages/contractkit/src/wallets/signers/rpc-signer.ts
@@ -1,4 +1,5 @@
 import { ensureLeading0x, normalizeAddressWith0x, trimLeading0x } from '@celo/base/lib/address'
+import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils'
 import BigNumber from 'bignumber.js'
 import BN from 'bn.js'
 import { EncodedTransaction, Tx } from 'web3-core'
@@ -25,6 +26,7 @@ enum RpcSignerEndpoint {
   UnlockAccount = 'personal_unlockAccount',
   SignTransaction = 'eth_signTransaction',
   SignBytes = 'eth_sign',
+  SignTypedData = 'eth_signTypedData',
   Decrypt = 'personal_decrypt',
 }
 
@@ -34,6 +36,7 @@ type RpcSignerEndpointInputs = {
   personal_unlockAccount: [string, string, number]
   eth_signTransaction: [any] // RpcTx doesn't match Tx because of nonce as string instead of number
   eth_sign: [string, string]
+  eth_signTypedData: [string, EIP712TypedData]
   personal_decrypt: [string, string]
 }
 
@@ -43,6 +46,7 @@ type RpcSignerEndpointResult = {
   personal_unlockAccount: boolean
   eth_signTransaction: EncodedTransaction
   eth_sign: string
+  eth_signTypedData: string
   personal_decrypt: string
 }
 
@@ -94,6 +98,15 @@ export class RpcSigner implements Signer {
 
   async signTransaction(): Promise<{ v: number; r: Buffer; s: Buffer }> {
     throw new Error('signTransaction unimplemented; use signRawTransaction')
+  }
+
+  async signTypedData(typedData: EIP712TypedData): Promise<{ v: number; r: Buffer; s: Buffer }> {
+    const result = await this.callAndCheckResponse(RpcSignerEndpoint.SignTypedData, [
+      this.account,
+      typedData,
+    ])
+
+    return decodeSig(result)
   }
 
   async signPersonalMessage(data: string): Promise<{ v: number; r: Buffer; s: Buffer }> {

--- a/packages/contractkit/src/wallets/signers/signer.ts
+++ b/packages/contractkit/src/wallets/signers/signer.ts
@@ -1,3 +1,4 @@
+import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils'
 import { RLPEncodedTx } from '../../utils/signing-utils'
 
 export interface Signer {
@@ -11,6 +12,7 @@ export interface Signer {
     encodedTx: RLPEncodedTx
   ) => Promise<{ v: number; r: Buffer; s: Buffer }>
   signPersonalMessage: (data: string) => Promise<{ v: number; r: Buffer; s: Buffer }>
+  signTypedData: (typedData: EIP712TypedData) => Promise<{ v: number; r: Buffer; s: Buffer }>
   getNativeKey: () => string
   decrypt: (ciphertext: Buffer) => Promise<Buffer>
 }

--- a/packages/contractkit/src/wallets/wallet.ts
+++ b/packages/contractkit/src/wallets/wallet.ts
@@ -1,5 +1,5 @@
 import { isHexString, normalizeAddressWith0x } from '@celo/base/lib/address'
-import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
+import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils'
 import * as ethUtil from 'ethereumjs-util'
 import { EncodedTransaction, Tx } from 'web3-core'
 import { Address } from '../base'
@@ -113,11 +113,8 @@ export abstract class WalletBase<TSigner extends Signer> implements ReadOnlyWall
       throw Error('wallet@signTypedData: TypedData Missing')
     }
 
-    const dataBuff = generateTypedDataHash(typedData)
-    const trimmedData = dataBuff.toString('hex')
-
     const signer = this.getSigner(address)
-    const sig = await signer.signPersonalMessage(trimmedData)
+    const sig = await signer.signTypedData(typedData)
 
     return ethUtil.toRpcSig(sig.v, sig.r, sig.s)
   }

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_aws_hsm_wallet_.awshsmwallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_aws_hsm_wallet_.awshsmwallet.md
@@ -59,7 +59,7 @@ Name | Type |
 
 *Inherited from [WalletBase](_wallets_wallet_.walletbase.md).[decrypt](_wallets_wallet_.walletbase.md#decrypt)*
 
-*Defined in [packages/contractkit/src/wallets/wallet.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L133)*
+*Defined in [packages/contractkit/src/wallets/wallet.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L130)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_azure_hsm_wallet_.azurehsmwallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_azure_hsm_wallet_.azurehsmwallet.md
@@ -54,7 +54,7 @@ Name | Type |
 
 *Inherited from [WalletBase](_wallets_wallet_.walletbase.md).[decrypt](_wallets_wallet_.walletbase.md#decrypt)*
 
-*Defined in [packages/contractkit/src/wallets/wallet.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L133)*
+*Defined in [packages/contractkit/src/wallets/wallet.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L130)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_ledger_wallet_.ledgerwallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_ledger_wallet_.ledgerwallet.md
@@ -104,7 +104,7 @@ Transport to connect the ledger device
 
 *Inherited from [WalletBase](_wallets_wallet_.walletbase.md).[decrypt](_wallets_wallet_.walletbase.md#decrypt)*
 
-*Defined in [packages/contractkit/src/wallets/wallet.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L133)*
+*Defined in [packages/contractkit/src/wallets/wallet.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L130)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_local_wallet_.localwallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_local_wallet_.localwallet.md
@@ -49,7 +49,7 @@ ___
 
 *Inherited from [WalletBase](_wallets_wallet_.walletbase.md).[decrypt](_wallets_wallet_.walletbase.md#decrypt)*
 
-*Defined in [packages/contractkit/src/wallets/wallet.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L133)*
+*Defined in [packages/contractkit/src/wallets/wallet.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L130)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_remote_wallet_.remotewallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_remote_wallet_.remotewallet.md
@@ -46,7 +46,7 @@ Abstract class representing a remote wallet that requires async initialization
 
 *Inherited from [WalletBase](_wallets_wallet_.walletbase.md).[decrypt](_wallets_wallet_.walletbase.md#decrypt)*
 
-*Defined in [packages/contractkit/src/wallets/wallet.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L133)*
+*Defined in [packages/contractkit/src/wallets/wallet.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L130)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_rpc_wallet_.rpcwallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_rpc_wallet_.rpcwallet.md
@@ -74,7 +74,7 @@ ___
 
 *Inherited from [WalletBase](_wallets_wallet_.walletbase.md).[decrypt](_wallets_wallet_.walletbase.md#decrypt)*
 
-*Defined in [packages/contractkit/src/wallets/wallet.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L133)*
+*Defined in [packages/contractkit/src/wallets/wallet.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L130)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_aws_hsm_signer_.awshsmsigner.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_aws_hsm_signer_.awshsmsigner.md
@@ -20,6 +20,7 @@
 * [getNativeKey](_wallets_signers_aws_hsm_signer_.awshsmsigner.md#getnativekey)
 * [signPersonalMessage](_wallets_signers_aws_hsm_signer_.awshsmsigner.md#signpersonalmessage)
 * [signTransaction](_wallets_signers_aws_hsm_signer_.awshsmsigner.md#signtransaction)
+* [signTypedData](_wallets_signers_aws_hsm_signer_.awshsmsigner.md#signtypeddata)
 
 ## Constructors
 
@@ -27,7 +28,7 @@
 
 \+ **new AwsHsmSigner**(`kms`: KMS, `keyId`: string, `publicKey`: BigNumber): *[AwsHsmSigner](_wallets_signers_aws_hsm_signer_.awshsmsigner.md)*
 
-*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:26](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L26)*
+*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:27](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L27)*
 
 **Parameters:**
 
@@ -45,7 +46,7 @@ Name | Type |
 
 ▸ **decrypt**(`_ciphertext`: Buffer): *Promise‹Buffer‹››*
 
-*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:100](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L100)*
+*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:112](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L112)*
 
 **Parameters:**
 
@@ -61,7 +62,7 @@ ___
 
 ▸ **getNativeKey**(): *string*
 
-*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:96](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L96)*
+*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:108](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L108)*
 
 **Returns:** *string*
 
@@ -71,7 +72,7 @@ ___
 
 ▸ **signPersonalMessage**(`data`: string): *Promise‹[Signature](_utils_signature_utils_.signature.md)›*
 
-*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:84](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L84)*
+*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:85](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L85)*
 
 **Parameters:**
 
@@ -87,7 +88,7 @@ ___
 
 ▸ **signTransaction**(`addToV`: number, `encodedTx`: [RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md)): *Promise‹[Signature](_utils_signature_utils_.signature.md)›*
 
-*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:72](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L72)*
+*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:73](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L73)*
 
 **Parameters:**
 
@@ -95,5 +96,21 @@ Name | Type |
 ------ | ------ |
 `addToV` | number |
 `encodedTx` | [RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md) |
+
+**Returns:** *Promise‹[Signature](_utils_signature_utils_.signature.md)›*
+
+___
+
+###  signTypedData
+
+▸ **signTypedData**(`typedData`: EIP712TypedData): *Promise‹[Signature](_utils_signature_utils_.signature.md)›*
+
+*Defined in [packages/contractkit/src/wallets/signers/aws-hsm-signer.ts:97](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/aws-hsm-signer.ts#L97)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typedData` | EIP712TypedData |
 
 **Returns:** *Promise‹[Signature](_utils_signature_utils_.signature.md)›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_azure_hsm_signer_.azurehsmsigner.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_azure_hsm_signer_.azurehsmsigner.md
@@ -47,7 +47,7 @@ Name | Type |
 
 ▸ **decrypt**(`_ciphertext`: Buffer): *Promise‹Buffer‹››*
 
-*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:78](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L78)*
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:75](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L75)*
 
 **Parameters:**
 
@@ -63,7 +63,7 @@ ___
 
 ▸ **getNativeKey**(): *string*
 
-*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L74)*
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:71](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L71)*
 
 **Returns:** *string*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_azure_hsm_signer_.azurehsmsigner.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_azure_hsm_signer_.azurehsmsigner.md
@@ -22,6 +22,7 @@ Signs the EVM transaction using an HSM key in Azure Key Vault
 * [getNativeKey](_wallets_signers_azure_hsm_signer_.azurehsmsigner.md#getnativekey)
 * [signPersonalMessage](_wallets_signers_azure_hsm_signer_.azurehsmsigner.md#signpersonalmessage)
 * [signTransaction](_wallets_signers_azure_hsm_signer_.azurehsmsigner.md#signtransaction)
+* [signTypedData](_wallets_signers_azure_hsm_signer_.azurehsmsigner.md#signtypeddata)
 
 ## Constructors
 
@@ -29,7 +30,7 @@ Signs the EVM transaction using an HSM key in Azure Key Vault
 
 \+ **new AzureHSMSigner**(`keyVaultClient`: [AzureKeyVaultClient](_utils_azure_key_vault_client_.azurekeyvaultclient.md), `keyName`: string): *[AzureHSMSigner](_wallets_signers_azure_hsm_signer_.azurehsmsigner.md)*
 
-*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:12](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L12)*
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L13)*
 
 **Parameters:**
 
@@ -46,7 +47,7 @@ Name | Type |
 
 ▸ **decrypt**(`_ciphertext`: Buffer): *Promise‹Buffer‹››*
 
-*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:60](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L60)*
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:78](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L78)*
 
 **Parameters:**
 
@@ -62,7 +63,7 @@ ___
 
 ▸ **getNativeKey**(): *string*
 
-*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L56)*
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L74)*
 
 **Returns:** *string*
 
@@ -72,7 +73,7 @@ ___
 
 ▸ **signPersonalMessage**(`data`: string): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:38](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L38)*
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:39](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L39)*
 
 **Parameters:**
 
@@ -88,7 +89,7 @@ ___
 
 ▸ **signTransaction**(`addToV`: number, `encodedTx`: [RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md)): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L22)*
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L23)*
 
 **Parameters:**
 
@@ -96,5 +97,21 @@ Name | Type |
 ------ | ------ |
 `addToV` | number |
 `encodedTx` | [RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md) |
+
+**Returns:** *Promise‹object›*
+
+___
+
+###  signTypedData
+
+▸ **signTypedData**(`typedData`: EIP712TypedData): *Promise‹object›*
+
+*Defined in [packages/contractkit/src/wallets/signers/azure-hsm-signer.ts:57](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/azure-hsm-signer.ts#L57)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typedData` | EIP712TypedData |
 
 **Returns:** *Promise‹object›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_ledger_signer_.ledgersigner.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_ledger_signer_.ledgersigner.md
@@ -58,7 +58,7 @@ Name | Type |
 
 ▸ **decrypt**(`_ciphertext`: Buffer): *Promise‹Buffer‹››*
 
-*Defined in [packages/contractkit/src/wallets/signers/ledger-signer.ts:185](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/ledger-signer.ts#L185)*
+*Defined in [packages/contractkit/src/wallets/signers/ledger-signer.ts:191](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/ledger-signer.ts#L191)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_local_signer_.localsigner.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_local_signer_.localsigner.md
@@ -22,6 +22,7 @@ Signs the EVM transaction using the provided private key
 * [getNativeKey](_wallets_signers_local_signer_.localsigner.md#getnativekey)
 * [signPersonalMessage](_wallets_signers_local_signer_.localsigner.md#signpersonalmessage)
 * [signTransaction](_wallets_signers_local_signer_.localsigner.md#signtransaction)
+* [signTypedData](_wallets_signers_local_signer_.localsigner.md#signtypeddata)
 
 ## Constructors
 
@@ -29,7 +30,7 @@ Signs the EVM transaction using the provided private key
 
 \+ **new LocalSigner**(`privateKey`: string): *[LocalSigner](_wallets_signers_local_signer_.localsigner.md)*
 
-*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L13)*
+*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:14](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L14)*
 
 **Parameters:**
 
@@ -45,7 +46,7 @@ Name | Type |
 
 ▸ **decrypt**(`ciphertext`: Buffer): *Promise‹Buffer‹››*
 
-*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:48](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L48)*
+*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:62](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L62)*
 
 **Parameters:**
 
@@ -61,7 +62,7 @@ ___
 
 ▸ **getNativeKey**(): *string*
 
-*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:19](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L19)*
+*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:20](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L20)*
 
 **Returns:** *string*
 
@@ -71,7 +72,7 @@ ___
 
 ▸ **signPersonalMessage**(`data`: string): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:32](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L32)*
+*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:33](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L33)*
 
 **Parameters:**
 
@@ -87,7 +88,7 @@ ___
 
 ▸ **signTransaction**(`addToV`: number, `encodedTx`: [RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md)): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L23)*
+*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:24](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L24)*
 
 **Parameters:**
 
@@ -95,5 +96,21 @@ Name | Type |
 ------ | ------ |
 `addToV` | number |
 `encodedTx` | [RLPEncodedTx](../interfaces/_utils_signing_utils_.rlpencodedtx.md) |
+
+**Returns:** *Promise‹object›*
+
+___
+
+###  signTypedData
+
+▸ **signTypedData**(`typedData`: EIP712TypedData): *Promise‹object›*
+
+*Defined in [packages/contractkit/src/wallets/signers/local-signer.ts:49](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/local-signer.ts#L49)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typedData` | EIP712TypedData |
 
 **Returns:** *Promise‹object›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_rpc_signer_.rpcsigner.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_signers_rpc_signer_.rpcsigner.md
@@ -25,6 +25,7 @@ Implements the signer interface on top of the JSON-RPC interface.
 * [signPersonalMessage](_wallets_signers_rpc_signer_.rpcsigner.md#signpersonalmessage)
 * [signRawTransaction](_wallets_signers_rpc_signer_.rpcsigner.md#signrawtransaction)
 * [signTransaction](_wallets_signers_rpc_signer_.rpcsigner.md#signtransaction)
+* [signTypedData](_wallets_signers_rpc_signer_.rpcsigner.md#signtypeddata)
 * [unlock](_wallets_signers_rpc_signer_.rpcsigner.md#unlock)
 
 ## Constructors
@@ -33,7 +34,7 @@ Implements the signer interface on top of the JSON-RPC interface.
 
 \+ **new RpcSigner**(`rpc`: [RpcCaller](../interfaces/_utils_rpc_caller_.rpccaller.md), `account`: string, `unlockBufferSeconds`: number, `unlockTime?`: undefined | number, `unlockDuration?`: undefined | number): *[RpcSigner](_wallets_signers_rpc_signer_.rpcsigner.md)*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:52](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L52)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L56)*
 
 Construct a new instance of the RPC signer
 
@@ -55,7 +56,7 @@ Name | Type | Default | Description |
 
 ▸ **decrypt**(`ciphertext`: Buffer): *Promise‹Buffer‹››*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:149](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L149)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:162](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L162)*
 
 **Parameters:**
 
@@ -71,7 +72,7 @@ ___
 
 ▸ **getNativeKey**(): *string*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:107](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L107)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:120](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L120)*
 
 **Returns:** *string*
 
@@ -81,7 +82,7 @@ ___
 
 ▸ **init**(`privateKey`: string, `passphrase`: string): *Promise‹string›*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:72](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L72)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:76](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L76)*
 
 **Parameters:**
 
@@ -98,7 +99,7 @@ ___
 
 ▸ **isUnlocked**(): *boolean*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:131](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L131)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:144](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L144)*
 
 **Returns:** *boolean*
 
@@ -108,7 +109,7 @@ ___
 
 ▸ **signPersonalMessage**(`data`: string): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:99](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L99)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:112](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L112)*
 
 **Parameters:**
 
@@ -124,7 +125,7 @@ ___
 
 ▸ **signRawTransaction**(`tx`: Tx): *Promise‹EncodedTransaction›*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:78](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L78)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:82](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L82)*
 
 **Parameters:**
 
@@ -140,7 +141,23 @@ ___
 
 ▸ **signTransaction**(): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:95](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L95)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:99](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L99)*
+
+**Returns:** *Promise‹object›*
+
+___
+
+###  signTypedData
+
+▸ **signTypedData**(`typedData`: EIP712TypedData): *Promise‹object›*
+
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:103](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L103)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typedData` | EIP712TypedData |
 
 **Returns:** *Promise‹object›*
 
@@ -150,7 +167,7 @@ ___
 
 ▸ **unlock**(`passphrase`: string, `duration`: number): *Promise‹boolean›*
 
-*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:109](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L109)*
+*Defined in [packages/contractkit/src/wallets/signers/rpc-signer.ts:122](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/rpc-signer.ts#L122)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_wallet_.walletbase.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_wallet_.walletbase.md
@@ -33,7 +33,7 @@
 
 ▸ **decrypt**(`address`: string, `ciphertext`: Buffer): *Promise‹Buffer‹››*
 
-*Defined in [packages/contractkit/src/wallets/wallet.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L133)*
+*Defined in [packages/contractkit/src/wallets/wallet.ts:130](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/wallet.ts#L130)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wallets_signers_signer_.signer.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wallets_signers_signer_.signer.md
@@ -20,6 +20,7 @@
 * [getNativeKey](_wallets_signers_signer_.signer.md#getnativekey)
 * [signPersonalMessage](_wallets_signers_signer_.signer.md#signpersonalmessage)
 * [signTransaction](_wallets_signers_signer_.signer.md#signtransaction)
+* [signTypedData](_wallets_signers_signer_.signer.md#signtypeddata)
 
 ## Properties
 
@@ -27,7 +28,7 @@
 
 • **decrypt**: *function*
 
-*Defined in [packages/contractkit/src/wallets/signers/signer.ts:15](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L15)*
+*Defined in [packages/contractkit/src/wallets/signers/signer.ts:17](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L17)*
 
 #### Type declaration:
 
@@ -45,7 +46,7 @@ ___
 
 • **getNativeKey**: *function*
 
-*Defined in [packages/contractkit/src/wallets/signers/signer.ts:14](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L14)*
+*Defined in [packages/contractkit/src/wallets/signers/signer.ts:16](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L16)*
 
 #### Type declaration:
 
@@ -57,7 +58,7 @@ ___
 
 • **signPersonalMessage**: *function*
 
-*Defined in [packages/contractkit/src/wallets/signers/signer.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L13)*
+*Defined in [packages/contractkit/src/wallets/signers/signer.ts:14](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L14)*
 
 #### Type declaration:
 
@@ -75,7 +76,7 @@ ___
 
 • **signTransaction**: *function*
 
-*Defined in [packages/contractkit/src/wallets/signers/signer.ts:9](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L9)*
+*Defined in [packages/contractkit/src/wallets/signers/signer.ts:10](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L10)*
 
 Signs the message and returns an EVM transaction
 
@@ -93,3 +94,21 @@ Name | Type |
 ------ | ------ |
 `addToV` | number |
 `encodedTx` | [RLPEncodedTx](_utils_signing_utils_.rlpencodedtx.md) |
+
+___
+
+###  signTypedData
+
+• **signTypedData**: *function*
+
+*Defined in [packages/contractkit/src/wallets/signers/signer.ts:15](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/signers/signer.ts#L15)*
+
+#### Type declaration:
+
+▸ (`typedData`: EIP712TypedData): *Promise‹object›*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typedData` | EIP712TypedData |

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
@@ -25,6 +25,7 @@
 * [recoverTransaction](_utils_signing_utils_.md#recovertransaction)
 * [rlpEncodedTx](_utils_signing_utils_.md#rlpencodedtx)
 * [verifyEIP712TypedDataSigner](_utils_signing_utils_.md#verifyeip712typeddatasigner)
+* [verifySignatureWithoutPrefix](_utils_signing_utils_.md#verifysignaturewithoutprefix)
 
 ## Variables
 
@@ -72,7 +73,7 @@ ___
 
 ▸ **decodeSig**(`sig`: any): *object*
 
-*Defined in [packages/contractkit/src/utils/signing-utils.ts:233](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L233)*
+*Defined in [packages/contractkit/src/utils/signing-utils.ts:245](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L245)*
 
 **Parameters:**
 
@@ -138,7 +139,7 @@ ___
 
 ▸ **getAddressFromPublicKey**(`publicKey`: BigNumber): *[Address](_base_.md#address)*
 
-*Defined in [packages/contractkit/src/utils/signing-utils.ts:266](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L266)*
+*Defined in [packages/contractkit/src/utils/signing-utils.ts:278](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L278)*
 
 **Parameters:**
 
@@ -170,7 +171,7 @@ ___
 
 ▸ **recoverKeyIndex**(`signature`: Uint8Array, `publicKey`: BigNumber, `hash`: Uint8Array): *number*
 
-*Defined in [packages/contractkit/src/utils/signing-utils.ts:245](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L245)*
+*Defined in [packages/contractkit/src/utils/signing-utils.ts:257](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L257)*
 
 Attempts each recovery key to find a match
 
@@ -248,5 +249,23 @@ Name | Type |
 `typedData` | EIP712TypedData |
 `signedData` | string |
 `expectedAddress` | string |
+
+**Returns:** *boolean*
+
+___
+
+###  verifySignatureWithoutPrefix
+
+▸ **verifySignatureWithoutPrefix**(`messageHash`: string, `signature`: string, `signer`: string): *boolean*
+
+*Defined in [packages/contractkit/src/utils/signing-utils.ts:232](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/utils/signing-utils.ts#L232)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`messageHash` | string |
+`signature` | string |
+`signer` | string |
 
 **Returns:** *boolean*

--- a/packages/mobile/src/geth/GethNativeBridgeSigner.ts
+++ b/packages/mobile/src/geth/GethNativeBridgeSigner.ts
@@ -6,6 +6,7 @@ import {
 } from '@celo/contractkit/lib/utils/signing-utils'
 import { Signer } from '@celo/contractkit/lib/wallets/signers/signer'
 import { ensureLeading0x } from '@celo/utils/lib/address'
+import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
 import { normalizeAddressWith0x } from '@celo/utils/src/address'
 import * as ethUtil from 'ethereumjs-util'
 import { GethNativeModule } from 'react-native-geth'
@@ -67,6 +68,15 @@ export class GethNativeBridgeSigner implements Signer {
   async signPersonalMessage(data: string): Promise<{ v: number; r: Buffer; s: Buffer }> {
     Logger.info(`${TAG}@signPersonalMessage`, `Signing ${data}`)
     const hash = ethUtil.hashPersonalMessage(Buffer.from(data.replace('0x', ''), 'hex'))
+    const signatureBase64 = await this.geth.signHash(hash.toString('base64'), this.account)
+    return ethUtil.fromRpcSig(this.base64ToHex(signatureBase64))
+  }
+
+  async signTypedData(typedData: EIP712TypedData): Promise<{ v: number; r: Buffer; s: Buffer }> {
+    // TODO: Not sure if it makes more sense to expose a `signTypedData` function on the RN Bridge
+    // or just construct the hash here.
+    Logger.info(`${TAG}@signTypedData`, `Signing typed data`)
+    const hash = generateTypedDataHash(typedData)
     const signatureBase64 = await this.geth.signHash(hash.toString('base64'), this.account)
     return ethUtil.fromRpcSig(this.base64ToHex(signatureBase64))
   }


### PR DESCRIPTION
### Description

While putting together the DevDay3 demo for fee-less onboarding I realised that the `signTypedData` function of the `LocalWallet` is using that wrong approach when we created a valid EIP712 hash and then wrapped that in an Ethereum personal message hash. I hacked the fix for the demo but I wanted to come back and revisit this and implement the right hashing pattern across the wallet/signer combos that we support.

I know @AlexBHarley you were looking at parts of this recently, I'm not sure if we want to approach this differently but I took a stab at this draft implementation to start the conversation. 

### Tested

Haven't added specs yet because I wasn't sure if we're going with a different approach but wanted to start the conv with this PR

### Backwards compatibility

💀 The signTypedData backwards compatibility on LocalWallet is broken. We need to figure out what the implications of that are - I couldn't find a usage of this.