### PR TITLE
[Wallet] Attempt to ignore SIGPIPE after sentry init

### DIFF
--- a/packages/mobile/ios/celo/AppDelegate.m
+++ b/packages/mobile/ios/celo/AppDelegate.m
@@ -84,6 +84,13 @@ static NSString * const kHasRunBeforeKey = @"RnSksIsAppInstalled";
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
 
+  // Ignore SIGPIPE signals
+  // SIGPIPE is sent when a process attempts to write to a socket that is no longer open for reading
+  // this is to handle crashes that happen when the app tries to make network requests after it has been
+  // backgrounded; the reason we need to do this after react has been inited is sentry sets up its own
+  // signal handlers which would overwrite our own
+  signal(SIGPIPE, SIG_IGN);
+
   return YES;
 }
 


### PR DESCRIPTION
### Description

Managed to reproduce this intermittent crash that has been happening for a long time and is the biggest cause of crashes in iOS: https://sentry.io/organizations/celo/issues/1387267537/?project=1250733&query=is%3Aunresolved+user%3A%22username%3A0x4d3a6da1a3a9a1d77f79f956460640770c565770%22&statsPeriod=1h

I tried but failed to consistently reproduce it in a test case but I think the problem is the app tries to make a network request right after it has been backgrounded.

It is safe to ignore this signal if the app properly handles error cases in all network requests.

### Other changes

No

### Tested

Manually by doing lots of random network requests and closing / opening the app, while also toggling airplane and wifi.

### Related issues

- Fixes #4867

### Backwards compatibility

Yes.
