### PR TITLE
[Wallet] Enable forno as default network setting

### DIFF
--- a/packages/mobile/.env.alfajores
+++ b/packages/mobile/.env.alfajores
@@ -4,7 +4,7 @@ DEFAULT_TESTNET=alfajores
 SMS_RETRIEVER_APP_SIGNATURE=GH+4Okn6nOW
 # If FORNO_ENABLED_INITIALLY, local geth will not run initially.
 # If toggled on, it will use DEFAULT_SYNC_MODE. See src/geth/consts.ts for more info
-FORNO_ENABLED_INITIALLY=false
+FORNO_ENABLED_INITIALLY=true
 DEFAULT_SYNC_MODE=5
 DEV_SETTINGS_ACTIVE_INITIALLY=false
 FIREBASE_ENABLED=true

--- a/packages/mobile/.env.alfajoresdev
+++ b/packages/mobile/.env.alfajoresdev
@@ -4,7 +4,7 @@ DEFAULT_TESTNET=alfajores
 SMS_RETRIEVER_APP_SIGNATURE=5yaJvJcZt2P
 # If FORNO_ENABLED_INITIALLY, local geth will not run initially.
 # If toggled on, it will use DEFAULT_SYNC_MODE. See src/geth/consts.ts for more info
-FORNO_ENABLED_INITIALLY=false
+FORNO_ENABLED_INITIALLY=true
 DEFAULT_SYNC_MODE=5
 FIREBASE_ENABLED=true
 SECRETS_KEY=debug

--- a/packages/mobile/.env.mainnet
+++ b/packages/mobile/.env.mainnet
@@ -4,7 +4,7 @@ DEFAULT_TESTNET=mainnet
 SMS_RETRIEVER_APP_SIGNATURE=bU9E4ctGtIW
 # If FORNO_ENABLED_INITIALLY, local geth will not run initially.
 # If toggled on, it will use DEFAULT_SYNC_MODE. See src/geth/consts.ts for more info
-FORNO_ENABLED_INITIALLY=false
+FORNO_ENABLED_INITIALLY=true
 DEFAULT_SYNC_MODE=5
 DEV_SETTINGS_ACTIVE_INITIALLY=false
 FIREBASE_ENABLED=true

--- a/packages/mobile/.env.mainnetdev
+++ b/packages/mobile/.env.mainnetdev
@@ -4,7 +4,7 @@ DEFAULT_TESTNET=mainnet
 SMS_RETRIEVER_APP_SIGNATURE=g9YQFjScXBz
 # If FORNO_ENABLED_INITIALLY, local geth will not run initially.
 # If toggled on, it will use DEFAULT_SYNC_MODE. See src/geth/consts.ts for more info
-FORNO_ENABLED_INITIALLY=false
+FORNO_ENABLED_INITIALLY=true
 DEFAULT_SYNC_MODE=5
 DEV_SETTINGS_ACTIVE_INITIALLY=true
 # Enable for true hot reloading while dev-ing UI

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -68,10 +68,10 @@ export const ATTESTATION_REVEAL_TIMEOUT_SECONDS = 60 // 1 minute
 // higher than this is incorrect (currently set to 10M)
 export const WALLET_BALANCE_UPPER_BOUND = new BigNumber('1e10')
 
-// TODO: remove special case for mainnet
-export const DEFAULT_FORNO_URL = `https://${
-  DEFAULT_TESTNET === 'mainnet' ? 'rc1' : DEFAULT_TESTNET
-}-forno.celo-testnet.org`
+export const DEFAULT_FORNO_URL =
+  DEFAULT_TESTNET === 'mainnet'
+    ? 'https://forno.celo.org/'
+    : 'https://alfajores-forno.celo-testnet.org/'
 
 // FEATURE FLAGS
 export const FIREBASE_ENABLED = stringToBoolean(Config.FIREBASE_ENABLED || 'true')


### PR DESCRIPTION
### Description
This PR:
- enables forno as the default network setting for fresh installs (new users)
- leaves the network setting unchanged for existing installs and app upgrades (existing users)
- points the mainnet forno URL to the new endpoint `https://forno.celo.org`

### Other changes
No

### Tested
Tested the fresh install and upgrade experience on both alfajores and mainnet.

### Related issues
- Fixes #6250

### Backwards compatibility
Yes