### PR TITLE
Replenish Quota Fix

### DIFF
--- a/packages/phone-number-privacy/common/src/test/utils.ts
+++ b/packages/phone-number-privacy/common/src/test/utils.ts
@@ -79,7 +79,7 @@ function uint8ArrayToBase64(bytes: Uint8Array) {
 export async function replenishQuota(account: string, contractKit: any) {
   const goldToken = await contractKit.contracts.getGoldToken()
   const selfTransferTx = goldToken.transfer(account, 1)
-  await selfTransferTx.sendAndWaitForReceipt()
+  await selfTransferTx.sendAndWaitForReceipt({ from: account })
 }
 
 export async function registerWalletAddress(


### PR DESCRIPTION
### Description

Force the `from` field to be specified. In the case that the default account is not set, the call fails with:
> No "from" address specified in neither the given options

### Other changes

Fix typo in docs.

### Tested

Tested manually using a funded mainnet account.

### Related issues

- Fixes #6247

### Backwards compatibility

Yes