### PR TITLE
chore: relax helm version to v3 instead of exactly v3.3

### DIFF
--- a/packages/celotool/src/lib/helm_deploy.ts
+++ b/packages/celotool/src/lib/helm_deploy.ts
@@ -870,7 +870,7 @@ function useStaticIPsForGethNodes() {
 }
 
 export async function checkHelmVersion() {
-  const requiredHelmVersion = 'v3.3'
+  const requiredHelmVersion = 'v3'
   const helmOK = await outputIncludes('helm version -c --short', requiredHelmVersion, `Checking local Helm version. Required ${requiredHelmVersion}`)
   if (helmOK) {
     return true


### PR DESCRIPTION
### Description

Helm v3.3 is too restrictive, I installed the latest and got v3.4