### PR TITLE
Symlink Mainnet with RC1 in truffle config

### DIFF
--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -56,6 +56,7 @@ const fornoUrls = {
   alfajores: 'https://alfajores-forno.celo-testnet.org',
   baklava: 'https://baklava-forno.celo-testnet.org',
   rc1: 'https://rc1-forno.celo-testnet.org',
+  mainnet: 'https://rc1-forno.celo-testnet.org',
 }
 
 const networks = {
@@ -177,6 +178,9 @@ const networks = {
     network_id: BAKLAVASTAGING_NETWORKID,
   },
 }
+// Equivalent
+networks.mainnet = networks.rc1
+
 // If an override was provided, apply it.
 // If the network is missing from networks, start with the default config.
 if (argv.truffle_override || !(argv.network in networks)) {


### PR DESCRIPTION
### Description

TruffleConfig still references mainnet by RC1, so I just "symlinked" it

### Tested
 
- Ran `yarn verify-deployed -b celo-core-contracts-v0.mainnet -f -n mainnet`

### Related issues

- Fixes #5784 
