### PR TITLE
Add ability to specify signing algorithm for Azure HSM

### DIFF
--- a/packages/sdk/wallets/wallet-hsm-azure/src/azure-key-vault-client.ts
+++ b/packages/sdk/wallets/wallet-hsm-azure/src/azure-key-vault-client.ts
@@ -13,6 +13,13 @@ import {
 } from '@celo/wallet-hsm'
 import { BigNumber } from 'bignumber.js'
 
+export enum AzureKeyVaultSigningAlgorithm {
+  ECDSA256 = 'ECDSA256',
+  ES256K = 'ES256K',
+}
+
+const DEFAULT_SIGNING_ALGORITHM = AzureKeyVaultSigningAlgorithm.ECDSA256
+
 /**
  * Provides an abstraction on Azure Key Vault for performing signing operations
  */
@@ -22,14 +29,14 @@ export class AzureKeyVaultClient {
   private readonly vaultUri: string
   private readonly credential: TokenCredential
   private readonly keyClient: KeyClient
-  private readonly SIGNING_ALGORITHM: string = 'ECDSA256'
+  private readonly SIGNING_ALGORITHM: AzureKeyVaultSigningAlgorithm
   private cryptographyClientSet: Map<string, CryptographyClient> = new Map<
     string,
     CryptographyClient
   >()
   private readonly secretClient: SecretClient
 
-  constructor(vaultName: string, credential?: TokenCredential) {
+  constructor(vaultName: string, credential?: TokenCredential, signingAlgorithm?: AzureKeyVaultSigningAlgorithm) {
     this.vaultName = vaultName
     this.vaultUri = `https://${this.vaultName}.vault.azure.net`
     // DefaultAzureCredential supports service principal or managed identity
@@ -37,6 +44,7 @@ export class AzureKeyVaultClient {
     this.credential = credential || new DefaultAzureCredential()
     this.keyClient = new KeyClient(this.vaultUri, this.credential)
     this.secretClient = new SecretClient(this.vaultUri, this.credential)
+    this.SIGNING_ALGORITHM = signingAlgorithm || DEFAULT_SIGNING_ALGORITHM
   }
 
   public async getKeys(): Promise<string[]> {


### PR DESCRIPTION
### Description

Azure HSM gives us the ability to create curves that support signing algorithms which we can use for managing Celo accounts. This feature has undergone some changes recently:

- Curve `SECP256K1` is now named `P-256K`
- Signing algorithm `ECDSA256` is now named `ES256K`

[Source](https://github.com/Azure/azure-sdk-for-node/issues/4603)

But when interacting with the signing API you can only use `ECDSA256` with `SECP256K1` curves and must use `ES256K` with `P-256K` curves, annoyingly. 

We currently have `SECP256K1` curves in Azure and have recently created `P-256K` for Komenci, but our KeyVaultClient was referencing `ECDSA256` as a constant. Thus I was seeing this error when trying to interact with the keys:

```
"message": "Key and signing algorithm are incompatible. Key https://mainnet-komenci-eastus.vault.azure.net/keys/mainnet-komenci-funder-eastus/0c6493f97acb41e7ba35546488b7f14a uses curve 'P-256K', and algorithm 'ECDSA256' can only be used with curve 'P-256' or 'SECP256K1'."
```

This PR adds the ability to specify an optional signing algorithm. This is intended as a temporary workaround in order to unblock Komenci work and for me to test the assumption that this is actually the issue.

I would suggest improving on this PR by deriving the signing algorithm to be used from the curve type of the key.
