### PR TITLE
[Wallet] Fix parallel import of SMSs on Android

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -42,7 +42,7 @@
     "@celo/client": "0.0.317",
     "@celo/contractkit": "0.4.16-dev",
     "@celo/react-components": "1.0.0",
-    "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#b88e502",
+    "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#11e078e",
     "@celo/utils": "0.1.22-dev",
     "@react-native-community/async-storage": "^1.9.0",
     "@react-native-community/clipboard": "git+https://github.com/celo-org/clipboard#5afb848",

--- a/packages/mobile/src/identity/verification.test.ts
+++ b/packages/mobile/src/identity/verification.test.ts
@@ -469,10 +469,6 @@ describe(doVerificationFlow, () => {
       .provide([
         [select(verificationStateSelector), mockVerificationStateUnverified],
         [call(getConnectedUnlockedAccount), mockAccount],
-        // TODO (i1skn): remove next two lines when
-        // https://github.com/celo-org/celo-labs/issues/578 is resolved
-        [delay(5000), true],
-        [delay(10000), true],
         [
           call([contractKit.contracts, contractKit.contracts.getAttestations]),
           mockAttestationsWrapperUnverified,
@@ -499,10 +495,6 @@ describe(doVerificationFlow, () => {
       .provide([
         [select(verificationStateSelector), mockVerificationStatePartlyVerified],
         [call(getConnectedUnlockedAccount), mockAccount],
-        // TODO (i1skn): remove next two lines when
-        // https://github.com/celo-org/celo-labs/issues/578 is resolved
-        [delay(5000), true],
-        [delay(10000), true],
         [
           call([contractKit.contracts, contractKit.contracts.getAttestations]),
           mockAttestationsWrapperPartlyVerified,
@@ -576,10 +568,6 @@ describe(doVerificationFlow, () => {
           mockVerificationStateUnverifiedWithActionableAttestations,
         ],
         [call(getConnectedUnlockedAccount), mockAccount],
-        // TODO (i1skn): remove next two lines when
-        // https://github.com/celo-org/celo-labs/issues/578 is resolved
-        [delay(5000), true],
-        [delay(10000), true],
         [
           call([contractKit.contracts, contractKit.contracts.getAttestations]),
           mockAttestationsWrapperRevealFailed,

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -68,7 +68,6 @@ export const VERIFICATION_TIMEOUT = 10 * 60 * 1000 // 10 minutes
 export const BALANCE_CHECK_TIMEOUT = 5 * 1000 // 5 seconds
 export const MAX_ACTIONABLE_ATTESTATIONS = 5
 const REVEAL_RETRY_DELAY = 10 * 1000 // 10 seconds
-const ANDROID_DELAY_REVEAL_ATTESTATION = 5000 // 5 sec after each
 
 export enum CodeInputType {
   AUTOMATIC = 'automatic',
@@ -649,16 +648,6 @@ function* revealAttestations(
       phoneHashDetails,
       attestation
     )
-    // TODO (i1skn): remove this clause when
-    // https://github.com/celo-org/celo-labs/issues/578 is resolved.
-    // This sends messages with 5000ms delay on Android if reveals is successful
-    if (success && Platform.OS === 'android') {
-      Logger.debug(
-        TAG + '@revealAttestations',
-        `Delaying the next one for: ${ANDROID_DELAY_REVEAL_ATTESTATION}ms`
-      )
-      yield delay(ANDROID_DELAY_REVEAL_ATTESTATION)
-    }
     reveals.push(success)
   }
   yield put(setLastRevealAttempt(Date.now()))

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -14,7 +14,7 @@
     "test:watch": "export TZ=UTC && jest --watch"
   },
   "dependencies": {
-    "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#b88e502",
+    "@celo/react-native-sms-retriever": "git+https://github.com/celo-org/react-native-sms-retriever#11e078e",
     "@celo/utils": "0.1.22-dev",
     "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2919,9 +2919,9 @@
   dependencies:
     bignumber.js "^9.0.0"
 
-"@celo/react-native-sms-retriever@git+https://github.com/celo-org/react-native-sms-retriever#b88e502":
+"@celo/react-native-sms-retriever@git+https://github.com/celo-org/react-native-sms-retriever#11e078e":
   version "1.0.3"
-  resolved "git+https://github.com/celo-org/react-native-sms-retriever#b88e502fcd5bab2b6b9a22f59829c3eb40e27780"
+  resolved "git+https://github.com/celo-org/react-native-sms-retriever#11e078e7631348d27bf7a0e8d0e172701ae30ea8"
 
 "@celo/typechain-target-web3-v1-celo@0.0.2":
   version "0.0.2"


### PR DESCRIPTION
### Description

Essentially revert https://github.com/celo-org/celo-monorepo/pull/4990 and send attestations SMSs immediately on Android again.

### Tested

TBD

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/578
- Fixes https://github.com/celo-org/celo-monorepo/issues/5209

### Backwards compatibility

Yes