### PR TITLE
[Wallet] Fix download link on invite text in spanish

### DIFF
--- a/packages/mobile/locales/es-419/sendFlow7.json
+++ b/packages/mobile/locales/es-419/sendFlow7.json
@@ -47,7 +47,7 @@
   "mobileNumber": "Número de teléfono",
   "walletAddress": "Dirección del Monedero",
   "inviteWithoutPayment": "Hola! Estoy usando {{appName}} para enviar dinero alrededor del mundo. Es fácil de usar y me gustaría invitarte a probarla con este link: {{link}}",
-  "inviteWithEscrowedPayment": "Hola! Estoy usando {{appName}} para enviar dinero alrededor del mundo. Acabo de enviarte {{amount}} Celo Dólares. Puedes descargar la App {{appName}} y usar tus Celo Dólares usando este link: {{link}.",
+  "inviteWithEscrowedPayment": "Hola! Estoy usando {{appName}} para enviar dinero alrededor del mundo. Acabo de enviarte {{amount}} Celo Dólares. Puedes descargar la App {{appName}} y usar tus Celo Dólares usando este link: {{link}}",
   "inviteSent": "Código de invitación enviado!",
   "inviteFailed": "Falló el envío de la invitación",
   "loadingContacts": "Encontrando tus contactos",


### PR DESCRIPTION
### Description

There was a `}` missing in a Spanish text.

### Tested

Manually

### Related issues

- Fixes #5972
