### PR TITLE
Fix celocli's attestation service test result output

### DIFF
--- a/packages/cli/src/commands/identity/test-attestation-service.ts
+++ b/packages/cli/src/commands/identity/test-attestation-service.ts
@@ -94,7 +94,7 @@ export default class TestAttestationService extends BaseCommand {
       cli.action.stop()
 
       const testRes = JSON.parse(await response.text())
-      if (testRes.success !== 'true') {
+      if (!testRes.success) {
         console.error('Request was not successful')
         cli.styledJSON(testRes)
         return


### PR DESCRIPTION
### Description

Successfully testing the attestation service (v1.0.5) with the celocli (v0.0.58) currently results in a `Request was not successful` output. The false-negative seems to be caused by the test response-checking condition (see change).

### Tested

Tested using the following command: `celocli identity:test-attestation-service`.

### Backwards compatibility

Change does not affect anything other than the celocli's identity test output.