### PR TITLE
Added change cause annotation to blockscout deployments

### DIFF
--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import { execCmdWithExitOnFailure } from './cmd-utils'
 import { envVar, fetchEnv, fetchEnvOrFallback, isVmBased } from './env-utils'
+import { getCurrentGcloudAccount } from './gcloud_utils'
 import { installGenericHelmChart, removeGenericHelmChart } from './helm_deploy'
 import { outputIncludes } from './utils'
 import { getInternalTxNodeLoadBalancerIP } from './vm-testnet-utils'
@@ -72,6 +73,7 @@ async function helmParameters(
   blockscoutDBPassword: string,
   blockscoutDBConnectionName: string
 ) {
+  const currentGcloudAccount = await getCurrentGcloudAccount()
   const privateNodes = parseInt(fetchEnv(envVar.PRIVATE_TX_NODES), 10)
   const useMetadataCrawler = fetchEnvOrFallback(
     envVar.BLOCKSCOUT_METADATA_CRAWLER_IMAGE_REPOSITORY,
@@ -79,6 +81,7 @@ async function helmParameters(
   )
   const params = [
     `--set domain.name=${fetchEnv(envVar.CLUSTER_DOMAIN_NAME)}`,
+    `--set blockscout.deployment.account="${currentGcloudAccount}"`,
     `--set blockscout.image.repository=${fetchEnv(envVar.BLOCKSCOUT_DOCKER_IMAGE_REPOSITORY)}`,
     `--set blockscout.image.tag=${fetchEnv(envVar.BLOCKSCOUT_DOCKER_IMAGE_TAG)}`,
     `--set blockscout.db.username=${blockscoutDBUsername}`,

--- a/packages/celotool/src/lib/gcloud_utils.ts
+++ b/packages/celotool/src/lib/gcloud_utils.ts
@@ -1,11 +1,12 @@
 import { execCmd } from './cmd-utils'
 import { envVar, fetchEnv } from './env-utils'
 
-async function getCurrentGcloudAccount() {
+export async function getCurrentGcloudAccount() {
   const [output] = await execCmd('gcloud config get-value account')
   if (output.trim() === '') {
     throw new Error('No Gcloud account set')
   }
+  return output.trim()
 }
 
 async function ensureGcloudInstalled() {

--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -9,6 +9,13 @@ heritage: {{ .Release.Service }}
 {{- end -}}
 
 {{- /*
+Defines common annotations across all blockscout components.
+*/ -}}
+{{- define "celo.blockscout.annotations" -}}
+kubernetes.io/change-cause: Deployed {{ .Values.blockscout.image.tag }} by {{ .Values.blockscout.deployment.account }}
+{{- end -}}
+
+{{- /*
 Defines the CloudSQL proxy container that terminates
 after termination of the main container.
 Should be included as the last container as it contains

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
     component: blockscout-api
+  annotations:
+    {{- include "celo.blockscout.annotations" . | nindent 4 }}
 spec:
   strategy:
     type: RollingUpdate

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
     component: blockscout-indexer
+  annotations:
+    {{- include "celo.blockscout.annotations" . | nindent 4 }}
 spec:
   strategy:
     type: RollingUpdate

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
     component: blockscout-web
+  annotations:
+    {{- include "celo.blockscout.annotations" . | nindent 4 }}
 spec:
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
### Description

Adds the change cause annotation to blockscout deployments so it's visible in the history of rollouts what version was deployed.
```
$ k rollout history deployment baklava-blockscout3-indexer
```
```
deployment.apps/baklava-blockscout3-indexer
REVISION  CHANGE-CAUSE
...
67        <none>
68        Deployed 330e57bb88472a655cb1b67d70131d8ecef56e49 by valentin@...
```

### Tested

Tested on baklava (blockscout3).