### PR TITLE
[Wallet] Enable forno by default for e2e tests

### DIFF
--- a/packages/mobile/.env.test
+++ b/packages/mobile/.env.test
@@ -2,7 +2,7 @@ DEFAULT_TESTNET=alfajores
 SMS_RETRIEVER_APP_SIGNATURE=TODO
 # If FORNO_ENABLED_INITIALLY, local geth will not run initially.
 # If toggled on, it will use DEFAULT_SYNC_MODE. See src/geth/consts.ts for more info
-FORNO_ENABLED_INITIALLY=false
+FORNO_ENABLED_INITIALLY=true
 DEFAULT_SYNC_MODE=5
 DEV_SETTINGS_ACTIVE_INITIALLY=true
 # Disable firebase b.c. google-services.json files are missing in CI


### PR DESCRIPTION
### Description

Enable forno by default for e2e tests. Follow up on #6257.

### Other changes

None

### Tested

CI passes

### Related issues

- #6250

### Backwards compatibility

Yes