### PR TITLE
Governance Propose proposal.json on Relative Path

### DIFF
--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -61,7 +61,7 @@ export default class Propose extends BaseCommand {
       jsonTransactions = await promptBuilder.promptTransactions()
     } else if (res.flags.jsonTransactions) {
       // BUILD FROM JSON
-      const jsonString = readFileSync(resolve(__dirname, res.flags.jsonTransactions)).toString()
+      const jsonString = readFileSync(resolve(res.flags.jsonTransactions)).toString()
       jsonTransactions = JSON.parse(jsonString)
     } else {
       throw new Error('No jsonTransactions provided and interactive mode not specified')

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -7,7 +7,7 @@ import {
 import { flags } from '@oclif/command'
 import { BigNumber } from 'bignumber.js'
 import { readFileSync } from 'fs'
-import { path } from 'path'
+import { resolve } from 'path'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx, printValueMapRecursive } from '../../utils/cli'
@@ -61,7 +61,7 @@ export default class Propose extends BaseCommand {
       jsonTransactions = await promptBuilder.promptTransactions()
     } else if (res.flags.jsonTransactions) {
       // BUILD FROM JSON
-      const jsonString = readFileSync(path.resolve(__dirname, res.flags.jsonTransactions)).toString()
+      const jsonString = readFileSync(resolve(__dirname, res.flags.jsonTransactions)).toString()
       jsonTransactions = JSON.parse(jsonString)
     } else {
       throw new Error('No jsonTransactions provided and interactive mode not specified')

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -7,6 +7,7 @@ import {
 import { flags } from '@oclif/command'
 import { BigNumber } from 'bignumber.js'
 import { readFileSync } from 'fs'
+import { path } from 'path'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx, printValueMapRecursive } from '../../utils/cli'
@@ -60,7 +61,7 @@ export default class Propose extends BaseCommand {
       jsonTransactions = await promptBuilder.promptTransactions()
     } else if (res.flags.jsonTransactions) {
       // BUILD FROM JSON
-      const jsonString = readFileSync(res.flags.jsonTransactions).toString()
+      const jsonString = readFileSync(path.resolve(__dirname, res.flags.jsonTransactions)).toString()
       jsonTransactions = JSON.parse(jsonString)
     } else {
       throw new Error('No jsonTransactions provided and interactive mode not specified')


### PR DESCRIPTION
Pull Request for this ticket: https://github.com/celo-org/celo-monorepo/issues/5713

Can be tested as follows:
```sh
$ ./cli/bin/run governance:propose --jsonTransactions proposal.json --deposit 100000000000000000000 --from 0xD30d08E9C0ad3D158953C062b6ee8ca53B706d2d --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33 --node https://alfajores-forno.celo-testnet.org

(node:10828) ExperimentalWarning: The fs.promises API is experimental
Running Checks:
   ✔  Account has at least 100 CELO
   ✔  Deposit is greater than or equal to governance proposal minDeposit

Sending Transaction: proposeTx... !
    Error: unknown account
```

with proposal.json inside the packages dir.

Now, say I move the proposal.json inside the `bin` directory.

```sh
$ ./run governance:propose --jsonTransactions proposal.json --deposit 100000000000000000000 --from 0xD30d08E9C0ad3D158953C062b6ee8ca53B706d2d --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33 --node https://alfajores-forno.celo-testnet.org

(node:11123) ExperimentalWarning: The fs.promises API is experimental
Running Checks:
   ✔  Account has at least 100 CELO
   ✔  Deposit is greater than or equal to governance proposal minDeposit

Sending Transaction: proposeTx... !
    Error: unknown account
```

In both cases, the path of the proposal.json is relative and the full path isn't specified or needed.

proposal.json has the following content for testing:
```json
[
  {
    "contract": "DowntimeSlasher",
    "function": "setSlashableDowntime",
    "args": [
      "8640"
    ],
    "value": "0"
  }
]
```