### PR TITLE
Remember the correct most recent proposal voted on

### DIFF
--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -187,7 +187,7 @@ contract Governance is
    * @return The storage, major, minor, and patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 2, 0, 0);
+    return (1, 2, 0, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -639,7 +639,7 @@ contract Governance is
     );
     proposal.networkWeight = getLockedGold().getTotalLockedGold();
     voter.referendumVotes[index] = VoteRecord(value, proposalId, weight);
-    if (proposal.timestamp > voter.mostRecentReferendumProposal) {
+    if (proposal.timestamp > proposals[voter.mostRecentReferendumProposal].timestamp) {
       voter.mostRecentReferendumProposal = proposalId;
     }
     emit ProposalVoted(proposalId, account, uint256(value), weight);

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -1633,6 +1633,34 @@ contract('Governance', (accounts: string[]) => {
         const mostRecent = await governance.getMostRecentReferendumProposal(accounts[0])
         assert.equal(mostRecent.toNumber(), proposalId2)
       })
+
+      it('should return true on `isVoting`', async () => {
+        await governance.vote(proposalId2, index2, value)
+        await governance.vote(proposalId1, index1, value)
+        const voting = await governance.isVoting(accounts[0])
+        assert.isTrue(voting)
+      })
+
+      describe('after the first proposal expires', () => {
+        beforeEach(async () => {
+          await governance.vote(proposalId2, index2, value)
+          await governance.vote(proposalId1, index1, value)
+          await timeTravel(referendumStageDuration - 10, web3)
+
+          assert.isTrue
+        })
+
+        it('should still return true on `isVoting`', async () => {
+          const voting = await governance.isVoting(accounts[0])
+          assert.isTrue(voting)
+        })
+
+        it('should no longer return true on `isVoting` after both expire', async () => {
+          await timeTravel(11, web3)
+          const voting = await governance.isVoting(accounts[0])
+          assert.isFalse(voting)
+        })
+      })
     })
 
     describe('when the account has already voted on this proposal', () => {

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -1611,7 +1611,6 @@ contract('Governance', (accounts: string[]) => {
         )
         await timeTravel(newDequeueFrequency, web3)
         await governance.approve(proposalId1, index1)
-        const stage1 = await governance.getProposalStage(proposalId1)
         await governance.propose(
           [transactionSuccess2.value],
           [transactionSuccess2.destination],

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -1612,7 +1612,6 @@ contract('Governance', (accounts: string[]) => {
         await timeTravel(newDequeueFrequency, web3)
         await governance.approve(proposalId1, index1)
         const stage1 = await governance.getProposalStage(proposalId1)
-        console.log(stage1.toNumber())
         await governance.propose(
           [transactionSuccess2.value],
           [transactionSuccess2.destination],

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -1646,8 +1646,6 @@ contract('Governance', (accounts: string[]) => {
           await governance.vote(proposalId2, index2, value)
           await governance.vote(proposalId1, index1, value)
           await timeTravel(referendumStageDuration - 10, web3)
-
-          assert.isTrue
         })
 
         it('should still return true on `isVoting`', async () => {


### PR DESCRIPTION
### Description

A bug was discovered in the Governance contract that, under very specific conditions, would allow multiple-voting in a Governance referendum.  The bug was caused by erroneously comparing a timestamp to a proposal ID (rather that that proposal's timestamp) when deciding which proposal is more recent. This PR fixes this issue.

The exploit would only be possible when there are multiple proposals in the referendum stage at the same time, with a difference between their respective referendum end times *longer* than 3 days (the time it takes  to unlock Locked CELO). Until this fix is published on-chain, the workaround to avoid this issue is for the Governance approvers to not approve proposals that would lead to the above scenario. Thus, no funds are in danger due to this bug, and it is still possible to conduct Governance proposals, even multiple concurrent proposals, as long as they are timed correctly.

### Tested

Added a regression test that fails without the fix.