### PR TITLE
Fetch transaction receipts as a backup to web3

### DIFF
--- a/packages/contractkit/src/wrappers/Attestations.ts
+++ b/packages/contractkit/src/wrappers/Attestations.ts
@@ -419,6 +419,12 @@ export class AttestationsWrapper extends BaseWrapper<Attestations> {
   }
 
   /**
+   * Returns the list of accounts associated with an identifier.
+   * @param identifier Attestation identifier (e.g. phone hash)
+   */
+  lookupAccountsForIdentifier = proxyCall(this.contract.methods.lookupAccountsForIdentifier)
+
+  /**
    * Lookup mapped wallet addresses for a given list of identifiers
    * @param identifiers Attestation identifiers (e.g. phone hashes)
    */
@@ -701,7 +707,7 @@ export class AttestationsWrapper extends BaseWrapper<Attestations> {
   }
 
   async revoke(identifer: string, account: Address) {
-    const accounts = await this.contract.methods.lookupAccountsForIdentifier(identifer).call()
+    const accounts = await this.lookupAccountsForIdentifier(identifer)
     const idx = accounts.findIndex((acc) => eqAddress(acc, account))
     if (idx < 0) {
       throw new Error("Account not found in identifier's accounts")

--- a/packages/komencikit/src/kit.ts
+++ b/packages/komencikit/src/kit.ts
@@ -406,12 +406,14 @@ export class KomenciKit {
     const signature = await wallet.signMetaTransaction(tx.txo, nonce)
     const rawMetaTx = toRawTransaction(wallet.executeMetaTransaction(tx.txo, signature).txo)
 
+    console.debug(`${TAG}/submitMetaTransaction Sending mtx to Komenci: ${rawMetaTx}`)
     const resp = await this.client.exec(submitMetaTransaction(rawMetaTx))
     if (!resp.ok) {
       return resp
     }
 
     const txHash = resp.result.txHash
+    console.debug(`${TAG}/submitMetaTransaction Waiting for transaction receipt: ${txHash}`)
     return this.waitForReceipt(txHash)
   }
 

--- a/packages/komencikit/src/kit.ts
+++ b/packages/komencikit/src/kit.ts
@@ -492,6 +492,7 @@ export class KomenciKit {
     if (!receiptResult.ok) {
       return receiptResult
     }
+    const receipt = receiptResult.result
 
     const deployer = await this.contractKit.contracts.getMetaTransactionWalletDeployer(receipt.to)
 

--- a/packages/komencikit/src/kit.ts
+++ b/packages/komencikit/src/kit.ts
@@ -438,6 +438,11 @@ export class KomenciKit {
       return Err(new TxTimeoutError())
     }
 
+    if (!receipt.status) {
+      // TODO: Possible to extract reason?
+      return Err(new TxRevertError(txHash, ''))
+    }
+
     return Ok(receipt)
   }
 

--- a/packages/komencikit/src/kit.ts
+++ b/packages/komencikit/src/kit.ts
@@ -493,12 +493,6 @@ export class KomenciKit {
       return receiptResult
     }
 
-    const receipt = receiptResult.result
-    if (!receipt.status) {
-      // TODO: Possible to extract reason?
-      return Err(new TxRevertError(txHash, ''))
-    }
-
     const deployer = await this.contractKit.contracts.getMetaTransactionWalletDeployer(receipt.to)
 
     const events = await deployer.getPastEvents(deployer.eventTypes.WalletDeployed, {

--- a/packages/komencikit/src/kit.ts
+++ b/packages/komencikit/src/kit.ts
@@ -406,7 +406,6 @@ export class KomenciKit {
     const signature = await wallet.signMetaTransaction(tx.txo, nonce)
     const rawMetaTx = toRawTransaction(wallet.executeMetaTransaction(tx.txo, signature).txo)
 
-    console.debug(`${TAG}/submitMetaTransaction Sending mtx to Komenci: ${rawMetaTx}`)
     const resp = await this.client.exec(submitMetaTransaction(rawMetaTx))
     if (!resp.ok) {
       return resp

--- a/packages/mobile/src/identity/feelessVerification.ts
+++ b/packages/mobile/src/identity/feelessVerification.ts
@@ -1044,8 +1044,8 @@ export function* feelessCompleteAttestation(
 
   ValoraAnalytics.track(VerificationEvents.verification_reveal_attestation_complete, { issuer })
 
-  yield put(feelessCompleteAttestationCode(code))
   Logger.debug(TAG + '@feelessCompleteAttestation', `Attestation for issuer ${issuer} completed`)
+  yield put(feelessCompleteAttestationCode(code))
 }
 
 // Get the code from the store if it's already there, otherwise wait for it

--- a/packages/mobile/src/identity/revoke.ts
+++ b/packages/mobile/src/identity/revoke.ts
@@ -1,7 +1,7 @@
 import { CeloTransactionObject, ContractKit } from '@celo/contractkit'
 import { AttestationsWrapper } from '@celo/contractkit/lib/wrappers/Attestations'
 import { MetaTransactionWalletWrapper } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
-import { AttestationsStatus } from '@celo/utils/src/attestations'
+import { eqAddress } from '@celo/utils/src/address'
 import { all, call, put, select } from 'redux-saga/effects'
 import { e164NumberSelector } from 'src/account/selectors'
 import { VerificationEvents } from 'src/analytics/Events'
@@ -9,7 +9,6 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { setNumberVerified } from 'src/app/actions'
 import { feelessRevokeVerificationState, revokeVerificationState } from 'src/identity/actions'
 import { fetchPhoneHashPrivate } from 'src/identity/privateHashing'
-import { getAttestationsStatus } from 'src/identity/verification'
 import { sendTransaction } from 'src/transactions/send'
 import { newTransactionContext } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
@@ -37,6 +36,10 @@ export function* revokeVerificationSaga() {
 
     const mtwAddress: string | null = yield select(mtwAddressSelector)
     const accountAddress: string = yield call(getAccountAddress)
+    Logger.debug(
+      TAG + '@revokeVerification',
+      `Checking for attestaions on ${mtwAddress ? 'MTW' : 'EOA'} account address ${accountAddress}`
+    )
 
     ValoraAnalytics.track(VerificationEvents.verification_revoke_start)
     const contractKit: ContractKit = yield call(getContractKit)
@@ -47,18 +50,22 @@ export function* revokeVerificationSaga() {
     const phoneHashDetails = yield call(fetchPhoneHashPrivate, e164Number)
     const phoneHash = phoneHashDetails.phoneHash
 
-    const status: AttestationsStatus = yield call(
-      getAttestationsStatus,
-      attestationsWrapper,
-      accountAddress,
+    // Check that the account is currently associated with the identifier.
+    const accounts: string[] = yield call(
+      [attestationsWrapper, attestationsWrapper.lookupAccountsForIdentifier],
       phoneHash
     )
+    const associated = accounts.some((acc) => eqAddress(acc, accountAddress))
 
-    if (status.isVerified) {
+    if (associated) {
       const tx: CeloTransactionObject<void> = mtwAddress
         ? yield call(createRevokeTxForMTW, contractKit, attestationsWrapper, phoneHash, mtwAddress)
         : yield call(createRevokeTxForEOA, attestationsWrapper, phoneHash, walletAddress)
 
+      Logger.debug(
+        TAG + '@revokeVerification',
+        'Account associated with our phone identifier, sending revoke trasaction'
+      )
       yield call(
         sendTransaction,
         tx.txo,
@@ -68,7 +75,10 @@ export function* revokeVerificationSaga() {
 
       // TODO clear old mapping from the contact maps (e164ToAddress, etc.) to prevent stale values there
     } else {
-      Logger.debug(TAG + '@revokeVerification', 'Account not verified, skipping actual revoke call')
+      Logger.debug(
+        TAG + '@revokeVerification',
+        'Account is not associated with our phone identifier, skipping revoke transaction'
+      )
     }
 
     const relevantStateRevoke = mtwAddress

--- a/packages/mobile/src/transactions/contract-utils.ts
+++ b/packages/mobile/src/transactions/contract-utils.ts
@@ -1,7 +1,10 @@
 import { values } from 'lodash'
-import { estimateGas } from 'src/web3/utils'
+import { estimateGas, getTransactionReceipt } from 'src/web3/utils'
 import { Tx } from 'web3-core'
 import { TransactionObject, TransactionReceipt } from 'web3-eth'
+import Logger from 'src/utils/Logger'
+
+const RECEIPT_POLL_INTERVAL = 5000 // 5s
 
 export type TxLogger = (event: SendTransactionLogEvent) => void
 
@@ -165,6 +168,38 @@ export async function sendTransactionAsync<T>(
     })
   }
 
+  // Periodically check for an transaction receipt, and inject events if one is found.
+  // This is a hack to prevent failure in cases where web3 has been obversed to
+  // never get the receipt for transactions that do get mined.
+  let timerID: number | undefined
+  let emitter: any = undefined
+  const pollTransactionReceipt = (txHash: string) => {
+    timerID = setInterval(() => {
+      getTransactionReceipt(txHash)
+        .then((receipt) => {
+          if (!(receipt && emitter)) {
+            return
+          }
+
+          // If the receipt indicates a revert, emit an error.
+          if (!receipt.status) {
+            emitter.emit('error', new Error('Recieved receipt for reverted transaction '))
+            return
+          }
+
+          // Emit events to indicate success.
+          emitter.emit('receipt', receipt)
+          emitter.emit('confirmation', 1, receipt)
+
+          // Prevent this timer from firing again.
+          clearInterval(timerID)
+        })
+        .catch((error) => {
+          Logger.error('Exception in polling for transaction receipt', error)
+        })
+    }, RECEIPT_POLL_INTERVAL)
+  }
+
   try {
     logger(Started)
     const txParams: Tx = {
@@ -181,7 +216,8 @@ export async function sendTransactionAsync<T>(
       logger(EstimatedGas(estimatedGas))
     }
 
-    tx.send({ ...txParams, gas: estimatedGas })
+    emitter = tx.send({ ...txParams, gas: estimatedGas })
+    emitter
       // @ts-ignore
       .once('receipt', (r: TransactionReceipt) => {
         logger(ReceiptReceived(r))
@@ -195,6 +231,7 @@ export async function sendTransactionAsync<T>(
         if (resolvers.transactionHash) {
           resolvers.transactionHash(txHash)
         }
+        pollTransactionReceipt(txHash)
       })
       .once('confirmation', (confirmationNumber: number) => {
         logger(Confirmed(confirmationNumber))
@@ -203,6 +240,11 @@ export async function sendTransactionAsync<T>(
       .once('error', (error: Error) => {
         logger(Failed(error))
         rejectAll(error)
+      })
+      .finally(() => {
+        if (timerID !== undefined) {
+          clearInterval(timerID)
+        }
       })
   } catch (error) {
     logger(Exception(error))

--- a/packages/mobile/src/transactions/contract-utils.ts
+++ b/packages/mobile/src/transactions/contract-utils.ts
@@ -1,8 +1,8 @@
 import { values } from 'lodash'
+import Logger from 'src/utils/Logger'
 import { estimateGas, getTransactionReceipt } from 'src/web3/utils'
 import { Tx } from 'web3-core'
 import { TransactionObject, TransactionReceipt } from 'web3-eth'
-import Logger from 'src/utils/Logger'
 
 const RECEIPT_POLL_INTERVAL = 5000 // 5s
 
@@ -172,24 +172,24 @@ export async function sendTransactionAsync<T>(
   // This is a hack to prevent failure in cases where web3 has been obversed to
   // never get the receipt for transactions that do get mined.
   let timerID: number | undefined
-  let emitter: any = undefined
+  let emitter: any
   const pollTransactionReceipt = (txHash: string) => {
     timerID = setInterval(() => {
       getTransactionReceipt(txHash)
-        .then((receipt) => {
-          if (!(receipt && emitter)) {
+        .then((r) => {
+          if (!(r && emitter)) {
             return
           }
 
           // If the receipt indicates a revert, emit an error.
-          if (!receipt.status) {
+          if (!r.status) {
             emitter.emit('error', new Error('Recieved receipt for reverted transaction '))
             return
           }
 
           // Emit events to indicate success.
-          emitter.emit('receipt', receipt)
-          emitter.emit('confirmation', 1, receipt)
+          emitter.emit('receipt', r)
+          emitter.emit('confirmation', 1, r)
 
           // Prevent this timer from firing again.
           clearInterval(timerID)

--- a/packages/mobile/src/web3/utils.ts
+++ b/packages/mobile/src/web3/utils.ts
@@ -6,7 +6,7 @@ import { ChainHead } from 'src/geth/actions'
 import Logger from 'src/utils/Logger'
 import { getWeb3, getWeb3Async } from 'src/web3/contracts'
 import { Tx } from 'web3-core'
-import { BlockHeader, TransactionObject } from 'web3-eth'
+import { BlockHeader, TransactionObject, TransactionReceipt } from 'web3-eth'
 
 const TAG = 'web3/utils'
 
@@ -29,6 +29,13 @@ export async function estimateGas(txObj: TransactionObject<any>, txParams: Tx) {
     .times(GAS_INFLATION_FACTOR)
     .integerValue()
   return gas
+}
+
+// Fetches the transaction receipt for a given hash, returning null if the transaction has not been mined.
+export async function getTransactionReceipt(txHash: string): Promise<TransactionReceipt | null> {
+  Logger.debug(TAG, `Getting transaction receipt for ${txHash}`)
+  const web3 = await getWeb3Async(false)
+  return web3.eth.getTransactionReceipt(txHash)
 }
 
 // Note: This returns Promise<Block>


### PR DESCRIPTION
### Description

Add a timer to periodically to poll for transaction receipts on outstanding transactions as a backup when `web3` does not emit them properly. This is in response to an issue we are seeing when the revoke verification transaction sent to through a meta transaction wallet fails to ever receive a receipt, despite the light client processing properly.

### Other changes

* Ensure that Komenci meta-transactions return an error if they revert.
* Change the check before sending an attestation revoking transaction to match the check that occurs on-chain
* Add `lookupAccountsForIdentifier` to the contractkit wrapper for `Attestations`

### Tested

* Tested manually to ensure that the revoke transaction send through MTW works

_Brief explanation of why these changes are/are not backwards compatible._