### PR TITLE
[Wallet] Fix redux store persistence

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -143,7 +143,7 @@
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
-    "redux-persist-fs-storage": "^1.3.0",
+    "redux-persist-fs-storage": "git+https://github.com/celo-org/redux-persist-fs-storage#54ffc50",
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
     "sleep-promise": "^8.0.1",
@@ -173,6 +173,7 @@
     "@types/lodash": "^4.14.136",
     "@types/react": "^16.9.34",
     "@types/react-native": "^0.63.37",
+
     "@types/react-native-fs": "^2.13.0",
     "@types/react-native-keep-awake": "^2.0.1",
     "@types/react-redux": "^7.1.7",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -109,7 +109,7 @@
     "react-native-email-link": "^1.9.1",
     "react-native-exit-app": "^1.1.0",
     "react-native-flag-secure-android": "git://github.com/kristiansorens/react-native-flag-secure-android#e234251",
-    "react-native-fs": "^2.16.6",
+    "react-native-fs": "git+https://github.com/celo-org/react-native-fs#aa6db0f",
     "react-native-gesture-handler": "^1.9.0",
     "react-native-geth": "https://github.com/celo-org/react-native-geth#5864c09",
     "react-native-google-safetynet": "https://github.com/celo-org/react-native-google-safetynet#8a0355f",
@@ -173,7 +173,6 @@
     "@types/lodash": "^4.14.136",
     "@types/react": "^16.9.34",
     "@types/react-native": "^0.63.37",
-
     "@types/react-native-fs": "^2.13.0",
     "@types/react-native-keep-awake": "^2.0.1",
     "@types/react-redux": "^7.1.7",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -143,7 +143,7 @@
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
-    "redux-persist-fs-storage": "git+https://github.com/celo-org/redux-persist-fs-storage#54ffc50",
+    "redux-persist-fs-storage": "^1.3.0",
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
     "sleep-promise": "^8.0.1",
@@ -198,6 +198,9 @@
     "redux-saga-test-plan": "^4.0.0-beta.2",
     "remote-redux-devtools": "^0.5.12",
     "tslint-react-native": "^0.0.7"
+  },
+  "resolutions": {
+    "react-native-fs": "git+https://github.com/celo-org/react-native-fs#aa6db0f"
   },
   "detox": {
     "test-runner": "jest",

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -2,6 +2,7 @@ import colors from '@celo/react-components/styles/colors'
 import { RouteProp } from '@react-navigation/core'
 import { createStackNavigator, StackScreenProps, TransitionPresets } from '@react-navigation/stack'
 import * as React from 'react'
+import { useAsync } from 'react-async-hook'
 import { Platform } from 'react-native'
 import SplashScreen from 'react-native-splash-screen'
 import AccountKeyEducation from 'src/account/AccountKeyEducation'
@@ -82,6 +83,7 @@ import PaymentRequestUnavailable, {
 } from 'src/paymentRequest/PaymentRequestUnavailable'
 import PincodeEnter from 'src/pincode/PincodeEnter'
 import PincodeSet from 'src/pincode/PincodeSet'
+import { waitForRehydrateAsync } from 'src/redux/persist-helper'
 import { RootState } from 'src/redux/reducers'
 import { store } from 'src/redux/store'
 import Send from 'src/send/Send'
@@ -481,9 +483,9 @@ const mapStateToProps = (state: RootState) => {
 type InitialRouteName = ExtractProps<typeof Stack.Navigator>['initialRouteName']
 
 export function MainStackScreen() {
-  const [initialRouteName, setInitialRoute] = React.useState<InitialRouteName>(undefined)
+  const initialRouteName = useAsync(async () => {
+    await waitForRehydrateAsync()
 
-  React.useEffect(() => {
     const {
       choseToRestoreAccount,
       language,
@@ -511,18 +513,18 @@ export function MainStackScreen() {
       initialRoute = Screens.DrawerNavigator
     }
 
-    setInitialRoute(initialRoute)
-
     // Wait for next frame to avoid slight gap when hiding the splash
     requestAnimationFrame(() => SplashScreen.hide())
+
+    return initialRoute
   }, [])
 
-  if (!initialRouteName) {
+  if (initialRouteName.loading) {
     return <AppLoading />
   }
 
   return (
-    <Stack.Navigator initialRouteName={initialRouteName} screenOptions={emptyHeader}>
+    <Stack.Navigator initialRouteName={initialRouteName.result} screenOptions={emptyHeader}>
       <Stack.Screen name={Screens.DrawerNavigator} component={DrawerNavigator} options={noHeader} />
       {commonScreens(Stack)}
       {sendScreens(Stack)}

--- a/packages/mobile/src/redux/persist-helper.ts
+++ b/packages/mobile/src/redux/persist-helper.ts
@@ -1,4 +1,3 @@
-import { sleep } from '@celo/utils/lib/async'
 import { REHYDRATE } from 'redux-persist/es/constants'
 import { take } from 'redux-saga/effects'
 
@@ -25,10 +24,4 @@ export function* waitForRehydrate() {
   yield take(REHYDRATE)
   didRehydrate = true
   return
-}
-
-export async function waitForRehydrateAsync() {
-  while (!didRehydrate) {
-    await sleep(100)
-  }
 }

--- a/packages/mobile/src/redux/persist-helper.ts
+++ b/packages/mobile/src/redux/persist-helper.ts
@@ -1,3 +1,4 @@
+import { sleep } from '@celo/utils/lib/async'
 import { REHYDRATE } from 'redux-persist/es/constants'
 import { take } from 'redux-saga/effects'
 
@@ -24,4 +25,10 @@ export function* waitForRehydrate() {
   yield take(REHYDRATE)
   didRehydrate = true
   return
+}
+
+export async function waitForRehydrateAsync() {
+  while (!didRehydrate) {
+    await sleep(100)
+  }
 }

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -37,6 +37,11 @@ const persistConfig: any = {
     }
     return stringifiedData
   },
+  deserialize: (data: string) => {
+    // This is the default implementation, but overriding to maintain compatibility with the serialize function
+    // in case the library changes.
+    return JSON.parse(data)
+  },
   timeout: null,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29573,10 +29573,17 @@ react-native-exit-app@^1.1.0:
   version "1.0.0"
   resolved "git://github.com/kristiansorens/react-native-flag-secure-android#e234251220f5d745eec8ebde3e83d4d369e81a14"
 
-react-native-fs@*, react-native-fs@^2.14.1, react-native-fs@^2.16.6:
+react-native-fs@*, react-native-fs@^2.16.6:
   version "2.16.6"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.16.6.tgz#2901789a43210a35a0ef0a098019bbef3af395fd"
   integrity sha512-ZWOooD1AuFoAGY3HS2GY7Qx2LZo4oIg6AK0wbC68detxwvX75R/q9lRqThXNKP6vIo2VHWa0fYUo/SrLw80E8w==
+  dependencies:
+    base-64 "^0.1.0"
+    utf8 "^3.0.0"
+
+"react-native-fs@git+https://github.com/celo-org/react-native-fs#aa6db0f":
+  version "2.16.6"
+  resolved "git+https://github.com/celo-org/react-native-fs#aa6db0f1d9b82bfdf58ebf72450c28311414f45f"
   dependencies:
     base-64 "^0.1.0"
     utf8 "^3.0.0"
@@ -30274,12 +30281,11 @@ redux-mock-store@^1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-persist-fs-storage@^1.3.0:
+"redux-persist-fs-storage@git+https://github.com/celo-org/redux-persist-fs-storage#54ffc50":
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/redux-persist-fs-storage/-/redux-persist-fs-storage-1.3.0.tgz#395d0c4b40985e04c480512ee1c469d6d2a9abd9"
-  integrity sha512-32FMEF5apIwlm7bnBq6VTmbK7sVVZ0bpTpMt8CUw5MMDXcsSfT4BSM5t6Y15V6KBRL9O11GDKAAV8a3/Hfj2Tg==
+  resolved "git+https://github.com/celo-org/redux-persist-fs-storage#54ffc501d7cb99856de6ad770d0689a450bcea57"
   dependencies:
-    react-native-fs "^2.14.1"
+    react-native-fs "git+https://github.com/celo-org/react-native-fs#aa6db0f"
 
 redux-persist@^6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29573,7 +29573,7 @@ react-native-exit-app@^1.1.0:
   version "1.0.0"
   resolved "git://github.com/kristiansorens/react-native-flag-secure-android#e234251220f5d745eec8ebde3e83d4d369e81a14"
 
-react-native-fs@*, "react-native-fs@git+https://github.com/celo-org/react-native-fs#aa6db0f":
+react-native-fs@*, react-native-fs@^2.14.1, "react-native-fs@git+https://github.com/celo-org/react-native-fs#aa6db0f":
   version "2.16.6"
   resolved "git+https://github.com/celo-org/react-native-fs#aa6db0f1d9b82bfdf58ebf72450c28311414f45f"
   dependencies:
@@ -30273,11 +30273,12 @@ redux-mock-store@^1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-"redux-persist-fs-storage@git+https://github.com/celo-org/redux-persist-fs-storage#54ffc50":
+redux-persist-fs-storage@^1.3.0:
   version "1.3.0"
-  resolved "git+https://github.com/celo-org/redux-persist-fs-storage#54ffc501d7cb99856de6ad770d0689a450bcea57"
+  resolved "https://registry.yarnpkg.com/redux-persist-fs-storage/-/redux-persist-fs-storage-1.3.0.tgz#395d0c4b40985e04c480512ee1c469d6d2a9abd9"
+  integrity sha512-32FMEF5apIwlm7bnBq6VTmbK7sVVZ0bpTpMt8CUw5MMDXcsSfT4BSM5t6Y15V6KBRL9O11GDKAAV8a3/Hfj2Tg==
   dependencies:
-    react-native-fs "git+https://github.com/celo-org/react-native-fs#aa6db0f"
+    react-native-fs "^2.14.1"
 
 redux-persist@^6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29573,15 +29573,7 @@ react-native-exit-app@^1.1.0:
   version "1.0.0"
   resolved "git://github.com/kristiansorens/react-native-flag-secure-android#e234251220f5d745eec8ebde3e83d4d369e81a14"
 
-react-native-fs@*, react-native-fs@^2.16.6:
-  version "2.16.6"
-  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.16.6.tgz#2901789a43210a35a0ef0a098019bbef3af395fd"
-  integrity sha512-ZWOooD1AuFoAGY3HS2GY7Qx2LZo4oIg6AK0wbC68detxwvX75R/q9lRqThXNKP6vIo2VHWa0fYUo/SrLw80E8w==
-  dependencies:
-    base-64 "^0.1.0"
-    utf8 "^3.0.0"
-
-"react-native-fs@git+https://github.com/celo-org/react-native-fs#aa6db0f":
+react-native-fs@*, "react-native-fs@git+https://github.com/celo-org/react-native-fs#aa6db0f":
   version "2.16.6"
   resolved "git+https://github.com/celo-org/react-native-fs#aa6db0f1d9b82bfdf58ebf72450c28311414f45f"
   dependencies:


### PR DESCRIPTION
### Description

The error was that when reading the state from the filesystem the `JSON.parse` function failed. Upon further inspection, we noticed that the json being stored wasn't valid. What happened is that we first stored a json string and then, when overwriting with a smaller string, the previous text was not deleted, it was just written over. An example of how this looked like is the following:
```
[...] ,"_persist":"{\"version\":7,\"rehydrated\":true}"}mentRequests\":[],\"outgoingPaymentRequests\":[]}","_persist":"{\"version\":7,\"rehydrated\":true}"}
```
Notice that the string should end just before the `mentRequests` thing.

The error comes from the `react-native-fs` library. When writing, it is using a `w` file, which behaved as expected on Android lower than 10. On Android 10 though, they changed it so that it doesn't erase data on the file before writing. We had to add a `t` flag to get that behaviour. This is a known issue of the library and [there's a PR ready since June](https://github.com/itinance/react-native-fs/pull/890) but it hasn't been merged yet, so [we had to fork the library](https://github.com/celo-org/react-native-fs) and [redux-persist-fs-storage](https://github.com/celo-org/redux-persist-fs-storage) in order to get the fix.

### Other changes

Added an extra log or two.

### Tested

Yes

### Related issues

- Fixes #6313

### Backwards compatibility

Yup