### PR TITLE
Change visibility from public to external

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -55,7 +55,7 @@ contract MetaTransactionWallet is
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @return The storage, major, minor, and patch version of the contract.
    */
-  function getVersionNumber() public pure returns (uint256, uint256, uint256, uint256) {
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 1);
   }
 
@@ -146,9 +146,9 @@ contract MetaTransactionWallet is
   function getMetaTransactionDigest(
     address destination,
     uint256 value,
-    bytes memory data,
+    bytes calldata data,
     uint256 _nonce
-  ) public view returns (bytes32) {
+  ) external view returns (bytes32) {
     bytes32 structHash = _getMetaTransactionStructHash(destination, value, data, _nonce);
     return Signatures.toEthSignedTypedDataHash(eip712DomainSeparator, structHash);
   }

--- a/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
@@ -38,7 +38,7 @@ contract MetaTransactionWalletDeployer is
      * @notice Returns the storage, major, minor, and patch version of the contract.
      * @return The storage, major, minor, and patch version of the contract.
      */
-  function getVersionNumber() public pure returns (uint256, uint256, uint256, uint256) {
+  function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);
   }
 

--- a/packages/protocol/lib/compatibility/ast-code.ts
+++ b/packages/protocol/lib/compatibility/ast-code.ts
@@ -67,7 +67,6 @@ export interface Change {
  */
 export interface ChangeVisitor<T> {
   onMethodMutability(change: MethodMutabilityChange): T
-  onMethodParameters(change: MethodParametersChange): T
   onMethodReturn(change: MethodReturnChange): T
   onMethodVisibility(change: MethodVisibilityChange): T
   onMethodAdded(change: MethodAddedChange): T
@@ -214,17 +213,6 @@ export class MethodMutabilityChange extends MethodValueChange {
 }
 
 /**
- * The input parameters of a method changed. Since the input parameters
- * are used as the id of a method, this should probably never appear.
- */
-export class MethodParametersChange extends MethodValueChange {
-  type = "MethodParameters"
-  accept<T>(visitor: ChangeVisitor<T>): T {
-    return visitor.onMethodParameters(this)
-  }
-}
-
-/**
  * The return parameters of a method changed.
  */
 export class MethodReturnChange extends MethodValueChange {
@@ -309,12 +297,6 @@ function checkMethodCompatibility(contract: string, m1: Method, m2: Method): AST
   // Visibility changes
   if (m1.visibility !== m2.visibility) {
     report.push(new MethodVisibilityChange(contract, signature, m1.visibility, m2.visibility))
-  }
-  // Parameters signature (types are already equal, but this will check for storage locations)
-  const par1 = parametersSignature(m1.parameters.parameters)
-  const par2 = parametersSignature(m2.parameters.parameters)
-  if (par1 !== par2) {
-    report.push(new MethodParametersChange(contract, signature, par1, par2))
   }
 
   // Return parameter changes

--- a/packages/protocol/lib/compatibility/categorizer.ts
+++ b/packages/protocol/lib/compatibility/categorizer.ts
@@ -2,7 +2,7 @@ import {
   Change,
   ChangeVisitor,
   ContractKindChange, DeployedBytecodeChange, MethodAddedChange,
-  MethodMutabilityChange, MethodParametersChange, MethodRemovedChange,
+  MethodMutabilityChange, MethodRemovedChange,
   MethodReturnChange, MethodVisibilityChange, NewContractChange
 } from '@celo/protocol/lib/compatibility/ast-code'
 
@@ -40,7 +40,6 @@ export function categorize(changes: Change[], categorizer: Categorizer): Change[
 export class DefaultCategorizer implements Categorizer {
   onNewContract = (_change: NewContractChange): ChangeType => ChangeType.Major
   onMethodMutability = (_change: MethodMutabilityChange): ChangeType => ChangeType.Major
-  onMethodParameters = (_change: MethodParametersChange): ChangeType => ChangeType.Major
   onMethodReturn = (_change: MethodReturnChange): ChangeType => ChangeType.Major
   onMethodRemoved = (_change: MethodRemovedChange): ChangeType => ChangeType.Major
   onContractKind = (_change: ContractKindChange): ChangeType => ChangeType.Major

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -48,6 +48,7 @@ if [ ! -z "$REPORT" ]; then
 fi
 
 git checkout -
+yarn build:ts
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -33,6 +33,7 @@ yarn build
 rm -rf $BUILD_DIR_1 && mkdir -p $BUILD_DIR_1
 mv build/contracts $BUILD_DIR_1
 
+git checkout -
 
 BUILD_DIR_2=$(echo build/$(echo $NEW_BRANCH | sed -e 's/\//_/g'))
 git checkout $NEW_BRANCH
@@ -45,6 +46,8 @@ REPORT_FLAG=""
 if [ ! -z "$REPORT" ]; then
   REPORT_FLAG="--output_file "$REPORT
 fi
+
+git checkout -
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.


### PR DESCRIPTION
### Description

Some functions previously declared `public` can be declared `external`, which is slightly more gas efficient.

### Tested

Unit tests still pass.

### Related issues

* Fixes https://github.com/celo-org/celo-labs/issues/690