### PR TITLE
Simplify registry address mapping fetch

### DIFF
--- a/packages/cli/src/commands/network/contracts.ts
+++ b/packages/cli/src/commands/network/contracts.ts
@@ -1,6 +1,5 @@
-import { CeloContract } from '@celo/contractkit/lib'
 import { BaseCommand } from '../../base'
-import { printValueMap } from '../../utils/cli'
+import { printValueMap2 } from '../../utils/cli'
 
 export default class Contracts extends BaseCommand {
   static description = 'Lists Celo core contracts and their addesses.'
@@ -10,11 +9,6 @@ export default class Contracts extends BaseCommand {
   }
 
   async run() {
-    const contractAddresses = await this.kit.registry.allAddresses()
-    for (const contract of Object.keys(contractAddresses)) {
-      const c = contract as CeloContract // https://github.com/microsoft/TypeScript/issues/12870
-      contractAddresses[c] = contractAddresses[c] ?? 'Address not found'
-    }
-    printValueMap(contractAddresses)
+    printValueMap2(await this.kit.registry.addressMapping())
   }
 }

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -51,6 +51,10 @@ export function printValueMap(valueMap: Record<string, any>, color = chalk.yello
   )
 }
 
+export function printValueMap2(valueMap: Map<any, any>, color = chalk.yellowBright.bold) {
+  valueMap.forEach((value, key) => console.log(color(`${key}: `) + value))
+}
+
 export function printValueMapRecursive(valueMap: Record<string, any>) {
   console.log(toStringValueMapRecursive(valueMap, ''))
 }

--- a/packages/contractkit/CHANGELOG.md
+++ b/packages/contractkit/CHANGELOG.md
@@ -13,7 +13,7 @@ Bug Fixes
 - [one-line summary] - ( [link PR] )
 
 Other Changes
-- [one-line summary - ( [link PR] )
+- Parallelize and simplify fetching of comprensive registry address map - [#5568](https://github.com/celo-org/celo-monorepo/pull/5568)
 
 ## Published
 
@@ -51,5 +51,6 @@ Other Changes
 - Add blockchain parameters to network config - [#5319](https://github.com/celo-org/celo-monorepo/pull/5319)
 - Make initialization of the proxy part of the governance proposal - [#5481](https://github.com/celo-org/celo-monorepo/pull/5481)
 
+## Published
 ### **[0.4.14]** -- 2020-09-23
 _Note: Changes before and including 0.4.14 are not documented_

--- a/packages/contractkit/src/address-registry.ts
+++ b/packages/contractkit/src/address-registry.ts
@@ -1,4 +1,4 @@
-import { mapFromPairs, zip } from '@celo/base/lib/collections'
+import { zip } from '@celo/base/lib/collections'
 import debugFactory from 'debug'
 import { Address, CeloContract, NULL_ADDRESS, RegisteredContracts } from './base'
 import { newRegistry, Registry } from './generated/Registry'
@@ -45,6 +45,6 @@ export class AddressRegistry {
    */
   async addressMapping() {
     const addresses = await Promise.all(RegisteredContracts.map((r) => this.addressFor(r)))
-    return mapFromPairs(zip((r, a) => [r, a], RegisteredContracts, addresses))
+    return new Map(zip((r, a) => [r, a], RegisteredContracts, addresses))
   }
 }

--- a/packages/contractkit/src/address-registry.ts
+++ b/packages/contractkit/src/address-registry.ts
@@ -1,5 +1,5 @@
+import { mapFromPairs, zip } from '@celo/base/lib/collections'
 import debugFactory from 'debug'
-import Web3 from 'web3'
 import { Address, CeloContract, NULL_ADDRESS, RegisteredContracts } from './base'
 import { newRegistry, Registry } from './generated/Registry'
 import { ContractKit } from './kit'
@@ -28,10 +28,9 @@ export class AddressRegistry {
     if (!this.cache.has(contract)) {
       const proxyStrippedContract = contract.replace('Proxy', '') as CeloContract
       debug('Fetching address from Registry for %s', contract)
-      const hash = Web3.utils.soliditySha3({ type: 'string', value: proxyStrippedContract })
-      const address = await this.registry.methods.getAddressFor(hash).call()
+      const address = await this.registry.methods.getAddressForString(proxyStrippedContract).call()
 
-      debug('Fetched address:  %s = %s', address)
+      debug('Fetched address %s', address)
       if (!address || address === NULL_ADDRESS) {
         throw new Error(`Failed to get address for ${contract} from the Registry`)
       }
@@ -42,19 +41,10 @@ export class AddressRegistry {
   }
 
   /**
-   * Get the address for all possible `CeloContract`
+   * Get the address mapping for known registered contracts
    */
-
-  async allAddresses(): Promise<Record<CeloContract, Address | null>> {
-    const res: Partial<Record<CeloContract, Address | null>> = {}
-    for (const contract of RegisteredContracts) {
-      try {
-        res[contract] = await this.addressFor(contract)
-      } catch (error) {
-        res[contract] = null
-        debug(`Failed to find address for ${contract}: ${error.message}`)
-      }
-    }
-    return res as Record<CeloContract, Address | null>
+  async addressMapping() {
+    const addresses = await Promise.all(RegisteredContracts.map((r) => this.addressFor(r)))
+    return mapFromPairs(zip((r, a) => [r, a], RegisteredContracts, addresses))
   }
 }

--- a/packages/docs/developer-resources/contractkit/reference/classes/_address_registry_.addressregistry.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_address_registry_.addressregistry.md
@@ -15,7 +15,7 @@ Celo Core Contract's Address Registry
 ### Methods
 
 * [addressFor](_address_registry_.addressregistry.md#addressfor)
-* [allAddresses](_address_registry_.addressregistry.md#alladdresses)
+* [addressMapping](_address_registry_.addressregistry.md#addressmapping)
 
 ## Constructors
 
@@ -53,12 +53,12 @@ Name | Type |
 
 ___
 
-###  allAddresses
+###  addressMapping
 
-▸ **allAddresses**(): *Promise‹Record‹[CeloContract](../enums/_base_.celocontract.md), [Address](../modules/_base_.md#address) | null››*
+▸ **addressMapping**(): *Promise‹Map‹[CeloContract](../enums/_base_.celocontract.md), string››*
 
-*Defined in [packages/contractkit/src/address-registry.ts:48](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/address-registry.ts#L48)*
+*Defined in [packages/contractkit/src/address-registry.ts:46](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/address-registry.ts#L46)*
 
-Get the address for all possible `CeloContract`
+Get the address mapping for known registered contracts
 
-**Returns:** *Promise‹Record‹[CeloContract](../enums/_base_.celocontract.md), [Address](../modules/_base_.md#address) | null››*
+**Returns:** *Promise‹Map‹[CeloContract](../enums/_base_.celocontract.md), string››*


### PR DESCRIPTION
### Description

- Use string identifiers in registry `addressForString` call
- Rename `registry.allAddresses` to `registry.addressMapping`
- Parallelize address mapping fetch

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

Tested with `packages/cli $./bin/run network:contracts`

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._