### PR TITLE
Updated default ingress controller config for Blockscout

### DIFF
--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -142,6 +142,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
     location ~ /admin/.* {

--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -160,6 +160,14 @@ spec:
   - host: ${celoEnv}-blockscout.${fetchEnv(envVar.CLUSTER_DOMAIN_NAME)}.org
     http:
       paths:
+      - path: /api/v1/(decompiled_smart_contract|verified_smart_contracts)
+        backend:
+          serviceName: ${ingressName}-web
+          servicePort: 4000
+      - path: /(graphql|graphiql|api)
+        backend:
+          serviceName: ${ingressName}-api
+          servicePort: 4000
       - backend:
           serviceName: ${ingressName}-web
           servicePort: 4000


### PR DESCRIPTION
### Description

Updates the default blockscout ingress paths in accordance with https://github.com/celo-org/celo-monorepo/pull/5710.