### PR TITLE
[L01] Use only one definition of the Registry's address

### DIFF
--- a/packages/protocol/scripts/truffle/deploy_release_contracts.ts
+++ b/packages/protocol/scripts/truffle/deploy_release_contracts.ts
@@ -1,4 +1,5 @@
 import { retryTx } from '@celo/protocol/lib/proxy-utils'
+import { celoRegistryAddress } from '@celo/protocol/lib/registry-utils'
 import { _setInitialProxyImplementation } from '@celo/protocol/lib/web3-utils'
 import { Address, isValidAddress } from '@celo/utils/src/address'
 import BigNumber from 'bignumber.js'
@@ -86,7 +87,7 @@ async function handleGrant(config: ReleaseGoldConfig, currGrant: number) {
     config.initialDistributionRatio,
     config.canValidate,
     config.canVote,
-    '0x000000000000000000000000000000000000ce10',
+    celoRegistryAddress,
   ]
 
   const bytecode = await web3.eth.getCode(config.beneficiary)


### PR DESCRIPTION
### Description

The Celo Registry's address, `0xce10`, was defined in several places or used as a magic constant, in the protocol package. Moved to importing a constant from `registry-utils.ts`. 

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/721