### PR TITLE
fix: add id field to eth_sign and eth_signTypedData calls

### DIFF
--- a/packages/sdk/connect/src/connection.ts
+++ b/packages/sdk/connect/src/connection.ts
@@ -255,7 +255,7 @@ export class Connection {
           id: getRandomId(),
           jsonrpc: '2.0',
           method: 'eth_signTypedData',
-          params: [signer, typedData],
+          params: [inputAddressFormatter(signer), typedData],
         },
         (error, resp) => {
           if (error) {

--- a/packages/sdk/connect/src/connection.ts
+++ b/packages/sdk/connect/src/connection.ts
@@ -29,7 +29,7 @@ import {
   outputCeloTxReceiptFormatter,
 } from './utils/formatter'
 import { hasProperty } from './utils/provider-utils'
-import { DefaultRpcCaller, RpcCaller } from './utils/rpc-caller'
+import { DefaultRpcCaller, getRandomId, RpcCaller } from './utils/rpc-caller'
 import { TxParamsNormalizer } from './utils/tx-params-normalizer'
 import { toTxResult, TransactionResult } from './utils/tx-result'
 import { ReadOnlyWallet } from './wallet'
@@ -252,6 +252,7 @@ export class Connection {
     const signature = await new Promise<string>((resolve, reject) => {
       ;(this.web3.currentProvider as Provider).send(
         {
+          id: getRandomId(),
           jsonrpc: '2.0',
           method: 'eth_signTypedData',
           params: [signer, typedData],
@@ -279,6 +280,7 @@ export class Connection {
     const signature = await new Promise<string>((resolve, reject) => {
       ;(this.web3.currentProvider as Provider).send(
         {
+          id: getRandomId(),
           jsonrpc: '2.0',
           method: 'eth_sign',
           params: [inputAddressFormatter(address.toString()), inputSignFormatter(dataToSign)],


### PR DESCRIPTION
### Description

This field is missing from the `sign` and `signTypedData` requests.

### Tested

Ran into this and tested with the attestation-service.

### Related issues

- Nada