### PR TITLE
[Wallet] Fix last alert banner redisplayed on re-render

### DIFF
--- a/packages/mobile/jest_setup.ts
+++ b/packages/mobile/jest_setup.ts
@@ -20,3 +20,12 @@ afterEach(cleanup)
 
 // Mock LayoutAnimation as it's done not automatically
 jest.mock('react-native/Libraries/LayoutAnimation/LayoutAnimation.js')
+
+// Mock Animated Views this way otherwise we get a
+// `JavaScript heap out of memory` error when a ref is set (?!)
+// See https://github.com/callstack/react-native-testing-library/issues/539
+jest.mock('react-native/Libraries/Animated/src/components/AnimatedView.js', () => 'View')
+jest.mock(
+  'react-native/Libraries/Animated/src/components/AnimatedScrollView.js',
+  () => 'RCTScrollView'
+)

--- a/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
@@ -41,14 +41,18 @@ exports[`FiatExchange renders correctly 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >

--- a/packages/mobile/src/account/__snapshots__/GoldEducation.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/GoldEducation.test.tsx.snap
@@ -45,14 +45,18 @@ exports[`renders correctly 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >

--- a/packages/mobile/src/account/__snapshots__/Settings.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Settings.test.tsx.snap
@@ -40,14 +40,18 @@ exports[`Account renders correctly 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >
@@ -2297,14 +2301,18 @@ exports[`Account renders correctly when dev mode active 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >
@@ -3349,10 +3357,14 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-                "width": 215,
-              }
+              Array [
+                Object {
+                  "width": 215,
+                },
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text
@@ -3388,9 +3400,12 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text>
@@ -3417,9 +3432,12 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text>
@@ -3446,9 +3464,12 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text>
@@ -3475,9 +3496,12 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text>
@@ -3504,9 +3528,12 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text>
@@ -3533,9 +3560,12 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text>
@@ -3562,9 +3592,12 @@ exports[`Account renders correctly when dev mode active 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <Text>
@@ -4818,14 +4851,18 @@ exports[`Account renders correctly when verification is not possible 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >

--- a/packages/mobile/src/account/__snapshots__/Support.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Support.test.tsx.snap
@@ -40,14 +40,18 @@ exports[`Support renders correctly 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >

--- a/packages/mobile/src/alert/AlertBanner.tsx
+++ b/packages/mobile/src/alert/AlertBanner.tsx
@@ -1,30 +1,37 @@
-import SmartTopAlert, { AlertTypes } from '@celo/react-components/components/SmartTopAlert'
-import * as React from 'react'
+import SmartTopAlert from '@celo/react-components/components/SmartTopAlert'
+import React, { memo, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
 import { hideAlert } from 'src/alert/actions'
 import { ErrorDisplayType } from 'src/alert/reducer'
 import useSelector from 'src/redux/useSelector'
 
-export default function AlertBanner() {
+function AlertBanner() {
   const alert = useSelector((state) => state.alert)
   const dispatch = useDispatch()
 
-  const onPress = () => {
-    const action = alert?.action ?? hideAlert()
-    dispatch(action)
-  }
+  const displayAlert = useMemo(() => {
+    if (alert?.displayMethod === ErrorDisplayType.BANNER && (alert.title || alert.message)) {
+      const onPress = () => {
+        const action = alert?.action ?? hideAlert()
+        dispatch(action)
+      }
 
-  return (
-    <SmartTopAlert
-      isVisible={!!alert && alert.displayMethod === ErrorDisplayType.BANNER}
-      // TODO: this looks like a hack to re-render, refactor!
-      timestamp={Date.now()}
-      text={alert && alert.message}
-      onPress={onPress}
-      type={alert && alert.type === 'error' ? AlertTypes.ERROR : AlertTypes.MESSAGE}
-      dismissAfter={alert && alert.dismissAfter}
-      buttonMessage={alert && alert.buttonMessage}
-      title={alert && alert.title}
-    />
-  )
+      const { type, title, message, buttonMessage, dismissAfter } = alert
+
+      return {
+        type,
+        title,
+        message,
+        buttonMessage,
+        dismissAfter,
+        onPress,
+      }
+    } else {
+      return null
+    }
+  }, [alert])
+
+  return <SmartTopAlert alert={displayAlert} />
 }
+
+export default memo(AlertBanner)

--- a/packages/mobile/src/alert/__snapshots__/AlertBanner.test.tsx.snap
+++ b/packages/mobile/src/alert/__snapshots__/AlertBanner.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`AlertBanner when an action is provided it dispatches the action when pr
   <View
     accessible={true}
     focusable={true}
-    forwardedRef={[Function]}
     onClick={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
@@ -21,20 +20,26 @@ exports[`AlertBanner when an action is provided it dispatches the action when pr
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#0768AE",
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingBottom": 10,
-        "paddingHorizontal": 25,
-        "paddingTop": 10,
-        "transform": Array [
-          Object {
-            "translateY": -500,
-          },
-        ],
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#0768AE",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingBottom": 10,
+          "paddingHorizontal": 25,
+        },
+        undefined,
+        false,
+        Object {
+          "paddingTop": 10,
+          "transform": Array [
+            Object {
+              "translateY": -500,
+            },
+          ],
+        },
+      ]
     }
     testID="SmartTopAlertTouchable"
   >
@@ -74,7 +79,6 @@ exports[`AlertBanner when error message passed in renders error message 1`] = `
   <View
     accessible={true}
     focusable={true}
-    forwardedRef={[Function]}
     onClick={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
@@ -83,20 +87,28 @@ exports[`AlertBanner when error message passed in renders error message 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#EA6042",
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingBottom": 10,
-        "paddingHorizontal": 25,
-        "paddingTop": 10,
-        "transform": Array [
-          Object {
-            "translateY": -500,
-          },
-        ],
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#0768AE",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingBottom": 10,
+          "paddingHorizontal": 25,
+        },
+        undefined,
+        Object {
+          "backgroundColor": "#EA6042",
+        },
+        Object {
+          "paddingTop": 10,
+          "transform": Array [
+            Object {
+              "translateY": -500,
+            },
+          ],
+        },
+      ]
     }
     testID="SmartTopAlertTouchable"
   >
@@ -174,7 +186,6 @@ exports[`AlertBanner when message and title passed in renders title with message
   <View
     accessible={true}
     focusable={true}
-    forwardedRef={[Function]}
     onClick={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
@@ -183,20 +194,26 @@ exports[`AlertBanner when message and title passed in renders title with message
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#0768AE",
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingBottom": 10,
-        "paddingHorizontal": 25,
-        "paddingTop": 10,
-        "transform": Array [
-          Object {
-            "translateY": -500,
-          },
-        ],
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#0768AE",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingBottom": 10,
+          "paddingHorizontal": 25,
+        },
+        undefined,
+        false,
+        Object {
+          "paddingTop": 10,
+          "transform": Array [
+            Object {
+              "translateY": -500,
+            },
+          ],
+        },
+      ]
     }
     testID="SmartTopAlertTouchable"
   >
@@ -257,7 +274,6 @@ exports[`AlertBanner when message passed in renders message 1`] = `
   <View
     accessible={true}
     focusable={true}
-    forwardedRef={[Function]}
     onClick={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
@@ -266,20 +282,26 @@ exports[`AlertBanner when message passed in renders message 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#0768AE",
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingBottom": 10,
-        "paddingHorizontal": 25,
-        "paddingTop": 10,
-        "transform": Array [
-          Object {
-            "translateY": -500,
-          },
-        ],
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#0768AE",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingBottom": 10,
+          "paddingHorizontal": 25,
+        },
+        undefined,
+        false,
+        Object {
+          "paddingTop": 10,
+          "transform": Array [
+            Object {
+              "translateY": -500,
+            },
+          ],
+        },
+      ]
     }
     testID="SmartTopAlertTouchable"
   >

--- a/packages/mobile/src/backup/__snapshots__/BackupIntroduction.test.tsx.snap
+++ b/packages/mobile/src/backup/__snapshots__/BackupIntroduction.test.tsx.snap
@@ -41,14 +41,18 @@ exports[`BackupIntroduction renders correctly when backup completed 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >
@@ -245,14 +249,18 @@ exports[`BackupIntroduction renders correctly when backup not complete 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >

--- a/packages/mobile/src/exchange/__snapshots__/ExchangeHomeScreen.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/ExchangeHomeScreen.test.tsx.snap
@@ -46,14 +46,18 @@ exports[`ExchangeHomeScreen renders and behaves correctly for CP-DOTO restricted
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >
@@ -130,229 +134,34 @@ exports[`ExchangeHomeScreen renders and behaves correctly for CP-DOTO restricted
     stickyHeaderIndices={Array []}
     testID="ExchangeScrollView"
   >
-    <View>
-      <RNCSafeAreaView
-        edges={
-          Array [
-            "bottom",
-          ]
+    <RNCSafeAreaView
+      edges={
+        Array [
+          "bottom",
+        ]
+      }
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "space-between",
         }
+      }
+    >
+      <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "space-between",
+            "padding": 16,
           }
         }
       >
         <View
           style={
             Object {
-              "padding": 16,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "marginBottom": 8,
-              }
-            }
-          >
-            <Text
-              style={
-                Object {
-                  "color": "#2E3338",
-                  "fontFamily": "Jost-Medium",
-                  "fontSize": 22,
-                  "lineHeight": 28,
-                  "marginRight": 8,
-                }
-              }
-            >
-              goldPrice
-            </Text>
-            <View
-              accessible={true}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              nativeBackgroundAndroid={
-                Object {
-                  "attribute": "selectableItemBackground",
-                  "rippleRadius": undefined,
-                  "type": "ThemeAttrAndroid",
-                }
-              }
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-            >
-              <svg
-                fill="none"
-                height={14}
-                style={Object {}}
-                viewBox="0 0 16 16"
-                width={14}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  r="7"
-                  stroke="#2E3338"
-                  stroke-width="1.25"
-                  style={Object {}}
-                />
-                <path
-                  d="M8 12V7M8 6V5"
-                  stroke="#2E3338"
-                  stroke-width="1.25"
-                  style={Object {}}
-                />
-              </svg>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "alignItems": "flex-end",
-                "flexDirection": "row",
-              }
-            }
-          >
-            <Text
-              style={
-                Object {
-                  "color": "#2E3338",
-                  "fontFamily": "Inter-Regular",
-                  "fontSize": 24,
-                  "height": 27,
-                  "lineHeight": 27,
-                }
-              }
-            >
-              $10.00
-            </Text>
-          </View>
-        </View>
-        <View
-          style={
-            Object {
               "alignItems": "center",
-              "height": 217.5,
-              "justifyContent": "center",
-              "width": 750,
+              "flexDirection": "row",
+              "marginBottom": 8,
             }
           }
-        >
-          <ActivityIndicator
-            animating={true}
-            color="#EEB93C"
-            hidesWhenStopped={true}
-            size="large"
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              Object {
-                "marginBottom": 16,
-                "marginHorizontal": 16,
-                "marginTop": 24,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "overflow": "hidden",
-                },
-                Object {
-                  "borderRadius": 100,
-                },
-              ]
-            }
-          >
-            <View
-              accessible={true}
-              focusable={true}
-              nativeBackgroundAndroid={
-                Object {
-                  "attribute": "selectableItemBackground",
-                  "rippleRadius": undefined,
-                  "type": "ThemeAttrAndroid",
-                }
-              }
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#EEB93C",
-                  "flexGrow": 1,
-                  "height": 48,
-                  "justifyContent": "center",
-                  "opacity": undefined,
-                  "paddingHorizontal": 24,
-                  "paddingVertical": 5,
-                }
-              }
-              testID="WithdrawCELO"
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontFamily": "Inter-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  }
-                }
-              >
-                withdrawCelo
-              </Text>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#EDEEEF",
-              "height": 1,
-              "marginHorizontal": 16,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "marginVertical": 16,
-              "paddingHorizontal": 16,
-            }
-          }
-          testID="ExchangeAccountOverview"
         >
           <Text
             style={
@@ -361,101 +170,294 @@ exports[`ExchangeHomeScreen renders and behaves correctly for CP-DOTO restricted
                 "fontFamily": "Jost-Medium",
                 "fontSize": 22,
                 "lineHeight": 28,
-                "marginBottom": 8,
+                "marginRight": 8,
               }
             }
           >
-            yourGoldBalance
+            goldPrice
           </Text>
+          <View
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "rippleRadius": undefined,
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+          >
+            <svg
+              fill="none"
+              height={14}
+              style={Object {}}
+              viewBox="0 0 16 16"
+              width={14}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="7"
+                stroke="#2E3338"
+                stroke-width="1.25"
+                style={Object {}}
+              />
+              <path
+                d="M8 12V7M8 6V5"
+                stroke="#2E3338"
+                stroke-width="1.25"
+                style={Object {}}
+              />
+            </svg>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "flexDirection": "row",
+            }
+          }
+        >
           <Text
             style={
               Object {
                 "color": "#2E3338",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 24,
+                "height": 27,
                 "lineHeight": 27,
-                "marginBottom": 8,
-              }
-            }
-            testID="CeloBalance"
-          >
-            <Text
-              numberOfLines={1}
-              style={
-                Array [
-                  undefined,
-                  Object {
-                    "color": undefined,
-                  },
-                ]
-              }
-            >
-              
-              
-              2.000
-            </Text>
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#9CA4A9",
-                "fontFamily": "Inter-Regular",
-                "fontSize": 16,
-                "lineHeight": 22,
               }
             }
           >
-            Equal to 
-            <Text
-              numberOfLines={1}
-              style={
-                Array [
-                  undefined,
-                  Object {
-                    "color": undefined,
-                  },
-                ]
-              }
-            >
-              
-              $
-              26.60
-            </Text>
+            $10.00
           </Text>
         </View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#EDEEEF",
-              "height": 1,
-              "marginHorizontal": 16,
-            }
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "height": 217.5,
+            "justifyContent": "center",
+            "width": 750,
           }
+        }
+      >
+        <ActivityIndicator
+          animating={true}
+          color="#EEB93C"
+          hidesWhenStopped={true}
+          size="large"
         />
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "column",
+            },
+            Object {
+              "marginBottom": 16,
+              "marginHorizontal": 16,
+              "marginTop": 24,
+            },
+          ]
+        }
+      >
         <View
           style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "borderRadius": 100,
+              },
+            ]
+          }
+        >
+          <View
+            accessible={true}
+            focusable={true}
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "rippleRadius": undefined,
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#EEB93C",
+                "flexGrow": 1,
+                "height": 48,
+                "justifyContent": "center",
+                "opacity": undefined,
+                "paddingHorizontal": 24,
+                "paddingVertical": 5,
+              }
+            }
+            testID="WithdrawCELO"
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Inter-SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              withdrawCelo
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#EDEEEF",
+            "height": 1,
+            "marginHorizontal": 16,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "marginVertical": 16,
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="ExchangeAccountOverview"
+      >
+        <Text
+          style={
             Object {
-              "paddingBottom": 8,
-              "paddingHorizontal": 16,
-              "paddingTop": 20,
+              "color": "#2E3338",
+              "fontFamily": "Jost-Medium",
+              "fontSize": 22,
+              "lineHeight": 28,
+              "marginBottom": 8,
             }
           }
         >
+          yourGoldBalance
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 24,
+              "lineHeight": 27,
+              "marginBottom": 8,
+            }
+          }
+          testID="CeloBalance"
+        >
           <Text
+            numberOfLines={1}
             style={
-              Object {
-                "color": "#2E3338",
-                "fontFamily": "Jost-Medium",
-                "fontSize": 22,
-                "lineHeight": 28,
-              }
+              Array [
+                undefined,
+                Object {
+                  "color": undefined,
+                },
+              ]
             }
           >
-            global:activity
+            
+            
+            2.000
           </Text>
-        </View>
-      </RNCSafeAreaView>
-    </View>
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#9CA4A9",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Equal to 
+          <Text
+            numberOfLines={1}
+            style={
+              Array [
+                undefined,
+                Object {
+                  "color": undefined,
+                },
+              ]
+            }
+          >
+            
+            $
+            26.60
+          </Text>
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#EDEEEF",
+            "height": 1,
+            "marginHorizontal": 16,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "paddingBottom": 8,
+            "paddingHorizontal": 16,
+            "paddingTop": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Jost-Medium",
+              "fontSize": 22,
+              "lineHeight": 28,
+            }
+          }
+        >
+          global:activity
+        </Text>
+      </View>
+    </RNCSafeAreaView>
   </RCTScrollView>
 </RNCSafeAreaView>
 `;
@@ -506,14 +508,18 @@ exports[`ExchangeHomeScreen renders and behaves correctly for non CP-DOTO restri
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >
@@ -590,60 +596,177 @@ exports[`ExchangeHomeScreen renders and behaves correctly for non CP-DOTO restri
     stickyHeaderIndices={Array []}
     testID="ExchangeScrollView"
   >
-    <View>
-      <RNCSafeAreaView
-        edges={
-          Array [
-            "bottom",
-          ]
+    <RNCSafeAreaView
+      edges={
+        Array [
+          "bottom",
+        ]
+      }
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "space-between",
         }
+      }
+    >
+      <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "space-between",
+            "padding": 16,
           }
         }
       >
         <View
           style={
             Object {
-              "padding": 16,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "marginBottom": 8,
             }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#2E3338",
+                "fontFamily": "Jost-Medium",
+                "fontSize": 22,
+                "lineHeight": 28,
+                "marginRight": 8,
+              }
+            }
+          >
+            goldPrice
+          </Text>
+          <View
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "rippleRadius": undefined,
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+          >
+            <svg
+              fill="none"
+              height={14}
+              style={Object {}}
+              viewBox="0 0 16 16"
+              width={14}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="7"
+                stroke="#2E3338"
+                stroke-width="1.25"
+                style={Object {}}
+              />
+              <path
+                d="M8 12V7M8 6V5"
+                stroke="#2E3338"
+                stroke-width="1.25"
+                style={Object {}}
+              />
+            </svg>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#2E3338",
+                "fontFamily": "Inter-Regular",
+                "fontSize": 24,
+                "height": 27,
+                "lineHeight": 27,
+              }
+            }
+          >
+            $10.00
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "height": 217.5,
+            "justifyContent": "center",
+            "width": 750,
+          }
+        }
+      >
+        <ActivityIndicator
+          animating={true}
+          color="#EEB93C"
+          hidesWhenStopped={true}
+          size="large"
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginBottom": 28,
+            "marginHorizontal": 12,
+            "marginTop": 24,
+          }
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "flex": 1,
+                "marginHorizontal": 4,
+              },
+            ]
           }
         >
           <View
             style={
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "marginBottom": 8,
-              }
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "borderRadius": 100,
+                },
+              ]
             }
           >
-            <Text
-              style={
-                Object {
-                  "color": "#2E3338",
-                  "fontFamily": "Jost-Medium",
-                  "fontSize": 22,
-                  "lineHeight": 28,
-                  "marginRight": 8,
-                }
-              }
-            >
-              goldPrice
-            </Text>
             <View
               accessible={true}
               focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
               nativeBackgroundAndroid={
                 Object {
                   "attribute": "selectableItemBackground",
@@ -658,439 +781,320 @@ exports[`ExchangeHomeScreen renders and behaves correctly for non CP-DOTO restri
               onResponderTerminate={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
-            >
-              <svg
-                fill="none"
-                height={14}
-                style={Object {}}
-                viewBox="0 0 16 16"
-                width={14}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  r="7"
-                  stroke="#2E3338"
-                  stroke-width="1.25"
-                  style={Object {}}
-                />
-                <path
-                  d="M8 12V7M8 6V5"
-                  stroke="#2E3338"
-                  stroke-width="1.25"
-                  style={Object {}}
-                />
-              </svg>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "alignItems": "flex-end",
-                "flexDirection": "row",
-              }
-            }
-          >
-            <Text
               style={
                 Object {
-                  "color": "#2E3338",
-                  "fontFamily": "Inter-Regular",
-                  "fontSize": 24,
-                  "height": 27,
-                  "lineHeight": 27,
+                  "alignItems": "center",
+                  "backgroundColor": "#EEB93C",
+                  "flexGrow": 1,
+                  "height": 48,
+                  "justifyContent": "center",
+                  "opacity": undefined,
+                  "paddingHorizontal": 24,
+                  "paddingVertical": 5,
                 }
               }
+              testID="BuyCelo"
             >
-              $10.00
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                buy
+              </Text>
+            </View>
           </View>
         </View>
         <View
           style={
-            Object {
-              "alignItems": "center",
-              "height": 217.5,
-              "justifyContent": "center",
-              "width": 750,
-            }
-          }
-        >
-          <ActivityIndicator
-            animating={true}
-            color="#EEB93C"
-            hidesWhenStopped={true}
-            size="large"
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 28,
-              "marginHorizontal": 12,
-              "marginTop": 24,
-            }
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "flex": 1,
+                "marginHorizontal": 4,
+              },
+            ]
           }
         >
           <View
             style={
               Array [
                 Object {
-                  "flexDirection": "column",
+                  "overflow": "hidden",
                 },
                 Object {
-                  "flex": 1,
-                  "marginHorizontal": 4,
+                  "borderRadius": 100,
                 },
               ]
             }
           >
             <View
-              style={
-                Array [
-                  Object {
-                    "overflow": "hidden",
-                  },
-                  Object {
-                    "borderRadius": 100,
-                  },
-                ]
-              }
-            >
-              <View
-                accessible={true}
-                focusable={true}
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "rippleRadius": undefined,
-                    "type": "ThemeAttrAndroid",
-                  }
+              accessible={true}
+              focusable={true}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackground",
+                  "rippleRadius": undefined,
+                  "type": "ThemeAttrAndroid",
                 }
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
+              }
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "#EEB93C",
+                  "flexGrow": 1,
+                  "height": 48,
+                  "justifyContent": "center",
+                  "opacity": undefined,
+                  "paddingHorizontal": 24,
+                  "paddingVertical": 5,
+                }
+              }
+              testID="SellCelo"
+            >
+              <Text
                 style={
                   Object {
-                    "alignItems": "center",
-                    "backgroundColor": "#EEB93C",
-                    "flexGrow": 1,
-                    "height": 48,
-                    "justifyContent": "center",
-                    "opacity": undefined,
-                    "paddingHorizontal": 24,
-                    "paddingVertical": 5,
+                    "color": "#FFFFFF",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
                   }
                 }
-                testID="BuyCelo"
               >
-                <Text
-                  style={
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontFamily": "Inter-SemiBold",
-                      "fontSize": 16,
-                      "lineHeight": 22,
-                    }
-                  }
-                >
-                  buy
-                </Text>
-              </View>
+                sell
+              </Text>
             </View>
           </View>
-          <View
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#EDEEEF",
+            "height": 1,
+            "marginHorizontal": 16,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "marginVertical": 16,
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="ExchangeAccountOverview"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Jost-Medium",
+              "fontSize": 22,
+              "lineHeight": 28,
+              "marginBottom": 8,
+            }
+          }
+        >
+          yourGoldBalance
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 24,
+              "lineHeight": 27,
+              "marginBottom": 8,
+            }
+          }
+          testID="CeloBalance"
+        >
+          <Text
+            numberOfLines={1}
             style={
               Array [
+                undefined,
                 Object {
-                  "flexDirection": "column",
-                },
-                Object {
-                  "flex": 1,
-                  "marginHorizontal": 4,
+                  "color": undefined,
                 },
               ]
             }
           >
+            
+            
+            2.000
+          </Text>
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#9CA4A9",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Equal to 
+          <Text
+            numberOfLines={1}
+            style={
+              Array [
+                undefined,
+                Object {
+                  "color": undefined,
+                },
+              ]
+            }
+          >
+            
+            $
+            26.60
+          </Text>
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#EDEEEF",
+            "height": 1,
+            "marginHorizontal": 16,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "#FFFFFF",
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          nativeBackgroundAndroid={
+            Object {
+              "attribute": "selectableItemBackgroundBorderless",
+              "rippleRadius": undefined,
+              "type": "ThemeAttrAndroid",
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          testID="WithdrawCELO"
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#EDEEEF",
+                "borderBottomWidth": 1,
+                "marginLeft": 16,
+                "paddingVertical": 16,
+              }
+            }
+          >
             <View
               style={
-                Array [
-                  Object {
-                    "overflow": "hidden",
-                  },
-                  Object {
-                    "borderRadius": 100,
-                  },
-                ]
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "paddingRight": 16,
+                }
               }
             >
               <View
-                accessible={true}
-                focusable={true}
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "rippleRadius": undefined,
-                    "type": "ThemeAttrAndroid",
-                  }
-                }
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  Object {
-                    "alignItems": "center",
-                    "backgroundColor": "#EEB93C",
-                    "flexGrow": 1,
-                    "height": 48,
-                    "justifyContent": "center",
-                    "opacity": undefined,
-                    "paddingHorizontal": 24,
-                    "paddingVertical": 5,
-                  }
+                  Array [
+                    Object {
+                      "justifyContent": "center",
+                    },
+                  ]
                 }
-                testID="SellCelo"
               >
                 <Text
                   style={
                     Object {
-                      "color": "#FFFFFF",
-                      "fontFamily": "Inter-SemiBold",
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
                       "fontSize": 16,
                       "lineHeight": 22,
                     }
                   }
                 >
-                  sell
+                  withdrawCelo
                 </Text>
               </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#EDEEEF",
-              "height": 1,
-              "marginHorizontal": 16,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "marginVertical": 16,
-              "paddingHorizontal": 16,
-            }
-          }
-          testID="ExchangeAccountOverview"
-        >
-          <Text
-            style={
-              Object {
-                "color": "#2E3338",
-                "fontFamily": "Jost-Medium",
-                "fontSize": 22,
-                "lineHeight": 28,
-                "marginBottom": 8,
-              }
-            }
-          >
-            yourGoldBalance
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#2E3338",
-                "fontFamily": "Inter-Regular",
-                "fontSize": 24,
-                "lineHeight": 27,
-                "marginBottom": 8,
-              }
-            }
-            testID="CeloBalance"
-          >
-            <Text
-              numberOfLines={1}
-              style={
-                Array [
-                  undefined,
-                  Object {
-                    "color": undefined,
-                  },
-                ]
-              }
-            >
-              
-              
-              2.000
-            </Text>
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#9CA4A9",
-                "fontFamily": "Inter-Regular",
-                "fontSize": 16,
-                "lineHeight": 22,
-              }
-            }
-          >
-            Equal to 
-            <Text
-              numberOfLines={1}
-              style={
-                Array [
-                  undefined,
-                  Object {
-                    "color": undefined,
-                  },
-                ]
-              }
-            >
-              
-              $
-              26.60
-            </Text>
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#EDEEEF",
-              "height": 1,
-              "marginHorizontal": 16,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "backgroundColor": "#FFFFFF",
-            }
-          }
-        >
-          <View
-            accessible={true}
-            focusable={true}
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackgroundBorderless",
-                "rippleRadius": undefined,
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            testID="WithdrawCELO"
-          >
-            <View
-              style={
-                Object {
-                  "borderBottomColor": "#EDEEEF",
-                  "borderBottomWidth": 1,
-                  "marginLeft": 16,
-                  "paddingVertical": 16,
-                }
-              }
-            >
               <View
                 style={
                   Object {
                     "alignItems": "center",
                     "flexDirection": "row",
-                    "justifyContent": "space-between",
-                    "paddingRight": 16,
                   }
                 }
               >
-                <View
-                  style={
-                    Array [
-                      Object {
-                        "justifyContent": "center",
-                      },
-                    ]
-                  }
+                <svg
+                  height={20}
+                  style={Object {}}
+                  viewBox="0 0 15 16"
+                  width={10}
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#2E3338",
-                        "fontFamily": "Inter-Regular",
-                        "fontSize": 16,
-                        "lineHeight": 22,
-                      }
-                    }
-                  >
-                    withdrawCelo
-                  </Text>
-                </View>
-                <View
-                  style={
-                    Object {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                    }
-                  }
-                >
-                  <svg
-                    height={20}
+                  <path
+                    d="M8.70376 9.12461L2.12123 15.7071C1.73071 16.0976 1.09755 16.0976 0.707015 15.7071C0.316497 15.3166 0.316497 14.6834 0.707015 14.2929L6.58575 8.41419L0.707091 2.53553C0.316573 2.14501 0.316573 1.51185 0.707091 1.12131C1.09761 0.730797 1.73079 0.730797 2.12131 1.12131L8.70708 7.70708C9.0976 8.09762 9.0976 8.73078 8.70708 9.1213L8.70376 9.12461Z"
+                    fill="#B4B9BD"
                     style={Object {}}
-                    viewBox="0 0 15 16"
-                    width={10}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8.70376 9.12461L2.12123 15.7071C1.73071 16.0976 1.09755 16.0976 0.707015 15.7071C0.316497 15.3166 0.316497 14.6834 0.707015 14.2929L6.58575 8.41419L0.707091 2.53553C0.316573 2.14501 0.316573 1.51185 0.707091 1.12131C1.09761 0.730797 1.73079 0.730797 2.12131 1.12131L8.70708 7.70708C9.0976 8.09762 9.0976 8.73078 8.70708 9.1213L8.70376 9.12461Z"
-                      fill="#B4B9BD"
-                      style={Object {}}
-                    />
-                  </svg>
-                </View>
+                  />
+                </svg>
               </View>
             </View>
           </View>
         </View>
-        <View
+      </View>
+      <View
+        style={
+          Object {
+            "paddingBottom": 8,
+            "paddingHorizontal": 16,
+            "paddingTop": 20,
+          }
+        }
+      >
+        <Text
           style={
             Object {
-              "paddingBottom": 8,
-              "paddingHorizontal": 16,
-              "paddingTop": 20,
+              "color": "#2E3338",
+              "fontFamily": "Jost-Medium",
+              "fontSize": 22,
+              "lineHeight": 28,
             }
           }
         >
-          <Text
-            style={
-              Object {
-                "color": "#2E3338",
-                "fontFamily": "Jost-Medium",
-                "fontSize": 22,
-                "lineHeight": 28,
-              }
-            }
-          >
-            global:activity
-          </Text>
-        </View>
-      </RNCSafeAreaView>
-    </View>
+          global:activity
+        </Text>
+      </View>
+    </RNCSafeAreaView>
   </RCTScrollView>
 </RNCSafeAreaView>
 `;

--- a/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
@@ -58,9 +58,12 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
             testID="ExchangeSwitchInput"
           >
@@ -212,9 +215,12 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "opacity": 1,
-      }
+      Array [
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+      ]
     }
   >
     <View

--- a/packages/mobile/src/exchange/__snapshots__/WithdrawCeloScreen.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/WithdrawCeloScreen.test.tsx.snap
@@ -224,9 +224,12 @@ exports[`WithdrawCeloScreen renders correctly 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 1,
-            }
+            Array [
+              undefined,
+              Object {
+                "opacity": 1,
+              },
+            ]
           }
           testID="MaxAmount"
         >

--- a/packages/mobile/src/home/__snapshots__/WalletHome.test.tsx.snap
+++ b/packages/mobile/src/home/__snapshots__/WalletHome.test.tsx.snap
@@ -41,14 +41,18 @@ exports[`Testnet banner Renders when connected with backup complete 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >
@@ -446,14 +450,18 @@ exports[`Testnet banner Renders when disconnected 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >
@@ -851,14 +859,18 @@ exports[`Testnet banner Shows testnet banner for 5 seconds 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "left": 0,
-          "marginBottom": 0,
-          "marginLeft": 16,
-          "opacity": 1,
-          "padding": 0,
-          "position": "absolute",
-        }
+        Array [
+          Object {
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 16,
+            "padding": 0,
+            "position": "absolute",
+          },
+          Object {
+            "opacity": 1,
+          },
+        ]
       }
       testID="Hamburguer"
     >

--- a/packages/mobile/src/verify/VerificationLoadingScreen.test.tsx
+++ b/packages/mobile/src/verify/VerificationLoadingScreen.test.tsx
@@ -7,13 +7,6 @@ import VerificationLoadingScreen from 'src/verify/VerificationLoadingScreen'
 import { createMockStore } from 'test/utils'
 import { mockNavigation } from 'test/values'
 
-// Mock AnimatedScrollView this way otherwise we get a
-// `JavaScript heap out of memory` error when ref is set (?!)
-jest.mock(
-  'react-native/Libraries/Animated/src/components/AnimatedScrollView.js',
-  () => 'RCTScrollView'
-)
-
 // Lock time so snapshots always show the same countdown value
 jest.spyOn(Date, 'now').mockImplementation(() => 1487076708000)
 

--- a/packages/mobile/src/verify/__snapshots__/VerificationLoadingScreen.test.tsx.snap
+++ b/packages/mobile/src/verify/__snapshots__/VerificationLoadingScreen.test.tsx.snap
@@ -244,11 +244,15 @@ exports[`VerificationLoadingScreen renders correctly 1`] = `
           <View
             accessible={true}
             style={
-              Object {
-                "alignItems": "center",
-                "opacity": 1,
-                "paddingVertical": 8,
-              }
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "paddingVertical": 8,
+                },
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <svg
@@ -1131,11 +1135,15 @@ exports[`VerificationLoadingScreen renders correctly with fail modal 1`] = `
           <View
             accessible={true}
             style={
-              Object {
-                "alignItems": "center",
-                "opacity": 1,
-                "paddingVertical": 8,
-              }
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "paddingVertical": 8,
+                },
+                Object {
+                  "opacity": 1,
+                },
+              ]
             }
           >
             <svg

--- a/packages/react-components/components/SmartTopAlert.test.tsx
+++ b/packages/react-components/components/SmartTopAlert.test.tsx
@@ -1,4 +1,4 @@
-import SmartTopAlert, { AlertTypes } from '@celo/react-components/components/SmartTopAlert'
+import SmartTopAlert from '@celo/react-components/components/SmartTopAlert'
 import * as React from 'react'
 import { render } from 'react-native-testing-library'
 
@@ -10,13 +10,13 @@ describe('SmartTopAlert', () => {
   it('renders correctly', async () => {
     const { toJSON } = render(
       <SmartTopAlert
-        isVisible={true}
-        timestamp={Date.now()}
-        dismissAfter={5}
-        title={'Smart Top Alert'}
-        text="dont get funny"
-        onPress={jest.fn()}
-        type={AlertTypes.MESSAGE}
+        alert={{
+          dismissAfter: 5,
+          title: 'Smart Top Alert',
+          message: 'dont get funny',
+          onPress: jest.fn(),
+          type: 'message',
+        }}
       />
     )
 

--- a/packages/react-components/components/SmartTopAlert.tsx
+++ b/packages/react-components/components/SmartTopAlert.tsx
@@ -2,65 +2,26 @@ import SmallButton from '@celo/react-components/components/SmallButton'
 import Error from '@celo/react-components/icons/Error'
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Animated, FlexStyle, StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-
-export enum AlertTypes {
-  MESSAGE = 'message',
-  ERROR = 'error',
-}
-
-interface AlertProps {
-  title?: string | null
-  text: string | null
-  onPress: () => void
-  type: AlertTypes
-  dismissAfter?: number | null
-  buttonMessage?: string | null
-}
-
-interface Props extends AlertProps {
-  isVisible: boolean
-  timestamp: number
+interface Props {
+  alert: {
+    type: 'message' | 'error'
+    title?: string | null
+    message: string
+    dismissAfter?: number | null
+    buttonMessage?: string | null
+    onPress: () => void
+  } | null
 }
 
 // This component needs to be always mounted for the hide animation to be visible
-function SmartTopAlert(props: Props) {
-  const [visibleAlertState, setVisibleAlertState] = useState<AlertProps | null>(null)
+function SmartTopAlert({ alert }: Props) {
+  const [visibleAlertState, setVisibleAlertState] = useState(alert)
   const insets = useSafeAreaInsets()
   const yOffset = useRef(new Animated.Value(-500))
   const containerRef = useRef<View>()
-  const animatedRef = useCallback((node) => {
-    containerRef.current = node && node.getNode()
-  }, [])
-
-  const alertState = useMemo(() => {
-    // tslint bug?
-    // tslint:disable-next-line: no-shadowed-variable
-    const { isVisible, type, title, text, buttonMessage, dismissAfter, onPress } = props
-    if (isVisible) {
-      return {
-        type,
-        title,
-        text,
-        buttonMessage,
-        dismissAfter,
-        onPress,
-      }
-    } else {
-      return null
-    }
-  }, [
-    props.timestamp,
-    props.isVisible,
-    props.type,
-    props.title,
-    props.text,
-    props.buttonMessage,
-    props.dismissAfter,
-    props.onPress,
-  ])
 
   function hide() {
     if (!containerRef.current) {
@@ -81,14 +42,14 @@ function SmartTopAlert(props: Props) {
   }
 
   useEffect(() => {
-    if (alertState) {
+    if (alert) {
       // show
-      setVisibleAlertState(alertState)
+      setVisibleAlertState(alert)
     } else {
       // hide
       hide()
     }
-  }, [alertState])
+  }, [alert])
 
   useEffect(() => {
     let rafHandle: number
@@ -132,8 +93,8 @@ function SmartTopAlert(props: Props) {
     return null
   }
 
-  const { type, title, text, buttonMessage, onPress } = visibleAlertState
-  const isError = type === AlertTypes.ERROR
+  const { type, title, message, buttonMessage, onPress } = visibleAlertState
+  const isError = type === 'error'
 
   const testID = isError ? 'errorBanner' : 'infoBanner'
 
@@ -141,7 +102,7 @@ function SmartTopAlert(props: Props) {
     <View style={styles.overflowContainer} testID={testID}>
       <TouchableWithoutFeedback onPress={onPress} testID="SmartTopAlertTouchable">
         <Animated.View
-          ref={animatedRef}
+          ref={containerRef}
           style={[
             styles.container,
             (buttonMessage && styles.containerWithButton) as FlexStyle,
@@ -156,7 +117,7 @@ function SmartTopAlert(props: Props) {
           {isError && <Error style={styles.errorIcon} />}
           <Text style={[fontStyles.small, isError && fontStyles.small500, styles.text]}>
             {!!title && <Text style={[fontStyles.small500, styles.text]}> {title} </Text>}
-            {text}
+            {message}
           </Text>
           {buttonMessage && (
             <SmallButton

--- a/packages/react-components/components/__snapshots__/CircleButton.test.tsx.snap
+++ b/packages/react-components/components/__snapshots__/CircleButton.test.tsx.snap
@@ -32,17 +32,29 @@ exports[`CircleButton renders correctly with minimum props 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#42D689",
-        "borderColor": "#42D689",
-        "borderRadius": 25,
-        "borderWidth": 0,
-        "height": 50,
-        "justifyContent": "center",
-        "opacity": 1,
-        "width": 50,
-      }
+      Array [
+        Array [
+          Object {
+            "alignItems": "center",
+            "justifyContent": "center",
+          },
+          Object {
+            "backgroundColor": "#42D689",
+          },
+          Object {
+            "borderWidth": 0,
+          },
+          Object {
+            "borderColor": "#42D689",
+            "borderRadius": 25,
+            "height": 50,
+            "width": 50,
+          },
+        ],
+        Object {
+          "opacity": 1,
+        },
+      ]
     }
   >
     <svg
@@ -101,17 +113,29 @@ exports[`CircleButton when given optional props renders correctly 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "transparent",
-        "borderColor": "#333333",
-        "borderRadius": 25,
-        "borderWidth": 3,
-        "height": 50,
-        "justifyContent": "center",
-        "opacity": 1,
-        "width": 50,
-      }
+      Array [
+        Array [
+          Object {
+            "alignItems": "center",
+            "justifyContent": "center",
+          },
+          Object {
+            "backgroundColor": "transparent",
+          },
+          Object {
+            "borderWidth": 3,
+          },
+          Object {
+            "borderColor": "#333333",
+            "borderRadius": 25,
+            "height": 50,
+            "width": 50,
+          },
+        ],
+        Object {
+          "opacity": 1,
+        },
+      ]
     }
   >
     <svg

--- a/packages/react-components/components/__snapshots__/ReviewFrame.test.tsx.snap
+++ b/packages/react-components/components/__snapshots__/ReviewFrame.test.tsx.snap
@@ -68,17 +68,29 @@ exports[`ReviewFrame renders correctly 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#42D689",
-            "borderColor": "#42D689",
-            "borderRadius": 25,
-            "borderWidth": 0,
-            "height": 50,
-            "justifyContent": "center",
-            "opacity": 1,
-            "width": 50,
-          }
+          Array [
+            Array [
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+              Object {
+                "backgroundColor": "#42D689",
+              },
+              Object {
+                "borderWidth": 0,
+              },
+              Object {
+                "borderColor": "#42D689",
+                "borderRadius": 25,
+                "height": 50,
+                "width": 50,
+              },
+            ],
+            Object {
+              "opacity": 1,
+            },
+          ]
         }
       >
         <svg

--- a/packages/react-components/components/__snapshots__/SmartTopAlert.test.tsx.snap
+++ b/packages/react-components/components/__snapshots__/SmartTopAlert.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`SmartTopAlert renders correctly 1`] = `
   <View
     accessible={true}
     focusable={true}
-    forwardedRef={[Function]}
     onClick={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
@@ -21,20 +20,26 @@ exports[`SmartTopAlert renders correctly 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#0768AE",
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingBottom": 10,
-        "paddingHorizontal": 25,
-        "paddingTop": 10,
-        "transform": Array [
-          Object {
-            "translateY": -500,
-          },
-        ],
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#0768AE",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingBottom": 10,
+          "paddingHorizontal": 25,
+        },
+        undefined,
+        false,
+        Object {
+          "paddingTop": 10,
+          "transform": Array [
+            Object {
+              "translateY": -500,
+            },
+          ],
+        },
+      ]
     }
     testID="SmartTopAlertTouchable"
   >

--- a/packages/react-components/components/__snapshots__/TextInputWithButtons.test.tsx.snap
+++ b/packages/react-components/components/__snapshots__/TextInputWithButtons.test.tsx.snap
@@ -46,9 +46,12 @@ exports[`TextInputWithButtons renders correctly 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "opacity": 1,
-      }
+      Array [
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+      ]
     }
     testID="Touchable"
   >

--- a/packages/react-components/jest_setup.js
+++ b/packages/react-components/jest_setup.js
@@ -16,3 +16,12 @@ if (typeof window !== 'object') {
   global.window = global
   global.window.navigator = {}
 }
+
+// Mock Animated Views this way otherwise we get a
+// `JavaScript heap out of memory` error when a ref is set (?!)
+// See https://github.com/callstack/react-native-testing-library/issues/539
+jest.mock('react-native/Libraries/Animated/src/components/AnimatedView.js', () => 'View')
+jest.mock(
+  'react-native/Libraries/Animated/src/components/AnimatedScrollView.js',
+  () => 'RCTScrollView'
+)


### PR DESCRIPTION
### Description

This fixes the regression described in #6314.

The change in #6230 made the underlying problem in `AlertBanner` more prominent as it caused the top level navigator to re-render on app state change (background/foreground/inactive) and hence the `AlertBanner`.

### Other changes

Globally mock `Animated.View` and `Animated.ScrollView` to prevent out of memory error when a ref is set.
See callstack/react-native-testing-library#539

Note: This change caused the Snapshot updates, because the styles are not flattened anymore for the mocked `Animated.View`.

### Tested

- Last alert is not redisplayed when navigating to different screens.
- New alert banner with same content can still be redisplayed when dispatched (causing a state change).

### Related issues

- Fixes #6314

### Backwards compatibility

Yes