### PR TITLE
Indicate to run from packages/protocol

### DIFF
--- a/packages/docs/community/release-process/smart-contracts.md
+++ b/packages/docs/community/release-process/smart-contracts.md
@@ -63,6 +63,7 @@ Using these tools, a contract release candidate can be built, deployed, and prop
 
 Use the following script to compile contracts at a release tag and verify that the deployed network bytecode matches the compiled bytecode.
 ```bash
+# Run from `packages/protocol` in the celo-monorepo
 NETWORK=${"baklava"|"alfajores"|"mainnet"}
 PREVIOUS_RELEASE="celo-core-contracts-v${N-1}.${NETWORK}"
 # A -f boolean flag can be provided to use a forno full node to connect to the provided network


### PR DESCRIPTION
### Description

Minor PR to clarify that release scripts should be run from the protocol

Fixes #5785 