### PR TITLE
Fix payments to unverified numbers

### DIFF
--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -188,7 +188,6 @@ export function* sendInvite(
       ? 'sendFlow7:inviteWithEscrowedPayment'
       : 'sendFlow7:inviteWithoutPayment'
     const message = i18n.t(messageProp, {
-      name,
       amount: amount?.toString(),
       link,
     })


### PR DESCRIPTION
### Description

 Unused and undefined name was causing sending payments to unverified numbers to fail

We used to use someone's name in the invite text but no longer do

### Tested

Sent a payment to an unverified number

### Related issues

- Fixes #5823 
