### PR TITLE
[Wallet] Bump app number to latest released version (v1.2.0)

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -159,7 +159,7 @@ android {
         minSdkVersion isDetoxTestBuild ? 18 : rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode appVersionCode
-        versionName "1.1.0"
+        versionName "1.2.0"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         resValue "string", "app_name", project.env.get("APP_DISPLAY_NAME")

--- a/packages/mobile/ios/celo.xcodeproj/project.pbxproj
+++ b/packages/mobile/ios/celo.xcodeproj/project.pbxproj
@@ -859,7 +859,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -892,7 +892,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/mobile",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Celo",
   "license": "Apache-2.0",
   "private": true,


### PR DESCRIPTION
Follow up from https://github.com/celo-org/celo-monorepo/pull/5420 which didn't contain the version number bump