### PR TITLE
Move "Sending custom transactions" section of the docs

### DIFF
--- a/packages/docs/developer-resources/contractkit/contracts-wrappers-registry.md
+++ b/packages/docs/developer-resources/contractkit/contracts-wrappers-registry.md
@@ -99,42 +99,6 @@ The complete list is:
 - StableToken
 - Validators
 
-## Sending Custom Transactions
-
-Celo transaction object is not the same as Ethereum's. There are three new fields present:
-
-- feeCurrency (address of the ERC20 contract to use to pay for gas and the gateway fee)
-- gatewayFeeRecipient (coinbase address of the full serving the light client's trasactions)
-- gatewayFee (value paid to the gateway fee recipient, denominated in the fee currency)
-
-This means that using `web3.eth.sendTransaction` or `myContract.methods.transfer().send()` should be **avoided**.
-
-Instead, `kit` provides an utility method to send transaction in both scenarios. **If you use contract wrappers, there is no need to use this.**
-
-For a raw transaction:
-
-```ts
-const tx = kit.sendTransaction({
-  from: myAddress,
-  to: someAddress,
-  value: oneGold,
-})
-const hash = await tx.getHash()
-const receipt = await tx.waitReceipt()
-```
-
-When interacting with a web3 contract object:
-
-```ts
-const goldtoken = await kit._web3Contracts.getGoldToken()
-const oneGold = kit.web3.utils.toWei('1', 'ether')
-
-const txo = await goldtoken.methods.transfer(someAddress, oneGold)
-const tx = await kit.sendTransactionObject(txo, { from: myAddress })
-const hash = await tx.getHash()
-const receipt = await tx.waitReceipt()
-```
-
 ## Debugging
 
 If you need to debug `kit`, we use the well known [debug](https://github.com/visionmedia/debug) node library.

--- a/packages/docs/developer-resources/contractkit/usage.md
+++ b/packages/docs/developer-resources/contractkit/usage.md
@@ -25,7 +25,7 @@ let totalBalance = await kit.getTotalBalance(myAddress)
 
 ## Deploy a contract
 
-Deploying a contract with the default account already set. Simply send a transaction with no `to:` field. See more about [sending custom transactions](https://docs.celo.org/developer-guide/overview/introduction/contractkit/contracts-wrappers-registry#sending-custom-transactions). 
+Deploying a contract with the default account already set. Simply send a transaction with no `to:` field. See more about sending custom transactions below. 
 
 You can verify the deployment on the [Alfajores block explorer here](https://alfajores-blockscout.celo-testnet.org/). Wait for the receipt and log it to get the transaction details.
 
@@ -38,6 +38,42 @@ let tx = await kit.sendTransaction({
 
 let receipt = tx.waitReceipt()
 console.log(receipt)
+```
+
+## Sending Custom Transactions
+
+Celo transaction object is not the same as Ethereum's. There are three new fields present:
+
+- `feeCurrency` (address of the ERC20 contract to use to pay for gas and the gateway fee)
+- `gatewayFeeRecipient` (coinbase address of the full serving the light client's trasactions)
+- `gatewayFee` (value paid to the gateway fee recipient, denominated in the fee currency)
+
+This means that using `web3.eth.sendTransaction` or `myContract.methods.transfer().send()` should be **avoided**.
+
+Instead, `contractkit` provides an utility method to send transaction in both scenarios. **If you use contract wrappers, there is no need to use this.**
+
+For a raw transaction:
+
+```ts
+const tx = kit.sendTransaction({
+  from: myAddress,
+  to: someAddress,
+  value: oneGold,
+})
+const hash = await tx.getHash()
+const receipt = await tx.waitReceipt()
+```
+
+When interacting with a web3 contract object:
+
+```ts
+const goldtoken = await kit._web3Contracts.getGoldToken()
+const oneGold = kit.web3.utils.toWei('1', 'ether')
+
+const txo = await goldtoken.methods.transfer(someAddress, oneGold)
+const tx = await kit.sendTransactionObject(txo, { from: myAddress })
+const hash = await tx.getHash()
+const receipt = await tx.waitReceipt()
 ```
 
 ## Selling CELO only if the rate is favorable


### PR DESCRIPTION
### Description

Moved the "Sending cutsom Transactions" w/ contractkit section of the docs from being buried in `contracts-wrappers-registry.md` to `usage.md` to make it more visible.

### Other changes

none
