### PR TITLE
Use published version of @celo/utils in packages/protocol

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -48,7 +48,7 @@
     "@0x/sol-trace": "^2.0.16",
     "@0x/subproviders": "^5.0.0",
     "@celo/ganache-cli": "git+https://github.com/celo-org/ganache-cli.git#e933297",
-    "@celo/utils": "0.1.23-dev",
+    "@celo/utils": "0.1.22",
     "@openzeppelin/upgrades": "^2.8.0",
     "apollo-client": "^2.4.13",
     "bip39": "^3.0.2",


### PR DESCRIPTION
### Description

Using the published versions makes protocol less dependent on build sibling packages
