### PR TITLE
[Wallet] Use names and pictures from known addresses

### DIFF
--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -256,6 +256,37 @@ export function appRemoteFeatureFlagChannel() {
   })
 }
 
+export async function knownAddressesChannel() {
+  if (!FIREBASE_ENABLED) {
+    return null
+  }
+
+  const errorCallback = (error: Error) => {
+    Logger.warn(TAG, error.toString())
+  }
+
+  return eventChannel((emit: any) => {
+    const emitter = (snapshot: FirebaseDatabaseTypes.DataSnapshot) => {
+      const addresses = snapshot.val()
+      Logger.debug(`Got known addresses: ${JSON.stringify(addresses)}`)
+      emit(addresses)
+    }
+    const cancel = () => {
+      firebase
+        .database()
+        .ref('addressesExtraInfo')
+        .off(VALUE_CHANGE_HOOK, emitter)
+    }
+
+    firebase
+      .database()
+      .ref('addressesExtraInfo')
+      .on(VALUE_CHANGE_HOOK, emitter, errorCallback)
+
+    return cancel
+  })
+}
+
 export async function setUserLanguage(address: string, language: string) {
   try {
     Logger.info(TAG, `Setting language selection for user ${address}`)

--- a/packages/mobile/src/identity/actions.ts
+++ b/packages/mobile/src/identity/actions.ts
@@ -1,6 +1,7 @@
 import { normalizeAddressWith0x } from '@celo/base'
 import { E164Number } from '@celo/utils/src/io'
 import {
+  AddressToDisplayNameType,
   AddressToE164NumberType,
   AddressValidationType,
   E164NumberToAddressType,
@@ -37,6 +38,7 @@ export enum Actions {
   UPDATE_E164_PHONE_NUMBER_ADDRESSES = 'IDENTITY/UPDATE_E164_PHONE_NUMBER_ADDRESSES',
   UPDATE_WALLET_TO_ACCOUNT_ADDRESS = 'UPDATE_WALLET_TO_ACCOUNT_ADDRESS',
   UPDATE_E164_PHONE_NUMBER_SALT = 'IDENTITY/UPDATE_E164_PHONE_NUMBER_SALT',
+  UPDATE_KNOWN_ADDRESSES = 'IDENTITY/UPDATE_KNOWN_ADDRESSES',
   FETCH_ADDRESSES_AND_VALIDATION_STATUS = 'IDENTITY/FETCH_ADDRESSES_AND_VALIDATION_STATUS',
   END_FETCHING_ADDRESSES = 'IDENTITY/END_FETCHING_ADDRESSES',
   IMPORT_CONTACTS = 'IDENTITY/IMPORT_CONTACTS',
@@ -172,6 +174,11 @@ export interface UpdateWalletToAccountAddressAction {
 export interface UpdateE164PhoneNumberSaltAction {
   type: Actions.UPDATE_E164_PHONE_NUMBER_SALT
   e164NumberToSalt: E164NumberToSaltType
+}
+
+export interface UpdateKnownAddressesAction {
+  type: Actions.UPDATE_KNOWN_ADDRESSES
+  knownAddresses: AddressToDisplayNameType
 }
 
 export interface FetchAddressesAndValidateAction {
@@ -318,6 +325,7 @@ export type ActionTypes =
   | UpdateE164PhoneNumberAddressesAction
   | UpdateWalletToAccountAddressAction
   | UpdateE164PhoneNumberSaltAction
+  | UpdateKnownAddressesAction
   | ImportContactsAction
   | UpdateImportContactProgress
   | EndImportContactsAction
@@ -500,6 +508,13 @@ export const updateE164PhoneNumberSalts = (
 ): UpdateE164PhoneNumberSaltAction => ({
   type: Actions.UPDATE_E164_PHONE_NUMBER_SALT,
   e164NumberToSalt,
+})
+
+export const updateKnownAddresses = (
+  addresses: AddressToDisplayNameType
+): UpdateKnownAddressesAction => ({
+  type: Actions.UPDATE_KNOWN_ADDRESSES,
+  knownAddresses: addresses,
 })
 
 export const importContacts = (doMatchmaking: boolean = false): ImportContactsAction => ({

--- a/packages/mobile/src/identity/reducer.ts
+++ b/packages/mobile/src/identity/reducer.ts
@@ -46,8 +46,13 @@ export interface AddressToDataEncryptionKeyType {
   [address: string]: string | null // null means no DEK registered
 }
 
+export interface AddressInfoToDisplay {
+  name: string
+  picture: string | null
+}
+
 export interface AddressToDisplayNameType {
-  [address: string]: string | undefined
+  [address: string]: AddressInfoToDisplay | undefined
 }
 
 export interface WalletToAccountAddressType {
@@ -392,11 +397,21 @@ export const reducer = (
       if (!action.recipient.address) {
         return state
       }
+      action = {
+        type: Actions.UPDATE_KNOWN_ADDRESSES,
+        knownAddresses: {
+          [action.recipient.address]: {
+            name: action.recipient.displayName,
+            picture: null,
+          },
+        },
+      }
+    case Actions.UPDATE_KNOWN_ADDRESSES:
       return {
         ...state,
         addressToDisplayName: {
           ...state.addressToDisplayName,
-          [action.recipient.address]: action.recipient.displayName,
+          ...action.knownAddresses,
         },
       }
     case Actions.IMPORT_CONTACTS:

--- a/packages/mobile/src/identity/reducer.ts
+++ b/packages/mobile/src/identity/reducer.ts
@@ -48,7 +48,7 @@ export interface AddressToDataEncryptionKeyType {
 
 export interface AddressInfoToDisplay {
   name: string
-  picture: string | null
+  imageUrl: string | null
 }
 
 export interface AddressToDisplayNameType {
@@ -402,7 +402,7 @@ export const reducer = (
         knownAddresses: {
           [action.recipient.address]: {
             name: action.recipient.displayName,
-            picture: null,
+            imageUrl: null,
           },
         },
       }

--- a/packages/mobile/src/redux/migrations.test.ts
+++ b/packages/mobile/src/redux/migrations.test.ts
@@ -118,6 +118,6 @@ describe('Redux persist migrations', () => {
     const migratedSchema = migrations[7](v6Stub)
     expect(Object.keys(migratedSchema.identity.addressToDisplayName).length).toEqual(1)
     expect(migratedSchema.identity.addressToDisplayName[mockAddress].name).toEqual(mockName)
-    expect(migratedSchema.identity.addressToDisplayName[mockAddress].picture).toBeNull()
+    expect(migratedSchema.identity.addressToDisplayName[mockAddress].imageUrl).toBeNull()
   })
 })

--- a/packages/mobile/src/redux/migrations.test.ts
+++ b/packages/mobile/src/redux/migrations.test.ts
@@ -103,4 +103,21 @@ describe('Redux persist migrations', () => {
     const migratedSchema = migrations[6](v5Stub)
     expect(migratedSchema.invite.redeemComplete).toBe(true)
   })
+
+  it('works for v6 to v7', () => {
+    const mockAddress = '0x00000000000000000000'
+    const mockName = 'Mock Name'
+
+    const v6Stub = {
+      identity: {
+        addressToDisplayName: {
+          [mockAddress]: mockName,
+        },
+      },
+    }
+    const migratedSchema = migrations[7](v6Stub)
+    expect(Object.keys(migratedSchema.identity.addressToDisplayName).length).toEqual(1)
+    expect(migratedSchema.identity.addressToDisplayName[mockAddress].name).toEqual(mockName)
+    expect(migratedSchema.identity.addressToDisplayName[mockAddress].picture).toBeNull()
+  })
 })

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -1,3 +1,5 @@
+import { AddressToDisplayNameType } from 'src/identity/reducer'
+
 export const migrations = {
   0: (state: any) => {
     const e164NumberToAddressOld = state.identity.e164NumberToAddress
@@ -88,6 +90,25 @@ export const migrations = {
       invite: {
         ...state.invite,
         redeemComplete: !!state.web3.account,
+      },
+    }
+  },
+  7: (state: any) => {
+    const newAddressToDisplayName = Object.keys(state.identity.addressToDisplayName).reduce(
+      (newMapping: AddressToDisplayNameType, address: string) => {
+        newMapping[address] = {
+          name: state.identity.addressToDisplayName[address],
+          picture: null,
+        }
+        return newMapping
+      },
+      {}
+    )
+    return {
+      ...state,
+      identity: {
+        ...state.identity,
+        addressToDisplayName: newAddressToDisplayName,
       },
     }
   },

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -98,7 +98,7 @@ export const migrations = {
       (newMapping: AddressToDisplayNameType, address: string) => {
         newMapping[address] = {
           name: state.identity.addressToDisplayName[address],
-          picture: null,
+          imageUrl: null,
         }
         return newMapping
       },

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -9,7 +9,7 @@ import { rootSaga } from 'src/redux/sagas'
 
 const persistConfig: any = {
   key: 'root',
-  version: 6, // default is -1, increment as we make migrations
+  version: 7, // default is -1, increment as we make migrations
   storage: AsyncStorage,
   blacklist: ['home', 'geth', 'networkInfo', 'alert', 'fees', 'recipients', 'imports'],
   stateReconciler: autoMergeLevel2,

--- a/packages/mobile/src/transactions/TransferAvatars.tsx
+++ b/packages/mobile/src/transactions/TransferAvatars.tsx
@@ -1,8 +1,10 @@
 import ContactCircle from '@celo/react-components/components/ContactCircle'
 import React from 'react'
 import { StyleSheet, View } from 'react-native'
+import { useSelector } from 'react-redux'
 import ContactCircleSelf from 'src/components/ContactCircleSelf'
 import CircleArrowIcon from 'src/icons/CircleArrowIcon'
+import { addressToDisplayNameSelector } from 'src/identity/reducer'
 import { getRecipientThumbnail, Recipient } from 'src/recipients/recipient'
 
 const AVATAR_SIZE = 40
@@ -14,12 +16,15 @@ interface Props {
 }
 
 export default function TransferAvatars({ type, address, recipient }: Props) {
+  const addressToDisplayName = useSelector(addressToDisplayNameSelector)
+  const userPicture = addressToDisplayName[address || '']?.picture
+
   const userAvatar = (
     <ContactCircle
       name={recipient ? recipient.displayName : null}
       address={address}
       size={AVATAR_SIZE}
-      thumbnailPath={getRecipientThumbnail(recipient)}
+      thumbnailPath={userPicture || getRecipientThumbnail(recipient)}
     />
   )
 

--- a/packages/mobile/src/transactions/TransferAvatars.tsx
+++ b/packages/mobile/src/transactions/TransferAvatars.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 export default function TransferAvatars({ type, address, recipient }: Props) {
   const addressToDisplayName = useSelector(addressToDisplayNameSelector)
-  const userPicture = addressToDisplayName[address || '']?.picture
+  const userPicture = addressToDisplayName[address || '']?.imageUrl
 
   const userAvatar = (
     <ContactCircle

--- a/packages/mobile/src/transactions/TransferFeedIcon.tsx
+++ b/packages/mobile/src/transactions/TransferFeedIcon.tsx
@@ -12,11 +12,11 @@ interface Props {
   type: TokenTransactionType
   recipient?: Recipient
   address?: string
-  picture?: string | null
+  imageUrl?: string | null
 }
 
 export default function TransferFeedIcon(props: Props) {
-  const { recipient, address, type, picture } = props
+  const { recipient, address, type, imageUrl } = props
 
   switch (type) {
     case TokenTransactionType.VerificationFee: // fallthrough
@@ -43,7 +43,7 @@ export default function TransferFeedIcon(props: Props) {
           address={address}
           name={recipient ? recipient.displayName : null}
           size={AVATAR_SIZE}
-          thumbnailPath={picture || getRecipientThumbnail(recipient)}
+          thumbnailPath={imageUrl || getRecipientThumbnail(recipient)}
         />
       )
     }

--- a/packages/mobile/src/transactions/TransferFeedIcon.tsx
+++ b/packages/mobile/src/transactions/TransferFeedIcon.tsx
@@ -12,10 +12,11 @@ interface Props {
   type: TokenTransactionType
   recipient?: Recipient
   address?: string
+  picture?: string | null
 }
 
 export default function TransferFeedIcon(props: Props) {
-  const { recipient, address, type } = props
+  const { recipient, address, type, picture } = props
 
   switch (type) {
     case TokenTransactionType.VerificationFee: // fallthrough
@@ -42,7 +43,7 @@ export default function TransferFeedIcon(props: Props) {
           address={address}
           name={recipient ? recipient.displayName : null}
           size={AVATAR_SIZE}
-          thumbnailPath={getRecipientThumbnail(recipient)}
+          thumbnailPath={picture || getRecipientThumbnail(recipient)}
         />
       )
     }

--- a/packages/mobile/src/transactions/TransferFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.test.tsx
@@ -429,7 +429,9 @@ describe('transfer feed item renders correctly', () => {
         store={createMockStore({
           identity: {
             addressToDisplayName: {
-              [mockAccount]: contactName,
+              [mockAccount]: {
+                name: contactName,
+              },
             },
           },
         })}
@@ -447,7 +449,9 @@ describe('transfer feed item renders correctly', () => {
         store={createMockStore({
           identity: {
             addressToDisplayName: {
-              [mockAccount2]: contactName,
+              [mockAccount2]: {
+                name: contactName,
+              },
             },
           },
         })}

--- a/packages/mobile/src/transactions/TransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.tsx
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import * as React from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { HomeEvents } from 'src/analytics/Events'
@@ -94,6 +94,7 @@ export function TransferFeedItem(props: Props) {
     timestamp,
     invitees
   )
+  const picture = addressToDisplayName[address]?.picture ?? null
 
   return (
     <TransactionFeedItem
@@ -101,7 +102,9 @@ export function TransferFeedItem(props: Props) {
       amount={amount}
       title={title}
       info={info}
-      icon={<TransferFeedIcon type={type} recipient={recipient} address={address} />}
+      icon={
+        <TransferFeedIcon type={type} recipient={recipient} address={address} picture={picture} />
+      }
       timestamp={timestamp}
       status={status}
       onPress={onPress}

--- a/packages/mobile/src/transactions/TransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.tsx
@@ -94,7 +94,7 @@ export function TransferFeedItem(props: Props) {
     timestamp,
     invitees
   )
-  const picture = addressToDisplayName[address]?.picture ?? null
+  const imageUrl = addressToDisplayName[address]?.imageUrl ?? null
 
   return (
     <TransactionFeedItem
@@ -103,7 +103,7 @@ export function TransferFeedItem(props: Props) {
       title={title}
       info={info}
       icon={
-        <TransferFeedIcon type={type} recipient={recipient} address={address} picture={picture} />
+        <TransferFeedIcon type={type} recipient={recipient} address={address} imageUrl={imageUrl} />
       }
       timestamp={timestamp}
       status={status}

--- a/packages/mobile/src/transactions/UserSection.tsx
+++ b/packages/mobile/src/transactions/UserSection.tsx
@@ -7,14 +7,24 @@ import { getDisplayNumberInternational } from '@celo/utils/src/phoneNumbers'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LayoutAnimation, StyleSheet, Text, View } from 'react-native'
+import { useSelector } from 'react-redux'
 import AccountNumber from 'src/components/AccountNumber'
 import { Namespaces } from 'src/i18n'
+import { addressToDisplayNameSelector } from 'src/identity/reducer'
 import { Screens } from 'src/navigator/Screens'
 import { Recipient } from 'src/recipients/recipient'
 
-function getDisplayName(recipient?: Recipient, e164Number?: string, address?: string) {
+function getDisplayName(
+  recipient?: Recipient,
+  cachedName?: string,
+  e164Number?: string,
+  address?: string
+) {
   if (recipient && recipient.displayName) {
     return recipient.displayName
+  }
+  if (cachedName) {
+    return cachedName
   }
   const number = getDisplayNumber(e164Number, recipient)
   if (number) {
@@ -57,12 +67,15 @@ export default function UserSection({
   const { t } = useTranslation(Namespaces.sendFlow7)
   const [expanded, setExpanded] = useState(addressHasChanged)
 
+  const addressToDisplayName = useSelector(addressToDisplayNameSelector)
+  const userName = addressToDisplayName[address || '']?.name
+
   const toggleExpanded = () => {
     LayoutAnimation.easeInEaseOut()
     setExpanded(!expanded)
   }
 
-  const displayName = getDisplayName(recipient, e164PhoneNumber, address)
+  const displayName = getDisplayName(recipient, userName, e164PhoneNumber, address)
   const displayNumber = getDisplayNumber(e164PhoneNumber, recipient)
   const e164Number = displayName !== displayNumber ? displayNumber : undefined
 

--- a/packages/mobile/src/transactions/transferFeedUtils.ts
+++ b/packages/mobile/src/transactions/transferFeedUtils.ts
@@ -90,7 +90,8 @@ export function getTransferFeedParams(
     timestamp,
     invitees
   )
-  const nameOrNumber = recipient?.displayName || addressToDisplayName[address] || e164PhoneNumber
+  const nameOrNumber =
+    recipient?.displayName || addressToDisplayName[address]?.name || e164PhoneNumber
   const comment = getDecryptedTransferFeedComment(rawComment, commentKey, type)
 
   let title, info


### PR DESCRIPTION
### Description

CIP-8 work will probably override this, but we want to be able to see names and pictures for known addresses such as Simplex purchases or the cUSD incentive program.

We are saving these names and pictures on Firebase and showing them if the address found on Firebase matches any addresses on the transaction feed.

### Tested

On simulator:
<img width="322" alt="Screen Shot 2020-12-10 at 02 56 39" src="https://user-images.githubusercontent.com/6062888/101730284-807c4580-3a98-11eb-84a5-62260a6eb357.png">
<img width="359" alt="Screen Shot 2020-12-10 at 03 33 02" src="https://user-images.githubusercontent.com/6062888/101730290-82de9f80-3a98-11eb-81a5-22df5d5fc018.png">


### Related issues

- Fixes #6175

### Backwards compatibility

Previous versions of the app won't see name and pictures but nothing should break either.