### PR TITLE
Provide initial value for reduce

### DIFF
--- a/packages/protocol/lib/compatibility/library-linking.ts
+++ b/packages/protocol/lib/compatibility/library-linking.ts
@@ -23,7 +23,7 @@ const getChangedLinkedLibraries = (linkedLibraries: string[], codeReport: ASTCod
 const reportToChanges = (report: LibraryLinkingReport): LibraryLinkingChange[] => {
   return Object.keys(report).map(contract => {
     return report[contract].map(library => new LibraryLinkingChange(contract, library))
-  }).reduce((changes, contractChanges) => changes.concat(contractChanges))
+  }).reduce((changes, contractChanges) => changes.concat(contractChanges), [])
 }
 
 export const reportLibraryLinkingIncompatibilities = (linkedLibraries: { [library: string]: string[] }, codeReport: ASTCodeCompatibilityReport): LibraryLinkingChange[] => {


### PR DESCRIPTION
### Description

Script was failing when there were no library changes due to a missing initial value.

### Tested

The CI release check should pass.