### PR TITLE
remove unnecessary check in vote function

### DIFF
--- a/packages/sdk/contractkit/src/wrappers/Election.ts
+++ b/packages/sdk/contractkit/src/wrappers/Election.ts
@@ -386,10 +386,6 @@ export class ElectionWrapper extends BaseWrapper<Election> {
    * @param value The amount of gold to use to vote.
    */
   async vote(validatorGroup: Address, value: BigNumber): Promise<CeloTransactionObject<boolean>> {
-    if (this.kit.connection.defaultAccount == null) {
-      throw new Error(`missing kit.defaultAccount`)
-    }
-
     const { lesser, greater } = await this.findLesserAndGreaterAfterVote(validatorGroup, value)
 
     return toTransactionObject(


### PR DESCRIPTION
### Description

Creating vote transaction object shouldn't require setting the defaultAccount. And as far as I can tell it doesn't actually require it.

### Other changes


### Tested

Will test with pull request.

### Related issues

### Backwards compatibility

N/A