### PR TITLE
[Wallet] Change the method used to get account addresses from phone numbers

### DIFF
--- a/packages/mobile/src/identity/commentEncryption.test.ts
+++ b/packages/mobile/src/identity/commentEncryption.test.ts
@@ -1,5 +1,5 @@
 import { PhoneNumberHashDetails } from '@celo/contractkit/lib/identity/odis/phone-number-identifier'
-import { IdentifierLookupResult } from '@celo/contractkit/lib/wrappers/Attestations'
+import { AttestationStat } from '@celo/contractkit/lib/wrappers/Attestations'
 import { hexToBuffer } from '@celo/utils/src/address'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
@@ -15,6 +15,7 @@ import {
 } from 'src/identity/commentEncryption'
 import { lookupAttestationIdentifiers } from 'src/identity/contactMapping'
 import { e164NumberToAddressSelector, e164NumberToSaltSelector } from 'src/identity/reducer'
+import { getContractKitAsync } from 'src/web3/contracts'
 import { doFetchDataEncryptionKey } from 'src/web3/dataEncryptionKey'
 import { dataEncryptionKeySelector } from 'src/web3/selectors'
 import { getMockStoreData } from 'test/utils'
@@ -23,7 +24,6 @@ import {
   mockAccount2,
   mockComment,
   mockE164Number,
-  mockE164NumberHashWithPepper,
   mockE164NumberPepper,
   mockPrivateDEK,
   mockPrivateDEK2,
@@ -226,15 +226,24 @@ describe(checkTxsForIdentityMetadata, () => {
   ]
 
   it('Finds metadata and dispatches updates', async () => {
-    const lookupResult: IdentifierLookupResult = {
-      [mockE164NumberHashWithPepper]: {
-        [mockAccount]: { completed: 3, total: 5 },
-      },
+    const contractKit = await getContractKitAsync()
+
+    const lookupResult: string[] = [mockAccount]
+    const stats: AttestationStat = {
+      completed: 3,
+      total: 5,
+    }
+    const mockAttestationsWrapper = {
+      getAttestationStat: jest.fn(() => stats),
     }
     await expectSaga(checkTxsForIdentityMetadata, { transactions })
       .provide([
         [select(dataEncryptionKeySelector), mockPrivateDEK2],
         [matchers.call.fn(lookupAttestationIdentifiers), lookupResult],
+        [
+          call([contractKit.contracts, contractKit.contracts.getAttestations]),
+          mockAttestationsWrapper,
+        ],
         [select(e164NumberToSaltSelector), {}],
         [select(e164NumberToAddressSelector), {}],
       ])

--- a/packages/mobile/src/identity/commentEncryption.test.ts
+++ b/packages/mobile/src/identity/commentEncryption.test.ts
@@ -13,7 +13,7 @@ import {
   encryptComment,
   extractPhoneNumberMetadata,
 } from 'src/identity/commentEncryption'
-import { lookupAttestationIdentifiers } from 'src/identity/contactMapping'
+import { lookupAccountAddressesForIdentifier } from 'src/identity/contactMapping'
 import { e164NumberToAddressSelector, e164NumberToSaltSelector } from 'src/identity/reducer'
 import { getContractKitAsync } from 'src/web3/contracts'
 import { doFetchDataEncryptionKey } from 'src/web3/dataEncryptionKey'
@@ -236,10 +236,14 @@ describe(checkTxsForIdentityMetadata, () => {
     const mockAttestationsWrapper = {
       getAttestationStat: jest.fn(() => stats),
     }
+    const mockAccountsWrapper = {
+      getWalletAddress: jest.fn((address) => address),
+    }
     await expectSaga(checkTxsForIdentityMetadata, { transactions })
       .provide([
         [select(dataEncryptionKeySelector), mockPrivateDEK2],
-        [matchers.call.fn(lookupAttestationIdentifiers), lookupResult],
+        [matchers.call.fn(lookupAccountAddressesForIdentifier), lookupResult],
+        [call([contractKit.contracts, contractKit.contracts.getAccounts]), mockAccountsWrapper],
         [
           call([contractKit.contracts, contractKit.contracts.getAttestations]),
           mockAttestationsWrapper,
@@ -261,7 +265,7 @@ describe(checkTxsForIdentityMetadata, () => {
     await expectSaga(checkTxsForIdentityMetadata, { transactions })
       .provide([
         [select(dataEncryptionKeySelector), mockPrivateDEK2],
-        [matchers.call.fn(lookupAttestationIdentifiers), {}],
+        [matchers.call.fn(lookupAccountAddressesForIdentifier), {}],
       ])
       .run()
   })

--- a/packages/mobile/src/identity/commentEncryption.ts
+++ b/packages/mobile/src/identity/commentEncryption.ts
@@ -240,12 +240,12 @@ function* verifyIdentityMetadata(data: IdentityMetadataInTx[]) {
     const accountAddresses: Address[] = yield call(lookupAccountAddressesForIdentifier, phoneHash)
 
     // Check that there are verified addresses.
-    const onChainAddresses: Address[] = yield call(
+    const verifiedAccountAddresses: Address[] = yield call(
       filterNonVerifiedAddresses,
       accountAddresses,
       phoneHash
     )
-    if (!onChainAddresses || !onChainAddresses.length) {
+    if (verifiedAccountAddresses.length === 0) {
       Logger.warn(
         TAG + 'verifyIdentityMetadata',
         `Phone number and/or salt claimed by address ${metadata.address} is not verified. Values are incorrect or sender is impersonating another number`
@@ -253,11 +253,11 @@ function* verifyIdentityMetadata(data: IdentityMetadataInTx[]) {
       continue
     }
     const walletAddresses: Address[] = yield all(
-      onChainAddresses.map((accountAddress) =>
+      verifiedAccountAddresses.map((accountAddress) =>
         call(accountsWrapper.getWalletAddress, accountAddress)
       )
     )
-    if (!walletAddresses.find((a) => eqAddress(a, metadata.address))) {
+    if (!walletAddresses.some((walletAddress) => eqAddress(walletAddress, metadata.address))) {
       Logger.warn(
         TAG + 'verifyIdentityMetadata',
         `Phone number and/or salt claimed by address ${metadata.address} does not match any on-chain addresses. Values are incorrect or sender is impersonating another number`

--- a/packages/mobile/src/identity/commentEncryption.ts
+++ b/packages/mobile/src/identity/commentEncryption.ts
@@ -232,11 +232,15 @@ function* verifyIdentityMetadata(data: IdentityMetadataInTx[]) {
     const lookupResult: string[] = yield call(lookupAttestationIdentifiers, phoneHash)
 
     // Check that there are verified addresses.
-    const onChainAddresses = yield call(getAddressesFromLookupResult, lookupResult, phoneHash)
+    const onChainAddresses: string[] = yield call(
+      getAddressesFromLookupResult,
+      lookupResult,
+      phoneHash
+    )
     if (!onChainAddresses || !onChainAddresses.length) {
       Logger.warn(
         TAG + 'verifyIdentityMetadata',
-        `Phone number and/or salt claimed by address ${d.address} is not verified. Values are incorrect or sender is impersonating another number`
+        `Phone number and/or salt claimed by address ${metadata.address} is not verified. Values are incorrect or sender is impersonating another number`
       )
       continue
     }

--- a/packages/mobile/src/identity/contactMapping.test.ts
+++ b/packages/mobile/src/identity/contactMapping.test.ts
@@ -1,5 +1,5 @@
 import { eqAddress, NULL_ADDRESS } from '@celo/base'
-import { IdentifierLookupResult } from '@celo/contractkit/lib/wrappers/Attestations'
+import { AttestationStat } from '@celo/contractkit/lib/wrappers/Attestations'
 import { expectSaga } from 'redux-saga-test-plan'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { call, select } from 'redux-saga/effects'
@@ -83,12 +83,16 @@ describe('Fetch Addresses Saga', () => {
       [mockE164Number]: [mockAccount.toLowerCase()],
     }
 
-    const mockPhoneNumberLookup: IdentifierLookupResult = {
-      [mockE164NumberHash]: { [mockAccount]: { completed: 3, total: 3 } },
+    const mockAccountsForIdentifier: string[] = [mockAccount]
+
+    const mockStats: AttestationStat = {
+      completed: 3,
+      total: 3,
     }
 
     const mockAttestationsWrapper = {
-      lookupIdentifiers: jest.fn(() => mockPhoneNumberLookup),
+      lookupAccountsForIdentifier: jest.fn(() => mockAccountsForIdentifier),
+      getAttestationStat: jest.fn(() => mockStats),
     }
 
     const mockAccountsWrapper = {
@@ -133,12 +137,16 @@ describe('Fetch Addresses Saga', () => {
       [mockE164Number]: [mockAccount.toLowerCase()],
     }
 
-    const mockPhoneNumberLookup: IdentifierLookupResult = {
-      [mockE164NumberHash]: { [mockAccount]: { completed: 3, total: 3 } },
+    const mockAccountsForIdentifier: string[] = [mockAccount]
+
+    const mockStats: AttestationStat = {
+      completed: 3,
+      total: 3,
     }
 
     const mockAttestationsWrapper = {
-      lookupIdentifiers: jest.fn(() => mockPhoneNumberLookup),
+      lookupAccountsForIdentifier: jest.fn(() => mockAccountsForIdentifier),
+      getAttestationStat: jest.fn(() => mockStats),
     }
 
     const mockAccountsWrapper = {
@@ -181,12 +189,16 @@ describe('Fetch Addresses Saga', () => {
       [mockE164Number]: [mockAccount.toLowerCase()],
     }
 
-    const mockPhoneNumberLookup: IdentifierLookupResult = {
-      [mockE164NumberHash]: { [mockAccount]: { completed: 3, total: 3 } },
+    const mockAccountsForIdentifier: string[] = [mockAccount]
+
+    const mockStats: AttestationStat = {
+      completed: 3,
+      total: 3,
     }
 
     const mockAttestationsWrapper = {
-      lookupIdentifiers: jest.fn(() => mockPhoneNumberLookup),
+      lookupAccountsForIdentifier: jest.fn(() => mockAccountsForIdentifier),
+      getAttestationStat: jest.fn(() => mockStats),
     }
 
     const mockAccountsWrapper = {
@@ -228,15 +240,16 @@ describe('Fetch Addresses Saga', () => {
     const mockWallet = mockAccount
     const mockWallet2 = mockAccount2
 
-    const mockPhoneNumberLookup: IdentifierLookupResult = {
-      [mockE164NumberHash]: {
-        [mockAccount]: { completed: 3, total: 3 },
-        [mockAccount2]: { completed: 3, total: 3 },
-      },
+    const mockAccountsForIdentifier: string[] = [mockAccount, mockAccount2]
+
+    const mockStats: AttestationStat = {
+      completed: 3,
+      total: 3,
     }
 
     const mockAttestationsWrapper = {
-      lookupIdentifiers: jest.fn(() => mockPhoneNumberLookup),
+      lookupAccountsForIdentifier: jest.fn(() => mockAccountsForIdentifier),
+      getAttestationStat: jest.fn(() => mockStats),
     }
 
     const mockAccountsWrapper = {
@@ -295,15 +308,16 @@ describe('Fetch Addresses Saga', () => {
     const mockWallet = mockAccount
     const mockWallet3 = mockAccount3
 
-    const mockPhoneNumberLookup: IdentifierLookupResult = {
-      [mockE164NumberHash]: {
-        [mockAccount]: { completed: 3, total: 3 },
-        [mockAccount3]: { completed: 3, total: 3 },
-      },
+    const mockAccountsForIdentifier: string[] = [mockAccount, mockAccount3]
+
+    const mockStats: AttestationStat = {
+      completed: 3,
+      total: 3,
     }
 
     const mockAttestationsWrapper = {
-      lookupIdentifiers: jest.fn(() => mockPhoneNumberLookup),
+      lookupAccountsForIdentifier: jest.fn(() => mockAccountsForIdentifier),
+      getAttestationStat: jest.fn(() => mockStats),
     }
 
     const mockAccountsWrapper = {

--- a/packages/mobile/src/identity/contactMapping.ts
+++ b/packages/mobile/src/identity/contactMapping.ts
@@ -222,8 +222,8 @@ export function* fetchAddressesAndValidateSaga({
 function* getAccountAddresses(e164Number: string) {
   const phoneHashDetails: PhoneNumberHashDetails = yield call(fetchPhoneHashPrivate, e164Number)
   const phoneHash = phoneHashDetails.phoneHash
-  const lookupResult: string[] = yield call(lookupAttestationIdentifiers, phoneHash)
-  return yield call(getAddressesFromLookupResult, lookupResult, phoneHash)
+  const accountAddresses: Address[] = yield call(lookupAccountAddressesForIdentifier, phoneHash)
+  return yield call(filterNonVerifiedAddresses, accountAddresses, phoneHash)
 }
 
 function* fetchWalletAddresses(e164Number: string) {
@@ -260,7 +260,7 @@ function* fetchWalletAddresses(e164Number: string) {
 }
 
 // Returns a list of account addresses for the identifier received.
-export function* lookupAttestationIdentifiers(id: string) {
+export function* lookupAccountAddressesForIdentifier(id: string) {
   const contractKit = yield call(getContractKit)
   const attestationsWrapper: AttestationsWrapper = yield call([
     contractKit.contracts,
@@ -272,8 +272,8 @@ export function* lookupAttestationIdentifiers(id: string) {
 
 // Deconstruct the lookup result and return
 // any addresess that are considered verified
-export function* getAddressesFromLookupResult(lookupResult: Address[], phoneHash: string) {
-  if (!lookupResult) {
+export function* filterNonVerifiedAddresses(accountAddresses: Address[], phoneHash: string) {
+  if (!accountAddresses) {
     return []
   }
 
@@ -284,7 +284,7 @@ export function* getAddressesFromLookupResult(lookupResult: Address[], phoneHash
   ])
 
   const verifiedAccountAddresses: Address[] = []
-  for (const address of lookupResult) {
+  for (const address of accountAddresses) {
     if (!isValidNon0Address(address)) {
       continue
     }


### PR DESCRIPTION
### Description

The method responsible for getting the account address is actually fetching the wallet address.

More info: https://celo-org.slack.com/archives/CL7BVQPHB/p1605282150297100

### Tested

Manually by verifying and sending stuff with comments and there are also tests.

### Related issues

- Fixes #5876

### Backwards compatibility

Should be