### PR TITLE
Categorize library linking changes

### DIFF
--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -73,7 +73,7 @@ contract Accounts is
    * @return The storage, major, minor, and patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 1, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -81,7 +81,7 @@ contract LockedGold is
   * @return The storage, major, minor, and patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 1, 1);
   }
 
   /**

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -171,7 +171,7 @@ contract Attestations is
    * @return The storage, major, minor, and patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 1, 1);
   }
 
   /**

--- a/packages/protocol/contracts/identity/Escrow.sol
+++ b/packages/protocol/contracts/identity/Escrow.sol
@@ -74,7 +74,7 @@ contract Escrow is
    * @return The storage, major, minor, and patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 1, 1);
   }
 
   /**

--- a/packages/protocol/lib/compatibility/report.ts
+++ b/packages/protocol/lib/compatibility/report.ts
@@ -69,7 +69,7 @@ export class CategorizedChanges {
     reports: ASTReports,
     categorizer: Categorizer): CategorizedChanges {
     const storage = reports.storage.filter(r => !r.compatible)
-    const c = categorize(reports.code.getChanges(), categorizer)
+    const c = categorize(reports.code.getChanges().concat(reports.libraryLinking), categorizer)
     const major = c[ChangeType.Major]
     const minor = c[ChangeType.Minor]
     const patch = c[ChangeType.Patch]

--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -2,10 +2,10 @@
 // tslint:disable: no-console
 import { ASTDetailedVersionedReport } from '@celo/protocol/lib/compatibility/report'
 import { getCeloContractDependencies } from '@celo/protocol/lib/contract-dependencies'
+import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { linkedLibraries } from '@celo/protocol/migrationsConfig'
 import { Address, eqAddress, NULL_ADDRESS } from '@celo/utils/lib/address'
 import { readdirSync, readJsonSync, writeJsonSync } from 'fs-extra'
-import { CeloContractName } from 'lib/registry-utils'
 import { basename, join } from 'path'
 import { RegistryInstance } from 'types'
 


### PR DESCRIPTION
### Description

I forgot to pass the output of the new library linking module of the version checker all the way through the version checking flow. 

### Other changes

Increase patch version numbers for contracts that need library relinking.

### Tested

`yarn test:devchain-release -b celo-core-contracts-v1.rc1 -l /dev/stdout` passes, whereas it did not before.