### PR TITLE
Remove LocalCommand and pass through cli table flags where applicable

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ This package will follow the release process outlined [here](https://docs.celo.o
 ## Development (not published yet)
 ### **[0.0.61--dev]**
 Features
-- [one-line summary] - ( [link PR] )
+- Pass through [oclif table flags](https://github.com/oclif/cli-ux#clitable) to commands which output tables - [#5618](https://github.com/celo-org/celo-monorepo/pull/5618)
 
 Bug Fixes
 - [one-line summary] - ( [link PR] )

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -14,29 +14,6 @@ import Web3 from 'web3'
 import { getGasCurrency, getNodeUrl } from './utils/config'
 import { requireNodeIsSynced } from './utils/helpers'
 
-// Base for commands that do not need web3.
-export abstract class LocalCommand extends Command {
-  static flags = {
-    logLevel: flags.string({ char: 'l', hidden: true }),
-    help: flags.help({ char: 'h', hidden: true }),
-    truncate: flags.boolean({
-      default: true,
-      hidden: true,
-      allowNo: true,
-      description: 'Truncate fields to fit line',
-    }),
-  }
-
-  // TODO(yorke): implement log(msg) switch on logLevel with chalk colored output
-  log(msg: string, logLevel: string = 'info') {
-    if (logLevel === 'info') {
-      console.debug(msg)
-    } else if (logLevel === 'error') {
-      console.error(msg)
-    }
-  }
-}
-
 export enum GasOptions {
   celo = 'celo',
   CELO = 'celo',
@@ -47,15 +24,22 @@ export enum GasOptions {
 }
 
 // tslint:disable-next-line:max-classes-per-file
-export abstract class BaseCommand extends LocalCommand {
+export abstract class BaseCommand extends Command {
   static flags = {
-    ...LocalCommand.flags,
-    privateKey: flags.string({ hidden: true }),
-    node: flags.string({ char: 'n', hidden: true }),
+    privateKey: flags.string({
+      char: 'k',
+      description: 'Use a private key to sign local transactions with',
+    }),
+    node: flags.string({
+      char: 'n',
+      description: "URL of the node to run commands against (defaults to 'http://localhost:8545')",
+      hidden: true,
+    }),
     gasCurrency: flags.enum({
       options: Object.keys(GasOptions),
       description:
         "Use a specific gas currency for transaction fees (defaults to 'auto' which uses whatever feeCurrency is available)",
+      hidden: true,
     }),
     useLedger: flags.boolean({
       default: false,

--- a/packages/cli/src/commands/account/get-metadata.ts
+++ b/packages/cli/src/commands/account/get-metadata.ts
@@ -1,5 +1,6 @@
 import { IdentityMetadataWrapper } from '@celo/contractkit/lib/identity'
 import { IArg } from '@oclif/parser/lib/args'
+import { cli } from 'cli-ux'
 import { BaseCommand } from '../../base'
 import { Args } from '../../utils/command'
 import { displayMetadata } from '../../utils/identity'
@@ -10,6 +11,7 @@ export default class GetMetadata extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flags,
+    ...(cli.table.flags() as object),
   }
 
   static args: IArg[] = [Args.address('address', { description: 'Address to get metadata for' })]
@@ -17,7 +19,7 @@ export default class GetMetadata extends BaseCommand {
   static examples = ['get-metadata 0x97f7333c51897469E8D98E7af8653aAb468050a3']
 
   async run() {
-    const { args } = this.parse(GetMetadata)
+    const { args, flags } = this.parse(GetMetadata)
     const address = args.address
     const accounts = await this.kit.contracts.getAccounts()
     const metadataURL = await accounts.getMetadataURL(address)
@@ -30,7 +32,7 @@ export default class GetMetadata extends BaseCommand {
     try {
       const metadata = await IdentityMetadataWrapper.fetchFromURL(this.kit, metadataURL)
       console.info('Metadata contains the following claims: \n')
-      await displayMetadata(metadata, this.kit)
+      await displayMetadata(metadata, this.kit, flags)
     } catch (error) {
       console.error(`Metadata could not be retrieved from ${metadataURL}: ${error.toString()}`)
     }

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -9,17 +9,17 @@ import { privateKeyToAddress } from '@celo/utils/lib/address'
 import { flags } from '@oclif/command'
 import { toChecksumAddress } from 'ethereumjs-util'
 import * as fs from 'fs-extra'
-import { LocalCommand } from '../../base'
+import { BaseCommand } from '../../base'
 import { printValueMap } from '../../utils/cli'
 
 const ETHEREUM_DERIVATION_PATH = "m/44'/60'/0'"
 
-export default class NewAccount extends LocalCommand {
+export default class NewAccount extends BaseCommand {
   static description =
     "Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/changeIndex/addressIndex) and print out the key information. Save this information for local transaction signing or import into a Celo node. Ledger: this command has been tested swapping mnemonics with the Ledger successfully (only supports english)"
 
   static flags = {
-    ...LocalCommand.flags,
+    ...BaseCommand.flags,
     passphrasePath: flags.string({
       description:
         'Path to a file that contains the BIP39 passphrase to combine with the mnemonic specified using the mnemonicPath flag and the index specified using the addressIndex flag. Every passphrase generates a different private key and wallet address.',

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -94,6 +94,8 @@ export default class NewAccount extends BaseCommand {
     throw new Error(`Invalid path: ${file}`)
   }
 
+  requireSynced = false
+
   async run() {
     const res = this.parse(NewAccount)
     let mnemonic = NewAccount.readFile(res.flags.mnemonicPath)

--- a/packages/cli/src/commands/account/register-metadata.ts
+++ b/packages/cli/src/commands/account/register-metadata.ts
@@ -1,5 +1,6 @@
 import { IdentityMetadataWrapper } from '@celo/contractkit/lib/identity'
 import { flags } from '@oclif/command'
+import { cli } from 'cli-ux'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx } from '../../utils/cli'
@@ -21,6 +22,8 @@ export default class RegisterMetadata extends BaseCommand {
       description: 'The url to the metadata you want to register',
     }),
     force: flags.boolean({ description: 'Ignore metadata validity checks' }),
+
+    ...(cli.table.flags() as object),
   }
 
   static examples = [
@@ -40,7 +43,7 @@ export default class RegisterMetadata extends BaseCommand {
       try {
         const metadata = await IdentityMetadataWrapper.fetchFromURL(this.kit, metadataURL)
         console.info('Metadata contains the following claims: \n')
-        await displayMetadata(metadata, this.kit)
+        await displayMetadata(metadata, this.kit, res.flags)
         console.info() // Print a newline.
       } catch (error) {
         console.error(`Metadata could not be retrieved from ${metadataURL}: ${error.toString()}`)

--- a/packages/cli/src/commands/account/show-metadata.ts
+++ b/packages/cli/src/commands/account/show-metadata.ts
@@ -1,5 +1,6 @@
 import { IdentityMetadataWrapper } from '@celo/contractkit/lib/identity'
 import { IArg } from '@oclif/parser/lib/args'
+import { cli } from 'cli-ux'
 import { BaseCommand } from '../../base'
 import { Args } from '../../utils/command'
 import { displayMetadata } from '../../utils/identity'
@@ -8,6 +9,7 @@ export default class ShowMetadata extends BaseCommand {
   static description = 'Show the data in a local metadata file'
   static flags = {
     ...BaseCommand.flags,
+    ...(cli.table.flags() as object),
   }
   static args: IArg[] = [Args.file('file', { description: 'Path of the metadata file' })]
   static examples = ['show-metadata ~/metadata.json']
@@ -17,6 +19,6 @@ export default class ShowMetadata extends BaseCommand {
     const res = this.parse(ShowMetadata)
     const metadata = await IdentityMetadataWrapper.fromFile(this.kit, res.args.file)
     console.info(`Metadata at ${res.args.file} contains the following claims: \n`)
-    await displayMetadata(metadata, this.kit)
+    await displayMetadata(metadata, this.kit, res.flags)
   }
 }

--- a/packages/cli/src/commands/config/get.ts
+++ b/packages/cli/src/commands/config/get.ts
@@ -1,12 +1,12 @@
-import { LocalCommand } from '../../base'
+import { BaseCommand } from '../../base'
 import { printValueMap } from '../../utils/cli'
 import { readConfig } from '../../utils/config'
 
-export default class Get extends LocalCommand {
+export default class Get extends BaseCommand {
   static description = 'Output network node configuration'
 
   static flags = {
-    ...LocalCommand.flags,
+    ...BaseCommand.flagsWithoutLocalAddresses(),
   }
 
   async run() {

--- a/packages/cli/src/commands/config/get.ts
+++ b/packages/cli/src/commands/config/get.ts
@@ -9,6 +9,8 @@ export default class Get extends BaseCommand {
     ...BaseCommand.flagsWithoutLocalAddresses(),
   }
 
+  requireSynced = false
+
   async run() {
     printValueMap(readConfig(this.config.configDir))
   }

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -23,6 +23,8 @@ export default class Set extends BaseCommand {
     'set --gasCurrency CELO',
   ]
 
+  requireSynced = false
+
   async run() {
     const res = this.parse(Set)
     const curr = readConfig(this.config.configDir)

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -1,23 +1,24 @@
-import { flags } from '@oclif/command'
-import { BaseCommand, GasOptions, LocalCommand } from '../../base'
+import { BaseCommand, GasOptions } from '../../base'
 import { readConfig, writeConfig } from '../../utils/config'
 
-export default class Set extends LocalCommand {
+export default class Set extends BaseCommand {
   static description = 'Configure running node information for propogating transactions to network'
 
   static flags = {
-    ...LocalCommand.flags,
-    // Overrides base command node flag.
-    node: flags.string({
-      char: 'n',
-      description: "URL of the node to run commands against (defaults to 'http://localhost:8545')",
-    }),
-    gasCurrency: BaseCommand.flags.gasCurrency,
+    ...BaseCommand.flagsWithoutLocalAddresses(),
+    node: {
+      ...BaseCommand.flags.node,
+      hidden: false,
+    },
+    gasCurrency: {
+      ...BaseCommand.flags.gasCurrency,
+      hidden: false,
+    },
   }
 
   static examples = [
-    'set  --node ws://localhost:2500',
-    'set  --node <geth-location>/geth.ipc',
+    'set --node ws://localhost:2500',
+    'set --node <geth-location>/geth.ipc',
     'set --gasCurrency cUSD',
     'set --gasCurrency CELO',
   ]

--- a/packages/cli/src/commands/election/current.ts
+++ b/packages/cli/src/commands/election/current.ts
@@ -21,6 +21,7 @@ export default class ElectionCurrent extends BaseCommand {
       description:
         'Show currently used signers from valset (by default the authorized validator signers are shown). Useful for checking if keys have been rotated.',
     }),
+    ...(cli.table.flags() as object),
   }
 
   async run() {
@@ -37,13 +38,13 @@ export default class ElectionCurrent extends BaseCommand {
         })
       )
       cli.action.stop()
-      cli.table(validatorList, otherValidatorTable, { 'no-truncate': !res.flags.truncate })
+      cli.table(validatorList, otherValidatorTable, res.flags)
     } else {
       const validatorList = await Promise.all(
         signers.map((addr) => validators.getValidatorFromSigner(addr))
       )
       cli.action.stop()
-      cli.table(validatorList, validatorTable, { 'no-truncate': !res.flags.truncate })
+      cli.table(validatorList, validatorTable, res.flags)
     }
   }
 }

--- a/packages/cli/src/commands/election/list.ts
+++ b/packages/cli/src/commands/election/list.ts
@@ -7,6 +7,7 @@ export default class List extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flagsWithoutLocalAddresses(),
+    ...(cli.table.flags() as object),
   }
 
   static examples = ['list']
@@ -26,7 +27,7 @@ export default class List extends BaseCommand {
         capacity: { get: (g) => g.capacity.toFixed() },
         eligible: {},
       },
-      { 'no-truncate': !res.flags.truncate }
+      res.flags
     )
   }
 }

--- a/packages/cli/src/commands/election/run.ts
+++ b/packages/cli/src/commands/election/run.ts
@@ -20,6 +20,7 @@ export default class ElectionRun extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flagsWithoutLocalAddresses(),
+    ...(cli.table.flags() as object),
   }
 
   async run() {
@@ -33,6 +34,6 @@ export default class ElectionRun extends BaseCommand {
       signers.map((addr) => validators.getValidatorFromSigner(addr))
     )
     cli.action.stop()
-    cli.table(validatorList, validatorTable, { 'no-truncate': !res.flags.truncate })
+    cli.table(validatorList, validatorTable, res.flags)
   }
 }

--- a/packages/cli/src/commands/governance/list.ts
+++ b/packages/cli/src/commands/governance/list.ts
@@ -10,12 +10,13 @@ export default class List extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flagsWithoutLocalAddresses(),
+    ...(cli.table.flags() as object),
   }
 
   static examples = ['list']
 
   async run() {
-    this.parse(List)
+    const res = this.parse(List)
 
     const governance = await this.kit.contracts.getGovernance()
     const queue = await governance.getQueue()
@@ -26,10 +27,14 @@ export default class List extends BaseCommand {
     const sortedQueue = governance.sortedQueue(unexpiredQueue)
 
     console.log(chalk.magenta.bold('Queued Proposals:'))
-    cli.table(sortedQueue, {
-      ID: { get: (p) => valueToString(p.proposalID) },
-      upvotes: { get: (p) => valueToString(p.upvotes) },
-    })
+    cli.table(
+      sortedQueue,
+      {
+        ID: { get: (p) => valueToString(p.proposalID) },
+        upvotes: { get: (p) => valueToString(p.upvotes) },
+      },
+      res.flags
+    )
 
     const dequeue = await governance.getDequeue(true)
     const expiredDequeueMap = await concurrentMap(5, dequeue, governance.isDequeuedProposalExpired)
@@ -38,10 +43,14 @@ export default class List extends BaseCommand {
     const proposals = zip((proposalID, stage) => ({ proposalID, stage }), unexpiredDequeue, stages)
 
     console.log(chalk.blue.bold('Dequeued Proposals:'))
-    cli.table(proposals, {
-      ID: { get: (p) => valueToString(p.proposalID) },
-      stage: {},
-    })
+    cli.table(
+      proposals,
+      {
+        ID: { get: (p) => valueToString(p.proposalID) },
+        stage: {},
+      },
+      res.flags
+    )
 
     console.log(chalk.red.bold('Expired Proposals:'))
     const expiredQueue = queue
@@ -50,8 +59,12 @@ export default class List extends BaseCommand {
     const expiredDequeue = dequeue
       .filter((_, idx) => expiredDequeueMap[idx])
       .map((_, idx) => dequeue[idx])
-    cli.table(expiredQueue.concat(expiredDequeue), {
-      ID: { get: (id) => valueToString(id) },
-    })
+    cli.table(
+      expiredQueue.concat(expiredDequeue),
+      {
+        ID: { get: (id) => valueToString(id) },
+      },
+      res.flags
+    )
   }
 }

--- a/packages/cli/src/commands/identity/current-attestation-services.ts
+++ b/packages/cli/src/commands/identity/current-attestation-services.ts
@@ -10,6 +10,7 @@ export default class AttestationServicesCurrent extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flagsWithoutLocalAddresses(),
+    ...(cli.table.flags() as object),
   }
 
   async run() {
@@ -66,7 +67,7 @@ export default class AttestationServicesCurrent extends BaseCommand {
         attestationServiceURL: {},
         smsProviders: {},
       },
-      { 'no-truncate': !res.flags.truncate }
+      res.flags
     )
   }
 }

--- a/packages/cli/src/commands/oracle/reports.ts
+++ b/packages/cli/src/commands/oracle/reports.ts
@@ -7,6 +7,7 @@ export default class Reports extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flagsWithoutLocalAddresses(),
+    ...(cli.table.flags() as object),
   }
 
   static args = [
@@ -33,7 +34,7 @@ export default class Reports extends BaseCommand {
         rate: { get: (r) => r.rate.toNumber() },
         timestamp: { get: (r) => r.timestamp.toNumber() },
       },
-      { 'no-truncate': !res.flags.truncate }
+      res.flags
     )
   }
 }

--- a/packages/cli/src/commands/rewards/show.ts
+++ b/packages/cli/src/commands/rewards/show.ts
@@ -33,6 +33,7 @@ export default class Show extends BaseCommand {
       default: 1,
       description: 'Show results for the last N epochs',
     }),
+    ...(cli.table.flags() as object),
   }
 
   static args = []
@@ -188,7 +189,7 @@ export default class Show extends BaseCommand {
           averageValidatorScore: { get: (e) => averageValidatorScore(e.validators).toFixed() },
           epochNumber: {},
         },
-        { 'no-truncate': !res.flags.truncate }
+        res.flags
       )
     } else if (groupVoterRewards.length > 0) {
       console.info('')
@@ -202,7 +203,7 @@ export default class Show extends BaseCommand {
           averageValidatorScore: { get: (e) => averageValidatorScore(e.validators).toFixed() },
           epochNumber: {},
         },
-        { 'no-truncate': !res.flags.truncate }
+        res.flags
       )
     }
 
@@ -234,7 +235,7 @@ export default class Show extends BaseCommand {
           group: { get: (e) => e.group.address },
           epochNumber: {},
         },
-        { 'no-truncate': !res.flags.truncate }
+        res.flags
       )
     }
 
@@ -257,7 +258,7 @@ export default class Show extends BaseCommand {
           validatorScore: { get: (e) => e.validator.score.toFixed() },
           epochNumber: {},
         },
-        { 'no-truncate': !res.flags.truncate }
+        res.flags
       )
     }
 
@@ -273,7 +274,7 @@ export default class Show extends BaseCommand {
           reward: { get: (e) => e.reward.toFixed() },
           epochNumber: {},
         },
-        { 'no-truncate': !res.flags.truncate }
+        res.flags
       )
     }
 

--- a/packages/cli/src/commands/validator/list.ts
+++ b/packages/cli/src/commands/validator/list.ts
@@ -18,6 +18,7 @@ export default class ValidatorList extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flagsWithoutLocalAddresses(),
+    ...(cli.table.flags() as object),
   }
 
   static examples = ['list']
@@ -30,6 +31,6 @@ export default class ValidatorList extends BaseCommand {
     const validatorList = await validators.getRegisteredValidators()
 
     cli.action.stop()
-    cli.table(validatorList, validatorTable, { 'no-truncate': !res.flags.truncate })
+    cli.table(validatorList, validatorTable, res.flags)
   }
 }

--- a/packages/cli/src/commands/validator/status.ts
+++ b/packages/cli/src/commands/validator/status.ts
@@ -58,6 +58,7 @@ export default class ValidatorStatus extends BaseCommand {
         'what block to end at when looking at signer activity. defaults to the latest block',
       default: -1,
     }),
+    ...(cli.table.flags() as object),
   }
 
   static examples = [
@@ -121,7 +122,7 @@ export default class ValidatorStatus extends BaseCommand {
     )
     cli.action.stop()
 
-    cli.table(validatorStatuses, statusTable, { 'no-truncate': !res.flags.truncate })
+    cli.table(validatorStatuses, statusTable, res.flags)
   }
 
   private async getSignatureCounts(

--- a/packages/cli/src/commands/validatorgroup/list.ts
+++ b/packages/cli/src/commands/validatorgroup/list.ts
@@ -7,6 +7,7 @@ export default class ValidatorGroupList extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flagsWithoutLocalAddresses(),
+    ...(cli.table.flags() as object),
   }
 
   static examples = ['list']
@@ -27,7 +28,7 @@ export default class ValidatorGroupList extends BaseCommand {
         commission: { get: (r) => r.commission.toFixed() },
         members: { get: (r) => r.members.length },
       },
-      { 'no-truncate': !res.flags.truncate }
+      res.flags
     )
   }
 }

--- a/packages/cli/src/utils/identity.ts
+++ b/packages/cli/src/utils/identity.ts
@@ -91,16 +91,13 @@ export abstract class ClaimCommand extends BaseCommand {
   }
 }
 
-export const claimFlags = {
-  from: Flags.address({
-    required: true,
-    description: 'Addess of the account to set metadata for',
-  }),
-}
-
 export const claimArgs = [Args.file('file', { description: 'Path of the metadata file' })]
 
-export const displayMetadata = async (metadata: IdentityMetadataWrapper, kit: ContractKit) => {
+export const displayMetadata = async (
+  metadata: IdentityMetadataWrapper,
+  kit: ContractKit,
+  tableFlags: object = {}
+) => {
   const data = await concurrentMap(5, metadata.claims, async (claim) => {
     const verifiable = VERIFIABLE_CLAIM_TYPES.includes(claim.type)
     const validatable = VALIDATABLE_CLAIM_TYPES.includes(claim.type)
@@ -154,7 +151,7 @@ export const displayMetadata = async (metadata: IdentityMetadataWrapper, kit: Co
       status: { header: 'Status' },
       createdAt: { header: 'Created At' },
     },
-    {}
+    tableFlags
   )
 }
 

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -479,6 +479,76 @@ EXAMPLES
 
 _See code: [packages/cli/src/commands/account/new.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/new.ts)_
 
+### Offchain-read
+
+DEV: Reads the name from offchain storage
+
+```
+USAGE
+  $ celocli account:offchain-read
+
+OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
+
+  --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
+                                                     addresses for local signing
+
+  --ledgerConfirmAddress                             Set it to ask confirmation for the address of the transaction from
+                                                     the ledger
+
+  --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
+                                                     index addresses for local signing. Example --ledgerCustomAddresses
+                                                     "[4,99]"
+
+  --name=name
+
+  --root=root
+
+  --useLedger                                        Set it to use a ledger wallet
+
+EXAMPLE
+  offchain-read --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+```
+
+_See code: [packages/cli/src/commands/account/offchain-read.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/offchain-read.ts)_
+
+### Offchain-write
+
+DEV: Writes a name to offchain storage
+
+```
+USAGE
+  $ celocli account:offchain-write
+
+OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+  --directory=directory                              (required) To which directory data should be written
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address with which to sign
+
+  --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
+                                                     addresses for local signing
+
+  --ledgerConfirmAddress                             Set it to ask confirmation for the address of the transaction from
+                                                     the ledger
+
+  --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
+                                                     index addresses for local signing. Example --ledgerCustomAddresses
+                                                     "[4,99]"
+
+  --name=name                                        (required)
+
+  --uploadWithGit                                    If the CLI should attempt to push changes to the origin via git
+
+  --useLedger                                        Set it to use a ledger wallet
+
+EXAMPLES
+  offchain-write --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+  offchain-write --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --name test-account
+```
+
+_See code: [packages/cli/src/commands/account/offchain-write.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/offchain-write.ts)_
+
 ### Proof-of-possession
 
 Generate proof-of-possession to be used to authorize a signer. See the "account:authorize" command for more details.

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -13,6 +13,7 @@ USAGE
   $ celocli account:authorize
 
 OPTIONS
+  -k, --privateKey=privateKey                          Use a private key to sign local transactions with
   -r, --role=vote|validator|attestation                (required) Role to delegate
 
   --blsKey=0x                                          The BLS public key that the validator is using for consensus,
@@ -22,9 +23,6 @@ OPTIONS
                                                        signature on the account address. 48 bytes.
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Account Address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)        Use a specific gas currency for transaction fees (defaults to
-                                                       'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                    [default: 1] If --useLedger is set, this will get the first N
                                                        addresses for local signing
@@ -67,10 +65,6 @@ View Celo Dollar and Gold balances for an address
 USAGE
   $ celocli account:balance ADDRESS
 
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
 EXAMPLE
   balance 0x5409ed021d9299bf6814279a6a1411a7e866a631
 ```
@@ -89,13 +83,11 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --address=address                                  (required) The address of the account you want to claim
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -131,13 +123,11 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --force                                            Ignore URL validity checks
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -172,13 +162,11 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --domain=domain                                    (required) The domain you want to claim
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -210,11 +198,10 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -248,11 +235,10 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -286,11 +272,10 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -324,11 +309,10 @@ ARGUMENTS
   FILE  Path where the metadata should be saved
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account to set metadata for or an
                                                      authorized signer for the address in the metadata
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -360,8 +344,11 @@ ARGUMENTS
   ADDRESS  Address to get metadata for
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
+  -x, --extended                                 show extra columns
+  --columns=columns                              only show provided columns (comma-separated)
+  --csv                                          output is csv format [alias: --output=csv]
+  --filter=filter                                filter property by partial string matching, ex: name=foo
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -371,6 +358,14 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
+
+  --no-header                                    hide table header from output
+
+  --no-truncate                                  do not truncate output to fit screen
+
+  --output=csv|json|yaml                         output in a more machine friendly format
+
+  --sort=sort                                    property to sort by (prepend '-' for descending)
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -389,8 +384,7 @@ USAGE
   $ celocli account:list
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -420,10 +414,6 @@ USAGE
 ARGUMENTS
   ACCOUNT  Account address
 
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
 EXAMPLE
   lock 0x5409ed021d9299bf6814279a6a1411a7e866a631
 ```
@@ -439,6 +429,9 @@ USAGE
   $ celocli account:new
 
 OPTIONS
+  -k, --privateKey=privateKey
+      Use a private key to sign local transactions with
+
   --addressIndex=addressIndex
       Choose the address index for the derivation path
 
@@ -453,6 +446,16 @@ OPTIONS
   --language=chinese_simplified|chinese_traditional|english|french|italian|japanese|korean|spanish
       [default: english] Language for the mnemonic words. **WARNING**, some hardware wallets don't support other languages
 
+  --ledgerAddresses=ledgerAddresses
+      [default: 1] If --useLedger is set, this will get the first N addresses for local signing
+
+  --ledgerConfirmAddress
+      Set it to ask confirmation for the address of the transaction from the ledger
+
+  --ledgerCustomAddresses=ledgerCustomAddresses
+      [default: [0]] If --useLedger is set, this will get the array of index addresses for local signing. Example
+      --ledgerCustomAddresses "[4,99]"
+
   --mnemonicPath=mnemonicPath
       Instead of generating a new mnemonic (seed phrase), use the user-supplied mnemonic instead. Path to a file that
       contains all the mnemonic words separated by a space (example: "word1 word2 word3 ... word24"). If the words are a
@@ -462,6 +465,9 @@ OPTIONS
       Path to a file that contains the BIP39 passphrase to combine with the mnemonic specified using the mnemonicPath flag
       and the index specified using the addressIndex flag. Every passphrase generates a different private key and wallet
       address.
+
+  --useLedger
+      Set it to use a ledger wallet
 
 EXAMPLES
   new
@@ -473,80 +479,6 @@ EXAMPLES
 
 _See code: [packages/cli/src/commands/account/new.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/new.ts)_
 
-### Offchain-read
-
-DEV: Reads the name from offchain storage
-
-```
-USAGE
-  $ celocli account:offchain-read
-
-OPTIONS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
-
-  --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
-                                                     addresses for local signing
-
-  --ledgerConfirmAddress                             Set it to ask confirmation for the address of the transaction from
-                                                     the ledger
-
-  --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
-                                                     index addresses for local signing. Example --ledgerCustomAddresses
-                                                     "[4,99]"
-
-  --name=name
-
-  --root=root
-
-  --useLedger                                        Set it to use a ledger wallet
-
-EXAMPLE
-  offchain-read --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
-```
-
-_See code: [packages/cli/src/commands/account/offchain-read.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/offchain-read.ts)_
-
-### Offchain-write
-
-DEV: Writes a name to offchain storage
-
-```
-USAGE
-  $ celocli account:offchain-write
-
-OPTIONS
-  --directory=directory                              (required) To which directory data should be written
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address with which to sign
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
-
-  --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
-                                                     addresses for local signing
-
-  --ledgerConfirmAddress                             Set it to ask confirmation for the address of the transaction from
-                                                     the ledger
-
-  --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
-                                                     index addresses for local signing. Example --ledgerCustomAddresses
-                                                     "[4,99]"
-
-  --name=name                                        (required)
-
-  --uploadWithGit                                    If the CLI should attempt to push changes to the origin via git
-
-  --useLedger                                        Set it to use a ledger wallet
-
-EXAMPLES
-  offchain-write --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
-  offchain-write --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --name test-account
-```
-
-_See code: [packages/cli/src/commands/account/offchain-write.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/offchain-write.ts)_
-
 ### Proof-of-possession
 
 Generate proof-of-possession to be used to authorize a signer. See the "account:authorize" command for more details.
@@ -556,11 +488,10 @@ USAGE
   $ celocli account:proof-of-possession
 
 OPTIONS
+  -k, --privateKey=privateKey                           Use a private key to sign local transactions with
+
   --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account that needs to prove possession
                                                         of the signer key.
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
-                                                        'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
@@ -592,6 +523,9 @@ USAGE
   $ celocli account:recover-old
 
 OPTIONS
+  -k, --privateKey=privateKey
+      Use a private key to sign local transactions with
+
   --addressIndex=addressIndex
       Choose the address index for the derivation path
 
@@ -606,6 +540,16 @@ OPTIONS
   --language=chinese_simplified|chinese_traditional|english|french|italian|japanese|korean|spanish
       [default: english] Language for the mnemonic words. **WARNING**, some hardware wallets don't support other languages
 
+  --ledgerAddresses=ledgerAddresses
+      [default: 1] If --useLedger is set, this will get the first N addresses for local signing
+
+  --ledgerConfirmAddress
+      Set it to ask confirmation for the address of the transaction from the ledger
+
+  --ledgerCustomAddresses=ledgerCustomAddresses
+      [default: [0]] If --useLedger is set, this will get the array of index addresses for local signing. Example
+      --ledgerCustomAddresses "[4,99]"
+
   --mnemonicPath=mnemonicPath
       (required) Path to a file that contains all the mnemonic words separated by a space (example: "word1 word2 word3 ...
       word24"). If the words are a language other than English, the --language flag must be used. Only BIP39 mnemonics are
@@ -615,6 +559,9 @@ OPTIONS
       Path to a file that contains the BIP39 passphrase to combine with the mnemonic specified using the mnemonicPath flag
       and the index specified using the addressIndex flag. Every passphrase generates a different private key and wallet
       address.
+
+  --useLedger
+      Set it to use a ledger wallet
 
 EXAMPLES
   recover-old --mnemonicPath some_folder/my_mnemonic_file
@@ -637,10 +584,8 @@ USAGE
   $ celocli account:register
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -672,10 +617,8 @@ USAGE
   $ celocli account:register-data-encryption-key
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Addess of the account to set the data encryption key for
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -706,11 +649,13 @@ USAGE
   $ celocli account:register-metadata
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+  -x, --extended                                     show extra columns
+  --columns=columns                                  only show provided columns (comma-separated)
+  --csv                                              output is csv format [alias: --output=csv]
+  --filter=filter                                    filter property by partial string matching, ex: name=foo
   --force                                            Ignore metadata validity checks
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Addess of the account to set metadata for
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -721,6 +666,14 @@ OPTIONS
   --ledgerCustomAddresses=ledgerCustomAddresses      [default: [0]] If --useLedger is set, this will get the array of
                                                      index addresses for local signing. Example --ledgerCustomAddresses
                                                      "[4,99]"
+
+  --no-header                                        hide table header from output
+
+  --no-truncate                                      do not truncate output to fit screen
+
+  --output=csv|json|yaml                             output in a more machine friendly format
+
+  --sort=sort                                        property to sort by (prepend '-' for descending)
 
   --url=https://www.celo.org                         (required) The url to the metadata you want to register
 
@@ -741,10 +694,8 @@ USAGE
   $ celocli account:set-name
 
 OPTIONS
+  -k, --privateKey=privateKey                           Use a private key to sign local transactions with
   --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
-                                                        'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
@@ -775,8 +726,7 @@ USAGE
   $ celocli account:show ADDRESS
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -804,8 +754,7 @@ USAGE
   $ celocli account:show-claimed-accounts ADDRESS
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -836,8 +785,11 @@ ARGUMENTS
   FILE  Path of the metadata file
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
+  -x, --extended                                 show extra columns
+  --columns=columns                              only show provided columns (comma-separated)
+  --csv                                          output is csv format [alias: --output=csv]
+  --filter=filter                                filter property by partial string matching, ex: name=foo
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -847,6 +799,14 @@ OPTIONS
 
   --ledgerCustomAddresses=ledgerCustomAddresses  [default: [0]] If --useLedger is set, this will get the array of index
                                                  addresses for local signing. Example --ledgerCustomAddresses "[4,99]"
+
+  --no-header                                    hide table header from output
+
+  --no-truncate                                  do not truncate output to fit screen
+
+  --output=csv|json|yaml                         output in a more machine friendly format
+
+  --sort=sort                                    property to sort by (prepend '-' for descending)
 
   --useLedger                                    Set it to use a ledger wallet
 
@@ -868,14 +828,8 @@ ARGUMENTS
   ACCOUNT  Account address
 
 OPTIONS
-  --duration=duration                            Duration in seconds to leave the account unlocked. Unlocks until the
-                                                 node exits by default.
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
-  --password=password                            Password used to unlock the account. If not specified, you will be
-                                                 prompted for a password.
+  --duration=duration  Duration in seconds to leave the account unlocked. Unlocks until the node exits by default.
+  --password=password  Password used to unlock the account. If not specified, you will be prompted for a password.
 
 EXAMPLES
   unlock 0x5409ed021d9299bf6814279a6a1411a7e866a631
@@ -893,11 +847,10 @@ USAGE
   $ celocli account:verify-proof-of-possession
 
 OPTIONS
+  -k, --privateKey=privateKey                           Use a private key to sign local transactions with
+
   --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account that needs to prove possession
                                                         of the signer key.
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
-                                                        'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing

--- a/packages/docs/command-line-interface/config.md
+++ b/packages/docs/command-line-interface/config.md
@@ -31,8 +31,8 @@ OPTIONS
                                                  which uses whatever feeCurrency is available)
 
 EXAMPLES
-  set  --node ws://localhost:2500
-  set  --node <geth-location>/geth.ipc
+  set --node ws://localhost:2500
+  set --node <geth-location>/geth.ipc
   set --gasCurrency cUSD
   set --gasCurrency CELO
 ```

--- a/packages/docs/command-line-interface/dkg.md
+++ b/packages/docs/command-line-interface/dkg.md
@@ -13,10 +13,8 @@ USAGE
   $ celocli dkg:deploy
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -46,11 +44,8 @@ USAGE
   $ celocli dkg:get
 
 OPTIONS
+  -k, --privateKey=privateKey                                          Use a private key to sign local transactions with
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d                 (required) DKG Contract Address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)                        Use a specific gas currency for transaction fees
-                                                                       (defaults to 'auto' which uses whatever
-                                                                       feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                                    [default: 1] If --useLedger is set, this will get
                                                                        the first N addresses for local signing
@@ -78,12 +73,10 @@ USAGE
   $ celocli dkg:publish
 
 OPTIONS
+  -k, --privateKey=privateKey                           Use a private key to sign local transactions with
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
   --data=data                                           (required) Path to the data being published
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
-                                                        'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
@@ -109,12 +102,10 @@ USAGE
   $ celocli dkg:register
 
 OPTIONS
+  -k, --privateKey=privateKey                           Use a private key to sign local transactions with
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
   --blsKey=blsKey                                       (required)
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
-                                                        'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
@@ -140,11 +131,9 @@ USAGE
   $ celocli dkg:start
 
 OPTIONS
+  -k, --privateKey=privateKey                           Use a private key to sign local transactions with
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
-                                                        'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing
@@ -170,11 +159,9 @@ USAGE
   $ celocli dkg:whitelist
 
 OPTIONS
+  -k, --privateKey=privateKey                           Use a private key to sign local transactions with
   --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)         Use a specific gas currency for transaction fees (defaults to
-                                                        'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                     [default: 1] If --useLedger is set, this will get the first N
                                                         addresses for local signing

--- a/packages/docs/command-line-interface/election.md
+++ b/packages/docs/command-line-interface/election.md
@@ -13,10 +13,8 @@ USAGE
   $ celocli election:activate
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -48,12 +46,17 @@ USAGE
   $ celocli election:current
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 
-  --valset                                       Show currently used signers from valset (by default the authorized
-                                                 validator signers are shown). Useful for checking if keys have been
-                                                 rotated.
+  --valset                Show currently used signers from valset (by default the authorized validator signers are
+                          shown). Useful for checking if keys have been rotated.
 ```
 
 _See code: [packages/cli/src/commands/election/current.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/election/current.ts)_
@@ -67,8 +70,14 @@ USAGE
   $ celocli election:list
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 
 EXAMPLE
   list
@@ -85,11 +94,9 @@ USAGE
   $ celocli election:revoke
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) ValidatorGroup's address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -121,8 +128,14 @@ USAGE
   $ celocli election:run
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 ```
 
 _See code: [packages/cli/src/commands/election/run.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/election/run.ts)_
@@ -139,12 +152,8 @@ ARGUMENTS
   ADDRESS  Voter or Validator Groups's address
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
-  --group                                        Show information about a group running in Validator elections
-
-  --voter                                        Show information about an account voting in Validator elections
+  --group  Show information about a group running in Validator elections
+  --voter  Show information about an account voting in Validator elections
 
 EXAMPLES
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3 --voter
@@ -162,11 +171,9 @@ USAGE
   $ celocli election:vote
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) ValidatorGroup's address
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing

--- a/packages/docs/command-line-interface/exchange.md
+++ b/packages/docs/command-line-interface/exchange.md
@@ -13,13 +13,12 @@ USAGE
   $ celocli exchange:celo
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum value of Celo Dollars to receive
                                                      in return
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with CELO to exchange
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -51,13 +50,12 @@ USAGE
   $ celocli exchange:dollars
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum value of CELO to receive in
                                                      return
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with Celo Dollars to exchange
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -89,13 +87,12 @@ USAGE
   $ celocli exchange:gold
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum value of Celo Dollars to receive
                                                      in return
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with CELO to exchange
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -127,11 +124,7 @@ USAGE
   $ celocli exchange:show
 
 OPTIONS
-  --amount=amount                                [default: 1000000000000000000] Amount of the token being exchanged to
-                                                 report rates for
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  --amount=amount  [default: 1000000000000000000] Amount of the token being exchanged to report rates for
 
 EXAMPLE
   list

--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -13,10 +13,8 @@ USAGE
   $ celocli governance:dequeue
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) From address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -45,10 +43,8 @@ USAGE
   $ celocli governance:execute
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Executor's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -79,11 +75,8 @@ USAGE
   $ celocli governance:executehotfix
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Executors's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
-
   --jsonTransactions=jsonTransactions                (required) Path to json transactions
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
@@ -116,9 +109,7 @@ USAGE
   $ celocli governance:hashhotfix
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
   --jsonTransactions=jsonTransactions            (required) Path to json transactions of the hotfix
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
@@ -150,8 +141,14 @@ USAGE
   $ celocli governance:list
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 
 EXAMPLE
   list
@@ -168,11 +165,8 @@ USAGE
   $ celocli governance:preparehotfix
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Preparer's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
-
   --hash=hash                                        (required) Hash of hotfix transactions
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
@@ -203,15 +197,13 @@ USAGE
   $ celocli governance:propose
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --deposit=deposit                                  (required) Amount of Gold to attach to proposal
 
   --descriptionURL=descriptionURL                    (required) A URL where further information about the proposal can
                                                      be viewed
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Proposer's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --interactive                                      Form proposal using an interactive prompt for Celo registry
                                                      contracts and functions
@@ -246,10 +238,8 @@ USAGE
   $ celocli governance:revokeupvote
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Upvoter's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -278,24 +268,14 @@ USAGE
   $ celocli governance:show
 
 OPTIONS
-  --account=account                              Address of account or voter
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
-  --hotfix=hotfix                                Hash of hotfix proposal
-
-  --jsonTransactions=jsonTransactions            Output proposal JSON to provided file
-
-  --nonwhitelisters                              If set, displays validators that have not whitelisted the hotfix.
-
-  --notwhitelisted                               List validators who have not whitelisted the specified hotfix
-
-  --proposalID=proposalID                        UUID of proposal to view
-
-  --raw                                          Display proposal in raw bytes format
-
-  --whitelisters                                 If set, displays validators that have whitelisted the hotfix.
+  --account=account                    Address of account or voter
+  --hotfix=hotfix                      Hash of hotfix proposal
+  --jsonTransactions=jsonTransactions  Output proposal JSON to provided file
+  --nonwhitelisters                    If set, displays validators that have not whitelisted the hotfix.
+  --notwhitelisted                     List validators who have not whitelisted the specified hotfix
+  --proposalID=proposalID              UUID of proposal to view
+  --raw                                Display proposal in raw bytes format
+  --whitelisters                       If set, displays validators that have whitelisted the hotfix.
 
 EXAMPLES
   show --proposalID 99
@@ -317,10 +297,8 @@ USAGE
   $ celocli governance:upvote
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Upvoter's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -351,12 +329,8 @@ USAGE
   $ celocli governance:view
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
-  --proposalID=proposalID                        (required) UUID of proposal to view
-
-  --raw                                          Display proposal in raw bytes format
+  --proposalID=proposalID  (required) UUID of proposal to view
+  --raw                    Display proposal in raw bytes format
 
 EXAMPLES
   view --proposalID 99
@@ -374,14 +348,9 @@ USAGE
   $ celocli governance:viewhotfix
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
-  --hash=hash                                    (required) Hash of hotfix transactions
-
-  --nonwhitelisters                              If set, displays validators that have not whitelisted the hotfix.
-
-  --whitelisters                                 If set, displays validators that have whitelisted the hotfix.
+  --hash=hash        (required) Hash of hotfix transactions
+  --nonwhitelisters  If set, displays validators that have not whitelisted the hotfix.
+  --whitelisters     If set, displays validators that have whitelisted the hotfix.
 
 EXAMPLES
   viewhotfix --hash 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658
@@ -400,10 +369,8 @@ USAGE
   $ celocli governance:vote
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -436,11 +403,8 @@ USAGE
   $ celocli governance:whitelisthotfix
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Whitelister's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
-
   --hash=hash                                        (required) Hash of hotfix transactions
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
@@ -471,10 +435,8 @@ USAGE
   $ celocli governance:withdraw
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Proposer's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing

--- a/packages/docs/command-line-interface/identity.md
+++ b/packages/docs/command-line-interface/identity.md
@@ -13,8 +13,14 @@ USAGE
   $ celocli identity:current-attestation-services
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 ```
 
 _See code: [packages/cli/src/commands/identity/current-attestation-services.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/identity/current-attestation-services.ts)_
@@ -28,11 +34,9 @@ USAGE
   $ celocli identity:identifier
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --context=context                                  mainnet (default), alfajores, or alfajoresstaging
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address from which to perform the query
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -64,10 +68,8 @@ USAGE
   $ celocli identity:test-attestation-service
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Your validator's signer or account address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing

--- a/packages/docs/command-line-interface/lockedgold.md
+++ b/packages/docs/command-line-interface/lockedgold.md
@@ -13,10 +13,8 @@ USAGE
   $ celocli lockedgold:lock
 
 OPTIONS
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
   --from=from                                    (required)
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -45,10 +43,6 @@ Show Locked Gold information for a given account. This includes the total amount
 USAGE
   $ celocli lockedgold:show ACCOUNT
 
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
 EXAMPLE
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631
 ```
@@ -64,10 +58,8 @@ USAGE
   $ celocli lockedgold:unlock
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -98,10 +90,8 @@ USAGE
   $ celocli lockedgold:withdraw
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing

--- a/packages/docs/command-line-interface/multisig.md
+++ b/packages/docs/command-line-interface/multisig.md
@@ -13,14 +13,9 @@ USAGE
   $ celocli multisig:show ADDRESS
 
 OPTIONS
-  --all                                          Show info about all transactions
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
-  --raw                                          Do not attempt to parse transactions
-
-  --tx=tx                                        Show info for a transaction
+  --all    Show info about all transactions
+  --raw    Do not attempt to parse transactions
+  --tx=tx  Show info for a transaction
 
 EXAMPLES
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631

--- a/packages/docs/command-line-interface/network.md
+++ b/packages/docs/command-line-interface/network.md
@@ -15,17 +15,6 @@ USAGE
 
 _See code: [packages/cli/src/commands/network/contracts.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/contracts.ts)_
 
-### Info
-
-View general network information such as the current block number
-
-```
-USAGE
-  $ celocli network:info
-```
-
-_See code: [packages/cli/src/commands/network/info.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/info.ts)_
-
 ### Parameters
 
 View parameters of the network, including but not limited to configuration for the various Celo core smart contracts.

--- a/packages/docs/command-line-interface/network.md
+++ b/packages/docs/command-line-interface/network.md
@@ -11,13 +11,20 @@ Lists Celo core contracts and their addesses.
 ```
 USAGE
   $ celocli network:contracts
-
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
 ```
 
 _See code: [packages/cli/src/commands/network/contracts.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/contracts.ts)_
+
+### Info
+
+View general network information such as the current block number
+
+```
+USAGE
+  $ celocli network:info
+```
+
+_See code: [packages/cli/src/commands/network/info.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/info.ts)_
 
 ### Parameters
 
@@ -26,10 +33,6 @@ View parameters of the network, including but not limited to configuration for t
 ```
 USAGE
   $ celocli network:parameters
-
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
 ```
 
 _See code: [packages/cli/src/commands/network/parameters.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/network/parameters.ts)_

--- a/packages/docs/command-line-interface/node.md
+++ b/packages/docs/command-line-interface/node.md
@@ -13,8 +13,7 @@ USAGE
   $ celocli node:accounts
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -39,10 +38,7 @@ USAGE
   $ celocli node:synced
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
-  --verbose                                      output the full status if syncing
+  --verbose  output the full status if syncing
 ```
 
 _See code: [packages/cli/src/commands/node/synced.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/node/synced.ts)_

--- a/packages/docs/command-line-interface/oracle.md
+++ b/packages/docs/command-line-interface/oracle.md
@@ -15,10 +15,6 @@ USAGE
 ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to list the oracles for
 
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
 EXAMPLES
   list StableToken
   list
@@ -38,10 +34,8 @@ ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to remove expired reports for
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account removing oracle reports
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -74,10 +68,8 @@ ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to report on
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the oracle account
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -112,8 +104,14 @@ ARGUMENTS
   TOKEN  (StableToken) [default: StableToken] Token to list the reports for
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 
 EXAMPLES
   reports StableToken

--- a/packages/docs/command-line-interface/releasegold.md
+++ b/packages/docs/command-line-interface/releasegold.md
@@ -13,6 +13,8 @@ USAGE
   $ celocli releasegold:authorize
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
+
   --blsKey=0x                                            The BLS public key that the validator is using for consensus,
                                                          should pass proof of possession. 96 bytes.
 
@@ -20,9 +22,6 @@ OPTIONS
                                                          signature on the account address. 48 bytes.
 
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -70,10 +69,8 @@ USAGE
   $ celocli releasegold:create-account
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -103,10 +100,8 @@ USAGE
 
 OPTIONS
   -a, --action=lock|unlock|withdraw                      (required) Action to perform on contract's gold
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -141,10 +136,8 @@ USAGE
   $ celocli releasegold:refund-and-finalize
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -173,10 +166,8 @@ USAGE
   $ celocli releasegold:revoke
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -207,11 +198,8 @@ USAGE
   $ celocli releasegold:revoke-votes
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
-
   --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the group to revoke votes from
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
@@ -244,12 +232,10 @@ USAGE
   $ celocli releasegold:set-account
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   -p, --property=name|dataEncryptionKey|metaURL          (required) Property type to set
   -v, --value=value                                      (required) Property value to set
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -282,10 +268,8 @@ USAGE
   $ celocli releasegold:set-account-wallet-address
 
 OPTIONS
+  -k, --privateKey=privateKey                                 Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)               Use a specific gas currency for transaction fees (defaults
-                                                              to 'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                           [default: 1] If --useLedger is set, this will get the
                                                               first N addresses for local signing
@@ -323,14 +307,12 @@ USAGE
   $ celocli releasegold:set-beneficiary
 
 OPTIONS
+  -k, --privateKey=privateKey                               Use a private key to sign local transactions with
   --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the new beneficiary
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the ReleaseGold Contract
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address to submit multisig transaction from (one
                                                             of the owners)
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)             Use a specific gas currency for transaction fees (defaults
-                                                            to 'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                         [default: 1] If --useLedger is set, this will get the first
                                                             N addresses for local signing
@@ -362,10 +344,8 @@ USAGE
   $ celocli releasegold:set-can-expire
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -398,10 +378,8 @@ USAGE
   $ celocli releasegold:set-liquidity-provision
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -432,13 +410,11 @@ USAGE
   $ celocli releasegold:set-max-distribution
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
 
   --distributionRatio=distributionRatio                  (required) Amount in range [0, 1000] (3 significant figures)
                                                          indicating % of total balance available for distribution.
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -469,10 +445,8 @@ USAGE
   $ celocli releasegold:show
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -501,10 +475,8 @@ USAGE
   $ celocli releasegold:transfer-dollars
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing
@@ -538,10 +510,8 @@ USAGE
   $ celocli releasegold:withdraw
 
 OPTIONS
+  -k, --privateKey=privateKey                            Use a private key to sign local transactions with
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)          Use a specific gas currency for transaction fees (defaults to
-                                                         'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                      [default: 1] If --useLedger is set, this will get the first N
                                                          addresses for local signing

--- a/packages/docs/command-line-interface/reserve.md
+++ b/packages/docs/command-line-interface/reserve.md
@@ -12,10 +12,6 @@ Shows information about reserve
 USAGE
   $ celocli reserve:status
 
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
 EXAMPLE
   status
 ```
@@ -31,10 +27,8 @@ USAGE
   $ celocli reserve:transfergold
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Spender's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing

--- a/packages/docs/command-line-interface/rewards.md
+++ b/packages/docs/command-line-interface/rewards.md
@@ -13,18 +13,19 @@ USAGE
   $ celocli rewards:show
 
 OPTIONS
+  -x, --extended                                          show extra columns
+  --columns=columns                                       only show provided columns (comma-separated)
+  --csv                                                   output is csv format [alias: --output=csv]
   --epochs=epochs                                         [default: 1] Show results for the last N epochs
   --estimate                                              Estimate voter rewards from current votes
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)           Use a specific gas currency for transaction fees (defaults to
-                                                          'auto' which uses whatever feeCurrency is available)
-
+  --filter=filter                                         filter property by partial string matching, ex: name=foo
   --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show rewards for
-
+  --no-header                                             hide table header from output
+  --no-truncate                                           do not truncate output to fit screen
+  --output=csv|json|yaml                                  output in a more machine friendly format
   --slashing                                              Show rewards for slashing
-
+  --sort=sort                                             property to sort by (prepend '-' for descending)
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Validator to show rewards for
-
   --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Voter to show rewards for
 
 EXAMPLE

--- a/packages/docs/command-line-interface/transfer.md
+++ b/packages/docs/command-line-interface/transfer.md
@@ -13,11 +13,9 @@ USAGE
   $ celocli transfer:celo
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --comment=comment                                  Transfer comment
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -51,11 +49,9 @@ USAGE
   $ celocli transfer:dollars
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --comment=comment                                  Transfer comment
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -89,11 +85,9 @@ USAGE
   $ celocli transfer:gold
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --comment=comment                                  Transfer comment
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing

--- a/packages/docs/command-line-interface/validator.md
+++ b/packages/docs/command-line-interface/validator.md
@@ -16,10 +16,8 @@ ARGUMENTS
   GROUPADDRESS  ValidatorGroup's address
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -50,10 +48,8 @@ USAGE
   $ celocli validator:deaffiliate
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -82,10 +78,8 @@ USAGE
   $ celocli validator:deregister
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -105,6 +99,39 @@ EXAMPLE
 
 _See code: [packages/cli/src/commands/validator/deregister.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/validator/deregister.ts)_
 
+### Downtime-slash
+
+Downtime slash a validator
+
+```
+USAGE
+  $ celocli validator:downtime-slash
+
+OPTIONS
+  -k, --privateKey=privateKey                             Use a private key to sign local transactions with
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Slasher
+
+  --ledgerAddresses=ledgerAddresses                       [default: 1] If --useLedger is set, this will get the first N
+                                                          addresses for local signing
+
+  --ledgerConfirmAddress                                  Set it to ask confirmation for the address of the transaction
+                                                          from the ledger
+
+  --ledgerCustomAddresses=ledgerCustomAddresses           [default: [0]] If --useLedger is set, this will get the array
+                                                          of index addresses for local signing. Example
+                                                          --ledgerCustomAddresses "[4,99]"
+
+  --useLedger                                             Set it to use a ledger wallet
+
+  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Validator's address
+
+EXAMPLE
+  downtime-slash --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --validator
+  0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD
+```
+
+_See code: [packages/cli/src/commands/validator/downtime-slash.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/validator/downtime-slash.ts)_
+
 ### Force-deaffiliate
 
 Force deaffiliate a Validator from a Validator Group, and remove it from the Group if it is also a member. Used by stake-off admins in order to remove validators from the next epoch's validator set if they are down and consistently unresponsive, in order to preserve the health of the network. This feature will be removed once slashing for downtime is implemented.
@@ -114,10 +141,8 @@ USAGE
   $ celocli validator:force-deaffiliate
 
 OPTIONS
+  -k, --privateKey=privateKey                             Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Initiator
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)           Use a specific gas currency for transaction fees (defaults to
-                                                          'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                       [default: 1] If --useLedger is set, this will get the first N
                                                           addresses for local signing
@@ -149,8 +174,14 @@ USAGE
   $ celocli validator:list
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 
 EXAMPLE
   list
@@ -167,13 +198,11 @@ USAGE
   $ celocli validator:register
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --blsKey=0x                                        (required) BLS Public Key
   --blsSignature=0x                                  (required) BLS Proof-of-Possession
   --ecdsaKey=0x                                      (required) ECDSA Public Key
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the Validator
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -208,10 +237,6 @@ List the Locked Gold requirements for registering a Validator. This consists of 
 USAGE
   $ celocli validator:requirements
 
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
 EXAMPLE
   requirements
 ```
@@ -229,10 +254,6 @@ USAGE
 ARGUMENTS
   VALIDATORADDRESS  Validator's address
 
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
-
 EXAMPLE
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3
 ```
@@ -249,14 +270,8 @@ USAGE
 
 OPTIONS
   --at-block=at-block                                  latest block to examine for signer activity
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)        Use a specific gas currency for transaction fees (defaults to
-                                                       'auto' which uses whatever feeCurrency is available)
-
   --lookback=lookback                                  [default: 120] how many blocks to look back for signer activity
-
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) address of the signer to check for signatures
-
   --width=width                                        [default: 40] line width for printing marks
 
 EXAMPLES
@@ -278,15 +293,25 @@ USAGE
   $ celocli validator:status
 
 OPTIONS
+  -x, --extended                                          show extra columns
   --all                                                   get the status of all registered validators
+  --columns=columns                                       only show provided columns (comma-separated)
+  --csv                                                   output is csv format [alias: --output=csv]
 
   --end=end                                               [default: -1] what block to end at when looking at signer
                                                           activity. defaults to the latest block
 
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)           Use a specific gas currency for transaction fees (defaults to
-                                                          'auto' which uses whatever feeCurrency is available)
+  --filter=filter                                         filter property by partial string matching, ex: name=foo
+
+  --no-header                                             hide table header from output
+
+  --no-truncate                                           do not truncate output to fit screen
+
+  --output=csv|json|yaml                                  output in a more machine friendly format
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     address of the signer to check if elected and validating
+
+  --sort=sort                                             property to sort by (prepend '-' for descending)
 
   --start=start                                           [default: -1] what block to start at when looking at signer
                                                           activity. defaults to the last 100 blocks
@@ -310,12 +335,10 @@ USAGE
   $ celocli validator:update-bls-public-key
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --blsKey=0x                                        (required) BLS Public Key
   --blsPop=0x                                        (required) BLS Proof-of-Possession
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Validator's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing

--- a/packages/docs/command-line-interface/validator.md
+++ b/packages/docs/command-line-interface/validator.md
@@ -99,39 +99,6 @@ EXAMPLE
 
 _See code: [packages/cli/src/commands/validator/deregister.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/validator/deregister.ts)_
 
-### Downtime-slash
-
-Downtime slash a validator
-
-```
-USAGE
-  $ celocli validator:downtime-slash
-
-OPTIONS
-  -k, --privateKey=privateKey                             Use a private key to sign local transactions with
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Slasher
-
-  --ledgerAddresses=ledgerAddresses                       [default: 1] If --useLedger is set, this will get the first N
-                                                          addresses for local signing
-
-  --ledgerConfirmAddress                                  Set it to ask confirmation for the address of the transaction
-                                                          from the ledger
-
-  --ledgerCustomAddresses=ledgerCustomAddresses           [default: [0]] If --useLedger is set, this will get the array
-                                                          of index addresses for local signing. Example
-                                                          --ledgerCustomAddresses "[4,99]"
-
-  --useLedger                                             Set it to use a ledger wallet
-
-  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Validator's address
-
-EXAMPLE
-  downtime-slash --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --validator
-  0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD
-```
-
-_See code: [packages/cli/src/commands/validator/downtime-slash.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/validator/downtime-slash.ts)_
-
 ### Force-deaffiliate
 
 Force deaffiliate a Validator from a Validator Group, and remove it from the Group if it is also a member. Used by stake-off admins in order to remove validators from the next epoch's validator set if they are down and consistently unresponsive, in order to preserve the health of the network. This feature will be removed once slashing for downtime is implemented.

--- a/packages/docs/command-line-interface/validatorgroup.md
+++ b/packages/docs/command-line-interface/validatorgroup.md
@@ -13,14 +13,13 @@ USAGE
   $ celocli validatorgroup:commission
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --apply                                            Applies a previously queued update. Should be called after the
                                                      update delay.
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the Validator Group or Validator Group
                                                      validator signer
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -53,10 +52,8 @@ USAGE
   $ celocli validatorgroup:deregister
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or ValidatorGroup's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -85,8 +82,14 @@ USAGE
   $ celocli validatorgroup:list
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
 
 EXAMPLE
   list
@@ -106,11 +109,9 @@ ARGUMENTS
   VALIDATORADDRESS  Validator's address
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
   --accept                                           Accept a validator whose affiliation is already set to the group
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) ValidatorGroup's address
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -147,13 +148,12 @@ USAGE
   $ celocli validatorgroup:register
 
 OPTIONS
+  -k, --privateKey=privateKey                        Use a private key to sign local transactions with
+
   --commission=commission                            (required) The share of the epoch rewards given to elected
                                                      Validators that goes to the group.
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the Validator Group
-
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)      Use a specific gas currency for transaction fees (defaults to
-                                                     'auto' which uses whatever feeCurrency is available)
 
   --ledgerAddresses=ledgerAddresses                  [default: 1] If --useLedger is set, this will get the first N
                                                      addresses for local signing
@@ -187,8 +187,7 @@ ARGUMENTS
   GROUPADDRESS  ValidatorGroup's address
 
 OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
+  -k, --privateKey=privateKey                    Use a private key to sign local transactions with
 
   --ledgerAddresses=ledgerAddresses              [default: 1] If --useLedger is set, this will get the first N addresses
                                                  for local signing
@@ -217,10 +216,6 @@ USAGE
 
 ARGUMENTS
   GROUPADDRESS  ValidatorGroup's address
-
-OPTIONS
-  --gasCurrency=(celo|CELO|cusd|cUSD|auto|Auto)  Use a specific gas currency for transaction fees (defaults to 'auto'
-                                                 which uses whatever feeCurrency is available)
 
 EXAMPLE
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3


### PR DESCRIPTION
### Description

- Pass through `cli-ux` table plugin flags which customize formatting of table outputs for relevant commands

### Other changes

- Remove `LocalCommand`

### Tested

![Screen Shot 2020-10-28 at 1 21 54 PM](https://user-images.githubusercontent.com/3020995/97492287-8e2e9f00-1920-11eb-9227-c7ddb2f66c50.png)

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/22 (as best as possible)

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._