### PR TITLE
[celotool] Add celostats config for multiproxy

### DIFF
--- a/packages/helm-charts/common/templates/_helpers.tpl
+++ b/packages/helm-charts/common/templates/_helpers.tpl
@@ -135,7 +135,14 @@ release: {{ .Release.Name }}
     {{- end }}
     {{- if .ethstats | default false }}
     ACCOUNT_ADDRESS=$(cat /root/.celo/address)
-    ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --ethstats=${HOSTNAME}@{{ .ethstats }} --etherbase=${ACCOUNT_ADDRESS}"
+    ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --etherbase=${ACCOUNT_ADDRESS}"
+    {{- if .proxy | default false }}
+    [[ "$RID" -eq 0 ]] && ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --ethstats=${HOSTNAME}@{{ .ethstats }}"
+    {{- else }}
+    {{- if not (.proxied | default false) }}
+    ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --ethstats=${HOSTNAME}@{{ .ethstats }}"
+    {{- end }}
+    {{- end }}
     {{- end }}
     {{- if .metrics | default true }}
     ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --metrics"

--- a/packages/helm-charts/testnet/templates/validators.statefulset.yaml
+++ b/packages/helm-charts/testnet/templates/validators.statefulset.yaml
@@ -171,7 +171,11 @@ spec:
           fi
 
           PROXY_COUNT=$(cat /root/.celo/proxyCount)
-          [ "$PROXY_COUNT" -gt 0 ] && ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --proxy.proxied ${PROXY_FLAG}=$(cat /root/.celo/proxyEnodeUrlPairs) --nodiscover --proxy.allowprivateip"
+          if [ "$PROXY_COUNT" -gt 0 ]; then
+            ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --proxy.proxied ${PROXY_FLAG}=$(cat /root/.celo/proxyEnodeUrlPairs) --nodiscover --proxy.allowprivateip"
+          else
+            ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --ethstats=${HOSTNAME}@${ETHSTATS_SVC}"
+          fi
 
           [[ "$PING_IP_FROM_PACKET" == "true" ]] && ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --ping-ip-from-packet"
 
@@ -200,7 +204,6 @@ spec:
             --etherbase=${ACCOUNT_ADDRESS} \
             --networkid=${NETWORK_ID} \
             --syncmode=full \
-            --ethstats=${HOSTNAME}@${ETHSTATS_SVC} \
             --consoleformat=json \
             --consoleoutput=stdout \
             --verbosity={{ .Values.geth.verbosity }} \


### PR DESCRIPTION
### Description

Change templates in celotool, to make the first proxy of a multiproxy configuration to be the one that send metrics to celostats

### Tested

Manually

In the custom environment set (for example)
```
GETH_NODE_DOCKER_IMAGE_TAG=<multiproxy commit>
VALIDATORS="4"
VALIDATOR_PROXY_COUNTS=1:3,1:2,1:1,1:0
```
then deploy the `testnet` and the `celostats`

### Backwards compatibility

Yes