### PR TITLE
Extend KomenciKit with CheckSession and QuotaExceededError

### DIFF
--- a/packages/komencikit/examples/attestation-flow.ts
+++ b/packages/komencikit/examples/attestation-flow.ts
@@ -41,6 +41,11 @@ const run = async () => {
   if (!startSession.ok) {
     return
   }
+  const checkSession = await komenciKit.checkSession()
+  console.log(checkSession)
+  if (!checkSession.ok) {
+    return
+  }
   const deployWallet = await komenciKit.deployWallet(WALLET_IMPLEMENTATION_ADDRESS)
   console.log('DeployWallet: ', deployWallet)
   if (!deployWallet.ok) {
@@ -57,6 +62,11 @@ const run = async () => {
   }
   const identifier = getIdentifier.result.identifier
   const pepper = getIdentifier.result.pepper
+  const checkSession2 = await komenciKit.checkSession()
+  console.log(checkSession2)
+  if (!checkSession2.ok) {
+    return
+  }
   const approveRes = await komenciKit.approveAttestations(walletAddress, 3)
   console.log(approveRes)
   if (!approveRes.ok) {

--- a/packages/komencikit/src/actions.ts
+++ b/packages/komencikit/src/actions.ts
@@ -8,6 +8,7 @@ export enum ActionTypes {
   SubmitMetaTransaction = 'SubmitMetaTransaction',
   RequestSubsidisedAttestation = 'RequestSubsidisedAttestation',
   CheckService = 'CheckService',
+  CheckSession = 'CheckSession',
 }
 
 export enum RequestMethod {
@@ -54,6 +55,32 @@ const _checkService = action<ActionTypes.CheckService, null, CheckServiceRespons
 )
 
 export const checkService = () => _checkService(null)
+
+export enum TrackedAction {
+  DistributedBlindedPepper = 'distributedBlindedPepper',
+  RequestSubsidisedAttestation = 'requestSubsidisedAttestation',
+  SubmitMetaTransaction = 'submitMetaTransaction',
+}
+
+export const CheckSessionResp = t.type({
+  quotaLeft: t.type({
+    distributedBlindedPepper: t.number,
+    requestSubsidisedAttestation: t.number,
+    submitMetaTransaction: t.number,
+  }),
+  metaTxWalletAddress: t.union([t.undefined, t.string]),
+})
+
+export type CheckSessionResp = t.TypeOf<typeof CheckSessionResp>
+
+export const _checkSession = action<ActionTypes.CheckSession, null, CheckSessionResp>(
+  ActionTypes.CheckSession,
+  RequestMethod.GET,
+  'v1/checkSession',
+  CheckSessionResp
+)
+
+export const checkSession = () => _checkSession(null)
 
 export interface StartSessionPayload {
   captchaResponseToken: string

--- a/packages/komencikit/src/actions.ts
+++ b/packages/komencikit/src/actions.ts
@@ -56,12 +56,6 @@ const _checkService = action<ActionTypes.CheckService, null, CheckServiceRespons
 
 export const checkService = () => _checkService(null)
 
-export enum TrackedAction {
-  DistributedBlindedPepper = 'distributedBlindedPepper',
-  RequestSubsidisedAttestation = 'requestSubsidisedAttestation',
-  SubmitMetaTransaction = 'submitMetaTransaction',
-}
-
 export const CheckSessionResp = t.type({
   quotaLeft: t.type({
     distributedBlindedPepper: t.number,

--- a/packages/komencikit/src/client.ts
+++ b/packages/komencikit/src/client.ts
@@ -8,6 +8,7 @@ import {
   FetchErrorTypes,
   NetworkError,
   NotFoundError,
+  QuotaExceededError,
   RequestError,
   ResponseDecodeError,
   ServiceUnavailable,
@@ -68,10 +69,12 @@ export class KomenciClient {
         } else {
           return Err(new ResponseDecodeError(payload))
         }
-      } else if (resp.status === 404) {
-        return Err(new NotFoundError(this.url + action.path))
       } else if (resp.status === 403) {
         return Err(new Unauthorised())
+      } else if (resp.status === 404) {
+        return Err(new NotFoundError(this.url + action.path))
+      } else if (resp.status === 429) {
+        return Err(new QuotaExceededError())
       } else if (resp.status === 400) {
         const payload = await resp.json()
         return Err(new RequestError(payload))

--- a/packages/komencikit/src/errors.ts
+++ b/packages/komencikit/src/errors.ts
@@ -8,6 +8,7 @@ export enum FetchErrorTypes {
   NetworkError = 'NetworkError',
   DecodeError = 'DecodeError',
   NotFoundError = 'NotFoundError',
+  QuotaExceededError = 'QuotaExceededError',
 }
 
 export class Unauthorised extends RootError<FetchErrorTypes.Unauthorised> {
@@ -58,6 +59,12 @@ export class NotFoundError extends RootError<FetchErrorTypes.NotFoundError> {
   }
 }
 
+export class QuotaExceededError extends RootError<FetchErrorTypes.QuotaExceededError> {
+  constructor() {
+    super(FetchErrorTypes.QuotaExceededError)
+  }
+}
+
 export type FetchError =
   | Unauthorised
   | RequestError
@@ -66,6 +73,7 @@ export type FetchError =
   | NetworkError
   | ResponseDecodeError
   | NotFoundError
+  | QuotaExceededError
 
 export enum TxErrorTypes {
   Timeout = 'Timeout',

--- a/packages/komencikit/src/kit.ts
+++ b/packages/komencikit/src/kit.ts
@@ -8,6 +8,7 @@ import {
 import { TransactionReceipt } from 'web3-core'
 import {
   checkService,
+  CheckSessionResp,
   deployWallet,
   getDistributedBlindedPepper,
   GetDistributedBlindedPepperResp,
@@ -15,6 +16,7 @@ import {
   startSession,
   StartSessionPayload,
   submitMetaTransaction,
+  checkSession,
 } from './actions'
 import { KomenciClient } from './client'
 import {
@@ -84,6 +86,17 @@ export class KomenciKit {
     }
 
     return Err(new KomenciDown())
+  }
+
+  /**
+   * checkSession: uses the /v1/checkSession endpoint to check the current session
+   * It returns the current quota usage and optionally a wallet address
+   * if one was deployed during the session
+   *
+   * @return Result<CheckSessionResp, FetchError>
+   */
+  checkSession = async (): Promise<Result<CheckSessionResp, FetchError>> => {
+    return this.client.exec(checkSession())
   }
 
   /**

--- a/packages/komencikit/src/kit.ts
+++ b/packages/komencikit/src/kit.ts
@@ -8,6 +8,7 @@ import {
 import { TransactionReceipt } from 'web3-core'
 import {
   checkService,
+  checkSession,
   CheckSessionResp,
   deployWallet,
   getDistributedBlindedPepper,
@@ -16,7 +17,6 @@ import {
   startSession,
   StartSessionPayload,
   submitMetaTransaction,
-  checkSession,
 } from './actions'
 import { KomenciClient } from './client'
 import {
@@ -141,10 +141,21 @@ export class KomenciKit {
    * @param clientVersion
    * @returns the identifier and the pepper
    */
-  getDistributedBlindedPepper = async (
+  @retry({
+    tries: 3,
+    bailOnErrorTypes: [
+      FetchErrorTypes.Unauthorised,
+      FetchErrorTypes.ServiceUnavailable,
+      FetchErrorTypes.QuotaExceededError,
+    ],
+    onRetry: (_args, error, attempt) => {
+      console.debug(`${TAG}/getDistributedBlindPepper attempt#${attempt} error: `, error)
+    },
+  })
+  public async getDistributedBlindedPepper(
     e164Number: string,
     clientVersion: string
-  ): Promise<Result<GetDistributedBlindedPepperResp, FetchError>> => {
+  ): Promise<Result<GetDistributedBlindedPepperResp, FetchError>> {
     return this.client.exec(getDistributedBlindedPepper({ e164Number, clientVersion }))
   }
 
@@ -215,6 +226,7 @@ export class KomenciKit {
     bailOnErrorTypes: [
       FetchErrorTypes.Unauthorised,
       FetchErrorTypes.ServiceUnavailable,
+      FetchErrorTypes.QuotaExceededError,
       TxErrorTypes.Revert,
     ],
     onRetry: (_args, error, attempt) => {
@@ -342,6 +354,7 @@ export class KomenciKit {
     bailOnErrorTypes: [
       FetchErrorTypes.Unauthorised,
       FetchErrorTypes.ServiceUnavailable,
+      FetchErrorTypes.QuotaExceededError,
       TxErrorTypes.Revert,
     ],
     onRetry: (_args, error, attempt) => {


### PR DESCRIPTION
### Description

Added a new action that verifies that a session is still around and returns the current action quota for that session.
Treat 429 explicitly by returning FetchError.QuotaExceededErrors that the client can interpret.  
