### PR TITLE
Add contractkit placeholder directory

### DIFF
--- a/packages/contractkit/README.md
+++ b/packages/contractkit/README.md
@@ -1,0 +1,5 @@
+This directory has been deprecated.
+
+ContractKit was split into 15 packages and is now located under [`/packages/sdk`](https://github.com/celo-org/celo-monorepo/tree/master/packages/sdk)
+
+See [#4790](https://github.com/celo-org/celo-monorepo/pull/4790) for details.

--- a/packages/contractkit/README.md
+++ b/packages/contractkit/README.md
@@ -1,5 +1,5 @@
 This directory has been deprecated.
 
-ContractKit was split into 15 packages and is now located under [`/packages/sdk`](https://github.com/celo-org/celo-monorepo/tree/master/packages/sdk)
+ContractKit was split into 15 packages and is now located under [`/packages/sdk/contractkit`](https://github.com/celo-org/celo-monorepo/tree/master/packages/sdk/contractkit)
 
 See [#4790](https://github.com/celo-org/celo-monorepo/pull/4790) for details.


### PR DESCRIPTION
### Description

External links pointing to the old location of contractkit return a 404. Adding this directory back to catch those until majority of links can be updated.

### Other changes

N/A

### Tested

N/A. No code changes.

### Related issues

N/A

### Backwards compatibility

N/A