### PR TITLE
Transfer onwership once

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -77,7 +77,7 @@ contract MetaTransactionWallet is
    * @notice Transfers control of the wallet to a new signer.
    * @param _signer The address authorized to execute transactions via this wallet.
    */
-  function setSigner(address _signer) public onlyOwner {
+  function setSigner(address _signer) external onlyOwner {
     _setSigner(_signer);
   }
 

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -64,8 +64,7 @@ contract MetaTransactionWallet is
    * @param _signer The address authorized to execute transactions via this wallet.
    */
   function initialize(address _signer) external initializer {
-    _transferOwnership(msg.sender);
-    setSigner(_signer);
+    _setSigner(_signer);
     setEip712DomainSeparator();
     // MetaTransactionWallet owns itself, which necessitates that all onlyOwner functions
     // be called via executeTransaction or executeMetaTransaction.
@@ -79,9 +78,7 @@ contract MetaTransactionWallet is
    * @param _signer The address authorized to execute transactions via this wallet.
    */
   function setSigner(address _signer) public onlyOwner {
-    require(_signer != address(0), "cannot assign zero address as signer");
-    signer = _signer;
-    emit SignerSet(signer);
+    _setSigner(_signer);
   }
 
   /**
@@ -277,5 +274,11 @@ contract MetaTransactionWallet is
       sliced = data.slice(start, length);
     }
     return sliced;
+  }
+
+  function _setSigner(address _signer) internal {
+    require(_signer != address(0), "cannot assign zero address as signer");
+    signer = _signer;
+    emit SignerSet(signer);
   }
 }

--- a/packages/protocol/test/common/metatransactionwallet.ts
+++ b/packages/protocol/test/common/metatransactionwallet.ts
@@ -129,7 +129,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
     })
 
     it('should emit the SignerSet event', () => {
-      assertLogMatches2(initializeRes.logs[1], {
+      assertLogMatches2(initializeRes.logs[0], {
         event: 'SignerSet',
         args: {
           signer,
@@ -138,7 +138,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
     })
 
     it('should emit the EIP712DomainSeparatorSet event', () => {
-      assertLogMatches2(initializeRes.logs[2], {
+      assertLogMatches2(initializeRes.logs[1], {
         event: 'EIP712DomainSeparatorSet',
         args: {
           eip712DomainSeparator: getDomainDigest(wallet.address),
@@ -147,7 +147,7 @@ contract('MetaTransactionWallet', (accounts: string[]) => {
     })
 
     it('should emit the OwnershipTransferred event', () => {
-      assertLogMatches2(initializeRes.logs[3], {
+      assertLogMatches2(initializeRes.logs[2], {
         event: 'OwnershipTransferred',
         args: {
           previousOwner: accounts[0],


### PR DESCRIPTION
### Description

Gas was being wasted by transferring ownership twice in a MetaTransactionWallet's initializer.

### Other changes

Tests adjusted.

### Tested

Unit tests pass.

### Related issues

* Fixes https://github.com/celo-org/celo-labs/issues/689