### PR TITLE
Increase blocks collected for key rotation e2e test

### DIFF
--- a/packages/celotool/src/e2e-tests/governance_tests.ts
+++ b/packages/celotool/src/e2e-tests/governance_tests.ts
@@ -994,7 +994,7 @@ describe('governance tests', () => {
           if (
             header.number % 10 === 0 &&
             errorWhileChangingValidatorSet === '' &&
-            lastRotated + 30 <= header.number
+            lastRotated + 60 <= header.number
           ) {
             // 1. Swap validator0 and validator1 so one is a member of the group and the other is not.
             // 2. Rotate keys for validator 2 by authorizing a new validating key.
@@ -1011,7 +1011,7 @@ describe('governance tests', () => {
       subscription.on('data', changeValidatorSet)
 
       // Wait for a few epochs while changing the validator set.
-      while (blockNumbers.length < 90) {
+      while (blockNumbers.length < 180) {
         // Prepare for member swapping.
         await sleep(epoch)
       }


### PR DESCRIPTION
### Description

Increases the number of blocks to collect for the key rotation e2e test.

### Tested

Ran e2e test locally on computer and circle CI.

### Backwards compatibility

N/A