### PR TITLE
Remove version numbers from wrong contracts/libraries

### DIFF
--- a/packages/protocol/contracts/common/FixidityLib.sol
+++ b/packages/protocol/contracts/common/FixidityLib.sol
@@ -11,20 +11,12 @@ pragma solidity ^0.5.13;
  * in the internal representation of a fraction.
  * When using this library be sure to use maxNewFixed() as the upper limit for
  * creation of fixed point numbers.
- * @dev All contained functions are pure and thus marked internal to be inlined 
- * on consuming contracts at compile time for gas efficiency. 
+ * @dev All contained functions are pure and thus marked internal to be inlined
+ * on consuming contracts at compile time for gas efficiency.
  */
 library FixidityLib {
   struct Fraction {
     uint256 value;
-  }
-
-  /**
-   * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
-   */
-  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
   }
 
   /**

--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.13;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../common/interfaces/ICeloVersionedContract.sol";
 
-contract UsingPrecompiles is ICeloVersionedContract {
+contract UsingPrecompiles {
   using SafeMath for uint256;
 
   address constant TRANSFER = address(0xff - 2);

--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -18,14 +18,6 @@ contract UsingPrecompiles is ICeloVersionedContract {
   address constant GET_VERIFIED_SEAL_BITMAP = address(0xff - 11);
 
   /**
-  * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return The storage, major, minor, and patch version of the contract.
-  */
-  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
-  }
-
-  /**
    * @notice calculate a * b^x for fractions a, b to `decimals` precision
    * @param aNumerator Numerator of first fraction
    * @param aDenominator Denominator of first fraction

--- a/packages/protocol/contracts/common/proxies/FixidityLibProxy.sol
+++ b/packages/protocol/contracts/common/proxies/FixidityLibProxy.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.3;
-
-import "../Proxy.sol";
-
-/* solhint-disable no-empty-blocks */
-contract FixidityLibProxy is Proxy {}

--- a/packages/protocol/contracts/governance/SlasherUtil.sol
+++ b/packages/protocol/contracts/governance/SlasherUtil.sol
@@ -29,14 +29,6 @@ contract SlasherUtil is
   event SlashingIncentivesSet(uint256 penalty, uint256 reward);
 
   /**
-  * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return The storage, major, minor, and patch version of the contract.
-  */
-  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
-  }
-
-  /**
    * @notice Sets slashing incentives.
    * @param penalty Penalty for the slashed signer.
    * @param reward Reward that the observer gets.

--- a/packages/protocol/contracts/governance/SlasherUtil.sol
+++ b/packages/protocol/contracts/governance/SlasherUtil.sol
@@ -8,13 +8,7 @@ import "../common/UsingRegistry.sol";
 import "../common/UsingPrecompiles.sol";
 import "../common/interfaces/ICeloVersionedContract.sol";
 
-contract SlasherUtil is
-  ICeloVersionedContract,
-  Ownable,
-  Initializable,
-  UsingRegistry,
-  UsingPrecompiles
-{
+contract SlasherUtil is Ownable, Initializable, UsingRegistry, UsingPrecompiles {
   using SafeMath for uint256;
 
   struct SlashingIncentives {


### PR DESCRIPTION
### Description

There are a few libraries/contracts which should not have `getVersionNumbers` as they are not deployed/linked.
