### PR TITLE
Don't dereference env name for testnets

### DIFF
--- a/packages/helm-charts/testnet/templates/validators.statefulset.yaml
+++ b/packages/helm-charts/testnet/templates/validators.statefulset.yaml
@@ -181,7 +181,7 @@ spec:
 
           [[ "$IN_MEMORY_DISCOVERY_TABLE" == "true" ]] && ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --use-in-memory-discovery-table"
 
-          if [[ "${{ .Release.Name }}" == "alfajores" || "${{ .Release.Name }}" == "baklava" ]]; then
+          if [[ "{{ .Release.Name }}" == "alfajores" || "{{ .Release.Name }}" == "baklava" ]]; then
             BOOTNODE_FLAG="--${network_name}"
           else
             BOOTNODE_FLAG="--bootnodes=enode://$(cat /root/.celo/bootnodeEnode)"


### PR DESCRIPTION
### Description

Does a literal comparison between env name rather than trying to dereference it in bash land (it already gets templated in).

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

Testnets deploy and validators don't get stuck in crash loops.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._