### PR TITLE
[M01] Match exact number of bytes for bytecode metadata

### DIFF
--- a/packages/protocol/lib/bytecode.ts
+++ b/packages/protocol/lib/bytecode.ts
@@ -9,9 +9,9 @@ import { NULL_ADDRESS, trimLeading0x } from '@celo/base/lib/address'
 
 const CONTRACT_METADATA_REGEXPS = [
   // 0.5.8
-  'a165627a7a72305820.*0029',
+  'a165627a7a72305820.{64}0029',
   // 0.5.13
-  'a265627a7a72315820.*64736f6c6343.*0032',
+  'a265627a7a72315820.{64}64736f6c6343.{6}0032',
 ]
 
 const GENERAL_METADATA_REGEXP = new RegExp(


### PR DESCRIPTION
### Description

Previously, the regexes for matching metadata at the end of contract bytecodes used `.*`, this could have potentially led to a match of a different part of a contract's bytecode. With this PR, the regexes define a fixed length pattern that must appear at the end of the bytecode.

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/720