### PR TITLE
Switch mtime to ctime for chain restore

### DIFF
--- a/packages/helm-charts/common/templates/_helpers.tpl
+++ b/packages/helm-charts/common/templates/_helpers.tpl
@@ -448,10 +448,10 @@ prometheus.io/port: "{{ $pprof.port | default 6060 }}"
   - |
      # If older than upload period, remove the chain data dir.
      if [ -d /root/.celo/celo/chaindata ]; then
-       mtime=$(stat --format "%Y" /root/.celo/celo/chaindata)
+       ctime=$(stat --format "%Z" /root/.celo/celo/chaindata)
        day=$(date +%s)
-       diff=$(($day - $mtime))
-       # If mtime is older than 1 day old, pull the chaindata rather than using the current PVC.
+       diff=$(($day - $ctime))
+       # If ctime is older than 1 day old, pull the chaindata rather than using the current PVC.
        if [ "$diff" -gt 86400 ]; then
          echo Chaindata is more than one day out of date. Wiping to use saved chaindata.
          rm -rf /root/.celo/celo/chaindata


### PR DESCRIPTION
### Description

We are looking at a directory so we want to get the latest mtime of any file in the directory.
From this [SO Answer](https://unix.stackexchange.com/questions/187225/change-of-atime-mtime-or-ctime-of-a-file-and-of-its-ancestral-dir) I think it should ctime not mtime. The chaindata directory is a dir that contains a level db database, so we want the last time any item in it was modified.

Infra context is that we don't delete PVCs when we scale down, so it is possible to scale up nodes to an out of date data dir. However it's not desirable to always use the dowloaded chaindata as that could be up to 24hours out of date while on a restart the node could be minutes out of date.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

Not yet

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Yes.