### PR TITLE
Add Blockscout API deployment

### DIFF
--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -56,6 +56,8 @@ volumes:
   value: "5432"
 - name: WOBSERVER_ENABLED
   value: "false"
+- name: POOL_SIZE
+  value: {{ .Values.blockscout.pool_size }}
 - name: HEALTHY_BLOCKS_PERIOD
   value: {{ .Values.blockscout.healthy_blocks_period | quote }}
 - name: MIX_ENV

--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -2,8 +2,12 @@
 - name: cloudsql-proxy
   image: gcr.io/cloudsql-docker/gce-proxy:1.11
   command: ["/cloud_sql_proxy",
-            "-instances={{ .Values.blockscout.db.connection_name }}=tcp:5432",
+            "-instances={{ .Values.blockscout.db.connection_name }}{{ .DbSuffix | default "" }}=tcp:5432",
             "-credential_file=/secrets/cloudsql/credentials.json"]
+  resources:
+    requests:
+      memory: 500Mi
+      cpu: 200m
   securityContext:
     runAsUser: 2  # non-root user
     allowPrivilegeEscalation: false
@@ -53,7 +57,7 @@ volumes:
 - name: WOBSERVER_ENABLED
   value: "false"
 - name: HEALTHY_BLOCKS_PERIOD
-  value: {{ .Values.blockscout.healthy_blocks_period }}
+  value: {{ .Values.blockscout.healthy_blocks_period | quote }}
 - name: MIX_ENV
   value: prod
 - name: LOGO

--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -52,6 +52,8 @@ volumes:
   value: "5432"
 - name: WOBSERVER_ENABLED
   value: "false"
+- name: HEALTHY_BLOCKS_PERIOD
+  value: {{ .Values.blockscout.healthy_blocks_period }}
 - name: MIX_ENV
   value: prod
 - name: LOGO

--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -57,7 +57,7 @@ volumes:
 - name: WOBSERVER_ENABLED
   value: "false"
 - name: POOL_SIZE
-  value: {{ .Values.blockscout.pool_size }}
+  value: {{ .Values.blockscout.pool_size | quote }}
 - name: HEALTHY_BLOCKS_PERIOD
   value: {{ .Values.blockscout.healthy_blocks_period | quote }}
 - name: MIX_ENV

--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -56,8 +56,6 @@ volumes:
   value: "5432"
 - name: WOBSERVER_ENABLED
   value: "false"
-- name: POOL_SIZE
-  value: {{ .Values.blockscout.pool_size | quote }}
 - name: HEALTHY_BLOCKS_PERIOD
   value: {{ .Values.blockscout.healthy_blocks_period | quote }}
 - name: MIX_ENV

--- a/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
@@ -19,4 +19,4 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 70
+      targetAverageUtilization: {{ .Values.blockscout.autoscaling.api.target.cpu }}

--- a/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    app: blockscout
+    chart: blockscout
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: blockscout-api-autoscaler
+spec:
+  minReplicas: {{ .Values.blockscout.autoscaling.api.minReplicas }}
+  maxReplicas: {{ .Values.blockscout.autoscaling.api.maxReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-api
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 70

--- a/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
@@ -9,8 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
     component: blockscout-api-autoscaler
 spec:
-  minReplicas: {{ .Values.blockscout.autoscaling.api.minReplicas }}
-  maxReplicas: {{ .Values.blockscout.autoscaling.api.maxReplicas }}
+  minReplicas: {{ .Values.blockscout.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.blockscout.api.autoscaling.maxReplicas }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -19,4 +19,4 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.blockscout.autoscaling.api.target.cpu }}
+      targetAverageUtilization: {{ .Values.blockscout.api.autoscaling.target.cpu }}

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -47,7 +47,8 @@ spec:
         - name: DISABLE_INDEXER
           value: "true"
 {{ include "celo.blockscout-env-vars" .  | indent 8 }}
-{{ include "celo.blockscout-db-sidecar" .  | indent 6 }}
+{{$data := dict "Values" .Values "DbSuffix" "-replica"}}
+{{ include "celo.blockscout-db-sidecar" $data  | indent 6 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    app: blockscout
+    chart: blockscout
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: blockscout-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blockscout
+      release: {{ .Release.Name }}
+      component: blockscout-api
+  template:
+    metadata:
+      labels:
+        app: blockscout
+        release: {{ .Release.Name }}
+        component: blockscout-api
+    spec:
+      containers:
+      - name: blockscout-api
+        image: {{ .Values.blockscout.image.repository }}:api-{{ .Values.blockscout.image.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - |
+           exec mix cmd --app block_scout_web mix phx.server | sed 's/^iex(1)> //'
+        ports:
+        - name: http
+          containerPort: 4000
+        resources:
+          requests:
+            memory: 500Mi
+            cpu: 500m
+        env:
+        - name: DISABLE_WEBAPP
+          value: "true"
+        - name: DISABLE_WRITE_API
+          value: "true"
+        - name: DISABLE_INDEXER
+          value: "true"
+{{ include "celo.blockscout-env-vars" .  | indent 8 }}
+{{ include "celo.blockscout-db-sidecar" .  | indent 6 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -46,6 +46,8 @@ spec:
           value: "true"
         - name: DISABLE_INDEXER
           value: "true"
+        - name: POOL_SIZE
+          value: {{ .Values.blockscout.api.pool_size | quote }}
 {{ include "celo.blockscout-env-vars" .  | indent 8 }}
 {{$data := dict "Values" .Values "DbSuffix" "-replica"}}
 {{ include "celo.blockscout-db-sidecar" $data  | indent 6 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-api.ingress.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-api-ingress
+  labels:
+    app: blockscout
+    chart: blockscout
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: blockscout-api-ingress
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      location ~ /admin/.* {
+        deny all;
+      }
+spec:
+  tls:
+  - hosts:
+    - {{ .Release.Name }}-api.{{ .Values.domain.name }}.org
+    secretName: {{ .Release.Name }}-api-tls
+  rules:
+  - host: {{ .Release.Name }}-api.{{ .Values.domain.name }}.org
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name }}-api
+          servicePort: 4000

--- a/packages/helm-charts/blockscout/templates/blockscout-api.service.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    app: blockscout
+    chart: blockscout
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: blockscout-api
+spec:
+  selector:
+    app: blockscout
+    release: {{ .Release.Name }}
+    component: blockscout-api
+  clusterIP: None
+  ports:
+  - name: http
+    port: 4000

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -43,6 +43,8 @@ spec:
         env:
         - name: DISABLE_WEBAPP
           value: "true"
+        - name: POOL_SIZE
+          value: {{ .Values.blockscout.indexer.pool_size | quote }}
 {{ include "celo.blockscout-env-vars" .  | indent 8 }}
 {{ include "celo.blockscout-db-sidecar" .  | indent 6 }}
     {{- with .Values.nodeSelector }}

--- a/packages/helm-charts/blockscout/templates/blockscout-metadata-crawler.cronjob.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-metadata-crawler.cronjob.yaml
@@ -41,7 +41,7 @@ spec:
               name: tmp-pod
               readOnly: true
           - name: metadata-crawler
-            image: {{ .Values.blockscout.metadata_crawler.image.repository }}:{{ .Values.blockscout.metadata_crawler.repository.tag }}
+            image: {{ .Values.blockscout.metadata_crawler.image.repository }}:{{ .Values.blockscout.metadata_crawler.image.tag }}
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh

--- a/packages/helm-charts/blockscout/templates/blockscout-web.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.autoscale.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-web
+  labels:
+    app: blockscout
+    chart: blockscout
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: blockscout-web-autoscaler
+spec:
+  minReplicas: {{ .Values.blockscout.autoscaling.web.minReplicas }}
+  maxReplicas: {{ .Values.blockscout.autoscaling.web.maxReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-web
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.blockscout.autoscaling.web.target.cpu }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.autoscale.yaml
@@ -9,8 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
     component: blockscout-web-autoscaler
 spec:
-  minReplicas: {{ .Values.blockscout.autoscaling.web.minReplicas }}
-  maxReplicas: {{ .Values.blockscout.autoscaling.web.maxReplicas }}
+  minReplicas: {{ .Values.blockscout.web.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.blockscout.web.autoscaling.maxReplicas }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -19,4 +19,4 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.blockscout.autoscaling.web.target.cpu }}
+      targetAverageUtilization: {{ .Values.blockscout.web.autoscaling.target.cpu }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -45,6 +45,8 @@ spec:
           value: "4000"
         - name: DISABLE_INDEXER
           value: "true"
+        - name: POOL_SIZE
+          value: {{ .Values.blockscout.web.pool_size | quote }}
 {{ include "celo.blockscout-env-vars" .  | indent 8 }}
 {{ include "celo.blockscout-db-sidecar" .  | indent 6 }}
     {{- with .Values.nodeSelector }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
     component: blockscout-web-ingress
   annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -31,6 +32,18 @@ spec:
   - host: {{ .Release.Name }}.{{ .Values.domain.name }}.org
     http:
       paths:
+      - path: /api/v1/(decompiled_smart_contract|verified_smart_contracts)
+        backend:
+          serviceName: {{ .Release.Name }}-web
+          servicePort: 4000
+      - path: /(graphql|graphiql)
+        backend:
+          serviceName: {{ .Release.Name }}-api
+          servicePort: 4000
+      - path: /api/.*
+        backend:
+          serviceName: {{ .Release.Name }}-api
+          servicePort: 4000
       - path: /
         backend:
           serviceName: {{ .Release.Name }}-web

--- a/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
@@ -36,11 +36,7 @@ spec:
         backend:
           serviceName: {{ .Release.Name }}-web
           servicePort: 4000
-      - path: /(graphql|graphiql)
-        backend:
-          serviceName: {{ .Release.Name }}-api
-          servicePort: 4000
-      - path: /api/.*
+      - path: /(graphql|graphiql|api)
         backend:
           serviceName: {{ .Release.Name }}-api
           servicePort: 4000

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -15,6 +15,7 @@ blockscout:
     repository: gcr.io/celo-testnet/blockscout
     tag: v2.0.4-beta-celo
   healthy_blocks_period: 60
+  pool_size: 20
   db:
     # ip: must be provided at runtime # IP address of the postgres DB
     # connection_name: must be provided at runtime # name of the cloud sql connection

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -4,6 +4,13 @@ blockscout:
     api:
       maxReplicas: 10
       minReplicas: 2
+      target:
+        cpu: 70
+    web:
+      maxReplicas: 5
+      minReplicas: 2
+      target:
+        cpu: 70
   image:
     repository: gcr.io/celo-testnet/blockscout
     tag: v2.0.4-beta-celo

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -1,5 +1,9 @@
 imagePullPolicy: IfNotPresent
 blockscout:
+  autoscaling:
+    api:
+      maxReplicas: 10
+      minReplicas: 2
   image:
     repository: gcr.io/celo-testnet/blockscout
     tag: v2.0.4-beta-celo

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -3,6 +3,7 @@ blockscout:
   image:
     repository: gcr.io/celo-testnet/blockscout
     tag: v2.0.4-beta-celo
+  healthy_blocks_period: 60
   db:
     # ip: must be provided at runtime # IP address of the postgres DB
     # connection_name: must be provided at runtime # name of the cloud sql connection

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -1,21 +1,25 @@
 imagePullPolicy: IfNotPresent
 blockscout:
-  autoscaling:
-    api:
-      maxReplicas: 10
-      minReplicas: 2
-      target:
-        cpu: 70
-    web:
+  indexer:
+    pool_size: 30
+  api:
+    autoscaling:
+        maxReplicas: 10
+        minReplicas: 2
+        target:
+          cpu: 70
+    pool_size: 40
+  web:
+    autoscaling:
       maxReplicas: 5
       minReplicas: 2
       target:
         cpu: 70
+    pool_size: 10
   image:
     repository: gcr.io/celo-testnet/blockscout
     tag: v2.0.4-beta-celo
   healthy_blocks_period: 60
-  pool_size: 20
   db:
     # ip: must be provided at runtime # IP address of the postgres DB
     # connection_name: must be provided at runtime # name of the cloud sql connection


### PR DESCRIPTION
### Description

Adds a new deployment for the Blockscout read-only API component connected to the read replica.

### Tested

Tested on Baklava (3).