### PR TITLE
[cli] Require --force with account:claim-attestation-service-url for non-TLS urls

### DIFF
--- a/packages/cli/src/commands/account/claim-attestation-service-url.ts
+++ b/packages/cli/src/commands/account/claim-attestation-service-url.ts
@@ -1,4 +1,5 @@
 import { createAttestationServiceURLClaim } from '@celo/contractkit/lib/identity/claims/attestation-service-url'
+import { flags } from '@oclif/command'
 import { Flags } from '../../utils/command'
 import { ClaimCommand } from '../../utils/identity'
 export default class ClaimAttestationServiceUrl extends ClaimCommand {
@@ -8,17 +9,24 @@ export default class ClaimAttestationServiceUrl extends ClaimCommand {
     ...ClaimCommand.flags,
     url: Flags.url({
       required: true,
-      description: 'The url you want to claim',
+      description: 'The URL you want to claim. Should begin http://',
     }),
+    force: flags.boolean({ description: 'Ignore URL validity checks' }),
   }
   static args = ClaimCommand.args
   static examples = [
-    'claim-attestation-service-url ~/metadata.json --url http://test.com/myurl --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95',
+    'claim-attestation-service-url ~/metadata.json --url https://test.com/myurl --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95',
   ]
   self = ClaimAttestationServiceUrl
 
   async run() {
     const res = this.parse(ClaimAttestationServiceUrl)
+    if (!res.flags.force && !res.flags.url.startsWith('https://')) {
+      this.error(
+        'Attestation Service URLs should begin https:// to be accessible to all clients. Use --force to proceed anyway.'
+      )
+      return
+    }
     const metadata = await this.readMetadata()
     await this.addClaim(metadata, createAttestationServiceURLClaim(res.flags.url))
     this.writeMetadata(metadata)

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -131,6 +131,8 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  --force                                            Ignore URL validity checks
+
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
 
@@ -147,12 +149,12 @@ OPTIONS
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
 
-  --url=https://www.celo.org                         (required) The url you want to claim
+  --url=https://www.celo.org                         (required) The URL you want to claim. Should begin http://
 
   --useLedger                                        Set it to use a ledger wallet
 
 EXAMPLE
-  claim-attestation-service-url ~/metadata.json --url http://test.com/myurl --from
+  claim-attestation-service-url ~/metadata.json --url https://test.com/myurl --from
   0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
 ```
 


### PR DESCRIPTION
### Description

In the future we will be requiring TLS for Attestation Service URLs. This adds a check to the CLI command to require `--force` to add a URL that doesn't begin `https://`.
 
### Tested

Locally

### Backwards compatibility

In the unlikely event that users have scripted this, and do not have TLS deployed, scripts will need modification. 