### PR TITLE
[Wallet] Try to fix flaky e2e test that reopens the app with a deep link

### DIFF
--- a/packages/mobile/e2e/src/DeepLinkDappkit.spec.js
+++ b/packages/mobile/e2e/src/DeepLinkDappkit.spec.js
@@ -5,5 +5,5 @@ import HandleDeepLinkDappkit from './usecases/HandleDeepLinkDappkit'
 describe('Deep Link with account dappkit', () => {
   beforeEach(dismissBanners)
   describe('Onboarding', RestoreAccountOnboarding)
-  describe('HandleDeepLinkSend', HandleDeepLinkDappkit)
+  describe('HandleDeepLinkDappkit', HandleDeepLinkDappkit)
 })

--- a/packages/mobile/e2e/src/usecases/HandleDeepLinkDappkit.js
+++ b/packages/mobile/e2e/src/usecases/HandleDeepLinkDappkit.js
@@ -1,4 +1,4 @@
-import { quote } from '../utils/utils'
+import { quote, sleep } from '../utils/utils'
 
 export default HandleDeepLinkDappkit = () => {
   const DAPPKIT_URL = quote(

--- a/packages/mobile/e2e/src/usecases/HandleDeepLinkDappkit.js
+++ b/packages/mobile/e2e/src/usecases/HandleDeepLinkDappkit.js
@@ -7,7 +7,12 @@ export default HandleDeepLinkDappkit = () => {
 
   it('Launch app with dappkit deep link', async () => {
     await device.terminateApp()
+    // I think at least on android we need this sleep because the
+    // OS has a timeout period in between closing and reopening an app
+    await sleep(5000)
     await device.launchApp({ url: DAPPKIT_URL, newInstance: true })
+    // this second sleep is to allow for navigation to reach the desired deep link handler
+    await sleep(5000)
 
     // press Allow button on DappKitSignTxScreen
     await element(by.id('DappkitAllow')).tap()

--- a/packages/mobile/e2e/src/usecases/HandleDeepLinkSend.js
+++ b/packages/mobile/e2e/src/usecases/HandleDeepLinkSend.js
@@ -7,7 +7,9 @@ export default HandleDeepLinkSend = () => {
 
   it('Launch app cold with url', async () => {
     await device.terminateApp()
+    await sleep(5000)
     await device.launchApp({ url: PAY_URL, newInstance: true })
+    await sleep(5000)
     // Arrived at SendAmount screen
     await expect(element(by.id('Review'))).toBeVisible()
   })

--- a/packages/mobile/e2e/src/usecases/HandleDeepLinkSend.js
+++ b/packages/mobile/e2e/src/usecases/HandleDeepLinkSend.js
@@ -1,4 +1,4 @@
-import { quote } from '../utils/utils'
+import { quote, sleep } from '../utils/utils'
 
 export default HandleDeepLinkSend = () => {
   const PAY_URL = quote(


### PR DESCRIPTION
### Description

A really flaky test is the deep link one, which closes and reopens the app with a deep link. From the screenshots it looks like the app does open properly but it does not navigate to the desired handler (handle send or dappkit).

I think there could be a timing issue which is why I am trying a couple sleeps to see if that improves flakiness.

Locally the e2e test runs fine for me but maybe on CI the emulator is slower which can cause timing failures.

### Other changes

None

### Tested

e2e

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Yes.