### PR TITLE
[Feature] added prometheus self-scrape job

### DIFF
--- a/packages/helm-charts/prometheus-stackdriver/templates/configmap.yaml
+++ b/packages/helm-charts/prometheus-stackdriver/templates/configmap.yaml
@@ -30,7 +30,10 @@ data:
       evaluation_interval: 5s
 
     scrape_configs:
-
+      - job_name: 'prometheus'
+        scrape_interval: 20s
+        static_configs:
+          - targets: ['localhost:9090']
       - job_name: 'kubernetes-apiservers'
 
         kubernetes_sd_configs:


### PR DESCRIPTION
### Description

Added a job to the prometheus helm chart, allowing prometheus to scrape itself.

### Other changes

N/A 

### Tested

This is just boilerplate prometheus config. 

### Backwards compatibility

This affects no existing scrape configs. 