### PR TITLE
Remove the MethodParameter check

### DIFF
--- a/packages/protocol/lib/compatibility/ast-code.ts
+++ b/packages/protocol/lib/compatibility/ast-code.ts
@@ -2,8 +2,8 @@ import { stripMetadata } from '@celo/protocol/lib/bytecode'
 import {
   Change,
   ContractKindChange, DeployedBytecodeChange, MethodAddedChange,
-  MethodMutabilityChange, MethodParametersChange, MethodRemovedChange,
-  MethodReturnChange, MethodVisibilityChange, NewContractChange
+  MethodMutabilityChange, MethodRemovedChange, MethodReturnChange,
+  MethodVisibilityChange, NewContractChange
 } from '@celo/protocol/lib/compatibility/change'
 import { makeZContract } from '@celo/protocol/lib/compatibility/internal'
 import {
@@ -132,12 +132,6 @@ function checkMethodCompatibility(contract: string, m1: Method, m2: Method): AST
   // Visibility changes
   if (m1.visibility !== m2.visibility) {
     report.push(new MethodVisibilityChange(contract, signature, m1.visibility, m2.visibility))
-  }
-  // Parameters signature (types are already equal, but this will check for storage locations)
-  const par1 = parametersSignature(m1.parameters.parameters)
-  const par2 = parametersSignature(m2.parameters.parameters)
-  if (par1 !== par2) {
-    report.push(new MethodParametersChange(contract, signature, par1, par2))
   }
 
   // Return parameter changes

--- a/packages/protocol/lib/compatibility/categorizer.ts
+++ b/packages/protocol/lib/compatibility/categorizer.ts
@@ -2,8 +2,8 @@ import {
   Change,
   ChangeVisitor,
   ContractKindChange, DeployedBytecodeChange, LibraryLinkingChange,
-  MethodAddedChange, MethodMutabilityChange, MethodParametersChange,
-  MethodRemovedChange, MethodReturnChange, MethodVisibilityChange, NewContractChange
+  MethodAddedChange, MethodMutabilityChange, MethodRemovedChange,
+  MethodReturnChange, MethodVisibilityChange, NewContractChange
 } from '@celo/protocol/lib/compatibility/change'
 
 /**
@@ -40,7 +40,6 @@ export function categorize(changes: Change[], categorizer: Categorizer): Change[
 export class DefaultCategorizer implements Categorizer {
   onNewContract = (_change: NewContractChange): ChangeType => ChangeType.Major
   onMethodMutability = (_change: MethodMutabilityChange): ChangeType => ChangeType.Major
-  onMethodParameters = (_change: MethodParametersChange): ChangeType => ChangeType.Major
   onMethodReturn = (_change: MethodReturnChange): ChangeType => ChangeType.Major
   onMethodRemoved = (_change: MethodRemovedChange): ChangeType => ChangeType.Major
   onContractKind = (_change: ContractKindChange): ChangeType => ChangeType.Major

--- a/packages/protocol/lib/compatibility/change.ts
+++ b/packages/protocol/lib/compatibility/change.ts
@@ -12,7 +12,6 @@ export interface Change {
  */
 export interface ChangeVisitor<T> {
   onMethodMutability(change: MethodMutabilityChange): T
-  onMethodParameters(change: MethodParametersChange): T
   onMethodReturn(change: MethodReturnChange): T
   onMethodVisibility(change: MethodVisibilityChange): T
   onMethodAdded(change: MethodAddedChange): T
@@ -156,17 +155,6 @@ export class MethodMutabilityChange extends MethodValueChange {
   type = "MethodMutability"
   accept<T>(visitor: ChangeVisitor<T>): T {
     return visitor.onMethodMutability(this)
-  }
-}
-
-/**
- * The input parameters of a method changed. Since the input parameters
- * are used as the id of a method, this should probably never appear.
- */
-export class MethodParametersChange extends MethodValueChange {
-  type = "MethodParameters"
-  accept<T>(visitor: ChangeVisitor<T>): T {
-    return visitor.onMethodParameters(this)
   }
 }
 


### PR DESCRIPTION
### Description

Previously the version checker checked whether input parameters of a function remain exactly the same between versions, otherwise reporting a major version number change. It also separately asserts that the function signature doesn't change. If the function signature doesn't change, the only thing that could change in the actual input parameters is data locations (e.g. going from `memory` to `calldata`), but this doesn't affect the external API for callers of the contract, so actually a version change need not be reported in this case.

As an example of where this is relevant, consider a function `foo` that goes from

    function foo(bytes memory x) public { ... }

to 

    function foo(bytes calldata x) external { ... }

Previously, the version checker would report a major version number change, which should typically imply a backwards compatibility breaking change in the API. In fact, backwards compatibility is not broken, `foo` can be called the same way by external users as before.

### Tested

This came up while working on #5944. Before this change, the protocol-test-common CI check fails. With this change, `yarn check-versions` succeeds.