### PR TITLE
Update docs CLI docs to not give running a full node as a prerequisite

### DIFF
--- a/packages/docs/celo-holder-guide/eth-recovery.md
+++ b/packages/docs/celo-holder-guide/eth-recovery.md
@@ -37,7 +37,7 @@ Write your recovery phrase to a file using the following commands:
 Recover your Ethereum address on the Celo network:
 
 ```
-celocli account:new --indexAddress 0 --mnemonicPath recovery.txt --derivationPath "m/44'/60'/0'/0" --node https://rc1-forno.celo-testnet.org
+celocli account:new --indexAddress 0 --mnemonicPath recovery.txt --derivationPath "m/44'/60'/0'/0" --node https://forno.celo.org
 ```
 
 This command will return you with:
@@ -51,7 +51,7 @@ This command will return you with:
 Check your Celo account balance using this command:
 
 ```
-celocli account:balance <accountAddress> --node https://rc1-forno.celo-testnet.org
+celocli account:balance <accountAddress> --node https://forno.celo.org
 ```
 
 Replace `<accountAddress>` with the `accountAddress` you got from the previous step.
@@ -61,7 +61,7 @@ Replace `<accountAddress>` with the `accountAddress` you got from the previous s
 Now, you can transfer your CELO to an address of choice:
 
 ```
-celocli transfer:celo --from <accountAddress> --to <addressOfChoice> --value <valueInCeloWei> --privateKey <privateKey> --node https://rc1-forno.celo-testnet.org
+celocli transfer:celo --from <accountAddress> --to <addressOfChoice> --value <valueInCeloWei> --privateKey <privateKey> --node https://forno.celo.org
 ```
 
 - Replace `<accountAddress>` with the `accountAddress` you got from the previous step.

--- a/packages/docs/celo-holder-guide/quick-start.md
+++ b/packages/docs/celo-holder-guide/quick-start.md
@@ -91,7 +91,7 @@ You will now need to point the Celo CLI to a node that is synchronized with the 
   To use Forno, run this command:
 
   ```bash
-  celocli config:set --node https://rc1-forno.celo-testnet.org
+  celocli config:set --node https://forno.celo.org
   ```
 
 ## Locate and verify your `ReleaseGold` contract address

--- a/packages/docs/command-line-interface/introduction.md
+++ b/packages/docs/command-line-interface/introduction.md
@@ -8,9 +8,9 @@ description: >-
 
 ## Getting Started
 
-### **Prerequisites**
+### **Optional**
 
-- **You have a Celo node running.** Commands will connect to a Celo node to execute most functionality. See the [Running a Full Node](../getting-started/running-a-full-node-in-mainnet.md) instructions for more details on running a full node.
+- **Run a Celo node full node.** Commands will connect to a Celo node to execute most functionality. You can either use [Forno](../developer-resources/forno/README.md) (this is the easiest way) or run your own full node if you prefer. See the [Running a Full Node](../getting-started/running-a-full-node-in-mainnet.md) instructions for more details on running a full node.
 
 ### NPM Package
 
@@ -36,7 +36,7 @@ The tool is broken down into modules and commands with the following pattern:
 celocli <module>:<command> <...args> <...flags?>
 ```
 
-The `celocli` tool assumes that users are running a node which they have access to signing transactions on. See documentation on the [config](config.md) module for information about how set which node commands are sent to.
+The `celocli` tool assumes that users are running a node which they have access to signing transactions on, or have another mechanism for signing transactions (such as a Ledger wallet or supplying the private key as an argument to the command). See the documentation on the [config](config.md) module for information about how to set which node commands are sent to.
 
 {% hint style="info" %}
 **All balances of CELO or Celo Dollars are expressed in units of 10-18**

--- a/packages/docs/developer-resources/integrations/general.md
+++ b/packages/docs/developer-resources/integrations/general.md
@@ -52,7 +52,7 @@ Alfajores = 'https://alfajores-forno.celo-testnet.org'
 
 Baklava = 'https://baklava-forno.celo-testnet.org'
 
-Mainnet = 'https://rc1-forno.celo-testnet.org'
+Mainnet = 'https://forno.celo.org'
 ```
 
 ### Blockscout

--- a/packages/phone-number-privacy/signer/README.md
+++ b/packages/phone-number-privacy/signer/README.md
@@ -28,7 +28,7 @@ The service currently supports Postgres, MSSQL, and MySQL.
 ### Blockchain provider
 
 The service needs a connection to a full node in order to access chain state. The `BLOCKCHAIN_PROVIDER` config should be a url to a node with its JSON RPC enabled.
-This could be a node with RPC set up. Preferably this would be an node dedicated to this service. Alternatively, the public Forno endpoints can be used but their uptime guarantees are not as strong. For development with Alfajores, the forno url is `https://alfajores-forno.celo-testnet.org`. For Mainnet, it would be `https://rc1-forno.celo-testnet.org`
+This could be a node with RPC set up. Preferably this would be an node dedicated to this service. Alternatively, the public Forno endpoints can be used but their uptime guarantees are not as strong. For development with Alfajores, the forno url is `https://alfajores-forno.celo-testnet.org`. For Mainnet, it would be `https://forno.celo.org`
 
 - `BLOCKCHAIN_PROVIDER` - The blockchain node provider for chain state access. `
 


### PR DESCRIPTION
### Description

Users on Discord have been having difficulties with the instructions on recovering Celo from an Ethereum address.  The primary issue is that the instructions point to the CLI introduction page in the docs, which lists running a full node as a prerequisite to using the CLI.  This isn't right, and running a full node is technically quite challenging (and would take a while for the node to sync even if you did do it).  So I updated the CLI docs to make clear that running a full node is optional and that using Forno is the easier way to go.

### Other changes

In passing, I noticed the Ethereum recovery page was referencing the old url for mainnet Forno (https://rc1-forno.celo-testnet.org).  I updated it there and elsewhere in the docs to instead use the new url (https://forno.celo.org/).  There are a couple of other references to the old url:  https://github.com/celo-org/celo-monorepo/blob/73e1fd0831f1975e8ff0683d64b46ec946b922db/packages/komencikit/examples/attestation-flow.ts#L83 and https://github.com/celo-org/celo-monorepo/blob/73e1fd0831f1975e8ff0683d64b46ec946b922db/packages/notification-service/config/config.mainnet.env#L10 , but these are not in the docs so I wasn't sure whether I should update them in this PR or not.

### Tested

Verified that the forno url and the cross-links to other doc pages are correct.