### PR TITLE
Unproxy/unversion linked libraries

### DIFF
--- a/packages/protocol/contracts/common/proxies/AddressLinkedListProxy.sol
+++ b/packages/protocol/contracts/common/proxies/AddressLinkedListProxy.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.3;
-
-import "../Proxy.sol";
-
-/* solhint-disable no-empty-blocks */
-contract AddressLinkedListProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/AddressSortedLinkedListProxy.sol
+++ b/packages/protocol/contracts/common/proxies/AddressSortedLinkedListProxy.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.3;
-
-import "../Proxy.sol";
-
-/* solhint-disable no-empty-blocks */
-contract AddressSortedLinkedListProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/AddressSortedLinkedListWithMedianProxy.sol
+++ b/packages/protocol/contracts/common/proxies/AddressSortedLinkedListWithMedianProxy.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.3;
-
-import "../Proxy.sol";
-
-/* solhint-disable no-empty-blocks */
-contract AddressSortedLinkedListWithMedianProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/IntegerSortedLinkedListProxy.sol
+++ b/packages/protocol/contracts/common/proxies/IntegerSortedLinkedListProxy.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.3;
-
-import "../Proxy.sol";
-
-/* solhint-disable no-empty-blocks */
-contract IntegerSortedLinkedListProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/SignaturesProxy.sol
+++ b/packages/protocol/contracts/common/proxies/SignaturesProxy.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.3;
-
-import "../Proxy.sol";
-
-/* solhint-disable no-empty-blocks */
-contract SignaturesProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/ProposalsProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ProposalsProxy.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.3;
-
-import "../../common/Proxy.sol";
-
-/* solhint-disable no-empty-blocks */
-contract ProposalsProxy is Proxy {}

--- a/packages/protocol/lib/compatibility/ast-version.ts
+++ b/packages/protocol/lib/compatibility/ast-version.ts
@@ -25,7 +25,7 @@ export class ASTContractVersions {
  * Gets the version of a contract by calling Contract.getVersionNumber() on
  * the contract deployed bytecode.
  *
- * If the contract version cannot be retrieved, returns version 1.0.0.0 by default.
+ * If the contract version cannot be retrieved, returns version 1.1.0.0 by default.
  */
 export async function getContractVersion(artifact: Artifact): Promise<ContractVersion> {
   const vm = new VM()

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -26,9 +26,6 @@ interface VerificationContext {
   proposal: ProposalTx[]
   Proxy: Truffle.Contract<ProxyInstance>
   web3: Web3
-
-  // TODO: remove this after first smart contracts release
-  isBeforeRelease1: boolean
 }
 
 // Checks if the given transaction is a repointing of the Proxy for the given
@@ -150,8 +147,7 @@ export const verifyBytecodes = async (
   registry: RegistryInstance,
   proposal: ProposalTx[],
   Proxy: Truffle.Contract<ProxyInstance>,
-  web3: Web3,
-  isBeforeRelease1: boolean = false
+  web3: Web3
 ) => {
   const invalidTransactions = proposal.filter(
     (tx) => !isProxyRepointTransaction(tx) && !isRegistryRepointTransaction(tx)
@@ -170,7 +166,6 @@ export const verifyBytecodes = async (
     proposal,
     Proxy,
     web3,
-    isBeforeRelease1,
   }
 
   while (queue.length > 0) {

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -81,19 +81,14 @@ const getImplementationAddress = async (contract: string, context: VerificationC
     return getProposedImplementationAddress(contract, context)
   }
 
-  let proxyAddress: string
   if (isLibrary(contract, context)) {
-    proxyAddress = context.libraryAddresses.addresses[contract]
-    // Before the first contracts upgrade libraries are not proxied.
-    if (context.isBeforeRelease1) {
-      return `0x${proxyAddress}`
-    }
-  } else {
-    // contract is registered but we need to check if the proxy is affected by the proposal
-    proxyAddress = isProxyChanged(contract, context)
-      ? getProposedProxyAddress(contract, context)
-      : await context.registry.getAddressForString(contract)
+    return `0x${context.libraryAddresses.addresses[contract]}`
   }
+
+  // contract is registered but we need to check if the proxy is affected by the proposal
+  const proxyAddress = isProxyChanged(contract, context)
+    ? getProposedProxyAddress(contract, context)
+    : await context.registry.getAddressForString(contract)
 
   // at() returns a promise despite Typescript labelling the await as extraneous
   const proxy: ProxyInstance = await context.Proxy.at(

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -60,5 +60,5 @@ git checkout $ORIGINAL_GIT_REF > $LOG_FILE
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.
-CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|Signatures|UsingPrecompiles"
+CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|Signatures|Proposals|UsingPrecompiles"
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR_1/contracts --new_contracts $BUILD_DIR_2/contracts --exclude $CONTRACT_EXCLUSION_REGEX $REPORT_FLAG

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -60,5 +60,5 @@ git checkout $ORIGINAL_GIT_REF > $LOG_FILE
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.
-CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|^LinkedList$|^SortedLinkedList$|^SortedLinkedListWithMedian$|MultiSig.*|ReleaseGold|FixidityLib|MetaTransactionWallet|SlasherUtil|UsingPrecompiles"
+CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|UsingPrecompiles"
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR_1/contracts --new_contracts $BUILD_DIR_2/contracts --exclude $CONTRACT_EXCLUSION_REGEX $REPORT_FLAG

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -60,5 +60,5 @@ git checkout $ORIGINAL_GIT_REF > $LOG_FILE
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.
-CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|^LinkedList$|^SortedLinkedList$|^SortedLinkedListWithMedian$|MultiSig.*|ReleaseGold|FixidityLib|MetaTransactionWallet|SlasherUtil|UsingPrecompiles"
+CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|UsingPrecompiles"
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR_1/contracts --new_contracts $BUILD_DIR_2/contracts --exclude $CONTRACT_EXCLUSION_REGEX $REPORT_FLAG

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -60,5 +60,5 @@ git checkout $ORIGINAL_GIT_REF > $LOG_FILE
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.
-CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|UsingPrecompiles"
+CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|UsingPrecompiles"
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR_1/contracts --new_contracts $BUILD_DIR_2/contracts --exclude $CONTRACT_EXCLUSION_REGEX $REPORT_FLAG

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -60,5 +60,5 @@ git checkout $ORIGINAL_GIT_REF > $LOG_FILE
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.
-CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|UsingPrecompiles"
+CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|Signatures|UsingPrecompiles"
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR_1/contracts --new_contracts $BUILD_DIR_2/contracts --exclude $CONTRACT_EXCLUSION_REGEX $REPORT_FLAG

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -7,16 +7,12 @@ set -euo pipefail
 # Flags:
 # -b: Branch containing smart contracts that currently comprise the Celo protocol
 # -n: The network to check
-# -r: Boolean flag to indicate if this is the first release (before linked
-#     libraries were proxied)
-#     TODO: remove -r in the future.
 # -f: Boolean flag to indicate if the Forno service should be used to connect to
 #     the network
 # -l: Path to a file to which logs should be appended
 
 BRANCH=""
 NETWORK=""
-RELEASE_1=""
 FORNO=""
 LOG_FILE="/dev/null"
 
@@ -24,7 +20,6 @@ while getopts 'b:n:rfl:' flag; do
   case "${flag}" in
     b) BRANCH="${OPTARG}" ;;
     n) NETWORK="${OPTARG}" ;;
-    r) RELEASE_1="--before_release_1" ;;
     f) FORNO="--forno" ;;
     l) LOG_FILE="${OPTARG}" ;;
     *) error "Unexpected option ${flag}" ;;
@@ -52,4 +47,4 @@ echo "- Build verification script"
 yarn build >> $LOG_FILE
 
 echo "- Run verification script"
-yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts $RELEASE_1 $FORNO
+yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts $FORNO

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -72,37 +72,6 @@ class ContractAddresses {
 
 const REGISTRY_ADDRESS = '0x000000000000000000000000000000000000ce10'
 
-// TODO: handle `exclude` better - probably shouldn't be a regexp, but an
-// explicit list of ignored contracts/subdirectories.
-const ensureAllContractsThatLinkLibrariesHaveChanges = (
-  dependencies: ContractDependencies,
-  report: ASTDetailedVersionedReport,
-  contracts: string[],
-  exclude: RegExp
-) => {
-  let anyContractViolates = false
-  contracts.map((contract) => {
-    const hasDependency = dependencies.get(contract).length > 0
-    const hasChanges = report.contracts[contract]
-    const isTest = contract.endsWith('Test')
-
-    // This check goes over all contracts, so we again have to exclude the
-    // contracts that were ignored in the version check.
-    if (hasDependency && !hasChanges && !isTest && !exclude.test(contract)) {
-      console.log(
-        `${contract} links ${dependencies.get(
-          contract
-        )} and needs to be upgraded to link proxied libraries.`
-      )
-      anyContractViolates = true
-    }
-  })
-
-  if (anyContractViolates) {
-    throw new Error('All contracts linking libraries should be upgraded in release 1')
-  }
-}
-
 const deployImplementation = async (
   contractName: string,
   Contract: Truffle.Contract<Truffle.ContractInstance>,
@@ -161,7 +130,6 @@ module.exports = async (callback: (error?: any) => number) => {
       boolean: ['dry_run'],
     })
     const fullReport = readJsonSync(argv.report)
-    const exclude = new RegExp(fullReport.exclude.slice(1, fullReport.exclude.length - 1))
     const report: ASTDetailedVersionedReport = fullReport.report
     const initializationData = readJsonSync(argv.initialize_data)
     const dependencies = new ContractDependencies(linkedLibraries)
@@ -172,13 +140,6 @@ module.exports = async (callback: (error?: any) => number) => {
     const addresses = await ContractAddresses.create(contracts, registry)
     const released: Set<string> = new Set([])
     const proposal: ProposalTx[] = []
-    // Release 1 will deploy all libraries with proxies so that they're more easily
-    // upgradable. All contracts that link libraries should be upgraded to instead link the proxied
-    // library.
-    // To ensure this actually happens, we check that all contracts that link libraries are marked
-    // as needing to be redeployed.
-    // TODO(asa): Remove this check after release 1.
-    ensureAllContractsThatLinkLibrariesHaveChanges(dependencies, report, contracts, exclude)
 
     const release = async (contractName: string) => {
       if (released.has(contractName)) {
@@ -193,15 +154,9 @@ module.exports = async (callback: (error?: any) => number) => {
         const Contract = await artifacts.require(contractName)
         await Promise.all(contractDependencies.map((d) => Contract.link(d, addresses.get(d))))
 
-        // This is a hack that will re-deploy all libraries with proxies, whether or not they have
-        // changes to them.
-        // TODO(asa): Remove `isLibrary` for future releases.
-        const isLibrary = linkedLibraries[contractName]
+        // 3. Deploy new versions of the contract, if needed.
         const shouldDeployImplementation = Object.keys(report.contracts).includes(contractName)
-        const shouldDeployProxy =
-          shouldDeployImplementation && report.contracts[contractName].changes.storage.length > 0
-        // 3. Deploy new versions of the contract and proxy, if needed.
-        if (shouldDeployImplementation || isLibrary) {
+        if (shouldDeployImplementation) {
           const contract = await deployImplementation(contractName, Contract, argv.dry_run)
           const setImplementationTx: ProposalTx = {
             contract: `${contractName}Proxy`,
@@ -210,11 +165,14 @@ module.exports = async (callback: (error?: any) => number) => {
             value: '0',
           }
 
-          if (shouldDeployProxy || isLibrary) {
-            // Changes need another proxy/registry repointing
+          // 4. Deploy new versions of the proxy, if needed
+          const shouldDeployProxy = report.contracts[contractName].changes.storage.length > 0
+          if (!shouldDeployProxy) {
+            proposal.push(setImplementationTx)
+          } else {
             const proxy = await deployProxy(contractName, addresses, argv.dry_run)
 
-            // 4. Update the contract's address, if needed.
+            // 5. Update the contract's address to the new proxy in the proposal
             addresses.set(contractName, proxy.address)
             proposal.push({
               contract: 'Registry',
@@ -224,7 +182,7 @@ module.exports = async (callback: (error?: any) => number) => {
               description: `Registry: ${contractName} -> ${proxy.address}`,
             })
 
-            // 5. If the implementation has an initialize function, add it to the proposal
+            // 6. If the implementation has an initialize function, add it to the proposal
             const initializeAbi = (contract as any).abi.find(
               (abi: any) => abi.type === 'function' && abi.name === 'initialize'
             )
@@ -241,11 +199,9 @@ module.exports = async (callback: (error?: any) => number) => {
             } else {
               proposal.push(setImplementationTx)
             }
-          } else {
-            proposal.push(setImplementationTx)
           }
         }
-        // 5. Mark the contract as released
+        // 7. Mark the contract as released
         released.add(contractName)
       }
     }

--- a/packages/protocol/scripts/truffle/verify-bytecode.ts
+++ b/packages/protocol/scripts/truffle/verify-bytecode.ts
@@ -12,22 +12,15 @@ import fs = require('fs')
  * proposal description.
  *
  * Expects the following flags:
- *   --build_artifacts: The directory in which smart contract build artifacts
+ *   --build_directory: The directory in which smart contract build artifacts
  *   can be found (defaults to ./build/contracts/)
  *   --proposal: The JSON file containing a Governance proposal that
  *   repoints the Registry to newly deployed Proxies and/or repoints existing
  *   Proxies to new implementation addresses.
- *   --before_release_1: a temporary feature flag needed before the first
- *   contracts upgrade establishes new conventions around how smart contracts
- *   are handled on chain. Specifically, after the first release, linked
- *   libraries will be proxied, so libraries before this release have to be
- *   handled differently by this script.
- *   TODO: remove --before_release_1 after the first release
  *
  * Run using truffle exec, e.g.:
  * truffle exec scripts/truffle/verify-bytecode \
- *   --network alfajores --build_directory build/alfajores/contracts --proposal proposal.json \
- *   --before_release_1
+ *   --network alfajores --build_directory build/alfajores/contracts --proposal proposal.json
  */
 
 const Registry: Truffle.Contract<RegistryInstance> = artifacts.require('Registry')
@@ -40,7 +33,6 @@ const argv = require('minimist')(process.argv.slice(2), {
 
 const artifactsDirectory = argv.build_artifacts ? argv.build_artifacts : './build/contracts'
 const proposal = argv.proposal ? JSON.parse(fs.readFileSync(argv.proposal).toString()) : []
-const beforeRelease1 = argv.before_release_1
 
 module.exports = async (callback: (error?: any) => number) => {
   try {
@@ -52,8 +44,7 @@ module.exports = async (callback: (error?: any) => number) => {
       registry,
       proposal,
       Proxy,
-      web3,
-      beforeRelease1
+      web3
     )
 
     // tslint:disable-next-line: no-console


### PR DESCRIPTION
### Description

- check-versions needs to bump major version of implementing contract if linked library has any changes
- implementation contract versioning must reflect linked library dependency

- if check-versions already captures inline library changes, then we don't need to version linked libraries such that check-versions reflects those linked library changes at compile time
- all libraries are now excluded from versioning report
- make-release will redeploy all linked libraries if implementing contract needs deploy

### Related issues

- Fixes #5580 
- Opens https://github.com/celo-org/celo-monorepo/issues/5589
- Opens https://github.com/celo-org/celo-monorepo/issues/5590

