### PR TITLE
Defer setImplementation to proposal execution time

### DIFF
--- a/packages/contractkit/src/explorer/block-explorer.ts
+++ b/packages/contractkit/src/explorer/block-explorer.ts
@@ -2,6 +2,7 @@ import { Address } from '@celo/utils/lib/address'
 import { Block, Transaction } from 'web3-eth'
 import abi, { ABIDefinition } from 'web3-eth-abi'
 import {
+  getInitializeAbiOfImplementation,
   PROXY_ABI,
   PROXY_SET_AND_INITIALIZE_IMPLEMENTATION_SIGNATURE,
   PROXY_SET_IMPLEMENTATION_SIGNATURE,
@@ -123,6 +124,20 @@ export class BlockExplorer {
     const { args, params } = parseDecodedParams(
       abi.decodeParameters(matchedAbi.inputs!, encodedParameters)
     )
+
+    // Transform delegate call data into a readable params map
+    if (
+      matchedAbi.signature === PROXY_SET_AND_INITIALIZE_IMPLEMENTATION_SIGNATURE &&
+      args.length === 2
+    ) {
+      const initializeAbi = getInitializeAbiOfImplementation(contract)
+      const encodedInitializeParameters = args[1].slice(10)
+
+      const { params: initializeParams } = parseDecodedParams(
+        abi.decodeParameters(initializeAbi.inputs!, encodedInitializeParameters)
+      )
+      params[`initialize@${abi.encodeFunctionSignature(initializeAbi)}`] = initializeParams
+    }
 
     return {
       contract,

--- a/packages/contractkit/src/governance/proposals.ts
+++ b/packages/contractkit/src/governance/proposals.ts
@@ -133,6 +133,7 @@ export class ProposalBuilder {
     if (tx.contract === 'Registry' && tx.function === 'setAddressFor') {
       // Update canonical registry addresses
       this.registryAdditions[tx.args[0]] = tx.args[1]
+      this.registryAdditions[tx.args[0] + 'Proxy'] = tx.args[1]
     } else if (
       tx.function === SET_AND_INITIALIZE_IMPLEMENTATION_ABI.name &&
       Array.isArray(tx.args[1])

--- a/packages/contractkit/src/governance/proposals.ts
+++ b/packages/contractkit/src/governance/proposals.ts
@@ -89,7 +89,13 @@ export class ProposalBuilder {
    * Build calls all of the added build steps and returns the final proposal.
    * @returns A constructed Proposal object (i.e. a list of ProposalTransaction)
    */
-  build = async () => concurrentMap(4, this.builders, (builder) => builder())
+  build = async () => {
+    const ret = []
+    for (const builder of this.builders) {
+      ret.push(await builder())
+    }
+    return ret
+  }
 
   /**
    * Converts a Web3 transaction into a proposal transaction object.

--- a/packages/contractkit/src/governance/proposals.ts
+++ b/packages/contractkit/src/governance/proposals.ts
@@ -133,8 +133,11 @@ export class ProposalBuilder {
 
   fromJsonTx = async (tx: ProposalTransactionJSON) => {
     // Account for canonical registry addresses from current proposal
-    const address =
-      this.registryAdditions[tx.contract] ?? (await this.kit.registry.addressFor(tx.contract))
+    let address = this.registryAdditions[tx.contract]
+
+    if (!address) {
+      address = await this.kit.registry.addressFor(tx.contract)
+    }
 
     if (tx.contract === 'Registry' && tx.function === 'setAddressFor') {
       // Update canonical registry addresses

--- a/packages/contractkit/src/governance/proxy.ts
+++ b/packages/contractkit/src/governance/proxy.ts
@@ -1,78 +1,20 @@
-import Web3 from 'web3'
-import { ABIDefinition } from 'web3-eth-abi'
+import { AbiItem } from 'web3-utils'
+import { ABI, newProxy } from '../generated/Proxy'
+import { ContractKit } from '../kit'
 
-export const GET_IMPLEMENTATION_ABI: ABIDefinition = {
-  constant: true,
-  inputs: [],
-  name: '_getImplementation',
-  outputs: [
-    {
-      name: 'implementation',
-      type: 'address',
-    },
-  ],
-  payable: false,
-  stateMutability: 'view',
-  type: 'function',
-  signature: '0x42404e07',
+export const getImplementation = (kit: ContractKit, proxyContractAddress: string) =>
+  newProxy(kit.web3, proxyContractAddress).methods._getImplementation()
+
+export const setImplementation = (kit: ContractKit, proxyAddress: string, implAddress: string) =>
+  newProxy(kit.web3, proxyAddress).methods._setImplementation(implAddress)
+
+export const getInitializeAbiOfImplementation = (proxyContractName: string) => {
+  const implementationABI = require(`../generated/${proxyContractName.replace('Proxy', '')}`)
+    .ABI as AbiItem[]
+  return implementationABI.find((item) => item.name === 'initialize')
 }
 
-export const SET_IMPLEMENTATION_ABI: ABIDefinition = {
-  constant: false,
-  inputs: [
-    {
-      name: 'implementation',
-      type: 'address',
-    },
-  ],
-  name: '_setImplementation',
-  outputs: [],
-  payable: false,
-  stateMutability: 'nonpayable',
-  type: 'function',
-  signature: '0xbb913f41',
-}
-
-export const SET_AND_INITIALIZE_IMPLEMENTATION_ABI: ABIDefinition = {
-  constant: false,
-  inputs: [
-    {
-      name: 'implementation',
-      type: 'address',
-    },
-    {
-      name: 'callbackData',
-      type: 'bytes',
-    },
-  ],
-  name: '_setAndInitializeImplementation',
-  outputs: [],
-  payable: true,
-  stateMutability: 'payable',
-  type: 'function',
-  signature: '0x03386ba3',
-}
-
-export const PROXY_ABI: ABIDefinition[] = [
-  GET_IMPLEMENTATION_ABI,
-  SET_IMPLEMENTATION_ABI,
-  SET_AND_INITIALIZE_IMPLEMENTATION_ABI,
-]
-
-export const PROXY_SET_IMPLEMENTATION_SIGNATURE = SET_IMPLEMENTATION_ABI.signature
-export const PROXY_SET_AND_INITIALIZE_IMPLEMENTATION_SIGNATURE =
-  SET_AND_INITIALIZE_IMPLEMENTATION_ABI.signature
-
-export const getImplementationOfProxy = async (
-  web3: Web3,
-  proxyContractAddress: string
-): Promise<string> => {
-  const proxyWeb3Contract = new web3.eth.Contract(PROXY_ABI, proxyContractAddress)
-  return proxyWeb3Contract.methods._getImplementation().call()
-}
-
-export const setImplementationOnProxy = (address: string) => {
-  const web3 = new Web3()
-  const proxyWeb3Contract = new web3.eth.Contract(PROXY_ABI)
-  return proxyWeb3Contract.methods._setImplementation(address)
-}
+export const SET_IMPLEMENTATION_ABI = ABI.find((item) => item.name === '_setImplementation')!
+export const SET_AND_INITIALIZE_IMPLEMENTATION_ABI = ABI.find(
+  (item) => item.name === '_setAndInitializeImplementation'
+)!

--- a/packages/contractkit/src/governance/proxy.ts
+++ b/packages/contractkit/src/governance/proxy.ts
@@ -1,20 +1,70 @@
+import { ABIDefinition } from 'web3-eth-abi'
 import { AbiItem } from 'web3-utils'
-import { ABI, newProxy } from '../generated/Proxy'
-import { ContractKit } from '../kit'
 
-export const getImplementation = (kit: ContractKit, proxyContractAddress: string) =>
-  newProxy(kit.web3, proxyContractAddress).methods._getImplementation()
+export const GET_IMPLEMENTATION_ABI: ABIDefinition = {
+  constant: true,
+  inputs: [],
+  name: '_getImplementation',
+  outputs: [
+    {
+      name: 'implementation',
+      type: 'address',
+    },
+  ],
+  payable: false,
+  stateMutability: 'view',
+  type: 'function',
+  signature: '0x42404e07',
+}
 
-export const setImplementation = (kit: ContractKit, proxyAddress: string, implAddress: string) =>
-  newProxy(kit.web3, proxyAddress).methods._setImplementation(implAddress)
+export const SET_IMPLEMENTATION_ABI: ABIDefinition = {
+  constant: false,
+  inputs: [
+    {
+      name: 'implementation',
+      type: 'address',
+    },
+  ],
+  name: '_setImplementation',
+  outputs: [],
+  payable: false,
+  stateMutability: 'nonpayable',
+  type: 'function',
+  signature: '0xbb913f41',
+}
+
+export const SET_AND_INITIALIZE_IMPLEMENTATION_ABI: ABIDefinition = {
+  constant: false,
+  inputs: [
+    {
+      name: 'implementation',
+      type: 'address',
+    },
+    {
+      name: 'callbackData',
+      type: 'bytes',
+    },
+  ],
+  name: '_setAndInitializeImplementation',
+  outputs: [],
+  payable: true,
+  stateMutability: 'payable',
+  type: 'function',
+  signature: '0x03386ba3',
+}
+
+export const PROXY_ABI: ABIDefinition[] = [
+  GET_IMPLEMENTATION_ABI,
+  SET_IMPLEMENTATION_ABI,
+  SET_AND_INITIALIZE_IMPLEMENTATION_ABI,
+]
+
+export const PROXY_SET_IMPLEMENTATION_SIGNATURE = SET_IMPLEMENTATION_ABI.signature
+export const PROXY_SET_AND_INITIALIZE_IMPLEMENTATION_SIGNATURE =
+  SET_AND_INITIALIZE_IMPLEMENTATION_ABI.signature
 
 export const getInitializeAbiOfImplementation = (proxyContractName: string) => {
   const implementationABI = require(`../generated/${proxyContractName.replace('Proxy', '')}`)
     .ABI as AbiItem[]
   return implementationABI.find((item) => item.name === 'initialize')
 }
-
-export const SET_IMPLEMENTATION_ABI = ABI.find((item) => item.name === '_setImplementation')!
-export const SET_AND_INITIALIZE_IMPLEMENTATION_ABI = ABI.find(
-  (item) => item.name === '_setAndInitializeImplementation'
-)!

--- a/packages/contractkit/src/governance/proxy.ts
+++ b/packages/contractkit/src/governance/proxy.ts
@@ -66,5 +66,9 @@ export const PROXY_SET_AND_INITIALIZE_IMPLEMENTATION_SIGNATURE =
 export const getInitializeAbiOfImplementation = (proxyContractName: string) => {
   const implementationABI = require(`../generated/${proxyContractName.replace('Proxy', '')}`)
     .ABI as AbiItem[]
-  return implementationABI.find((item) => item.name === 'initialize')
+  const initializeAbi = implementationABI.find((item) => item.name === 'initialize')
+  if (!initializeAbi) {
+    throw new Error(`Initialize method not found on implementation of ${proxyContractName}`)
+  }
+  return initializeAbi
 }

--- a/packages/contractkit/src/web3-contract-cache.ts
+++ b/packages/contractkit/src/web3-contract-cache.ts
@@ -148,15 +148,15 @@ export class Web3ContractCache {
    * Get native web3 contract wrapper
    */
   async getContract<C extends keyof typeof ContractFactories>(contract: C, address?: string) {
-    if (this.cacheMap[contract] == null) {
+    if (this.cacheMap[contract] == null || address !== undefined) {
       debug('Initiating contract %s', contract)
       const createFn = ProxyContracts.includes(contract)
         ? newProxy
         : (ContractFactories[contract] as CFType[C])
-      // @ts-ignore: Too compplex union type
+      // @ts-ignore: Too complex union type
       this.cacheMap[contract] = createFn(
         this.kit.web3,
-        address ? address : await this.kit.registry.addressFor(contract)
+        address ?? (await this.kit.registry.addressFor(contract))
       ) as NonNullable<ContractCacheMap[C]>
     }
     // we know it's defined (thus the !)

--- a/packages/contractkit/src/web3-contract-cache.ts
+++ b/packages/contractkit/src/web3-contract-cache.ts
@@ -152,7 +152,9 @@ export class Web3ContractCache {
       debug('Initiating contract %s', contract)
       const createFn = ProxyContracts.includes(contract)
         ? newProxy
-        : (ContractFactories[contract] as CFType[C])
+        : ContractFactories[contract]
+        ? (ContractFactories[contract] as CFType[C])
+        : newProxy
       // @ts-ignore: Too complex union type
       this.cacheMap[contract] = createFn(
         this.kit.web3,

--- a/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
@@ -22,6 +22,7 @@
 * [parseBlock](_explorer_block_explorer_.blockexplorer.md#parseblock)
 * [tryParseTx](_explorer_block_explorer_.blockexplorer.md#tryparsetx)
 * [tryParseTxInput](_explorer_block_explorer_.blockexplorer.md#tryparsetxinput)
+* [updateContractDetailsMapping](_explorer_block_explorer_.blockexplorer.md#updatecontractdetailsmapping)
 
 ## Constructors
 
@@ -29,7 +30,7 @@
 
 \+ **new BlockExplorer**(`kit`: [ContractKit](_kit_.contractkit.md), `contractDetails`: [ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]): *[BlockExplorer](_explorer_block_explorer_.blockexplorer.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L41)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L56)*
 
 **Parameters:**
 
@@ -46,7 +47,7 @@ Name | Type |
 
 • **contractDetails**: *[ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L43)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:58](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L58)*
 
 ## Methods
 
@@ -54,7 +55,7 @@ Name | Type |
 
 ▸ **fetchBlock**(`blockNumber`: number): *Promise‹Block›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:63](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L63)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:73](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L73)*
 
 **Parameters:**
 
@@ -70,7 +71,7 @@ ___
 
 ▸ **fetchBlockByHash**(`blockHash`: string): *Promise‹Block›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:59](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L59)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:69](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L69)*
 
 **Parameters:**
 
@@ -86,7 +87,7 @@ ___
 
 ▸ **fetchBlockRange**(`from`: number, `to`: number): *Promise‹Block[]›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:67](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L67)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:77](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L77)*
 
 **Parameters:**
 
@@ -103,7 +104,7 @@ ___
 
 ▸ **parseBlock**(`block`: Block): *[ParsedBlock](../interfaces/_explorer_block_explorer_.parsedblock.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:75](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L75)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:85](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L85)*
 
 **Parameters:**
 
@@ -119,7 +120,7 @@ ___
 
 ▸ **tryParseTx**(`tx`: Transaction): *null | [ParsedTx](../interfaces/_explorer_block_explorer_.parsedtx.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:92](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L92)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:102](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L102)*
 
 **Parameters:**
 
@@ -135,7 +136,7 @@ ___
 
 ▸ **tryParseTxInput**(`address`: string, `input`: string): *null | [CallDetails](../interfaces/_explorer_block_explorer_.calldetails.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:104](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L104)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:114](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L114)*
 
 **Parameters:**
 
@@ -145,3 +146,20 @@ Name | Type |
 `input` | string |
 
 **Returns:** *null | [CallDetails](../interfaces/_explorer_block_explorer_.calldetails.md)*
+
+___
+
+###  updateContractDetailsMapping
+
+▸ **updateContractDetailsMapping**(`name`: string, `address`: string): *Promise‹void›*
+
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:64](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L64)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`address` | string |
+
+**Returns:** *Promise‹void›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
@@ -29,7 +29,7 @@
 
 \+ **new BlockExplorer**(`kit`: [ContractKit](_kit_.contractkit.md), `contractDetails`: [ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]): *[BlockExplorer](_explorer_block_explorer_.blockexplorer.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:40](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L40)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L41)*
 
 **Parameters:**
 
@@ -46,7 +46,7 @@ Name | Type |
 
 • **contractDetails**: *[ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L42)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L43)*
 
 ## Methods
 
@@ -54,7 +54,7 @@ Name | Type |
 
 ▸ **fetchBlock**(`blockNumber`: number): *Promise‹Block›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:62](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L62)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:63](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L63)*
 
 **Parameters:**
 
@@ -70,7 +70,7 @@ ___
 
 ▸ **fetchBlockByHash**(`blockHash`: string): *Promise‹Block›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:58](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L58)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:59](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L59)*
 
 **Parameters:**
 
@@ -86,7 +86,7 @@ ___
 
 ▸ **fetchBlockRange**(`from`: number, `to`: number): *Promise‹Block[]›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:66](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L66)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:67](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L67)*
 
 **Parameters:**
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **parseBlock**(`block`: Block): *[ParsedBlock](../interfaces/_explorer_block_explorer_.parsedblock.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L74)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:75](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L75)*
 
 **Parameters:**
 
@@ -119,7 +119,7 @@ ___
 
 ▸ **tryParseTx**(`tx`: Transaction): *null | [ParsedTx](../interfaces/_explorer_block_explorer_.parsedtx.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:91](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L91)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:92](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L92)*
 
 **Parameters:**
 
@@ -135,7 +135,7 @@ ___
 
 ▸ **tryParseTxInput**(`address`: string, `input`: string): *null | [CallDetails](../interfaces/_explorer_block_explorer_.calldetails.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:103](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L103)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:104](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L104)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.interactiveproposalbuilder.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.interactiveproposalbuilder.md
@@ -21,7 +21,7 @@
 
 \+ **new InteractiveProposalBuilder**(`builder`: [ProposalBuilder](_governance_proposals_.proposalbuilder.md)): *[InteractiveProposalBuilder](_governance_proposals_.interactiveproposalbuilder.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:166](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L166)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:188](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L188)*
 
 **Parameters:**
 
@@ -37,7 +37,7 @@ Name | Type |
 
 ▸ **outputTransactions**(): *Promise‹void›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:169](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L169)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:191](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L191)*
 
 **Returns:** *Promise‹void›*
 
@@ -47,6 +47,6 @@ ___
 
 ▸ **promptTransactions**(): *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:174](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L174)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:196](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L196)*
 
 **Returns:** *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.interactiveproposalbuilder.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.interactiveproposalbuilder.md
@@ -21,7 +21,7 @@
 
 \+ **new InteractiveProposalBuilder**(`builder`: [ProposalBuilder](_governance_proposals_.proposalbuilder.md)): *[InteractiveProposalBuilder](_governance_proposals_.interactiveproposalbuilder.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:170](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L170)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:166](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L166)*
 
 **Parameters:**
 
@@ -37,7 +37,7 @@ Name | Type |
 
 ▸ **outputTransactions**(): *Promise‹void›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:173](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L173)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:169](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L169)*
 
 **Returns:** *Promise‹void›*
 
@@ -47,6 +47,6 @@ ___
 
 ▸ **promptTransactions**(): *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:178](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L178)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:174](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L174)*
 
 **Returns:** *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
@@ -15,7 +15,6 @@ Builder class to construct proposals from JSON or transaction objects.
 ### Methods
 
 * [addJsonTx](_governance_proposals_.proposalbuilder.md#addjsontx)
-* [addProxyRepointingTx](_governance_proposals_.proposalbuilder.md#addproxyrepointingtx)
 * [addTx](_governance_proposals_.proposalbuilder.md#addtx)
 * [addWeb3Tx](_governance_proposals_.proposalbuilder.md#addweb3tx)
 * [build](_governance_proposals_.proposalbuilder.md#build)
@@ -28,7 +27,7 @@ Builder class to construct proposals from JSON or transaction objects.
 
 \+ **new ProposalBuilder**(`kit`: [ContractKit](_kit_.contractkit.md), `builders`: Array‹function›, `registryAdditions`: RegistryAdditions): *[ProposalBuilder](_governance_proposals_.proposalbuilder.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:80](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L80)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:81](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L81)*
 
 **Parameters:**
 
@@ -46,7 +45,7 @@ Name | Type | Default |
 
 ▸ **addJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *number*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:165](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L165)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:161](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L161)*
 
 **Parameters:**
 
@@ -58,30 +57,11 @@ Name | Type |
 
 ___
 
-###  addProxyRepointingTx
-
-▸ **addProxyRepointingTx**(`contract`: [CeloContract](../enums/_base_.celocontract.md), `newImplementationAddress`: string): *void*
-
-*Defined in [packages/contractkit/src/governance/proposals.ts:109](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L109)*
-
-Adds a transaction to set the implementation on a proxy to the given address.
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-`contract` | [CeloContract](../enums/_base_.celocontract.md) | Celo contract name of the proxy which should have its implementation set. |
-`newImplementationAddress` | string | Address of the new contract implementation.  |
-
-**Returns:** *void*
-
-___
-
 ###  addTx
 
 ▸ **addTx**(`tx`: [CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹any›, `params`: Partial‹ProposalTxParams›): *void*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:132](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L132)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:118](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L118)*
 
 Adds a Celo transaction to the list for proposal construction.
 
@@ -100,7 +80,7 @@ ___
 
 ▸ **addWeb3Tx**(`tx`: TransactionObject‹any›, `params`: ProposalTxParams): *number*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:124](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L124)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:110](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L110)*
 
 Adds a Web3 transaction to the list for proposal construction.
 
@@ -119,7 +99,7 @@ ___
 
 ▸ **build**(): *Promise‹object[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:91](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L91)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:92](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L92)*
 
 Build calls all of the added build steps and returns the final proposal.
 
@@ -133,7 +113,7 @@ ___
 
 ▸ **fromJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:142](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L142)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:128](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L128)*
 
 **Parameters:**
 
@@ -149,7 +129,7 @@ ___
 
 ▸ **fromWeb3tx**(`tx`: TransactionObject‹any›, `params`: ProposalTxParams): *[ProposalTransaction](../modules/_wrappers_governance_.md#proposaltransaction)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:98](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L98)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:99](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L99)*
 
 Converts a Web3 transaction into a proposal transaction object.
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
@@ -27,7 +27,7 @@ Builder class to construct proposals from JSON or transaction objects.
 
 \+ **new ProposalBuilder**(`kit`: [ContractKit](_kit_.contractkit.md), `builders`: Array‹function›, `registryAdditions`: RegistryAdditions): *[ProposalBuilder](_governance_proposals_.proposalbuilder.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:81](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L81)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:93](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L93)*
 
 **Parameters:**
 
@@ -45,7 +45,7 @@ Name | Type | Default |
 
 ▸ **addJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *number*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:161](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L161)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:183](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L183)*
 
 **Parameters:**
 
@@ -61,7 +61,7 @@ ___
 
 ▸ **addTx**(`tx`: [CeloTransactionObject](_wrappers_basewrapper_.celotransactionobject.md)‹any›, `params`: Partial‹ProposalTxParams›): *void*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:118](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L118)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:136](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L136)*
 
 Adds a Celo transaction to the list for proposal construction.
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **addWeb3Tx**(`tx`: TransactionObject‹any›, `params`: ProposalTxParams): *number*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:110](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L110)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:128](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L128)*
 
 Adds a Web3 transaction to the list for proposal construction.
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **build**(): *Promise‹object[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:92](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L92)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:104](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L104)*
 
 Build calls all of the added build steps and returns the final proposal.
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **fromJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *Promise‹object›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:128](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L128)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:146](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L146)*
 
 **Parameters:**
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **fromWeb3tx**(`tx`: TransactionObject‹any›, `params`: ProposalTxParams): *[ProposalTransaction](../modules/_wrappers_governance_.md#proposaltransaction)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:99](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L99)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:117](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L117)*
 
 Converts a Web3 transaction into a proposal transaction object.
 

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.calldetails.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.calldetails.md
@@ -19,7 +19,7 @@
 
 • **argList**: *any[]*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:17](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L17)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:18](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L18)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **contract**: *string*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:14](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L14)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:15](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L15)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **function**: *string*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:15](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L15)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:16](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L16)*
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 • **paramMap**: *Record‹string, any›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:16](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L16)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:17](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L17)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.calldetails.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.calldetails.md
@@ -19,7 +19,7 @@
 
 • **argList**: *any[]*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:18](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L18)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:24](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L24)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **contract**: *string*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:15](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L15)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L21)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **function**: *string*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:16](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L16)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L22)*
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 • **paramMap**: *Record‹string, any›*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:17](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L17)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L23)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedblock.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedblock.md
@@ -17,7 +17,7 @@
 
 • **block**: *Block*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:27](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L27)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:33](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L33)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **parsedTx**: *[ParsedTx](_explorer_block_explorer_.parsedtx.md)[]*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:28](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L28)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:34](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L34)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedblock.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedblock.md
@@ -17,7 +17,7 @@
 
 • **block**: *Block*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:26](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L26)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:27](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L27)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **parsedTx**: *[ParsedTx](_explorer_block_explorer_.parsedtx.md)[]*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:27](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L27)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:28](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L28)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedtx.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedtx.md
@@ -17,7 +17,7 @@
 
 • **callDetails**: *[CallDetails](_explorer_block_explorer_.calldetails.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L21)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L22)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **tx**: *Transaction*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L22)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L23)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedtx.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_explorer_block_explorer_.parsedtx.md
@@ -17,7 +17,7 @@
 
 • **callDetails**: *[CallDetails](_explorer_block_explorer_.calldetails.md)*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L22)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:28](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L28)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **tx**: *Transaction*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L23)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:29](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L29)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_governance_proposals_.proposaltransactionjson.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_governance_proposals_.proposaltransactionjson.md
@@ -32,7 +32,7 @@ Example:
 
 • **args**: *any[]*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L42)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L43)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **contract**: *[CeloContract](../enums/_base_.celocontract.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:40](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L40)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L41)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **function**: *string*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L41)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L42)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **params**? : *Record‹string, any›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L43)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L44)*
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 • **value**: *string*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L44)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:45](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L45)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_governance_proposals_.proposaltransactionjson.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_governance_proposals_.proposaltransactionjson.md
@@ -32,7 +32,7 @@ Example:
 
 • **args**: *any[]*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L43)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L42)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **contract**: *[CeloContract](../enums/_base_.celocontract.md)*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L41)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:40](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L40)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **function**: *string*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L42)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L41)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **params**? : *Record‹string, any›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L44)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L43)*
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 • **value**: *string*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:45](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L45)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L44)*

--- a/packages/docs/developer-resources/contractkit/reference/modules/_explorer_base_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_explorer_base_.md
@@ -8,16 +8,35 @@
 
 ### Functions
 
+* [getContractDetailsFromContract](_explorer_base_.md#const-getcontractdetailsfromcontract)
 * [mapFromPairs](_explorer_base_.md#mapfrompairs)
 * [obtainKitContractDetails](_explorer_base_.md#obtainkitcontractdetails)
 
 ## Functions
 
+### `Const` getContractDetailsFromContract
+
+▸ **getContractDetailsFromContract**(`kit`: [ContractKit](../classes/_kit_.contractkit.md), `celoContract`: [CeloContract](../enums/_base_.celocontract.md), `address?`: undefined | string): *Promise‹object›*
+
+*Defined in [packages/contractkit/src/explorer/base.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/base.ts#L13)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`kit` | [ContractKit](../classes/_kit_.contractkit.md) |
+`celoContract` | [CeloContract](../enums/_base_.celocontract.md) |
+`address?` | undefined &#124; string |
+
+**Returns:** *Promise‹object›*
+
+___
+
 ###  mapFromPairs
 
 ▸ **mapFromPairs**<**A**, **B**>(`pairs`: Array‹[A, B]›): *Map‹A, B›*
 
-*Defined in [packages/contractkit/src/explorer/base.ts:24](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/base.ts#L24)*
+*Defined in [packages/contractkit/src/explorer/base.ts:32](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/base.ts#L32)*
 
 **Type parameters:**
 
@@ -39,7 +58,7 @@ ___
 
 ▸ **obtainKitContractDetails**(`kit`: [ContractKit](../classes/_kit_.contractkit.md)): *Promise‹[ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]›*
 
-*Defined in [packages/contractkit/src/explorer/base.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/base.ts#L13)*
+*Defined in [packages/contractkit/src/explorer/base.ts:26](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/base.ts#L26)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
@@ -22,7 +22,7 @@
 
 ▸ **newBlockExplorer**(`kit`: [ContractKit](../classes/_kit_.contractkit.md)): *Promise‹[BlockExplorer](../classes/_explorer_block_explorer_.blockexplorer.md)‹››*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:36](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L36)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L42)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
@@ -22,7 +22,7 @@
 
 ▸ **newBlockExplorer**(`kit`: [ContractKit](../classes/_kit_.contractkit.md)): *Promise‹[BlockExplorer](../classes/_explorer_block_explorer_.blockexplorer.md)‹››*
 
-*Defined in [packages/contractkit/src/explorer/block-explorer.ts:35](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L35)*
+*Defined in [packages/contractkit/src/explorer/block-explorer.ts:36](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/explorer/block-explorer.ts#L36)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_governance_proposals_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_governance_proposals_.md
@@ -27,7 +27,7 @@
 
 • **HOTFIX_PARAM_ABI_TYPES**: *string[]* = getAbiTypes(GovernanceABI as any, 'executeHotfix')
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:19](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L19)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:18](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L18)*
 
 ## Functions
 
@@ -35,7 +35,7 @@
 
 ▸ **hotfixToEncodedParams**(`kit`: [ContractKit](../classes/_kit_.contractkit.md), `proposal`: [Proposal](_wrappers_governance_.md#proposal), `salt`: Buffer): *string*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L21)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:20](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L20)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 ▸ **hotfixToHash**(`kit`: [ContractKit](../classes/_kit_.contractkit.md), `proposal`: [Proposal](_wrappers_governance_.md#proposal), `salt`: Buffer): *Buffer‹›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:24](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L24)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L23)*
 
 **Parameters:**
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **proposalToJSON**(`kit`: [ContractKit](../classes/_kit_.contractkit.md), `proposal`: [Proposal](_wrappers_governance_.md#proposal)): *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:54](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L54)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L56)*
 
 Convert a compiled proposal to a human-readable JSON form using network information.
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_governance_proposals_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_governance_proposals_.md
@@ -27,7 +27,7 @@
 
 • **HOTFIX_PARAM_ABI_TYPES**: *string[]* = getAbiTypes(GovernanceABI as any, 'executeHotfix')
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:18](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L18)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:19](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L19)*
 
 ## Functions
 
@@ -35,7 +35,7 @@
 
 ▸ **hotfixToEncodedParams**(`kit`: [ContractKit](../classes/_kit_.contractkit.md), `proposal`: [Proposal](_wrappers_governance_.md#proposal), `salt`: Buffer): *string*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:20](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L20)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L21)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 ▸ **hotfixToHash**(`kit`: [ContractKit](../classes/_kit_.contractkit.md), `proposal`: [Proposal](_wrappers_governance_.md#proposal), `salt`: Buffer): *Buffer‹›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L23)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:24](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L24)*
 
 **Parameters:**
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **proposalToJSON**(`kit`: [ContractKit](../classes/_kit_.contractkit.md), `proposal`: [Proposal](_wrappers_governance_.md#proposal)): *Promise‹[ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)[]›*
 
-*Defined in [packages/contractkit/src/governance/proposals.ts:53](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L53)*
+*Defined in [packages/contractkit/src/governance/proposals.ts:54](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L54)*
 
 Convert a compiled proposal to a human-readable JSON form using network information.
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_governance_proxy_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_governance_proxy_.md
@@ -10,8 +10,7 @@
 
 ### Functions
 
-* [getImplementationOfProxy](_governance_proxy_.md#const-getimplementationofproxy)
-* [setImplementationOnProxy](_governance_proxy_.md#const-setimplementationonproxy)
+* [getInitializeAbiOfImplementation](_governance_proxy_.md#const-getinitializeabiofimplementation)
 
 ### Object literals
 
@@ -49,9 +48,9 @@ ___
 
 ## Functions
 
-### `Const` getImplementationOfProxy
+### `Const` getInitializeAbiOfImplementation
 
-▸ **getImplementationOfProxy**(`web3`: Web3, `proxyContractAddress`: string): *Promise‹string›*
+▸ **getInitializeAbiOfImplementation**(`proxyContractName`: string): *AbiItem*
 
 *Defined in [packages/contractkit/src/governance/proxy.ts:66](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proxy.ts#L66)*
 
@@ -59,26 +58,9 @@ ___
 
 Name | Type |
 ------ | ------ |
-`web3` | Web3 |
-`proxyContractAddress` | string |
+`proxyContractName` | string |
 
-**Returns:** *Promise‹string›*
-
-___
-
-### `Const` setImplementationOnProxy
-
-▸ **setImplementationOnProxy**(`address`: string): *any*
-
-*Defined in [packages/contractkit/src/governance/proxy.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proxy.ts#L74)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`address` | string |
-
-**Returns:** *any*
+**Returns:** *AbiItem*
 
 ## Object literals
 

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -203,6 +203,13 @@ module.exports = async (callback: (error?: any) => number) => {
         // 3. Deploy new versions of the contract and proxy, if needed.
         if (shouldDeployImplementation || isLibrary) {
           const contract = await deployImplementation(contractName, Contract, argv.dry_run)
+          const setImplementationTx: ProposalTx = {
+            contract: `${contractName}Proxy`,
+            function: '_setImplementation',
+            args: [contract.address],
+            value: '0',
+          }
+
           if (shouldDeployProxy || isLibrary) {
             // Changes need another proxy/registry repointing
             const proxy = await deployProxy(contractName, addresses, argv.dry_run)
@@ -232,13 +239,10 @@ module.exports = async (callback: (error?: any) => number) => {
                 value: '0',
               })
             } else {
-              proposal.push({
-                contract: `${contractName}Proxy`,
-                function: '_setImplementation',
-                args: [contract.address],
-                value: '0',
-              })
+              proposal.push(setImplementationTx)
             }
+          } else {
+            proposal.push(setImplementationTx)
           }
         }
         // 5. Mark the contract as released

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -223,11 +223,12 @@ module.exports = async (callback: (error?: any) => number) => {
             )
             if (initializeAbi) {
               const args = initializationData[contractName]
+              const callData = web3.eth.abi.encodeFunctionCall(initializeAbi, args)
               console.log(`Add 'Initializing ${contractName} with: ${args}' to proposal`)
               proposal.push({
                 contract: `${contractName}Proxy`,
                 function: '_setAndInitializeImplementation',
-                args: [contract.address, args],
+                args: [contract.address, callData],
                 value: '0',
               })
             } else {


### PR DESCRIPTION
- Modify release script `make-release` such that governance will perform `Proxy._setImplementation` after registry repointing a newly deployed proxy or deploying a new implementation
- Modify governance proposal transaction decoding/encoding to account for canonical registry addresses being modified by preceding transactions
- 

### Description

Defer set implementation and initialize implementation calls to proposal execution time to make verification of "pure" proxy storage roots using `eth_getProof` against a constant storage hash possible. 

### Other changes

- Allow `InteractiveProposalBuilder` to accept `BigNumber` inputs
- Add mutate contract details functionality to `BlockExplorer`
- Make building happen sequentially for correct simulation

### Tested

See https://app.zenhub.com/workspaces/celo-5d94ef61d9b1e40001114c02/issues/celo-org/celo-monorepo/5485

### Related issues

- Fixes #5472

### Backwards compatibility

Yes