### PR TITLE
[Wallet] Fix translation of Home text in Spanish

### DIFF
--- a/packages/mobile/locales/es-419/global.json
+++ b/packages/mobile/locales/es-419/global.json
@@ -169,7 +169,7 @@
   "providerRateFetchFailed": "No se pudo obtener la tarifa del proveedor. Puede continuar sin una tasa precargada.",
   "helpFindAccount": "Ayuda a tu contacto a encontrar tu número de cuenta",
   "close": "Cerrar",
-  "home": "Casa",
+  "home": "Inicio",
   "accountKey": "Clave de Cuenta",
   "addAndWithdraw": "Agregar y Retirar",
   "invite": "Invitar",


### PR DESCRIPTION
### Description

The translation of the "Home" button in the side menu is "Casa" right now, which is the literal translation but doesn't make much sense in context. Switch for "Inicio" which is the more reasonable translation for the Home screen.

### Tested

Manually
<img width="214" alt="Screen Shot 2020-11-09 at 10 08 05" src="https://user-images.githubusercontent.com/6062888/98544958-7980ce00-2273-11eb-963e-56f534fcd64d.png">
