### PR TITLE
Introduce LibraryProxies

### DIFF
--- a/packages/protocol/contracts/common/LibraryProxy.sol
+++ b/packages/protocol/contracts/common/LibraryProxy.sol
@@ -9,8 +9,9 @@ import "./Registry.sol";
  * for calls to a linked library pointed to by a Registry.
  * @dev This contract should be inherited from (e.g. for a library called Math,
  * create `contract MathProxy is LibraryProxy`). The inheriting contract should
- * implement a fallback function that calls `_delegateToLibrary`, passing in a
- * Registry hashed identifier referencing the implementation library.
+ * implement a fallback function that calls `_delegateToRegisteredLibrary`,
+ * passing in a Registry hashed identifier referencing the implementation
+ * library.
  */
 contract LibraryProxy {
   // Used to store the address of the registry contract.
@@ -39,7 +40,7 @@ contract LibraryProxy {
     }
   }
 
-  function _delegateToLibrary(bytes32 libraryIdentifier) internal {
+  function _delegateToRegisteredLibrary(bytes32 libraryIdentifier) internal {
     Registry registry = Registry(_getRegistry());
 
     address implementationAddress = registry.getAddressForOrDie(libraryIdentifier);

--- a/packages/protocol/contracts/common/LibraryProxy.sol
+++ b/packages/protocol/contracts/common/LibraryProxy.sol
@@ -1,0 +1,85 @@
+pragma solidity ^0.5.13;
+/* solhint-disable no-inline-assembly, no-complex-fallback, avoid-low-level-calls */
+
+import "openzeppelin-solidity/contracts/utils/Address.sol";
+import "./Registry.sol";
+
+/**
+ * @title A library proxy utilizing the Unstructured Storage pattern, allowing
+ * for calls to a linked library pointed to by a Registry.
+ * @dev This contract should be inherited from (e.g. for a library called Math,
+ * create `contract MathProxy is LibraryProxy`). The inheriting contract should
+ * implement a fallback function that calls `_delegateToLibrary`, passing in a
+ * Registry hashed identifier referencing the implementation library.
+ */
+contract LibraryProxy {
+  // Used to store the address of the registry contract.
+  // NOTE: non-standard EIP1967 value to not clash with the calling contract's
+  // underlying Proxy.
+  bytes32 private constant REGISTRY_POSITION = bytes32(
+    uint256(keccak256("eip1967.proxy.registry")) - 1
+  );
+
+  function _setRegistry(address registryAddress) public {
+    bytes32 registryPosition = REGISTRY_POSITION;
+
+    require(Address.isContract(registryAddress), "Invalid contract address");
+
+    // Store the address of the implementation contract in an explicit storage slot.
+    assembly {
+      sstore(registryPosition, registryAddress)
+    }
+  }
+
+  function _getRegistry() public view returns (address registry) {
+    bytes32 registryPosition = REGISTRY_POSITION;
+    // Load the address of the implementation contract from an explicit storage slot.
+    assembly {
+      registry := sload(registryPosition)
+    }
+  }
+
+  function _delegateToLibrary(bytes32 libraryIdentifier) internal {
+    Registry registry = Registry(_getRegistry());
+
+    address implementationAddress = registry.getAddressForOrDie(libraryIdentifier);
+
+    // Avoid checking if address is a contract or executing delegated call when
+    // implementation address is 0x0
+    require(implementationAddress != address(0), "No Implementation set");
+    require(Address.isContract(implementationAddress), "Invalid contract address");
+
+    assembly {
+      // Extract the position of the transaction data (i.e. function ID and arguments).
+      let newCallDataPosition := mload(0x40)
+      mstore(0x40, add(newCallDataPosition, calldatasize))
+      calldatacopy(newCallDataPosition, 0, calldatasize)
+
+      // Call the smart contract at `implementationAddress` in the context of the proxy contract,
+      // with the same msg.sender and value.
+      let delegatecallSuccess := delegatecall(
+        gas,
+        implementationAddress,
+        newCallDataPosition,
+        calldatasize,
+        0,
+        0
+      )
+
+      // Copy the return value of the call so it can be returned.
+      let returnDataSize := returndatasize
+      let returnDataPosition := mload(0x40)
+      mstore(0x40, add(returnDataPosition, returnDataSize))
+      returndatacopy(returnDataPosition, 0, returnDataSize)
+
+      // Revert or return depending on whether or not the call was successful.
+      switch delegatecallSuccess
+        case 0 {
+          revert(returnDataPosition, returnDataSize)
+        }
+        default {
+          return(returnDataPosition, returnDataSize)
+        }
+    }
+  }
+}

--- a/packages/protocol/contracts/common/LibraryProxyShim.sol
+++ b/packages/protocol/contracts/common/LibraryProxyShim.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.5.13;
+
+library LibraryProxyShim {
+  function _setRegistry(address registryAddress) public {}
+
+  function _getRegistry() public view returns (address) {
+    return address(0);
+  }
+}

--- a/packages/protocol/contracts/common/LibraryProxyShim.sol
+++ b/packages/protocol/contracts/common/LibraryProxyShim.sol
@@ -1,5 +1,9 @@
 pragma solidity ^0.5.13;
 
+/**
+ * @dev A workaround for easily `delegatecall`ing to a linked proxied library's
+ * LibraryProxy.
+ */
 library LibraryProxyShim {
   function _setRegistry(address registryAddress) public {}
 

--- a/packages/protocol/contracts/common/UsingProxiedLibraries.sol
+++ b/packages/protocol/contracts/common/UsingProxiedLibraries.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.13;
+
+import "./LibraryProxyShim.sol";
+
+/**
+ * @notice A helper contract that abstracts away some of the boilerplate around
+ * proxied libraries.
+ */
+contract UsingProxiedLibraries {
+  function setLibraryRegistry(address registryAddress) internal {
+    LibraryProxyShim._setRegistry(registryAddress);
+  }
+
+  function getLibraryRegistry() public view returns (address) {
+    return LibraryProxyShim._getRegistry();
+  }
+}

--- a/packages/protocol/contracts/common/test/ProxiedLibraryTest.sol
+++ b/packages/protocol/contracts/common/test/ProxiedLibraryTest.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.5.13;
+
+import "../LibraryProxyShim.sol";
+import "./TestLibrary1.sol";
+import "./TestLibraryStruct.sol";
+
+contract ProxiedLibraryTest {
+  // For the test, we need to pull the library's struct definition out to a
+  // separate library because the logic library's name changes. In the expected
+  // production use case, a library's name would stay the same across upgrades
+  // so this will not be necessary.
+  using TestLibrary1 for TestLibraryStruct.S;
+  using TestLibrary1 for uint256;
+
+  TestLibraryStruct.S x;
+
+  function initialize(address registryAddress) public {
+    setLibraryRegistry(registryAddress);
+  }
+
+  function set(uint256 _x) public {
+    x.x = _x;
+  }
+
+  function get() public view returns (uint256) {
+    return x.x;
+  }
+
+  function librarySet(uint256 _x) public {
+    x.set(_x);
+  }
+
+  function setLibraryRegistry(address registryAddress) public {
+    LibraryProxyShim._setRegistry(registryAddress);
+  }
+
+  function getLibraryRegistryAddress() public view returns (address) {
+    return LibraryProxyShim._getRegistry();
+  }
+
+  function increase(uint256 n) public view returns (uint256) {
+    return n.increase();
+  }
+
+  function combine(uint256 n, uint256 m) public view returns (uint256) {
+    return n.combine(m);
+  }
+}

--- a/packages/protocol/contracts/common/test/ProxiedLibraryTest.sol
+++ b/packages/protocol/contracts/common/test/ProxiedLibraryTest.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.13;
 
-import "../LibraryProxyShim.sol";
+import "../UsingProxiedLibraries.sol";
 import "./TestLibrary1.sol";
 import "./TestLibraryStruct.sol";
 
-contract ProxiedLibraryTest {
+contract ProxiedLibraryTest is UsingProxiedLibraries {
   // For the test, we need to pull the library's struct definition out to a
   // separate library because the logic library's name changes. In the expected
   // production use case, a library's name would stay the same across upgrades
@@ -18,6 +18,10 @@ contract ProxiedLibraryTest {
     setLibraryRegistry(registryAddress);
   }
 
+  function setLibraryRegistryExternal(address registryAddress) external {
+    setLibraryRegistry(registryAddress);
+  }
+
   function set(uint256 _x) public {
     x.x = _x;
   }
@@ -28,14 +32,6 @@ contract ProxiedLibraryTest {
 
   function librarySet(uint256 _x) public {
     x.set(_x);
-  }
-
-  function setLibraryRegistry(address registryAddress) public {
-    LibraryProxyShim._setRegistry(registryAddress);
-  }
-
-  function getLibraryRegistryAddress() public view returns (address) {
-    return LibraryProxyShim._getRegistry();
   }
 
   function increase(uint256 n) public view returns (uint256) {

--- a/packages/protocol/contracts/common/test/TestLibrary1.sol
+++ b/packages/protocol/contracts/common/test/TestLibrary1.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.13;
+
+import "./TestLibraryStruct.sol";
+
+library TestLibrary1 {
+  function increase(uint256 x) public view returns (uint256) {
+    return x + 1;
+  }
+
+  function combine(uint256 x, uint256 y) public view returns (uint256) {
+    return x + y;
+  }
+
+  function set(TestLibraryStruct.S storage s, uint256 x) public {
+    s.x = x;
+  }
+}

--- a/packages/protocol/contracts/common/test/TestLibrary2.sol
+++ b/packages/protocol/contracts/common/test/TestLibrary2.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.13;
+
+import "./TestLibraryStruct.sol";
+
+library TestLibrary2 {
+  function increase(uint256 x) public view returns (uint256) {
+    return x * 2;
+  }
+
+  function combine(uint256 x, uint256 y) public view returns (uint256) {
+    return x * y;
+  }
+
+  function set(TestLibraryStruct.S storage s, uint256 x) public {
+    s.x = x / 2;
+  }
+}

--- a/packages/protocol/contracts/common/test/TestLibraryProxy.sol
+++ b/packages/protocol/contracts/common/test/TestLibraryProxy.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.13;
+
+import "../LibraryProxy.sol";
+
+contract TestLibraryProxy is LibraryProxy {
+  bytes32 private constant LIBRARY_IDENTIFIER_HASH = keccak256(abi.encodePacked("TestLibrary"));
+
+  function() external {
+    _delegateToLibrary(LIBRARY_IDENTIFIER_HASH);
+  }
+}

--- a/packages/protocol/contracts/common/test/TestLibraryProxy.sol
+++ b/packages/protocol/contracts/common/test/TestLibraryProxy.sol
@@ -6,6 +6,6 @@ contract TestLibraryProxy is LibraryProxy {
   bytes32 private constant LIBRARY_IDENTIFIER_HASH = keccak256(abi.encodePacked("TestLibrary"));
 
   function() external {
-    _delegateToLibrary(LIBRARY_IDENTIFIER_HASH);
+    _delegateToRegisteredLibrary(LIBRARY_IDENTIFIER_HASH);
   }
 }

--- a/packages/protocol/contracts/common/test/TestLibraryStruct.sol
+++ b/packages/protocol/contracts/common/test/TestLibraryStruct.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.13;
+
+library TestLibraryStruct {
+  struct S {
+    uint256 x;
+  }
+}

--- a/packages/protocol/test/common/libraryproxy.ts
+++ b/packages/protocol/test/common/libraryproxy.ts
@@ -1,0 +1,118 @@
+// import { assertRevert } from '@celo/protocol/lib/test-utils'
+import {
+  TestLibraryProxyInstance,
+  TestLibrary1Instance,
+  TestLibrary2Instance,
+  ProxiedLibraryTestInstance,
+  ProxyInstance,
+  RegistryInstance,
+} from 'types'
+
+const TestLibraryProxy: Truffle.Contract<TestLibraryProxyInstance> = artifacts.require(
+  'TestLibraryProxy'
+)
+const TestLibrary1: Truffle.Contract<TestLibrary1Instance> = artifacts.require('TestLibrary1')
+const TestLibrary2: Truffle.Contract<TestLibrary2Instance> = artifacts.require('TestLibrary2')
+const ProxiedLibraryTest: Truffle.Contract<ProxiedLibraryTestInstance> = artifacts.require(
+  'ProxiedLibraryTest'
+)
+const Proxy: Truffle.Contract<ProxyInstance> = artifacts.require('Proxy')
+const Registry: Truffle.Contract<RegistryInstance> = artifacts.require('Registry')
+
+contract('LibraryProxy', (accounts: string[]) => {
+  let libraryProxy: TestLibraryProxyInstance
+  let proxiedLibraryTest: ProxiedLibraryTestInstance
+  let registry: RegistryInstance
+
+  const owner = accounts[0]
+
+  beforeEach(async () => {
+    libraryProxy = await TestLibraryProxy.new({ from: owner })
+
+    registry = await Registry.new()
+    const testLibrary1 = await TestLibrary1.new()
+    await registry.setAddressFor('TestLibrary', testLibrary1.address)
+
+    // Technically, this test suite should be complete enough without proxying
+    // the library consumer, but we do it anyway to sanity check the standard
+    // way core Celo contracts are deployed.
+    const proxy = await Proxy.new({ from: owner })
+
+    // @ts-ignore Typechain doesn't expose `link`
+    ProxiedLibraryTest.link('LibraryProxyShim', libraryProxy.address)
+    // @ts-ignore
+    ProxiedLibraryTest.link('TestLibrary1', libraryProxy.address)
+    const proxiedLibraryTestImplementation = await ProxiedLibraryTest.new({ from: owner })
+    await proxy._setImplementation(proxiedLibraryTestImplementation.address)
+    proxiedLibraryTest = await ProxiedLibraryTest.at(proxy.address)
+    await proxiedLibraryTest.initialize(registry.address)
+  })
+
+  describe('#_setRegistry', () => {
+    it('should set the registry', async () => {
+      await proxiedLibraryTest.setLibraryRegistry(registry.address)
+      const res = await proxiedLibraryTest.getLibraryRegistryAddress()
+      assert.equal(res, registry.address)
+    })
+
+    it('should allow the registry to be updated', async () => {
+      await proxiedLibraryTest.setLibraryRegistry(libraryProxy.address)
+      await proxiedLibraryTest.setLibraryRegistry(registry.address)
+      const res = await proxiedLibraryTest.getLibraryRegistryAddress()
+      assert.equal(res, registry.address)
+    })
+
+    it(`should not affect the contract's own storage`, async () => {
+      await proxiedLibraryTest.set(42)
+      await proxiedLibraryTest.setLibraryRegistry(registry.address)
+
+      const res = await proxiedLibraryTest.get()
+      assert.equal(res.toNumber(), 42)
+    })
+  })
+
+  describe('when the Registry is set', () => {
+    beforeEach(async () => {
+      await proxiedLibraryTest.setLibraryRegistry(registry.address)
+    })
+
+    it('can call a library function', async () => {
+      const res = await proxiedLibraryTest.increase(2)
+      assert.equal(res.toNumber(), 3)
+    })
+
+    it('can call another library function', async () => {
+      const res = await proxiedLibraryTest.combine(2, 3)
+      assert.equal(res.toNumber(), 5)
+    })
+
+    it(`can modify the contract's storage`, async () => {
+      await proxiedLibraryTest.librarySet(42)
+      const res = await proxiedLibraryTest.get()
+      assert.equal(res.toNumber(), 42)
+    })
+
+    describe('when the Registry is repointed', async () => {
+      beforeEach(async () => {
+        const testLibrary2 = await TestLibrary2.new()
+        await registry.setAddressFor('TestLibrary', testLibrary2.address)
+      })
+
+      it(`can change a library function's outcome`, async () => {
+        const res = await proxiedLibraryTest.increase(2)
+        assert.equal(res.toNumber(), 4)
+      })
+
+      it(`can change another library function's outcome`, async () => {
+        const res = await proxiedLibraryTest.combine(2, 3)
+        assert.equal(res.toNumber(), 6)
+      })
+
+      it(`can change a function that affects storage`, async () => {
+        await proxiedLibraryTest.librarySet(42)
+        const res = await proxiedLibraryTest.get()
+        assert.equal(res.toNumber(), 21)
+      })
+    })
+  })
+})

--- a/packages/protocol/test/common/libraryproxy.ts
+++ b/packages/protocol/test/common/libraryproxy.ts
@@ -50,21 +50,21 @@ contract('LibraryProxy', (accounts: string[]) => {
 
   describe('#_setRegistry', () => {
     it('should set the registry', async () => {
-      await proxiedLibraryTest.setLibraryRegistry(registry.address)
-      const res = await proxiedLibraryTest.getLibraryRegistryAddress()
+      await proxiedLibraryTest.setLibraryRegistryExternal(registry.address)
+      const res = await proxiedLibraryTest.getLibraryRegistry()
       assert.equal(res, registry.address)
     })
 
     it('should allow the registry to be updated', async () => {
-      await proxiedLibraryTest.setLibraryRegistry(libraryProxy.address)
-      await proxiedLibraryTest.setLibraryRegistry(registry.address)
-      const res = await proxiedLibraryTest.getLibraryRegistryAddress()
+      await proxiedLibraryTest.setLibraryRegistryExternal(libraryProxy.address)
+      await proxiedLibraryTest.setLibraryRegistryExternal(registry.address)
+      const res = await proxiedLibraryTest.getLibraryRegistry()
       assert.equal(res, registry.address)
     })
 
     it(`should not affect the contract's own storage`, async () => {
       await proxiedLibraryTest.set(42)
-      await proxiedLibraryTest.setLibraryRegistry(registry.address)
+      await proxiedLibraryTest.setLibraryRegistryExternal(registry.address)
 
       const res = await proxiedLibraryTest.get()
       assert.equal(res.toNumber(), 42)
@@ -73,7 +73,7 @@ contract('LibraryProxy', (accounts: string[]) => {
 
   describe('when the Registry is set', () => {
     beforeEach(async () => {
-      await proxiedLibraryTest.setLibraryRegistry(registry.address)
+      await proxiedLibraryTest.setLibraryRegistryExternal(registry.address)
     })
 
     it('can call a library function', async () => {

--- a/packages/protocol/test/common/libraryproxy.ts
+++ b/packages/protocol/test/common/libraryproxy.ts
@@ -1,11 +1,11 @@
 // import { assertRevert } from '@celo/protocol/lib/test-utils'
 import {
-  TestLibraryProxyInstance,
-  TestLibrary1Instance,
-  TestLibrary2Instance,
   ProxiedLibraryTestInstance,
   ProxyInstance,
   RegistryInstance,
+  TestLibrary1Instance,
+  TestLibrary2Instance,
+  TestLibraryProxyInstance,
 } from 'types'
 
 const TestLibraryProxy: Truffle.Contract<TestLibraryProxyInstance> = artifacts.require(


### PR DESCRIPTION
### Description

We tried proxying libraries using our standard Proxies, but that approach does not work - when we `delegatecall` to a library's Proxy, we're still using the original contract's storage so there's no way to dynamically read an implementation's address from a central library proxy.

This PR introduces a separate proxy type specifically for linked libraries. The design is inspired by [OpenZeppelin's Dispatcher](https://blog.openzeppelin.com/proxy-libraries-in-solidity-79fbe4b970fd/), but adapted to use the Celo Registry.

LibraryProxy implements a `_delegateToRegisteredLibrary(bytes32 libraryIdentifier)` function. This contract should be inherited from, and the inheriting contract's fallback function should call `_delegateToRegisteredLibrary` with the Registry identifier of the library being proxied to.

Any contract linking proxied libraries should inherit from `UsingProxiedLibraries` and call `setLibraryRegistry` with the Registry's address. This only needs to be done once per main contract, no matter how many linked libraries it uses, since all LibraryProxies will read the Registry's address from the same storage slot of the calling contract.

Before deployment of the calling contract, it should link `LibraryProxyShim` (a workaround library that allows us to delegatecall LibraryProxy functions) and the implementation library, *both* at the corresponding LibraryProxy's deployed address.

### Tested

Unit tests. Let me know if you see any potential edge cases that should still be tested.

### Related issues

- Related to #4812 since originally the first release was supposed to include proxied libraries. 

### Backwards compatibility

Doesn't touch any core contracts yet. Utilizing this for all linked libraries will require changes in contracts using them (as described above), as well as changes to migration, release, verification scripts, etc.