### PR TITLE
[Wallet] Remove force unlock from initial onboarding flow

### DIFF
--- a/packages/mobile/e2e/src/usecases/RestoreAccountOnboarding.js
+++ b/packages/mobile/e2e/src/usecases/RestoreAccountOnboarding.js
@@ -78,11 +78,6 @@ export default RestoreAccountOnboarding = () => {
     await sleep(5000)
   })
 
-  it('Pin', async () => {
-    // Enter pin before verification starts
-    await enterPinUi()
-  })
-
   it('VerifyEducation', async () => {
     await waitForElementId('VerificationEducationSkipHeader')
 

--- a/packages/mobile/src/identity/actions.ts
+++ b/packages/mobile/src/identity/actions.ts
@@ -182,6 +182,7 @@ export interface UpdateAddressDekMapAction {
 
 export interface FetchVerificationState {
   type: Actions.FETCH_VERIFICATION_STATE
+  forceUnlockAccount: boolean
 }
 
 export interface UpdateVerificationState {
@@ -405,8 +406,9 @@ export const updateAddressDekMap = (
   dataEncryptionKey,
 })
 
-export const fetchVerificationState = (): FetchVerificationState => ({
+export const fetchVerificationState = (forceUnlockAccount: boolean): FetchVerificationState => ({
   type: Actions.FETCH_VERIFICATION_STATE,
+  forceUnlockAccount,
 })
 
 export const udpateVerificationState = (

--- a/packages/mobile/src/identity/saga.ts
+++ b/packages/mobile/src/identity/saga.ts
@@ -1,4 +1,5 @@
 import {
+  call,
   cancelled,
   put,
   select,
@@ -13,6 +14,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import {
   Actions,
+  FetchVerificationState,
   ValidateRecipientAddressAction,
   validateRecipientAddressSuccess,
 } from 'src/identity/actions'
@@ -92,8 +94,13 @@ export function* validateRecipientAddressSaga({
   }
 }
 
+function* handleFetchVerificationState(action: FetchVerificationState) {
+  const { forceUnlockAccount } = action
+  yield call(fetchVerificationState, forceUnlockAccount)
+}
+
 function* watchVerification() {
-  yield takeLeading(Actions.FETCH_VERIFICATION_STATE, fetchVerificationState)
+  yield takeLeading(Actions.FETCH_VERIFICATION_STATE, handleFetchVerificationState)
   yield takeLatest(Actions.START_VERIFICATION, startVerification)
   yield takeLeading(Actions.REVOKE_VERIFICATION, revokeVerificationSaga)
 }

--- a/packages/mobile/src/identity/verification.test.ts
+++ b/packages/mobile/src/identity/verification.test.ts
@@ -318,8 +318,6 @@ describe(startVerification, () => {
         [call(getConnectedAccount), null],
         [select(isVerificationStateExpiredSelector), true],
         [call(doVerificationFlow, false), true],
-        // [call(fetchVerificationState), true],
-        // [matchers.call.fn(fetchVerificationState), fetchVerificationStateMock],
       ])
       .call.fn(fetchVerificationState)
       .run()
@@ -331,7 +329,7 @@ describe(fetchVerificationState, () => {
     const contractKit = await getContractKitAsync()
     const unlockAccountMock = jest.fn(async () => true)
     unlockAccount.mockImplementationOnce(unlockAccountMock)
-    await expectSaga(fetchVerificationState, { forceUnlockAccount: false })
+    await expectSaga(fetchVerificationState)
       .provide([
         [call(getConnectedAccount), mockAccount],
         [select(e164NumberSelector), mockE164Number],
@@ -377,7 +375,7 @@ describe(fetchVerificationState, () => {
     const contractKit = await getContractKitAsync()
     const unlockAccountMock = jest.fn(async () => true)
     unlockAccount.mockImplementationOnce(unlockAccountMock)
-    await expectSaga(fetchVerificationState, { forceUnlockAccount: false })
+    await expectSaga(fetchVerificationState)
       .provide([
         [call(getConnectedAccount), mockAccount],
         [select(e164NumberSelector), mockE164Number],
@@ -423,7 +421,7 @@ describe(fetchVerificationState, () => {
     const contractKit = await getContractKitAsync()
     const unlockAccountMock = jest.fn(async () => true)
     unlockAccount.mockImplementationOnce(unlockAccountMock)
-    await expectSaga(fetchVerificationState, { forceUnlockAccount: true })
+    await expectSaga(fetchVerificationState, true)
       .provide([
         [call(getConnectedAccount), mockAccount],
         [select(e164NumberSelector), mockE164Number],
@@ -467,7 +465,7 @@ describe(fetchVerificationState, () => {
 
   it('catches insufficient balance for sig retrieval', async () => {
     const contractKit = await getContractKitAsync()
-    await expectSaga(fetchVerificationState, { forceUnlockAccount: false })
+    await expectSaga(fetchVerificationState)
       .provide([
         [call(getConnectedUnlockedAccount), mockAccount],
         [select(e164NumberSelector), mockE164Number],
@@ -498,7 +496,7 @@ describe(fetchVerificationState, () => {
   })
   it('catches when balances are not fetched', async () => {
     const contractKit = await getContractKitAsync()
-    await expectSaga(fetchVerificationState, { forceUnlockAccount: false })
+    await expectSaga(fetchVerificationState)
       .provide([
         [call(getConnectedUnlockedAccount), mockAccount],
         [select(e164NumberSelector), mockE164Number],

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -26,7 +26,6 @@ import { refreshAllBalances } from 'src/home/actions'
 import {
   Actions,
   completeAttestationCode,
-  FetchVerificationState,
   inputAttestationCode,
   InputAttestationCodeAction,
   ReceiveAttestationMessageAction,
@@ -91,14 +90,14 @@ export interface AttestationCode {
   issuer: string
 }
 
-export function* fetchVerificationState({ forceUnlockAccount }: FetchVerificationState) {
+export function* fetchVerificationState(forceUnlockAccount?: boolean) {
   try {
     const account: string = yield call(getConnectedAccount)
     if (forceUnlockAccount) {
       // we want to reset password before force unlock account
       clearPasswordCaches()
     }
-    yield call(unlockAccount, account, forceUnlockAccount)
+    yield call(unlockAccount, account, !!forceUnlockAccount)
     const e164Number: string = yield select(e164NumberSelector)
     const contractKit = yield call(getContractKit)
     const attestationsWrapper: AttestationsWrapper = yield call([
@@ -207,7 +206,7 @@ export function* restartableVerification(initialWithoutRevealing: boolean) {
     yield put(resetVerification())
     yield call(getConnectedAccount)
     if (isRestarted || (yield select(isVerificationStateExpiredSelector))) {
-      yield call(fetchVerificationState, { forceUnlockAccount: true })
+      yield call(fetchVerificationState, true)
     }
 
     const { verification, restart } = yield race({

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -26,6 +26,7 @@ import { refreshAllBalances } from 'src/home/actions'
 import {
   Actions,
   completeAttestationCode,
+  FetchVerificationState,
   inputAttestationCode,
   InputAttestationCodeAction,
   ReceiveAttestationMessageAction,
@@ -90,20 +91,20 @@ export interface AttestationCode {
   issuer: string
 }
 
-export function* fetchVerificationState() {
+export function* fetchVerificationState({ forceUnlockAccount }: FetchVerificationState) {
   try {
     const account: string = yield call(getConnectedAccount)
+    if (forceUnlockAccount) {
+      // we want to reset password before force unlock account
+      clearPasswordCaches()
+    }
+    yield call(unlockAccount, account, forceUnlockAccount)
     const e164Number: string = yield select(e164NumberSelector)
     const contractKit = yield call(getContractKit)
     const attestationsWrapper: AttestationsWrapper = yield call([
       contractKit.contracts,
       contractKit.contracts.getAttestations,
     ])
-
-    // Lock and ask user for a PIN because we
-    // want to reset timeout for unlocked account
-    clearPasswordCaches()
-    yield call(unlockAccount, account, true)
 
     const { timeout } = yield race({
       balances: all([
@@ -206,7 +207,7 @@ export function* restartableVerification(initialWithoutRevealing: boolean) {
     yield put(resetVerification())
     yield call(getConnectedAccount)
     if (isRestarted || (yield select(isVerificationStateExpiredSelector))) {
-      yield call(fetchVerificationState)
+      yield call(fetchVerificationState, { forceUnlockAccount: true })
     }
 
     const { verification, restart } = yield race({

--- a/packages/mobile/src/verify/VerificationEducationScreen.tsx
+++ b/packages/mobile/src/verify/VerificationEducationScreen.tsx
@@ -75,7 +75,7 @@ function VerificationEducationScreen({ route, navigation }: Props) {
   useFocusEffect(
     // useCallback is needed here: https://bit.ly/2G0WKTJ
     useCallback(() => {
-      dispatch(fetchVerificationState())
+      dispatch(fetchVerificationState(!partOfOnboarding))
     }, [])
   )
 


### PR DESCRIPTION
### Description

https://github.com/celo-org/celo-monorepo/pull/5656 has introduced mandatory enter of PIN code while onboarding flow to prevent account unlock timeout issue.

This PR would disable it specifically to the initial onboarding (we hope that 10 minutes since user sets the PIN would be enough to finish onboarding initially) and keep it if user comes back to verification later. 

### Caveat
The only one I see is when user goes to verification from Home screen, enters PIN, press Start/Resume, press back, user again needs to enter a PIN code. Not sure how often this is happening and to which extent it would ruin the UX.

### Tested

Initial onboarding with verification and return to verification flow later.

### Backwards compatibility

Yes