### PR TITLE
WS support for forno in k8s-based testnets

### DIFF
--- a/packages/helm-charts/testnet/templates/forno.ingress.yaml
+++ b/packages/helm-charts/testnet/templates/forno.ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
+    # Allows WS connections to be 20 minutes long, see https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#websockets
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "1200"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "1200"
 spec:
   tls:
   - hosts:
@@ -21,3 +24,7 @@ spec:
         backend:
           serviceName: tx-nodes
           servicePort: 8545
+      - path: /ws
+        backend:
+          serviceName: tx-nodes
+          servicePort: 8546


### PR DESCRIPTION
### Description

Updates k8s-based testnet envs (notably alfajores and alfajoresstaging) to have forno support websockets at `/ws`. The annotation changes allow WS connections to stay open 20 minutes

### Other changes

n/a

### Tested

made the relevant changes on alfajores & alfajoresstaging

### Related issues

n/a

### Backwards compatibility

Yes