### PR TITLE
Bump typedoc in contractkit to 0.19.2

### DIFF
--- a/packages/contractkit/package.json
+++ b/packages/contractkit/package.json
@@ -71,7 +71,7 @@
     "jest": "^25.2.4",
     "@types/inquirer": "^6.5.0",
     "ts-node": "8.3.0",
-    "typedoc": "^0.16.9",
+    "typedoc": "^0.19.2",
     "typedoc-plugin-markdown": "^2.2.16"
   },
   "engines": {

--- a/packages/docs/SUMMARY.md
+++ b/packages/docs/SUMMARY.md
@@ -98,7 +98,7 @@
 - [Reference](developer-resources/contractkit/reference/SUMMARY.md)
   <!-- contractkit-reference-start -->
   - [Globals](developer-resources/contractkit/reference/globals.md)
-  - [External Modules]()
+  - [Modules]()
     - [address-registry](developer-resources/contractkit/reference/modules/_address_registry_.md)
     - [AddressRegistry](developer-resources/contractkit/reference/classes/_address_registry_.addressregistry.md)
     - [base](developer-resources/contractkit/reference/modules/_base_.md)

--- a/packages/docs/developer-resources/contractkit/reference/SUMMARY.md
+++ b/packages/docs/developer-resources/contractkit/reference/SUMMARY.md
@@ -1,5 +1,5 @@
 * [Globals](globals.md)
-* [External Modules]()
+* [Modules]()
   * [address-registry](modules/_address_registry_.md)
   * [AddressRegistry](classes/_address_registry_.addressregistry.md)
   * [base](modules/_base_.md)

--- a/packages/docs/developer-resources/contractkit/reference/classes/_contract_cache_.wrappercache.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_contract_cache_.wrappercache.md
@@ -16,7 +16,7 @@ Provides access to all contract wrappers for celo core contracts
 
 ### Properties
 
-* [kit](_contract_cache_.wrappercache.md#kit)
+* [kit](_contract_cache_.wrappercache.md#readonly-kit)
 
 ### Methods
 
@@ -60,7 +60,7 @@ Name | Type |
 
 ## Properties
 
-###  kit
+### `Readonly` kit
 
 • **kit**: *[ContractKit](_kit_.contractkit.md)*
 
@@ -100,7 +100,7 @@ ___
 
 ###  getContract
 
-▸ **getContract**<**C**>(`contract`: C, `address?`: undefined | string): *Promise‹WrapperCacheMap[C] extends undefined | null ? never : WrapperCacheMap[C]›*
+▸ **getContract**<**C**>(`contract`: C, `address?`: undefined | string): *Promise‹NonNullable‹WrapperCacheMap[C]››*
 
 *Defined in [packages/contractkit/src/contract-cache.ts:166](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/contract-cache.ts#L166)*
 
@@ -117,7 +117,7 @@ Name | Type |
 `contract` | C |
 `address?` | undefined &#124; string |
 
-**Returns:** *Promise‹WrapperCacheMap[C] extends undefined | null ? never : WrapperCacheMap[C]›*
+**Returns:** *Promise‹NonNullable‹WrapperCacheMap[C]››*
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_explorer_block_explorer_.blockexplorer.md
@@ -12,7 +12,7 @@
 
 ### Properties
 
-* [contractDetails](_explorer_block_explorer_.blockexplorer.md#contractdetails)
+* [contractDetails](_explorer_block_explorer_.blockexplorer.md#readonly-contractdetails)
 
 ### Methods
 
@@ -43,7 +43,7 @@ Name | Type |
 
 ## Properties
 
-###  contractDetails
+### `Readonly` contractDetails
 
 • **contractDetails**: *[ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_explorer_log_explorer_.logexplorer.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_explorer_log_explorer_.logexplorer.md
@@ -12,7 +12,7 @@
 
 ### Properties
 
-* [contractDetails](_explorer_log_explorer_.logexplorer.md#contractdetails)
+* [contractDetails](_explorer_log_explorer_.logexplorer.md#readonly-contractdetails)
 
 ### Methods
 
@@ -39,7 +39,7 @@ Name | Type |
 
 ## Properties
 
-###  contractDetails
+### `Readonly` contractDetails
 
 • **contractDetails**: *[ContractDetails](../interfaces/_explorer_base_.contractdetails.md)[]*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_governance_proposals_.proposalbuilder.md
@@ -97,13 +97,13 @@ ___
 
 ###  build
 
-▸ **build**(): *Promise‹object[]›*
+▸ **build**(): *Promise‹Pick‹Transaction, "to" | "value" | "input"›[]›*
 
 *Defined in [packages/contractkit/src/governance/proposals.ts:134](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L134)*
 
 Build calls all of the added build steps and returns the final proposal.
 
-**Returns:** *Promise‹object[]›*
+**Returns:** *Promise‹Pick‹Transaction, "to" | "value" | "input"›[]›*
 
 A constructed Proposal object (i.e. a list of ProposalTransaction)
 
@@ -111,7 +111,7 @@ ___
 
 ###  fromJsonTx
 
-▸ **fromJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *Promise‹object›*
+▸ **fromJsonTx**(`tx`: [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md)): *Promise‹Pick‹Transaction, "to" | "value" | "input"››*
 
 *Defined in [packages/contractkit/src/governance/proposals.ts:176](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/governance/proposals.ts#L176)*
 
@@ -121,7 +121,7 @@ Name | Type |
 ------ | ------ |
 `tx` | [ProposalTransactionJSON](../interfaces/_governance_proposals_.proposaltransactionjson.md) |
 
-**Returns:** *Promise‹object›*
+**Returns:** *Promise‹Pick‹Transaction, "to" | "value" | "input"››*
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_metadata_.identitymetadatawrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_metadata_.identitymetadatawrapper.md
@@ -93,7 +93,7 @@ ___
 
 **Type parameters:**
 
-▪ **K**: *[ClaimTypes](../enums/_identity_claims_types_.claimtypes.md)*
+▪ **K**: *[ClaimTypes](../modules/_identity_metadata_.md#claimtypes)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 **Type parameters:**
 
-▪ **K**: *[ClaimTypes](../enums/_identity_claims_types_.claimtypes.md)*
+▪ **K**: *[ClaimTypes](../modules/_identity_metadata_.md#claimtypes)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_authorized_signer_.authorizedsigneraccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_authorized_signer_.authorizedsigneraccessor.md
@@ -14,7 +14,7 @@
 
 * [basePath](_identity_offchain_accessors_authorized_signer_.authorizedsigneraccessor.md#basepath)
 * [read](_identity_offchain_accessors_authorized_signer_.authorizedsigneraccessor.md#read)
-* [wrapper](_identity_offchain_accessors_authorized_signer_.authorizedsigneraccessor.md#wrapper)
+* [wrapper](_identity_offchain_accessors_authorized_signer_.authorizedsigneraccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -65,7 +65,7 @@ Name | Type |
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 
@@ -75,7 +75,7 @@ ___
 
 ###  readAsResult
 
-▸ **readAsResult**(`account`: [Address](../modules/_base_.md#address), `signer`: [Address](../modules/_base_.md#address)): *Promise‹ErrorResult‹[InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md)‹› | [OffchainError](_identity_offchain_accessors_errors_.offchainerror.md)‹› | [UnknownCiphertext](_identity_offchain_accessors_errors_.unknownciphertext.md)‹› | [UnavailableKey](_identity_offchain_accessors_errors_.unavailablekey.md)‹› | [InvalidKey](_identity_offchain_accessors_errors_.invalidkey.md)‹›› | OkResult‹object››*
+▸ **readAsResult**(`account`: [Address](../modules/_base_.md#address), `signer`: [Address](../modules/_base_.md#address)): *Promise‹Result‹object, [SchemaErrors](../modules/_identity_offchain_accessors_errors_.md#schemaerrors)››*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/authorized-signer.ts:20](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/authorized-signer.ts#L20)*
 
@@ -86,7 +86,7 @@ Name | Type |
 `account` | [Address](../modules/_base_.md#address) |
 `signer` | [Address](../modules/_base_.md#address) |
 
-**Returns:** *Promise‹ErrorResult‹[InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md)‹› | [OffchainError](_identity_offchain_accessors_errors_.offchainerror.md)‹› | [UnknownCiphertext](_identity_offchain_accessors_errors_.unknownciphertext.md)‹› | [UnavailableKey](_identity_offchain_accessors_errors_.unavailablekey.md)‹› | [InvalidKey](_identity_offchain_accessors_errors_.invalidkey.md)‹›› | OkResult‹object››*
+**Returns:** *Promise‹Result‹object, [SchemaErrors](../modules/_identity_offchain_accessors_errors_.md#schemaerrors)››*
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_binary_.privatebinaryaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_binary_.privatebinaryaccessor.md
@@ -20,9 +20,9 @@ Schema for writing any encrypted binary data.
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#read)
-* [wrapper](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#wrapper)
+* [wrapper](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -48,7 +48,7 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
@@ -76,7 +76,7 @@ Name | Type |
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 
@@ -86,7 +86,7 @@ ___
 
 ###  readAsResult
 
-▸ **readAsResult**(`account`: [Address](../modules/_base_.md#address)): *Promise‹OkResult‹Buffer‹›› | ErrorResult‹[InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md)‹› | [OffchainError](_identity_offchain_accessors_errors_.offchainerror.md)‹› | [UnknownCiphertext](_identity_offchain_accessors_errors_.unknownciphertext.md)‹› | [UnavailableKey](_identity_offchain_accessors_errors_.unavailablekey.md)‹› | [InvalidKey](_identity_offchain_accessors_errors_.invalidkey.md)‹›››*
+▸ **readAsResult**(`account`: [Address](../modules/_base_.md#address)): *Promise‹Result‹Buffer‹›, [SchemaErrors](../modules/_identity_offchain_accessors_errors_.md#schemaerrors)››*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/binary.ts:48](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/binary.ts#L48)*
 
@@ -96,7 +96,7 @@ Name | Type |
 ------ | ------ |
 `account` | [Address](../modules/_base_.md#address) |
 
-**Returns:** *Promise‹OkResult‹Buffer‹›› | ErrorResult‹[InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md)‹› | [OffchainError](_identity_offchain_accessors_errors_.offchainerror.md)‹› | [UnknownCiphertext](_identity_offchain_accessors_errors_.unknownciphertext.md)‹› | [UnavailableKey](_identity_offchain_accessors_errors_.unavailablekey.md)‹› | [InvalidKey](_identity_offchain_accessors_errors_.invalidkey.md)‹›››*
+**Returns:** *Promise‹Result‹Buffer‹›, [SchemaErrors](../modules/_identity_offchain_accessors_errors_.md#schemaerrors)››*
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_binary_.publicbinaryaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_binary_.publicbinaryaccessor.md
@@ -20,9 +20,9 @@ Schema for writing any generic binary data
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#read)
-* [wrapper](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#wrapper)
+* [wrapper](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -48,7 +48,7 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
@@ -76,7 +76,7 @@ Name | Type |
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.invaliddataerror.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.invaliddataerror.md
@@ -18,7 +18,7 @@
 
 ### Properties
 
-* [errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#errortype)
+* [errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#readonly-errortype)
 * [message](_identity_offchain_accessors_errors_.invaliddataerror.md#message)
 * [name](_identity_offchain_accessors_errors_.invaliddataerror.md#name)
 * [stack](_identity_offchain_accessors_errors_.invaliddataerror.md#optional-stack)
@@ -37,11 +37,11 @@
 
 ## Properties
 
-###  errorType
+### `Readonly` errorType
 
 • **errorType**: *[InvalidDataError](../enums/_identity_offchain_accessors_errors_.schemaerrortypes.md#invaliddataerror)*
 
-*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#errortype)*
+*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#readonly-errortype)*
 
 Defined in packages/base/lib/result.d.ts:19
 
@@ -53,7 +53,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[message](_identity_offchain_accessors_errors_.invaliddataerror.md#message)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
+Defined in node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[name](_identity_offchain_accessors_errors_.invaliddataerror.md#name)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
+Defined in node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[stack](_identity_offchain_accessors_errors_.invaliddataerror.md#optional-stack)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+Defined in node_modules/typescript/lib/lib.es5.d.ts:975

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.invalidkey.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.invalidkey.md
@@ -18,7 +18,7 @@
 
 ### Properties
 
-* [errorType](_identity_offchain_accessors_errors_.invalidkey.md#errortype)
+* [errorType](_identity_offchain_accessors_errors_.invalidkey.md#readonly-errortype)
 * [message](_identity_offchain_accessors_errors_.invalidkey.md#message)
 * [name](_identity_offchain_accessors_errors_.invalidkey.md#name)
 * [stack](_identity_offchain_accessors_errors_.invalidkey.md#optional-stack)
@@ -37,11 +37,11 @@
 
 ## Properties
 
-###  errorType
+### `Readonly` errorType
 
 • **errorType**: *[InvalidKey](../enums/_identity_offchain_accessors_errors_.schemaerrortypes.md#invalidkey)*
 
-*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#errortype)*
+*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#readonly-errortype)*
 
 Defined in packages/base/lib/result.d.ts:19
 
@@ -53,7 +53,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[message](_identity_offchain_accessors_errors_.invaliddataerror.md#message)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
+Defined in node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[name](_identity_offchain_accessors_errors_.invaliddataerror.md#name)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
+Defined in node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[stack](_identity_offchain_accessors_errors_.invaliddataerror.md#optional-stack)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+Defined in node_modules/typescript/lib/lib.es5.d.ts:975

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.offchainerror.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.offchainerror.md
@@ -18,8 +18,8 @@
 
 ### Properties
 
-* [error](_identity_offchain_accessors_errors_.offchainerror.md#error)
-* [errorType](_identity_offchain_accessors_errors_.offchainerror.md#errortype)
+* [error](_identity_offchain_accessors_errors_.offchainerror.md#readonly-error)
+* [errorType](_identity_offchain_accessors_errors_.offchainerror.md#readonly-errortype)
 * [message](_identity_offchain_accessors_errors_.offchainerror.md#message)
 * [name](_identity_offchain_accessors_errors_.offchainerror.md#name)
 * [stack](_identity_offchain_accessors_errors_.offchainerror.md#optional-stack)
@@ -44,7 +44,7 @@ Name | Type |
 
 ## Properties
 
-###  error
+### `Readonly` error
 
 • **error**: *[OffchainErrors](../modules/_identity_offchain_data_wrapper_.md#offchainerrors)*
 
@@ -52,11 +52,11 @@ Name | Type |
 
 ___
 
-###  errorType
+### `Readonly` errorType
 
 • **errorType**: *[OffchainError](../enums/_identity_offchain_accessors_errors_.schemaerrortypes.md#offchainerror)*
 
-*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#errortype)*
+*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#readonly-errortype)*
 
 Defined in packages/base/lib/result.d.ts:19
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[message](_identity_offchain_accessors_errors_.invaliddataerror.md#message)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
+Defined in node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[name](_identity_offchain_accessors_errors_.invaliddataerror.md#name)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
+Defined in node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[stack](_identity_offchain_accessors_errors_.invaliddataerror.md#optional-stack)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+Defined in node_modules/typescript/lib/lib.es5.d.ts:975

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.unavailablekey.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.unavailablekey.md
@@ -18,8 +18,8 @@
 
 ### Properties
 
-* [account](_identity_offchain_accessors_errors_.unavailablekey.md#account)
-* [errorType](_identity_offchain_accessors_errors_.unavailablekey.md#errortype)
+* [account](_identity_offchain_accessors_errors_.unavailablekey.md#readonly-account)
+* [errorType](_identity_offchain_accessors_errors_.unavailablekey.md#readonly-errortype)
 * [message](_identity_offchain_accessors_errors_.unavailablekey.md#message)
 * [name](_identity_offchain_accessors_errors_.unavailablekey.md#name)
 * [stack](_identity_offchain_accessors_errors_.unavailablekey.md#optional-stack)
@@ -44,7 +44,7 @@ Name | Type |
 
 ## Properties
 
-###  account
+### `Readonly` account
 
 • **account**: *[Address](../modules/_base_.md#address)*
 
@@ -52,11 +52,11 @@ Name | Type |
 
 ___
 
-###  errorType
+### `Readonly` errorType
 
 • **errorType**: *[UnavailableKey](../enums/_identity_offchain_accessors_errors_.schemaerrortypes.md#unavailablekey)*
 
-*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#errortype)*
+*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#readonly-errortype)*
 
 Defined in packages/base/lib/result.d.ts:19
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[message](_identity_offchain_accessors_errors_.invaliddataerror.md#message)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
+Defined in node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[name](_identity_offchain_accessors_errors_.invaliddataerror.md#name)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
+Defined in node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[stack](_identity_offchain_accessors_errors_.invaliddataerror.md#optional-stack)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+Defined in node_modules/typescript/lib/lib.es5.d.ts:975

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.unknownciphertext.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_errors_.unknownciphertext.md
@@ -18,7 +18,7 @@
 
 ### Properties
 
-* [errorType](_identity_offchain_accessors_errors_.unknownciphertext.md#errortype)
+* [errorType](_identity_offchain_accessors_errors_.unknownciphertext.md#readonly-errortype)
 * [message](_identity_offchain_accessors_errors_.unknownciphertext.md#message)
 * [name](_identity_offchain_accessors_errors_.unknownciphertext.md#name)
 * [stack](_identity_offchain_accessors_errors_.unknownciphertext.md#optional-stack)
@@ -37,11 +37,11 @@
 
 ## Properties
 
-###  errorType
+### `Readonly` errorType
 
 • **errorType**: *[UnknownCiphertext](../enums/_identity_offchain_accessors_errors_.schemaerrortypes.md#unknownciphertext)*
 
-*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#errortype)*
+*Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[errorType](_identity_offchain_accessors_errors_.invaliddataerror.md#readonly-errortype)*
 
 Defined in packages/base/lib/result.d.ts:19
 
@@ -53,7 +53,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[message](_identity_offchain_accessors_errors_.invaliddataerror.md#message)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
+Defined in node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[name](_identity_offchain_accessors_errors_.invaliddataerror.md#name)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
+Defined in node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 *Inherited from [InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md).[stack](_identity_offchain_accessors_errors_.invaliddataerror.md#optional-stack)*
 
-Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+Defined in node_modules/typescript/lib/lib.es5.d.ts:975

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_name_.privatenameaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_name_.privatenameaccessor.md
@@ -18,10 +18,10 @@
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_name_.privatenameaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_name_.privatenameaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_name_.privatenameaccessor.md#read)
-* [type](_identity_offchain_accessors_name_.privatenameaccessor.md#type)
-* [wrapper](_identity_offchain_accessors_name_.privatenameaccessor.md#wrapper)
+* [type](_identity_offchain_accessors_name_.privatenameaccessor.md#readonly-type)
+* [wrapper](_identity_offchain_accessors_name_.privatenameaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -48,11 +48,11 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
-*Inherited from [PrivateSimpleAccessor](_identity_offchain_accessors_simple_.privatesimpleaccessor.md).[dataPath](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#datapath)*
+*Inherited from [PrivateSimpleAccessor](_identity_offchain_accessors_simple_.privatesimpleaccessor.md).[dataPath](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#readonly-datapath)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/simple.ts:72](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/simple.ts#L72)*
 
@@ -80,21 +80,21 @@ Name | Type |
 
 ___
 
-###  type
+### `Readonly` type
 
 • **type**: *Type‹[NameType](../modules/_identity_offchain_accessors_name_.md#nametype)›*
 
-*Inherited from [PrivateSimpleAccessor](_identity_offchain_accessors_simple_.privatesimpleaccessor.md).[type](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#type)*
+*Inherited from [PrivateSimpleAccessor](_identity_offchain_accessors_simple_.privatesimpleaccessor.md).[type](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#readonly-type)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/simple.ts:71](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/simple.ts#L71)*
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 
-*Overrides [PrivateSimpleAccessor](_identity_offchain_accessors_simple_.privatesimpleaccessor.md).[wrapper](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#wrapper)*
+*Overrides [PrivateSimpleAccessor](_identity_offchain_accessors_simple_.privatesimpleaccessor.md).[wrapper](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#readonly-wrapper)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/name.ts:18](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/name.ts#L18)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_name_.publicnameaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_name_.publicnameaccessor.md
@@ -18,10 +18,10 @@
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_name_.publicnameaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_name_.publicnameaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_name_.publicnameaccessor.md#read)
-* [type](_identity_offchain_accessors_name_.publicnameaccessor.md#type)
-* [wrapper](_identity_offchain_accessors_name_.publicnameaccessor.md#wrapper)
+* [type](_identity_offchain_accessors_name_.publicnameaccessor.md#readonly-type)
+* [wrapper](_identity_offchain_accessors_name_.publicnameaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -48,11 +48,11 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
-*Inherited from [PublicSimpleAccessor](_identity_offchain_accessors_simple_.publicsimpleaccessor.md).[dataPath](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#datapath)*
+*Inherited from [PublicSimpleAccessor](_identity_offchain_accessors_simple_.publicsimpleaccessor.md).[dataPath](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#readonly-datapath)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/simple.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/simple.ts#L21)*
 
@@ -80,21 +80,21 @@ Name | Type |
 
 ___
 
-###  type
+### `Readonly` type
 
 • **type**: *Type‹[NameType](../modules/_identity_offchain_accessors_name_.md#nametype)›*
 
-*Inherited from [PublicSimpleAccessor](_identity_offchain_accessors_simple_.publicsimpleaccessor.md).[type](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#type)*
+*Inherited from [PublicSimpleAccessor](_identity_offchain_accessors_simple_.publicsimpleaccessor.md).[type](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#readonly-type)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/simple.ts:20](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/simple.ts#L20)*
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 
-*Overrides [PublicSimpleAccessor](_identity_offchain_accessors_simple_.publicsimpleaccessor.md).[wrapper](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#wrapper)*
+*Overrides [PublicSimpleAccessor](_identity_offchain_accessors_simple_.publicsimpleaccessor.md).[wrapper](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#readonly-wrapper)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/name.ts:12](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/name.ts#L12)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_pictures_.privatepictureaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_pictures_.privatepictureaccessor.md
@@ -18,9 +18,9 @@
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_pictures_.privatepictureaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_pictures_.privatepictureaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_pictures_.privatepictureaccessor.md#read)
-* [wrapper](_identity_offchain_accessors_pictures_.privatepictureaccessor.md#wrapper)
+* [wrapper](_identity_offchain_accessors_pictures_.privatepictureaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -47,11 +47,11 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
-*Inherited from [PrivateBinaryAccessor](_identity_offchain_accessors_binary_.privatebinaryaccessor.md).[dataPath](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#datapath)*
+*Inherited from [PrivateBinaryAccessor](_identity_offchain_accessors_binary_.privatebinaryaccessor.md).[dataPath](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#readonly-datapath)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/binary.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/binary.ts#L42)*
 
@@ -79,11 +79,11 @@ Name | Type |
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 
-*Overrides [PrivateBinaryAccessor](_identity_offchain_accessors_binary_.privatebinaryaccessor.md).[wrapper](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#wrapper)*
+*Overrides [PrivateBinaryAccessor](_identity_offchain_accessors_binary_.privatebinaryaccessor.md).[wrapper](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#readonly-wrapper)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/pictures.ts:11](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/pictures.ts#L11)*
 
@@ -91,7 +91,7 @@ ___
 
 ###  readAsResult
 
-▸ **readAsResult**(`account`: [Address](../modules/_base_.md#address)): *Promise‹OkResult‹Buffer‹›› | ErrorResult‹[InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md)‹› | [OffchainError](_identity_offchain_accessors_errors_.offchainerror.md)‹› | [UnknownCiphertext](_identity_offchain_accessors_errors_.unknownciphertext.md)‹› | [UnavailableKey](_identity_offchain_accessors_errors_.unavailablekey.md)‹› | [InvalidKey](_identity_offchain_accessors_errors_.invalidkey.md)‹›››*
+▸ **readAsResult**(`account`: [Address](../modules/_base_.md#address)): *Promise‹Result‹Buffer‹›, [SchemaErrors](../modules/_identity_offchain_accessors_errors_.md#schemaerrors)››*
 
 *Inherited from [PrivateBinaryAccessor](_identity_offchain_accessors_binary_.privatebinaryaccessor.md).[readAsResult](_identity_offchain_accessors_binary_.privatebinaryaccessor.md#readasresult)*
 
@@ -103,7 +103,7 @@ Name | Type |
 ------ | ------ |
 `account` | [Address](../modules/_base_.md#address) |
 
-**Returns:** *Promise‹OkResult‹Buffer‹›› | ErrorResult‹[InvalidDataError](_identity_offchain_accessors_errors_.invaliddataerror.md)‹› | [OffchainError](_identity_offchain_accessors_errors_.offchainerror.md)‹› | [UnknownCiphertext](_identity_offchain_accessors_errors_.unknownciphertext.md)‹› | [UnavailableKey](_identity_offchain_accessors_errors_.unavailablekey.md)‹› | [InvalidKey](_identity_offchain_accessors_errors_.invalidkey.md)‹›››*
+**Returns:** *Promise‹Result‹Buffer‹›, [SchemaErrors](../modules/_identity_offchain_accessors_errors_.md#schemaerrors)››*
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_pictures_.publicpictureaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_pictures_.publicpictureaccessor.md
@@ -18,9 +18,9 @@
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_pictures_.publicpictureaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_pictures_.publicpictureaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_pictures_.publicpictureaccessor.md#read)
-* [wrapper](_identity_offchain_accessors_pictures_.publicpictureaccessor.md#wrapper)
+* [wrapper](_identity_offchain_accessors_pictures_.publicpictureaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -47,11 +47,11 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
-*Inherited from [PublicBinaryAccessor](_identity_offchain_accessors_binary_.publicbinaryaccessor.md).[dataPath](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#datapath)*
+*Inherited from [PublicBinaryAccessor](_identity_offchain_accessors_binary_.publicbinaryaccessor.md).[dataPath](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#readonly-datapath)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/binary.ts:12](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/binary.ts#L12)*
 
@@ -79,11 +79,11 @@ Name | Type |
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 
-*Overrides [PublicBinaryAccessor](_identity_offchain_accessors_binary_.publicbinaryaccessor.md).[wrapper](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#wrapper)*
+*Overrides [PublicBinaryAccessor](_identity_offchain_accessors_binary_.publicbinaryaccessor.md).[wrapper](_identity_offchain_accessors_binary_.publicbinaryaccessor.md#readonly-wrapper)*
 
 *Defined in [packages/contractkit/src/identity/offchain/accessors/pictures.ts:5](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/accessors/pictures.ts#L5)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_simple_.privatesimpleaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_simple_.privatesimpleaccessor.md
@@ -25,10 +25,10 @@ in a type parameter is supported for runtime type safety.
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#read)
-* [type](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#type)
-* [wrapper](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#wrapper)
+* [type](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#readonly-type)
+* [wrapper](_identity_offchain_accessors_simple_.privatesimpleaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -55,7 +55,7 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
@@ -83,7 +83,7 @@ Name | Type |
 
 ___
 
-###  type
+### `Readonly` type
 
 • **type**: *Type‹DataType›*
 
@@ -91,7 +91,7 @@ ___
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_simple_.publicsimpleaccessor.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_accessors_simple_.publicsimpleaccessor.md
@@ -25,10 +25,10 @@ in a type parameter is supported for runtime type safety.
 
 ### Properties
 
-* [dataPath](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#datapath)
+* [dataPath](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#readonly-datapath)
 * [read](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#read)
-* [type](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#type)
-* [wrapper](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#wrapper)
+* [type](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#readonly-type)
+* [wrapper](_identity_offchain_accessors_simple_.publicsimpleaccessor.md#readonly-wrapper)
 
 ### Methods
 
@@ -55,7 +55,7 @@ Name | Type |
 
 ## Properties
 
-###  dataPath
+### `Readonly` dataPath
 
 • **dataPath**: *string*
 
@@ -83,7 +83,7 @@ Name | Type |
 
 ___
 
-###  type
+### `Readonly` type
 
 • **type**: *Type‹DataType›*
 
@@ -91,7 +91,7 @@ ___
 
 ___
 
-###  wrapper
+### `Readonly` wrapper
 
 • **wrapper**: *[OffchainDataWrapper](_identity_offchain_data_wrapper_.offchaindatawrapper.md)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_data_wrapper_.offchaindatawrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_data_wrapper_.offchaindatawrapper.md
@@ -12,9 +12,9 @@
 
 ### Properties
 
-* [kit](_identity_offchain_data_wrapper_.offchaindatawrapper.md#kit)
+* [kit](_identity_offchain_data_wrapper_.offchaindatawrapper.md#readonly-kit)
 * [readDataFrom](_identity_offchain_data_wrapper_.offchaindatawrapper.md#readdatafrom)
-* [self](_identity_offchain_data_wrapper_.offchaindatawrapper.md#self)
+* [self](_identity_offchain_data_wrapper_.offchaindatawrapper.md#readonly-self)
 * [signer](_identity_offchain_data_wrapper_.offchaindatawrapper.md#signer)
 * [storageWriter](_identity_offchain_data_wrapper_.offchaindatawrapper.md#storagewriter)
 
@@ -43,7 +43,7 @@ Name | Type |
 
 ## Properties
 
-###  kit
+### `Readonly` kit
 
 • **kit**: *[ContractKit](_kit_.contractkit.md)*
 
@@ -59,7 +59,7 @@ ___
 
 ___
 
-###  self
+### `Readonly` self
 
 • **self**: *string*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.gitstoragewriter.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.gitstoragewriter.md
@@ -14,7 +14,7 @@
 
 ### Properties
 
-* [root](_identity_offchain_storage_writers_.gitstoragewriter.md#root)
+* [root](_identity_offchain_storage_writers_.gitstoragewriter.md#readonly-root)
 
 ### Methods
 
@@ -40,11 +40,11 @@ Name | Type |
 
 ## Properties
 
-###  root
+### `Readonly` root
 
 • **root**: *string*
 
-*Inherited from [LocalStorageWriter](_identity_offchain_storage_writers_.localstoragewriter.md).[root](_identity_offchain_storage_writers_.localstoragewriter.md#root)*
+*Inherited from [LocalStorageWriter](_identity_offchain_storage_writers_.localstoragewriter.md).[root](_identity_offchain_storage_writers_.localstoragewriter.md#readonly-root)*
 
 *Defined in [packages/contractkit/src/identity/offchain/storage-writers.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/storage-writers.ts#L13)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.googlestoragewriter.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.googlestoragewriter.md
@@ -14,8 +14,8 @@
 
 ### Properties
 
-* [local](_identity_offchain_storage_writers_.googlestoragewriter.md#local)
-* [root](_identity_offchain_storage_writers_.googlestoragewriter.md#root)
+* [local](_identity_offchain_storage_writers_.googlestoragewriter.md#readonly-local)
+* [root](_identity_offchain_storage_writers_.googlestoragewriter.md#readonly-root)
 
 ### Methods
 
@@ -42,7 +42,7 @@ Name | Type |
 
 ## Properties
 
-###  local
+### `Readonly` local
 
 • **local**: *string*
 
@@ -50,11 +50,11 @@ Name | Type |
 
 ___
 
-###  root
+### `Readonly` root
 
 • **root**: *string*
 
-*Inherited from [LocalStorageWriter](_identity_offchain_storage_writers_.localstoragewriter.md).[root](_identity_offchain_storage_writers_.localstoragewriter.md#root)*
+*Inherited from [LocalStorageWriter](_identity_offchain_storage_writers_.localstoragewriter.md).[root](_identity_offchain_storage_writers_.localstoragewriter.md#readonly-root)*
 
 *Defined in [packages/contractkit/src/identity/offchain/storage-writers.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/storage-writers.ts#L13)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.localstoragewriter.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.localstoragewriter.md
@@ -20,7 +20,7 @@
 
 ### Properties
 
-* [root](_identity_offchain_storage_writers_.localstoragewriter.md#root)
+* [root](_identity_offchain_storage_writers_.localstoragewriter.md#readonly-root)
 
 ### Methods
 
@@ -44,7 +44,7 @@ Name | Type |
 
 ## Properties
 
-###  root
+### `Readonly` root
 
 • **root**: *string*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.mockstoragewriter.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_identity_offchain_storage_writers_.mockstoragewriter.md
@@ -14,9 +14,9 @@
 
 ### Properties
 
-* [fetchMock](_identity_offchain_storage_writers_.mockstoragewriter.md#fetchmock)
-* [mockedStorageRoot](_identity_offchain_storage_writers_.mockstoragewriter.md#mockedstorageroot)
-* [root](_identity_offchain_storage_writers_.mockstoragewriter.md#root)
+* [fetchMock](_identity_offchain_storage_writers_.mockstoragewriter.md#readonly-fetchmock)
+* [mockedStorageRoot](_identity_offchain_storage_writers_.mockstoragewriter.md#readonly-mockedstorageroot)
+* [root](_identity_offchain_storage_writers_.mockstoragewriter.md#readonly-root)
 
 ### Methods
 
@@ -44,7 +44,7 @@ Name | Type |
 
 ## Properties
 
-###  fetchMock
+### `Readonly` fetchMock
 
 • **fetchMock**: *any*
 
@@ -52,7 +52,7 @@ Name | Type |
 
 ___
 
-###  mockedStorageRoot
+### `Readonly` mockedStorageRoot
 
 • **mockedStorageRoot**: *string*
 
@@ -60,11 +60,11 @@ ___
 
 ___
 
-###  root
+### `Readonly` root
 
 • **root**: *string*
 
-*Overrides [LocalStorageWriter](_identity_offchain_storage_writers_.localstoragewriter.md).[root](_identity_offchain_storage_writers_.localstoragewriter.md#root)*
+*Overrides [LocalStorageWriter](_identity_offchain_storage_writers_.localstoragewriter.md).[root](_identity_offchain_storage_writers_.localstoragewriter.md#readonly-root)*
 
 *Defined in [packages/contractkit/src/identity/offchain/storage-writers.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/identity/offchain/storage-writers.ts#L56)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
@@ -12,10 +12,10 @@
 
 ### Properties
 
-* [_web3Contracts](_kit_.contractkit.md#_web3contracts)
-* [contracts](_kit_.contractkit.md#contracts)
-* [registry](_kit_.contractkit.md#registry)
-* [web3](_kit_.contractkit.md#web3)
+* [_web3Contracts](_kit_.contractkit.md#readonly-_web3contracts)
+* [contracts](_kit_.contractkit.md#readonly-contracts)
+* [registry](_kit_.contractkit.md#readonly-registry)
+* [web3](_kit_.contractkit.md#readonly-web3)
 
 ### Accessors
 
@@ -63,7 +63,7 @@ Name | Type |
 
 ## Properties
 
-###  _web3Contracts
+### `Readonly` _web3Contracts
 
 • **_web3Contracts**: *[Web3ContractCache](_web3_contract_cache_.web3contractcache.md)*
 
@@ -73,7 +73,7 @@ factory for core contract's native web3 wrappers
 
 ___
 
-###  contracts
+### `Readonly` contracts
 
 • **contracts**: *[WrapperCache](_contract_cache_.wrappercache.md)*
 
@@ -83,7 +83,7 @@ factory for core contract's kit wrappers
 
 ___
 
-###  registry
+### `Readonly` registry
 
 • **registry**: *[AddressRegistry](_address_registry_.addressregistry.md)*
 
@@ -93,7 +93,7 @@ core contract's address registry
 
 ___
 
-###  web3
+### `Readonly` web3
 
 • **web3**: *Web3*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_providers_celo_provider_.celoprovider.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_providers_celo_provider_.celoprovider.md
@@ -12,7 +12,7 @@
 
 ### Properties
 
-* [existingProvider](_providers_celo_provider_.celoprovider.md#existingprovider)
+* [existingProvider](_providers_celo_provider_.celoprovider.md#readonly-existingprovider)
 * [nonceLock](_providers_celo_provider_.celoprovider.md#noncelock)
 * [wallet](_providers_celo_provider_.celoprovider.md#wallet)
 
@@ -49,7 +49,7 @@ Name | Type | Default |
 
 ## Properties
 
-###  existingProvider
+### `Readonly` existingProvider
 
 • **existingProvider**: *provider*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_utils_rpc_caller_.defaultrpccaller.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_utils_rpc_caller_.defaultrpccaller.md
@@ -16,8 +16,8 @@
 
 ### Properties
 
-* [defaultProvider](_utils_rpc_caller_.defaultrpccaller.md#defaultprovider)
-* [jsonrpcVersion](_utils_rpc_caller_.defaultrpccaller.md#jsonrpcversion)
+* [defaultProvider](_utils_rpc_caller_.defaultrpccaller.md#readonly-defaultprovider)
+* [jsonrpcVersion](_utils_rpc_caller_.defaultrpccaller.md#readonly-jsonrpcversion)
 
 ### Methods
 
@@ -43,7 +43,7 @@ Name | Type | Default |
 
 ## Properties
 
-###  defaultProvider
+### `Readonly` defaultProvider
 
 • **defaultProvider**: *provider*
 
@@ -51,7 +51,7 @@ Name | Type | Default |
 
 ___
 
-###  jsonrpcVersion
+### `Readonly` jsonrpcVersion
 
 • **jsonrpcVersion**: *string*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_utils_tx_params_normalizer_.txparamsnormalizer.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_utils_tx_params_normalizer_.txparamsnormalizer.md
@@ -12,7 +12,7 @@
 
 ### Properties
 
-* [rpcCaller](_utils_tx_params_normalizer_.txparamsnormalizer.md#rpccaller)
+* [rpcCaller](_utils_tx_params_normalizer_.txparamsnormalizer.md#readonly-rpccaller)
 
 ### Methods
 
@@ -36,7 +36,7 @@ Name | Type |
 
 ## Properties
 
-###  rpcCaller
+### `Readonly` rpcCaller
 
 • **rpcCaller**: *[RpcCaller](../interfaces/_utils_rpc_caller_.rpccaller.md)*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_ledger_wallet_.ledgerwallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_ledger_wallet_.ledgerwallet.md
@@ -20,10 +20,10 @@
 
 ### Properties
 
-* [baseDerivationPath](_wallets_ledger_wallet_.ledgerwallet.md#basederivationpath)
-* [derivationPathIndexes](_wallets_ledger_wallet_.ledgerwallet.md#derivationpathindexes)
-* [ledgerAddressValidation](_wallets_ledger_wallet_.ledgerwallet.md#ledgeraddressvalidation)
-* [transport](_wallets_ledger_wallet_.ledgerwallet.md#transport)
+* [baseDerivationPath](_wallets_ledger_wallet_.ledgerwallet.md#readonly-basederivationpath)
+* [derivationPathIndexes](_wallets_ledger_wallet_.ledgerwallet.md#readonly-derivationpathindexes)
+* [ledgerAddressValidation](_wallets_ledger_wallet_.ledgerwallet.md#readonly-ledgeraddressvalidation)
+* [transport](_wallets_ledger_wallet_.ledgerwallet.md#readonly-transport)
 
 ### Methods
 
@@ -59,7 +59,7 @@ Name | Type | Default | Description |
 
 ## Properties
 
-###  baseDerivationPath
+### `Readonly` baseDerivationPath
 
 • **baseDerivationPath**: *string*
 
@@ -69,7 +69,7 @@ base derivation path. Default: "44'/52752'/0'/0"
 
 ___
 
-###  derivationPathIndexes
+### `Readonly` derivationPathIndexes
 
 • **derivationPathIndexes**: *number[]*
 
@@ -82,7 +82,7 @@ Example: [3, 99, 53] will retrieve the derivation paths of
 
 ___
 
-###  ledgerAddressValidation
+### `Readonly` ledgerAddressValidation
 
 • **ledgerAddressValidation**: *[AddressValidation](../enums/_wallets_ledger_wallet_.addressvalidation.md)*
 
@@ -90,7 +90,7 @@ ___
 
 ___
 
-###  transport
+### `Readonly` transport
 
 • **transport**: *any*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wallets_rpc_wallet_.rpcwallet.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wallets_rpc_wallet_.rpcwallet.md
@@ -195,6 +195,8 @@ ___
 
 ▸ **loadAccountSigners**(): *Promise‹Map‹string, [RpcSigner](_wallets_signers_rpc_signer_.rpcsigner.md)››*
 
+*Overrides void*
+
 *Defined in [packages/contractkit/src/wallets/rpc-wallet.ts:26](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wallets/rpc-wallet.ts#L26)*
 
 **Returns:** *Promise‹Map‹string, [RpcSigner](_wallets_signers_rpc_signer_.rpcsigner.md)››*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_web3_contract_cache_.web3contractcache.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_web3_contract_cache_.web3contractcache.md
@@ -19,7 +19,7 @@ a contract wrapper
 
 ### Properties
 
-* [kit](_web3_contract_cache_.web3contractcache.md#kit)
+* [kit](_web3_contract_cache_.web3contractcache.md#readonly-kit)
 
 ### Methods
 
@@ -68,7 +68,7 @@ Name | Type |
 
 ## Properties
 
-###  kit
+### `Readonly` kit
 
 • **kit**: *[ContractKit](_kit_.contractkit.md)*
 
@@ -108,7 +108,7 @@ ___
 
 ###  getContract
 
-▸ **getContract**<**C**>(`contract`: C, `address?`: undefined | string): *Promise‹ContractCacheMap[C] extends undefined | null ? never : ContractCacheMap[C]›*
+▸ **getContract**<**C**>(`contract`: C, `address?`: undefined | string): *Promise‹NonNullable‹ContractCacheMap[C]››*
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:155](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L155)*
 
@@ -125,7 +125,7 @@ Name | Type |
 `contract` | C |
 `address?` | undefined &#124; string |
 
-**Returns:** *Promise‹ContractCacheMap[C] extends undefined | null ? never : ContractCacheMap[C]›*
+**Returns:** *Promise‹NonNullable‹ContractCacheMap[C]››*
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_accounts_.accountswrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_accounts_.accountswrapper.md
@@ -99,7 +99,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -107,8 +107,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -346,7 +344,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -361,8 +359,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_attestations_.attestationswrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_attestations_.attestationswrapper.md
@@ -129,7 +129,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -137,8 +137,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -291,7 +289,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -306,8 +304,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 
@@ -595,6 +591,8 @@ ___
 
 *Defined in [packages/contractkit/src/wrappers/Attestations.ts:148](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Attestations.ts#L148)*
 
+**`notice`** Checks if attestation request is expired.
+
 **Parameters:**
 
 Name | Type | Description |
@@ -747,6 +745,8 @@ ___
 ▸ **waitForSelectingIssuers**(`identifier`: string, `account`: [Address](../modules/_base_.md#address), `timeoutSeconds`: number, `pollDurationSeconds`: number): *Promise‹void›*
 
 *Defined in [packages/contractkit/src/wrappers/Attestations.ts:160](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/Attestations.ts#L160)*
+
+**`notice`** Waits for appropriate block numbers for before issuer can be selected
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_baseslasher_.baseslasher.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_baseslasher_.baseslasher.md
@@ -58,7 +58,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -66,8 +66,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -83,7 +81,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -98,8 +96,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_basewrapper_.basewrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_basewrapper_.basewrapper.md
@@ -91,14 +91,12 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -112,7 +110,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -125,8 +123,6 @@ ___
   )
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ## Accessors
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_basewrapper_.celotransactionobject.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_basewrapper_.celotransactionobject.md
@@ -16,8 +16,8 @@
 
 ### Properties
 
-* [defaultParams](_wrappers_basewrapper_.celotransactionobject.md#optional-defaultparams)
-* [txo](_wrappers_basewrapper_.celotransactionobject.md#txo)
+* [defaultParams](_wrappers_basewrapper_.celotransactionobject.md#optional-readonly-defaultparams)
+* [txo](_wrappers_basewrapper_.celotransactionobject.md#readonly-txo)
 
 ### Methods
 
@@ -44,7 +44,7 @@ Name | Type |
 
 ## Properties
 
-### `Optional` defaultParams
+### `Optional` `Readonly` defaultParams
 
 • **defaultParams**? : *[CeloTransactionParams](../modules/_wrappers_basewrapper_.md#celotransactionparams)*
 
@@ -52,7 +52,7 @@ Name | Type |
 
 ___
 
-###  txo
+### `Readonly` txo
 
 • **txo**: *TransactionObject‹O›*
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_blockchainparameters_.blockchainparameterswrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_blockchainparameters_.blockchainparameterswrapper.md
@@ -58,7 +58,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -66,8 +66,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -127,7 +125,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -142,8 +140,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_doublesigningslasher_.doublesigningslasherwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_doublesigningslasher_.doublesigningslasherwrapper.md
@@ -55,7 +55,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -63,8 +63,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -80,7 +78,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -95,8 +93,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_downtimeslasher_.downtimeslasherwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_downtimeslasher_.downtimeslasherwrapper.md
@@ -64,7 +64,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -72,8 +72,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -169,7 +167,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -184,8 +182,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_election_.electionwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_election_.electionwrapper.md
@@ -109,7 +109,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -117,8 +117,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -230,7 +228,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -245,8 +243,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_escrow_.escrowwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_escrow_.escrowwrapper.md
@@ -77,7 +77,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -85,8 +85,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -138,7 +136,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -153,8 +151,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_exchange_.exchangewrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_exchange_.exchangewrapper.md
@@ -72,7 +72,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -80,8 +80,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -185,7 +183,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -200,8 +198,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_freezer_.freezerwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_freezer_.freezerwrapper.md
@@ -52,7 +52,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -60,8 +60,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -113,7 +111,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -128,8 +126,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_gaspriceminimum_.gaspriceminimumwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_gaspriceminimum_.gaspriceminimumwrapper.md
@@ -82,7 +82,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -90,8 +90,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -155,7 +153,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -170,8 +168,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_goldtokenwrapper_.goldtokenwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_goldtokenwrapper_.goldtokenwrapper.md
@@ -163,7 +163,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -171,8 +171,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -218,7 +216,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -233,8 +231,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_governance_.governancewrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_governance_.governancewrapper.md
@@ -199,7 +199,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -207,8 +207,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -732,7 +730,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -747,8 +745,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_lockedgold_.lockedgoldwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_lockedgold_.lockedgoldwrapper.md
@@ -96,7 +96,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -104,8 +104,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -225,7 +223,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -240,8 +238,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_metatransactionwallet_.metatransactionwalletwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_metatransactionwallet_.metatransactionwalletwrapper.md
@@ -110,7 +110,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -118,8 +118,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -197,7 +195,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -212,8 +210,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_metatransactionwalletdeployer_.metatransactionwalletdeployerwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_metatransactionwalletdeployer_.metatransactionwalletdeployerwrapper.md
@@ -68,7 +68,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -76,8 +76,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -93,7 +91,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -108,8 +106,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ## Accessors
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_multisig_.multisigwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_multisig_.multisigwrapper.md
@@ -60,7 +60,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -68,8 +68,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -179,7 +177,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -194,8 +192,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_releasegold_.releasegoldwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_releasegold_.releasegoldwrapper.md
@@ -147,7 +147,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -155,8 +155,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -469,7 +467,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -484,8 +482,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_reserve_.reservewrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_reserve_.reservewrapper.md
@@ -86,7 +86,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -94,8 +94,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -271,7 +269,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -286,8 +284,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_sortedoracles_.sortedoracleswrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_sortedoracles_.sortedoracleswrapper.md
@@ -66,7 +66,7 @@ Name | Type |
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -74,8 +74,6 @@ Name | Type |
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -91,7 +89,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -106,8 +104,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_stabletokenwrapper_.stabletokenwrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_stabletokenwrapper_.stabletokenwrapper.md
@@ -220,7 +220,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -228,8 +228,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -275,7 +273,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -290,8 +288,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_validators_.validatorswrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_validators_.validatorswrapper.md
@@ -142,7 +142,7 @@ ___
 
 ###  eventTypes
 
-• **eventTypes**: *object* = Object.keys(this.events).reduce<EventsEnum<T>>(
+• **eventTypes**: *EventsEnum‹T›* = Object.keys(this.events).reduce<EventsEnum<T>>(
     (acc, key) => ({ ...acc, [key]: key }),
     {} as any
   )
@@ -150,8 +150,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[eventTypes](_wrappers_basewrapper_.basewrapper.md#eventtypes)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L42)*
-
-#### Type declaration:
 
 ___
 
@@ -462,7 +460,7 @@ ___
 
 ###  methodIds
 
-• **methodIds**: *object* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
+• **methodIds**: *Record‹keyof T["methods"], string›* = Object.keys(this.contract.methods).reduce<Record<Methods<T>, string>>(
     (acc, method: Methods<T>) => {
       const methodABI = this.contract.options.jsonInterface.find((item) => item.name === method)
 
@@ -477,8 +475,6 @@ ___
 *Inherited from [BaseWrapper](_wrappers_basewrapper_.basewrapper.md).[methodIds](_wrappers_basewrapper_.basewrapper.md#methodids)*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L47)*
-
-#### Type declaration:
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/globals.md
+++ b/packages/docs/developer-resources/contractkit/reference/globals.md
@@ -2,7 +2,7 @@
 
 ## Index
 
-### External modules
+### Modules
 
 * ["address-registry"](modules/_address_registry_.md)
 * ["base"](modules/_base_.md)

--- a/packages/docs/developer-resources/contractkit/reference/modules/_address_registry_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_address_registry_.md
@@ -1,4 +1,4 @@
-# External module: "address-registry"
+# Module: "address-registry"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_base_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_base_.md
@@ -1,4 +1,4 @@
-# External module: "base"
+# Module: "base"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_contract_cache_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_contract_cache_.md
@@ -1,4 +1,4 @@
-# External module: "contract-cache"
+# Module: "contract-cache"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_explorer_base_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_explorer_base_.md
@@ -1,4 +1,4 @@
-# External module: "explorer/base"
+# Module: "explorer/base"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_explorer_block_explorer_.md
@@ -1,4 +1,4 @@
-# External module: "explorer/block-explorer"
+# Module: "explorer/block-explorer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_explorer_log_explorer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_explorer_log_explorer_.md
@@ -1,4 +1,4 @@
-# External module: "explorer/log-explorer"
+# Module: "explorer/log-explorer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_governance_proposals_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_governance_proposals_.md
@@ -1,4 +1,4 @@
-# External module: "governance/proposals"
+# Module: "governance/proposals"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_governance_proxy_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_governance_proxy_.md
@@ -1,4 +1,4 @@
-# External module: "governance/proxy"
+# Module: "governance/proxy"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_account_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_account_.md
@@ -1,4 +1,4 @@
-# External module: "identity/claims/account"
+# Module: "identity/claims/account"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_attestation_service_url_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_attestation_service_url_.md
@@ -1,4 +1,4 @@
-# External module: "identity/claims/attestation-service-url"
+# Module: "identity/claims/attestation-service-url"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_claim_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_claim_.md
@@ -1,4 +1,4 @@
-# External module: "identity/claims/claim"
+# Module: "identity/claims/claim"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_keybase_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_keybase_.md
@@ -1,4 +1,4 @@
-# External module: "identity/claims/keybase"
+# Module: "identity/claims/keybase"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_types_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_types_.md
@@ -1,4 +1,4 @@
-# External module: "identity/claims/types"
+# Module: "identity/claims/types"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_verify_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_claims_verify_.md
@@ -1,4 +1,4 @@
-# External module: "identity/claims/verify"
+# Module: "identity/claims/verify"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_metadata_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_metadata_.md
@@ -1,4 +1,4 @@
-# External module: "identity/metadata"
+# Module: "identity/metadata"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_bls_blinding_client_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_bls_blinding_client_.md
@@ -1,4 +1,4 @@
-# External module: "identity/odis/bls-blinding-client"
+# Module: "identity/odis/bls-blinding-client"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_matchmaking_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_matchmaking_.md
@@ -1,4 +1,4 @@
-# External module: "identity/odis/matchmaking"
+# Module: "identity/odis/matchmaking"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_phone_number_identifier_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_phone_number_identifier_.md
@@ -1,4 +1,4 @@
-# External module: "identity/odis/phone-number-identifier"
+# Module: "identity/odis/phone-number-identifier"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_query_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_odis_query_.md
@@ -1,4 +1,4 @@
-# External module: "identity/odis/query"
+# Module: "identity/odis/query"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_authorized_signer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_authorized_signer_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/accessors/authorized-signer"
+# Module: "identity/offchain/accessors/authorized-signer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_binary_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_binary_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/accessors/binary"
+# Module: "identity/offchain/accessors/binary"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_errors_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_errors_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/accessors/errors"
+# Module: "identity/offchain/accessors/errors"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_interfaces_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_interfaces_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/accessors/interfaces"
+# Module: "identity/offchain/accessors/interfaces"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_name_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_name_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/accessors/name"
+# Module: "identity/offchain/accessors/name"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_pictures_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_pictures_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/accessors/pictures"
+# Module: "identity/offchain/accessors/pictures"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_simple_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_accessors_simple_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/accessors/simple"
+# Module: "identity/offchain/accessors/simple"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_data_wrapper_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_data_wrapper_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain-data-wrapper"
+# Module: "identity/offchain-data-wrapper"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_storage_writers_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_storage_writers_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/storage-writers"
+# Module: "identity/offchain/storage-writers"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_identity_offchain_utils_.md
@@ -1,4 +1,4 @@
-# External module: "identity/offchain/utils"
+# Module: "identity/offchain/utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_kit_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_kit_.md
@@ -1,4 +1,4 @@
-# External module: "kit"
+# Module: "kit"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_network_utils_genesis_block_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_network_utils_genesis_block_utils_.md
@@ -1,4 +1,4 @@
-# External module: "network-utils/genesis-block-utils"
+# Module: "network-utils/genesis-block-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_network_utils_google_storage_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_network_utils_google_storage_utils_.md
@@ -1,4 +1,4 @@
-# External module: "network-utils/google-storage-utils"
+# Module: "network-utils/google-storage-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_network_utils_static_node_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_network_utils_static_node_utils_.md
@@ -1,4 +1,4 @@
-# External module: "network-utils/static-node-utils"
+# Module: "network-utils/static-node-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_providers_celo_provider_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_providers_celo_provider_.md
@@ -1,4 +1,4 @@
-# External module: "providers/celo-provider"
+# Module: "providers/celo-provider"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_test_utils_promieventstub_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_test_utils_promieventstub_.md
@@ -1,4 +1,4 @@
-# External module: "test-utils/PromiEventStub"
+# Module: "test-utils/PromiEventStub"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_test_utils_setup_global_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_test_utils_setup_global_.md
@@ -1,4 +1,4 @@
-# External module: "test-utils/setup.global"
+# Module: "test-utils/setup.global"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_test_utils_teardown_global_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_test_utils_teardown_global_.md
@@ -1,4 +1,4 @@
-# External module: "test-utils/teardown.global"
+# Module: "test-utils/teardown.global"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_array_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_array_.md
@@ -1,4 +1,4 @@
-# External module: "utils/array"
+# Module: "utils/array"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_azure_key_vault_client_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_azure_key_vault_client_.md
@@ -1,4 +1,4 @@
-# External module: "utils/azure-key-vault-client"
+# Module: "utils/azure-key-vault-client"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_ber_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_ber_utils_.md
@@ -1,4 +1,4 @@
-# External module: "utils/ber-utils"
+# Module: "utils/ber-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_ledger_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_ledger_utils_.md
@@ -1,4 +1,4 @@
-# External module: "utils/ledger-utils"
+# Module: "utils/ledger-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_provider_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_provider_utils_.md
@@ -1,4 +1,4 @@
-# External module: "utils/provider-utils"
+# Module: "utils/provider-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_rpc_caller_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_rpc_caller_.md
@@ -1,4 +1,4 @@
-# External module: "utils/rpc-caller"
+# Module: "utils/rpc-caller"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_signature_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_signature_utils_.md
@@ -1,4 +1,4 @@
-# External module: "utils/signature-utils"
+# Module: "utils/signature-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_signing_utils_.md
@@ -1,4 +1,4 @@
-# External module: "utils/signing-utils"
+# Module: "utils/signing-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_timezone_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_timezone_.md
@@ -1,4 +1,4 @@
-# External module: "utils/timezone"
+# Module: "utils/timezone"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_tx_params_normalizer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_tx_params_normalizer_.md
@@ -1,4 +1,4 @@
-# External module: "utils/tx-params-normalizer"
+# Module: "utils/tx-params-normalizer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_tx_result_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_tx_result_.md
@@ -1,4 +1,4 @@
-# External module: "utils/tx-result"
+# Module: "utils/tx-result"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_tx_uri_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_tx_uri_.md
@@ -1,4 +1,4 @@
-# External module: "utils/tx-uri"
+# Module: "utils/tx-uri"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_utils_web3_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_utils_web3_utils_.md
@@ -1,4 +1,4 @@
-# External module: "utils/web3-utils"
+# Module: "utils/web3-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_aws_hsm_wallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_aws_hsm_wallet_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/aws-hsm-wallet"
+# Module: "wallets/aws-hsm-wallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_azure_hsm_wallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_azure_hsm_wallet_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/azure-hsm-wallet"
+# Module: "wallets/azure-hsm-wallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_ledger_utils_data_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_ledger_utils_data_.md
@@ -1,3 +1,3 @@
-# External module: "wallets/ledger-utils/data"
+# Module: "wallets/ledger-utils/data"
 
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_ledger_utils_tokens_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_ledger_utils_tokens_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/ledger-utils/tokens"
+# Module: "wallets/ledger-utils/tokens"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_ledger_wallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_ledger_wallet_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/ledger-wallet"
+# Module: "wallets/ledger-wallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_local_wallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_local_wallet_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/local-wallet"
+# Module: "wallets/local-wallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_remote_wallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_remote_wallet_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/remote-wallet"
+# Module: "wallets/remote-wallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_rpc_wallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_rpc_wallet_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/rpc-wallet"
+# Module: "wallets/rpc-wallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_aws_hsm_signer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_aws_hsm_signer_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/signers/aws-hsm-signer"
+# Module: "wallets/signers/aws-hsm-signer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_azure_hsm_signer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_azure_hsm_signer_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/signers/azure-hsm-signer"
+# Module: "wallets/signers/azure-hsm-signer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_ledger_signer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_ledger_signer_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/signers/ledger-signer"
+# Module: "wallets/signers/ledger-signer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_local_signer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_local_signer_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/signers/local-signer"
+# Module: "wallets/signers/local-signer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_rpc_signer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_rpc_signer_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/signers/rpc-signer"
+# Module: "wallets/signers/rpc-signer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_signer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_signers_signer_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/signers/signer"
+# Module: "wallets/signers/signer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_test_utils_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_test_utils_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/test-utils"
+# Module: "wallets/test-utils"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wallets_wallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wallets_wallet_.md
@@ -1,4 +1,4 @@
-# External module: "wallets/wallet"
+# Module: "wallets/wallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_web3_contract_cache_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_web3_contract_cache_.md
@@ -1,4 +1,4 @@
-# External module: "web3-contract-cache"
+# Module: "web3-contract-cache"
 
 ## Index
 
@@ -30,56 +30,152 @@
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:33](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L33)*
 
-###  __computed
+###  [CeloContract.Accounts]
 
-• **__computed**: *newValidators* = newValidators
+• **[CeloContract.Accounts]**: *newAccounts* = newAccounts
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:34](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L34)*
 
+###  [CeloContract.Attestations]
+
+• **[CeloContract.Attestations]**: *newAttestations* = newAttestations
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:35](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L35)*
+
+###  [CeloContract.BlockchainParameters]
+
+• **[CeloContract.BlockchainParameters]**: *newBlockchainParameters* = newBlockchainParameters
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:36](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L36)*
 
+###  [CeloContract.DoubleSigningSlasher]
+
+• **[CeloContract.DoubleSigningSlasher]**: *newDoubleSigningSlasher* = newDoubleSigningSlasher
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:37](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L37)*
+
+###  [CeloContract.DowntimeSlasher]
+
+• **[CeloContract.DowntimeSlasher]**: *newDowntimeSlasher* = newDowntimeSlasher
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:38](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L38)*
 
+###  [CeloContract.Election]
+
+• **[CeloContract.Election]**: *newElection* = newElection
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:39](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L39)*
+
+###  [CeloContract.EpochRewards]
+
+• **[CeloContract.EpochRewards]**: *newEpochRewards* = newEpochRewards
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:40](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L40)*
 
+###  [CeloContract.Escrow]
+
+• **[CeloContract.Escrow]**: *newEscrow* = newEscrow
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L41)*
+
+###  [CeloContract.Exchange]
+
+• **[CeloContract.Exchange]**: *newExchange* = newExchange
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L42)*
 
+###  [CeloContract.FeeCurrencyWhitelist]
+
+• **[CeloContract.FeeCurrencyWhitelist]**: *newFeeCurrencyWhitelist* = newFeeCurrencyWhitelist
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L43)*
+
+###  [CeloContract.Freezer]
+
+• **[CeloContract.Freezer]**: *newFreezer* = newFreezer
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L44)*
 
+###  [CeloContract.GasPriceMinimum]
+
+• **[CeloContract.GasPriceMinimum]**: *newGasPriceMinimum* = newGasPriceMinimum
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:45](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L45)*
+
+###  [CeloContract.GoldToken]
+
+• **[CeloContract.GoldToken]**: *newGoldToken* = newGoldToken
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:46](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L46)*
 
+###  [CeloContract.Governance]
+
+• **[CeloContract.Governance]**: *newGovernance* = newGovernance
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L47)*
+
+###  [CeloContract.LockedGold]
+
+• **[CeloContract.LockedGold]**: *newLockedGold* = newLockedGold
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:48](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L48)*
 
-*Defined in [packages/contractkit/src/web3-contract-cache.ts:49](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L49)*
+###  [CeloContract.MetaTransactionWalletDeployer]
+
+• **[CeloContract.MetaTransactionWalletDeployer]**: *newMetaTransactionWalletDeployer* = newMetaTransactionWalletDeployer
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:50](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L50)*
 
+###  [CeloContract.MetaTransactionWallet]
+
+• **[CeloContract.MetaTransactionWallet]**: *newMetaTransactionWallet* = newMetaTransactionWallet
+
+*Defined in [packages/contractkit/src/web3-contract-cache.ts:49](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L49)*
+
+###  [CeloContract.MultiSig]
+
+• **[CeloContract.MultiSig]**: *newMultiSig* = newMultiSig
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:51](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L51)*
+
+###  [CeloContract.Random]
+
+• **[CeloContract.Random]**: *newRandom* = newRandom
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:52](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L52)*
 
+###  [CeloContract.Registry]
+
+• **[CeloContract.Registry]**: *newRegistry* = newRegistry
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:53](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L53)*
+
+###  [CeloContract.Reserve]
+
+• **[CeloContract.Reserve]**: *newReserve* = newReserve
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:54](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L54)*
 
+###  [CeloContract.SortedOracles]
+
+• **[CeloContract.SortedOracles]**: *newSortedOracles* = newSortedOracles
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:55](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L55)*
+
+###  [CeloContract.StableToken]
+
+• **[CeloContract.StableToken]**: *newStableToken* = newStableToken
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L56)*
 
+###  [CeloContract.TransferWhitelist]
+
+• **[CeloContract.TransferWhitelist]**: *newTransferWhitelist* = newTransferWhitelist
+
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:57](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L57)*
+
+###  [CeloContract.Validators]
+
+• **[CeloContract.Validators]**: *newValidators* = newValidators
 
 *Defined in [packages/contractkit/src/web3-contract-cache.ts:58](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/web3-contract-cache.ts#L58)*

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_accounts_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_accounts_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Accounts"
+# Module: "wrappers/Accounts"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_attestations_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_attestations_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Attestations"
+# Module: "wrappers/Attestations"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_baseslasher_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_baseslasher_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/BaseSlasher"
+# Module: "wrappers/BaseSlasher"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_basewrapper_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_basewrapper_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/BaseWrapper"
+# Module: "wrappers/BaseWrapper"
 
 ## Index
 
@@ -64,7 +64,7 @@ ___
 
 ### `Const` bufferToSolidityBytes
 
-▸ **bufferToSolidityBytes**(`input`: Buffer): *string | number[]*
+▸ **bufferToSolidityBytes**(`input`: Buffer): *SolidityBytes*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:134](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L134)*
 
@@ -74,7 +74,7 @@ Name | Type |
 ------ | ------ |
 `input` | Buffer |
 
-**Returns:** *string | number[]*
+**Returns:** *SolidityBytes*
 
 ___
 
@@ -372,7 +372,7 @@ ___
 
 ### `Const` stringToSolidityBytes
 
-▸ **stringToSolidityBytes**(`input`: string): *string | number[]*
+▸ **stringToSolidityBytes**(`input`: string): *SolidityBytes*
 
 *Defined in [packages/contractkit/src/wrappers/BaseWrapper.ts:133](https://github.com/celo-org/celo-monorepo/blob/master/packages/contractkit/src/wrappers/BaseWrapper.ts#L133)*
 
@@ -382,7 +382,7 @@ Name | Type |
 ------ | ------ |
 `input` | string |
 
-**Returns:** *string | number[]*
+**Returns:** *SolidityBytes*
 
 ___
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_blockchainparameters_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_blockchainparameters_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/BlockchainParameters"
+# Module: "wrappers/BlockchainParameters"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_doublesigningslasher_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_doublesigningslasher_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/DoubleSigningSlasher"
+# Module: "wrappers/DoubleSigningSlasher"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_downtimeslasher_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_downtimeslasher_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/DowntimeSlasher"
+# Module: "wrappers/DowntimeSlasher"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_election_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_election_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Election"
+# Module: "wrappers/Election"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_escrow_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_escrow_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Escrow"
+# Module: "wrappers/Escrow"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_exchange_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_exchange_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Exchange"
+# Module: "wrappers/Exchange"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_freezer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_freezer_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Freezer"
+# Module: "wrappers/Freezer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_gaspriceminimum_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_gaspriceminimum_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/GasPriceMinimum"
+# Module: "wrappers/GasPriceMinimum"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_goldtokenwrapper_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_goldtokenwrapper_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/GoldTokenWrapper"
+# Module: "wrappers/GoldTokenWrapper"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_governance_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_governance_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Governance"
+# Module: "wrappers/Governance"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_lockedgold_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_lockedgold_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/LockedGold"
+# Module: "wrappers/LockedGold"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_metatransactionwallet_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_metatransactionwallet_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/MetaTransactionWallet"
+# Module: "wrappers/MetaTransactionWallet"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_metatransactionwalletdeployer_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_metatransactionwalletdeployer_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/MetaTransactionWalletDeployer"
+# Module: "wrappers/MetaTransactionWalletDeployer"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_multisig_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_multisig_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/MultiSig"
+# Module: "wrappers/MultiSig"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_releasegold_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_releasegold_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/ReleaseGold"
+# Module: "wrappers/ReleaseGold"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_reserve_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_reserve_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Reserve"
+# Module: "wrappers/Reserve"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_sortedoracles_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_sortedoracles_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/SortedOracles"
+# Module: "wrappers/SortedOracles"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_stabletokenwrapper_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_stabletokenwrapper_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/StableTokenWrapper"
+# Module: "wrappers/StableTokenWrapper"
 
 ## Index
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_validators_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_validators_.md
@@ -1,4 +1,4 @@
-# External module: "wrappers/Validators"
+# Module: "wrappers/Validators"
 
 ## Index
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6756,7 +6756,7 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
   integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
-"@types/minimatch@*", "@types/minimatch@3.0.3", "@types/minimatch@^3.0.3":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -10051,13 +10051,6 @@ bach@^1.0.0:
     async-done "^1.2.2"
     async-settle "^1.0.0"
     now-and-later "^2.0.0"
-
-backbone@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
-  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
-  dependencies:
-    underscore ">=1.8.3"
 
 backo2@^1.0.2:
   version "1.0.2"
@@ -18280,7 +18273,7 @@ handlebars@4.0.11:
   optionalDependencies:
     uglify-js "^2.6"
 
-handlebars@^4.0.1, handlebars@^4.0.3, handlebars@^4.1.0, handlebars@^4.5.3, handlebars@^4.7.2:
+handlebars@^4.0.1, handlebars@^4.0.3, handlebars@^4.1.0, handlebars@^4.5.3:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.2.tgz#01127b3840156a0927058779482031afe0e730d7"
   integrity sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==
@@ -18288,6 +18281,18 @@ handlebars@^4.0.1, handlebars@^4.0.3, handlebars@^4.1.0, handlebars@^4.5.3, hand
     neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.7.6:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -18525,10 +18530,10 @@ highlight.js@9.8.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.8.0.tgz#38eeef40cd45eaddbec8c9e5238fb7a783a3b685"
   integrity sha1-OO7vQM1F6t2+yMnlI4+3p4OjtoU=
 
-highlight.js@^9.17.1:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+highlight.js@^10.2.0:
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.3.2.tgz#135fd3619a00c3cbb8b4cd6dbc78d56bfcbc46f1"
+  integrity sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -21150,11 +21155,6 @@ join-path@^1.1.1:
     url-join "0.0.1"
     valid-url "^1"
 
-jquery@^3.4.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
@@ -22609,7 +22609,7 @@ lodash.xorby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
-lodash@4.17.14, lodash@4.17.15, lodash@4.17.4, lodash@4.x.x, lodash@^2.4.1, lodash@^3.10.1, lodash@^4.0.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.0:
+lodash@4.17.14, lodash@4.17.15, lodash@4.17.4, lodash@4.x.x, lodash@^2.4.1, lodash@^3.10.1, lodash@^4.0.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -22843,10 +22843,10 @@ lunr@0.5.12:
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-0.5.12.tgz#a2f6b7d7801cbe2ccb1696da67f1f7788f89e0c8"
   integrity sha1-ova314AcvizLFpbaZ/H3eI+J4Mg=
 
-lunr@^2.3.8:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.8.tgz#a8b89c31f30b5a044b97d2d28e2da191b6ba2072"
-  integrity sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -23078,10 +23078,10 @@ marked@^0.7.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
-marked@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.0.tgz#ec5c0c9b93878dc52dd54be8d0e524097bd81a99"
-  integrity sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==
+marked@^1.1.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.4.tgz#94e99230b03496c9383b1322ac51bc17dd388a1d"
+  integrity sha512-6x5TFGCTKSQBLTZtOburGxCxFEBJEGYVLwCMTBCxzvyuisGcC20UNzDSJhCr/cJ/Kmh6ulfJm10g6WWEAJ3kvg==
 
 matchdep@^2.0.0:
   version "2.0.0"
@@ -30338,10 +30338,10 @@ shell-utils@^1.0.9:
   dependencies:
     lodash "4.x.x"
 
-shelljs@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
-  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -33018,15 +33018,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.7.2.tgz#1e9896f920b58e6da0bba9d7e643738d02405a5a"
-  integrity sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==
-  dependencies:
-    backbone "^1.4.0"
-    jquery "^3.4.1"
-    lunr "^2.3.8"
-    underscore "^1.9.1"
+typedoc-default-themes@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
+  integrity sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==
 
 typedoc-plugin-markdown@^2.2.16:
   version "2.2.16"
@@ -33036,22 +33031,22 @@ typedoc-plugin-markdown@^2.2.16:
     fs-extra "^8.1.0"
     handlebars "^4.5.3"
 
-typedoc@^0.16.9:
-  version "0.16.9"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.16.9.tgz#d6f46f4dea7d3362029927a92981efdf896f435b"
-  integrity sha512-UvOGoy76yqwCXwxPgatwgXWfsQ3FczyZ6ZNLjhCPK+TsDir6LiU3YB6N9XZmPv36E+7LA860mnc8a0v6YADKFw==
+typedoc@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
+  integrity sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==
   dependencies:
-    "@types/minimatch" "3.0.3"
-    fs-extra "^8.1.0"
-    handlebars "^4.7.2"
-    highlight.js "^9.17.1"
-    lodash "^4.17.15"
-    marked "^0.8.0"
+    fs-extra "^9.0.1"
+    handlebars "^4.7.6"
+    highlight.js "^10.2.0"
+    lodash "^4.17.20"
+    lunr "^2.3.9"
+    marked "^1.1.1"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.3"
-    typedoc-default-themes "^0.7.2"
-    typescript "3.7.x"
+    semver "^7.3.2"
+    shelljs "^0.8.4"
+    typedoc-default-themes "^0.11.4"
 
 typeforce@^1.11.5:
   version "1.18.0"
@@ -33090,11 +33085,6 @@ typescript@3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
   integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
-
-typescript@3.7.x:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typescript@^3.6.4, typescript@^3.8.3:
   version "3.8.3"
@@ -33222,7 +33212,7 @@ underscore@1.9.1:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
-underscore@>1.4.4, "underscore@>= 1.3.1", underscore@>=1.8.3, underscore@^1.7.0, underscore@^1.8.3, underscore@^1.9.1:
+underscore@>1.4.4, "underscore@>= 1.3.1", underscore@^1.7.0, underscore@^1.8.3:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.2.tgz#0c8d6f536d6f378a5af264a72f7bec50feb7cf2f"
   integrity sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==


### PR DESCRIPTION
### Description
This fix bumps the contractkit typedoc version to 0.19.2 in order to try to fix some weird linking/formatting in the `developer-resources` section of the docs. This fix also changes `External Modules` to `Modules`.
Note: this also adds `readonly` in front of readonly function parameters and reformats some types.

### Tested
- Forked the monorepo and created a new gitbook for that which showed similar strikethrough formatting issues
- Bumped the package there which seemed to fix the formatting issues in docs
- Freshly cloned the repo + checked that building the repo works as before

