### PR TITLE
Make initialization of the proxy part of the governance proposal

### DIFF
--- a/packages/contractkit/src/governance/proposals.ts
+++ b/packages/contractkit/src/governance/proposals.ts
@@ -70,7 +70,7 @@ export const proposalToJSON = async (kit: ContractKit, proposal: Proposal) => {
 }
 
 type ProposalTxParams = Pick<ProposalTransaction, 'to' | 'value'>
-type RegistryAdditions = { [contractNameHash: string]: Address }
+type RegistryAdditions = { [contractName: string]: Address }
 /**
  * Builder class to construct proposals from JSON or transaction objects.
  */
@@ -153,12 +153,8 @@ export class ProposalBuilder {
       address = await this.kit.registry.addressFor(tx.contract)
     } catch (error) {
       // Check if prior proposal TXs include setting the registry for this contract
-      const contractNameHash = this.kit.web3.utils.soliditySha3({
-        type: 'string',
-        value: tx.contract,
-      })
-      if (this.registryAdditions[contractNameHash]) {
-        address = this.registryAdditions[contractNameHash]
+      if (this.registryAdditions[tx.contract]) {
+        address = this.registryAdditions[tx.contract]
       } else {
         throw new Error(
           `Could not find address for contract ${tx.contract} in Registry or Proposal`

--- a/packages/contractkit/src/governance/proposals.ts
+++ b/packages/contractkit/src/governance/proposals.ts
@@ -148,19 +148,9 @@ export class ProposalBuilder {
       throw new Error(`Arguments ${tx.args} did not match ${methodName} signature`)
     }
 
-    let address: Address
-    try {
-      address = await this.kit.registry.addressFor(tx.contract)
-    } catch (error) {
-      // Check if prior proposal TXs include setting the registry for this contract
-      if (this.registryAdditions[tx.contract]) {
-        address = this.registryAdditions[tx.contract]
-      } else {
-        throw new Error(
-          `Could not find address for contract ${tx.contract} in Registry or Proposal`
-        )
-      }
-    }
+    const address = this.registryAdditions[tx.contract]
+      ? this.registryAdditions[tx.contract]
+      : await this.kit.registry.addressFor(tx.contract)
 
     if (tx.contract === 'Registry' && tx.function === 'setAddressFor') {
       this.registryAdditions[tx.args[0]] = tx.args[1]

--- a/packages/contractkit/src/governance/proposals.ts
+++ b/packages/contractkit/src/governance/proposals.ts
@@ -70,7 +70,9 @@ export const proposalToJSON = async (kit: ContractKit, proposal: Proposal) => {
 }
 
 type ProposalTxParams = Pick<ProposalTransaction, 'to' | 'value'>
-type RegistryAdditions = { [contractName: string]: Address }
+interface RegistryAdditions {
+  [contractName: string]: Address
+}
 /**
  * Builder class to construct proposals from JSON or transaction objects.
  */

--- a/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.interactiveproposalbuilder.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.interactiveproposalbuilder.md
@@ -21,7 +21,7 @@
 
 \+ **new InteractiveProposalBuilder**(`builder`: [ProposalBuilder](_governance_proposals_.proposalbuilder.md)): *[InteractiveProposalBuilder](_governance_proposals_.interactiveproposalbuilder.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:158](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L158)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:169](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L169)*
 
 **Parameters:**
 
@@ -37,7 +37,7 @@ Name | Type |
 
 ▸ **outputTransactions**(): *Promise‹void›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:161](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L161)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:172](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L172)*
 
 **Returns:** *Promise‹void›*
 
@@ -47,6 +47,6 @@ ___
 
 ▸ **promptTransactions**(): *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:166](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L166)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:177](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L177)*
 
 **Returns:** *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
@@ -26,9 +26,9 @@ Builder class to construct proposals from JSON or transaction objects.
 
 ###  constructor
 
-\+ **new ProposalBuilder**(`kit`: [ContractKit](_kit_.contractkit.md), `builders`: Array‹function›): *[ProposalBuilder](_governance_proposals_.proposalbuilder.md)*
+\+ **new ProposalBuilder**(`kit`: [ContractKit](_kit_.contractkit.md), `builders`: Array‹function›, `registryAdditions`: RegistryAdditions): *[ProposalBuilder](_governance_proposals_.proposalbuilder.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:77](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L77)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:79](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L79)*
 
 **Parameters:**
 
@@ -36,6 +36,7 @@ Name | Type | Default |
 ------ | ------ | ------ |
 `kit` | [ContractKit](_kit_.contractkit.md) | - |
 `builders` | Array‹function› | [] |
+`registryAdditions` | RegistryAdditions | {} |
 
 **Returns:** *[ProposalBuilder](_governance_proposals_.proposalbuilder.md)*
 
@@ -45,7 +46,7 @@ Name | Type | Default |
 
 ▸ **addJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *number*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:153](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L153)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:164](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L164)*
 
 **Parameters:**
 
@@ -61,7 +62,7 @@ ___
 
 ▸ **addProxyRepointingTx**(`contract`: [CeloContract](../enums/_base_.celocontract.md), `newImplementationAddress`: string): *void*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:105](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L105)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:108](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L108)*
 
 Adds a transaction to set the implementation on a proxy to the given address.
 
@@ -80,7 +81,7 @@ ___
 
 ▸ **addTx**(`tx`: [CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹any›, `params`: Partial‹ProposalTxParams›): *void*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:128](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L128)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:131](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L131)*
 
 Adds a Celo transaction to the list for proposal construction.
 
@@ -99,7 +100,7 @@ ___
 
 ▸ **addWeb3Tx**(`tx`: TransactionObject‹any›, `params`: ProposalTxParams): *number*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:120](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L120)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:123](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L123)*
 
 Adds a Web3 transaction to the list for proposal construction.
 
@@ -118,7 +119,7 @@ ___
 
 ▸ **build**(): *Promise‹object[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:87](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L87)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:90](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L90)*
 
 Build calls all of the added build steps and returns the final proposal.
 
@@ -132,7 +133,7 @@ ___
 
 ▸ **fromJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:138](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L138)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:141](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L141)*
 
 **Parameters:**
 
@@ -148,7 +149,7 @@ ___
 
 ▸ **fromWeb3tx**(`tx`: TransactionObject‹any›, `params`: ProposalTxParams): *[ProposalTransaction](../modules/_wrappers_governance_.md#proposaltransaction)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:94](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L94)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:97](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L97)*
 
 Converts a Web3 transaction into a proposal transaction object.
 

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -34,7 +34,8 @@ interface VerificationContext {
 // Checks if the given transaction is a repointing of the Proxy for the given
 // contract.
 const isProxyRepointTransaction = (tx: ProposalTx, contract: string) =>
-  tx.contract === `${contract}Proxy` && (tx.function === '_setImplementation' || tx.function === '_setAndInitializeImplementation')
+  tx.contract === `${contract}Proxy` &&
+  (tx.function === '_setImplementation' || tx.function === 'initialize')
 
 const isImplementationChanged = (contract: string, context: VerificationContext): boolean =>
   context.proposal.some((tx: ProposalTx) => isProxyRepointTransaction(tx, contract))
@@ -127,7 +128,10 @@ const dfsStep = async (queue: string[], visited: Set<string>, context: Verificat
   } else {
     // tslint:disable-next-line: no-console
     console.log(
-      `${isLibrary(contract, context) ? 'Library' : 'Contract'} deployed at ${implementationAddress} matches ${contract}`)
+      `${
+        isLibrary(contract, context) ? 'Library' : 'Contract'
+      } deployed at ${implementationAddress} matches ${contract}`
+    )
   }
 
   // push unvisited libraries to DFS queue
@@ -148,7 +152,7 @@ export const verifyBytecodes = async (
   proposal: ProposalTx[],
   Proxy: Truffle.Contract<ProxyInstance>,
   web3: Web3,
-  isBeforeRelease1: boolean = false,
+  isBeforeRelease1: boolean = false
 ) => {
   const queue = contracts.filter((contract) => !ignoredContracts.includes(contract))
   const visited: Set<string> = new Set(queue)

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -3,7 +3,7 @@ import {
   LibraryPositions,
   linkLibraries,
   stripMetadata,
-  verifyLibraryPrefix,
+  verifyLibraryPrefix
 } from '@celo/protocol/lib/bytecode'
 import { ProposalTx } from '@celo/protocol/scripts/truffle/make-release'
 import { BuildArtifacts } from '@openzeppelin/upgrades'
@@ -34,7 +34,7 @@ interface VerificationContext {
 // Checks if the given transaction is a repointing of the Proxy for the given
 // contract.
 const isProxyRepointTransaction = (tx: ProposalTx, contract: string) =>
-  tx.contract === `${contract}Proxy` && tx.function === '_setImplementation'
+  tx.contract === `${contract}Proxy` && (tx.function === '_setImplementation' || tx.function === '_setAndInitializeImplementation')
 
 const isImplementationChanged = (contract: string, context: VerificationContext): boolean =>
   context.proposal.some((tx: ProposalTx) => isProxyRepointTransaction(tx, contract))

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -48,13 +48,11 @@ const isRegistryRepointTransaction = (tx: ProposalTx, registryId: string) =>
   tx.contract === `Registry` && tx.function === 'setAddressFor' && tx.args[0] === registryId
 
 const isProxyChanged = (contract: string, context: VerificationContext): boolean => {
-  const registryId = context.web3.utils.soliditySha3({ type: 'string', value: contract })
-  return context.proposal.some((tx) => isRegistryRepointTransaction(tx, registryId))
+  return context.proposal.some((tx) => isRegistryRepointTransaction(tx, contract))
 }
 
 const getProposedProxyAddress = (contract: string, context: VerificationContext): string => {
-  const registryId = context.web3.utils.soliditySha3({ type: 'string', value: contract })
-  const relevantTx = context.proposal.find((tx) => isRegistryRepointTransaction(tx, registryId))
+  const relevantTx = context.proposal.find((tx) => isRegistryRepointTransaction(tx, contract))
   return relevantTx.args[1]
 }
 

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -34,8 +34,7 @@ interface VerificationContext {
 // Checks if the given transaction is a repointing of the Proxy for the given
 // contract.
 const isProxyRepointTransaction = (tx: ProposalTx, contract: string) =>
-  tx.contract === `${contract}Proxy` &&
-  (tx.function === '_setImplementation' || tx.function === 'initialize')
+  tx.contract === `${contract}Proxy` && tx.function === '_setImplementation'
 
 const isImplementationChanged = (contract: string, context: VerificationContext): boolean =>
   context.proposal.some((tx: ProposalTx) => isProxyRepointTransaction(tx, contract))

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -34,7 +34,7 @@ interface VerificationContext {
 // Checks if the given transaction is a repointing of the Proxy for the given
 // contract.
 const isProxyRepointTransaction = (tx: ProposalTx, contract: string) =>
-  tx.contract === `${contract}Proxy` && tx.function === '_setImplementation'
+  tx.contract === `${contract}Proxy` && (tx.function === '_setImplementation' || tx.function === '_setAndInitializeImplementation')
 
 const isImplementationChanged = (contract: string, context: VerificationContext): boolean =>
   context.proposal.some((tx: ProposalTx) => isProxyRepointTransaction(tx, contract))

--- a/packages/protocol/scripts/bash/make-release.sh
+++ b/packages/protocol/scripts/bash/make-release.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # -i: Path to the data needed to initialize contracts.
 # -r: Path to the contract compatibility report.
 # -d: Whether to dry-run this deploy
+# -t: Whether to dry-run this deploy
 
 NETWORK=""
 PROPOSAL=""
@@ -18,8 +19,9 @@ BRANCH=""
 INITIALIZE_DATA=""
 REPORT=""
 DRYRUN=""
+TRUFFLE_OVERRIDE=""
 
-while getopts 'b:n:p:i:r:d' flag; do
+while getopts 'b:n:p:i:r:dt:' flag; do
   case "${flag}" in
     b) BRANCH="${OPTARG}" ;;
     n) NETWORK="${OPTARG}" ;;
@@ -27,6 +29,7 @@ while getopts 'b:n:p:i:r:d' flag; do
     i) INITIALIZE_DATA="${OPTARG}" ;;
     r) REPORT="${OPTARG}" ;;
     d) DRYRUN="--dry_run" ;;
+    t) TRUFFLE_OVERRIDE="${OPTARG}" ;;
     *) error "Unexpected option ${flag}" ;;
   esac
 done
@@ -48,11 +51,10 @@ mv build/contracts $BUILD_DIR
 git checkout -
 yarn build
 
-# TODO: remove the truffle_override
 yarn run truffle exec ./scripts/truffle/make-release.js \
   --network $NETWORK \
   --build_directory $BUILD_DIR \
   --report $REPORT \
   --proposal $PROPOSAL \
-  --truffle_override '{"gasLimit": 13000000, "gas": 13000000 }' \
+  --truffle_override $TRUFFLE_OVERRIDE \
   --initialize_data $INITIALIZE_DATA $DRYRUN

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -238,11 +238,10 @@ module.exports = async (callback: (error?: any) => number) => {
             const initializeAbi = (contract as any).abi.find(
               (abi: any) => abi.type === 'function' && abi.name === 'initialize'
             )
-            console.log(`Adding initialization of ${contractName} to proposal`)
             if (initializeAbi) {
               const args = initializationData[contractName]
               const callData = web3.eth.abi.encodeFunctionCall(initializeAbi, args)
-              console.log(`Initializing ${contractName} with: ${args}`)
+              console.log(`Add 'Initializing ${contractName} with: ${args}' to proposal`)
               proposal.push({
                 contract: `${contractName}Proxy`,
                 function: '_setAndInitializeImplementation',

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -248,7 +248,7 @@ module.exports = async (callback: (error?: any) => number) => {
               const args = initializationData[contractName]
               console.log(`Initializing ${contractName} with: ${args}`)
               proposal.push({
-                contract: `${contractName}Proxy`,
+                contract: contractName,
                 function: 'initialize',
                 args,
                 value: '0',

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -231,10 +231,7 @@ module.exports = async (callback: (error?: any) => number) => {
             proposal.push({
               contract: 'Registry',
               function: 'setAddressFor',
-              args: [
-                web3.utils.soliditySha3({ type: 'string', value: contractName }),
-                proxy.address,
-              ],
+              args: [contractName, proxy.address],
               value: '0',
               description: `Registry: ${contractName} -> ${proxy.address}`,
             })

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -142,6 +142,11 @@ const deployProxy = async (
   // Hack to trick truffle, which checks that the provided address has code
   const proxy = await (dryRun ? Proxy.at(REGISTRY_ADDRESS) : Proxy.new())
 
+  console.log(`Setting ${contractName}Proxy implementation to ${contract.address}`)
+  if (!dryRun) {
+    await proxy._setImplementation(contract.address)
+  }
+
   // This makes essentially every contract dependent on Governance.
   console.log(`Transferring ownership of ${contractName}Proxy to Governance`)
   if (!dryRun) {
@@ -233,15 +238,8 @@ module.exports = async (callback: (error?: any) => number) => {
               )
               proposal.push({
                 contract: `${contractName}Proxy`,
-                function: '_setAndInitializeImplementation',
-                args: [contract.address, callData],
-                value: '0',
-              })
-            } else {
-              proposal.push({
-                contract: `${contractName}Proxy`,
-                function: '_setImplementation',
-                args: [contract.address],
+                function: 'initialize',
+                args: [callData],
                 value: '0',
               })
             }

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -1,7 +1,6 @@
 // tslint:disable: max-classes-per-file
 // tslint:disable: no-console
 import { ASTDetailedVersionedReport } from '@celo/protocol/lib/compatibility/report'
-import { setAndInitializeImplementation } from '@celo/protocol/lib/proxy-utils'
 import { linkedLibraries } from '@celo/protocol/migrationsConfig'
 import { Address, eqAddress, NULL_ADDRESS } from '@celo/utils/lib/address'
 import { readdirSync, readJsonSync, writeJsonSync } from 'fs-extra'
@@ -126,7 +125,6 @@ const deployProxy = async (
   contractName: string,
   contract: Truffle.ContractInstance,
   addresses: ContractAddresses,
-  initializationData: { [contract: string]: any[] },
   dryRun: boolean
 ) => {
   // Explicitly forbid upgrading to a new Governance proxy contract.
@@ -143,28 +141,7 @@ const deployProxy = async (
   const Proxy = await artifacts.require(`${contractName}Proxy`)
   // Hack to trick truffle, which checks that the provided address has code
   const proxy = await (dryRun ? Proxy.at(REGISTRY_ADDRESS) : Proxy.new())
-  const initializeAbi = (contract as any).abi.find(
-    (abi: any) => abi.type === 'function' && abi.name === 'initialize'
-  )
-  console.log(`Setting ${contractName}Proxy implementation to ${contract.address}`)
-  if (initializeAbi) {
-    const args = initializationData[contractName]
-    console.log(`Initializing ${contractName} with: ${args}`)
-    if (!dryRun) {
-      await setAndInitializeImplementation(
-        web3,
-        proxy,
-        contract.address,
-        initializeAbi,
-        {},
-        ...args
-      )
-    }
-  } else {
-    if (!dryRun) {
-      await proxy._setImplementation(contract.address)
-    }
-  }
+
   // This makes essentially every contract dependent on Governance.
   console.log(`Transferring ownership of ${contractName}Proxy to Governance`)
   if (!dryRun) {
@@ -241,13 +218,33 @@ module.exports = async (callback: (error?: any) => number) => {
         if (shouldDeployImplementation || isLibrary) {
           const contract = await deployImplementation(contractName, Contract, argv.dry_run)
           if (shouldDeployProxy || isLibrary) {
-            const proxy = await deployProxy(
-              contractName,
-              contract,
-              addresses,
-              initializationData,
-              argv.dry_run
+            // Changes need another proxy/registry repointing
+            const proxy = await deployProxy(contractName, contract, addresses, argv.dry_run)
+
+            const initializeAbi = (contract as any).abi.find(
+              (abi: any) => abi.type === 'function' && abi.name === 'initialize'
             )
+            console.log(`Adding initialization of ${contractName} to proposal`)
+            if (initializeAbi) {
+              const args = initializationData[contractName]
+              const callData = web3.eth.abi.encodeFunctionCall(initializeAbi, args)
+              console.log(
+                `Initializing ${contractName} with: ${args} (encoded as callData: ${callData})`
+              )
+              proposal.push({
+                contract: `${contractName}Proxy`,
+                function: '_setAndInitializeImplementation',
+                args: [contract.address, callData],
+                value: '0',
+              })
+            } else {
+              proposal.push({
+                contract: `${contractName}Proxy`,
+                function: '_setImplementation',
+                args: [contract.address],
+                value: '0',
+              })
+            }
             // 4. Update the contract's address, if needed.
             addresses.set(contractName, proxy.address)
             proposal.push({
@@ -261,6 +258,7 @@ module.exports = async (callback: (error?: any) => number) => {
               description: `Registry: ${contractName} -> ${proxy.address}`,
             })
           } else {
+            // Proxy can be repointed to new implementation
             proposal.push({
               contract: `${contractName}Proxy`,
               function: '_setImplementation',

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -145,6 +145,8 @@ const deployProxy = async (
   const initializeAbi = (contract as any).abi.find(
     (abi: any) => abi.type === 'function' && abi.name === 'initialize'
   )
+  // Only set implementation if there is no initialize on the implementation contract,
+  // as otherwise anyone could initialize via the proxy and become the owner
   if (!initializeAbi) {
     console.log(`Setting ${contractName}Proxy implementation to ${contract.address}`)
     if (!dryRun) {

--- a/packages/protocol/test/compatibility/verify-bytecode.ts
+++ b/packages/protocol/test/compatibility/verify-bytecode.ts
@@ -361,10 +361,7 @@ contract('', (accounts) => {
             {
               contract: 'Registry',
               function: 'setAddressFor',
-              args: [
-                web3.utils.soliditySha3({ type: 'string', value: 'TestContract' }),
-                testContract.address,
-              ],
+              args: ['TestContract', testContract.address],
               value: '0',
             },
           ]
@@ -385,10 +382,7 @@ contract('', (accounts) => {
             {
               contract: 'Registry',
               function: 'setAddressFor',
-              args: [
-                web3.utils.soliditySha3({ type: 'string', value: 'TestContract' }),
-                testContract.address,
-              ],
+              args: ['TestContract', testContract.address],
               value: '0',
             },
           ]
@@ -403,10 +397,7 @@ contract('', (accounts) => {
             {
               contract: 'Registry',
               function: 'setAddressFor',
-              args: [
-                web3.utils.soliditySha3({ type: 'string', value: 'TestContract' }),
-                accounts[0],
-              ],
+              args: ['TestContract', accounts[0]],
               value: '0',
             },
           ]

--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -36,7 +36,6 @@ const RC0_FROM = '0x469be98FE71AFf8F6e7f64F9b732e28A03596B5C'
 const BAKLAVA_FROM = '0x0Cc59Ed03B3e763c02d54D695FFE353055f1502D'
 const BAKLAVASTAGING_FROM = '0x4588ABb84e1BBEFc2BcF4b2296F785fB7AD9F285'
 
-// Gas limit is doubled for initial contract deployment.
 const gasLimit = 13000000
 
 const defaultConfig = {

--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -37,7 +37,7 @@ const BAKLAVA_FROM = '0x0Cc59Ed03B3e763c02d54D695FFE353055f1502D'
 const BAKLAVASTAGING_FROM = '0x4588ABb84e1BBEFc2BcF4b2296F785fB7AD9F285'
 
 // Gas limit is doubled for initial contract deployment.
-const gasLimit = argv.reset ? 20000000 : 12500000
+const gasLimit = 13000000
 
 const defaultConfig = {
   host: '127.0.0.1',


### PR DESCRIPTION
### Description

This PR removes the initialization of the proxy in `make-release` and instead makes it part of the proposal. This allows the initialization be more verifiable instead of relying on the deployer of the proxy to have initialized it correctly.

For that, we have to skip the setting of the implementation on the proxy, as otherwise any caller to `initialize` would be able to make themselves owner. That also means that we are no longer transferring ownership with respect to the implementation contract functions in proxy storage.

A follow up PR should do the [verification of the initialization transaction](https://github.com/celo-org/celo-monorepo/issues/5484) as well as [verifying that the storage root is "pure"](https://github.com/celo-org/celo-monorepo/issues/5483)

This PR also fixes a grave issue where we are passing the hashed contract name to `Registry#setAddressFor` when in reality, it takes the plain contract name and hashes on-chain.

Fixes #5479