### PR TITLE
Remove MTW from CK registered contracts

### DIFF
--- a/packages/contractkit/src/base.ts
+++ b/packages/contractkit/src/base.ts
@@ -33,7 +33,11 @@ export const ProxyContracts = Object.keys(CeloContract).map((c) => `${c}Proxy`)
 export type CeloToken = CeloContract.GoldToken | CeloContract.StableToken
 
 export const AllContracts = Object.keys(CeloContract) as CeloContract[]
-const AuxiliaryContracts = [CeloContract.MultiSig, CeloContract.MetaTransactionWalletDeployer]
+const AuxiliaryContracts = [
+  CeloContract.MultiSig,
+  CeloContract.MetaTransactionWalletDeployer,
+  CeloContract.MetaTransactionWallet,
+]
 export const RegisteredContracts = AllContracts.filter((v) => !AuxiliaryContracts.includes(v))
 
 export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000' as Address

--- a/packages/docs/developer-resources/contractkit/reference/modules/_base_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_base_.md
@@ -48,7 +48,7 @@ ___
 
 • **NULL_ADDRESS**: *string* = '0x0000000000000000000000000000000000000000' as Address
 
-*Defined in [packages/contractkit/src/base.ts:39](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/base.ts#L39)*
+*Defined in [packages/contractkit/src/base.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/base.ts#L43)*
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 • **RegisteredContracts**: *[CeloContract](../enums/_base_.celocontract.md)[]* = AllContracts.filter((v) => !AuxiliaryContracts.includes(v))
 
-*Defined in [packages/contractkit/src/base.ts:37](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/base.ts#L37)*
+*Defined in [packages/contractkit/src/base.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/base.ts#L41)*


### PR DESCRIPTION
### Description

Remove MetaTransactionWallet from `RegisteredContracts` which is used in various indexers like `BlockExplorer` and `celocli network:contracts`

Fixes bugs introduced by https://github.com/celo-org/celo-monorepo/pull/5156

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

![Screen Shot 2020-10-22 at 10 52 37 AM](https://user-images.githubusercontent.com/3020995/96910688-b6b42600-1454-11eb-8c3d-5a931f4603e7.png)

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._