### PR TITLE
Remove broken header links in generated CLI docs

### DIFF
--- a/packages/cli/generate_docs.sh
+++ b/packages/cli/generate_docs.sh
@@ -1,0 +1,5 @@
+set -e
+export COLUMNS=88
+yarn oclif-dev readme --multi --dir=../docs/command-line-interface
+yarn prettier --write ../docs/command-line-interface/*
+sed -i '' '/^- \[/d' ../docs/command-line-interface/*

--- a/packages/cli/generate_docs.sh
+++ b/packages/cli/generate_docs.sh
@@ -2,4 +2,5 @@ set -e
 export COLUMNS=88
 yarn oclif-dev readme --multi --dir=../docs/command-line-interface
 yarn prettier --write ../docs/command-line-interface/*
+rm -rf ../docs/command-line-interface/*.bak
 sed -i.bak '/^- \[/d' ../docs/command-line-interface/*

--- a/packages/cli/generate_docs.sh
+++ b/packages/cli/generate_docs.sh
@@ -2,4 +2,4 @@ set -e
 export COLUMNS=88
 yarn oclif-dev readme --multi --dir=../docs/command-line-interface
 yarn prettier --write ../docs/command-line-interface/*
-sed -i '' '/^- \[/d' ../docs/command-line-interface/*
+sed -i.bak '/^- \[/d' ../docs/command-line-interface/*

--- a/packages/cli/generate_docs.sh
+++ b/packages/cli/generate_docs.sh
@@ -2,5 +2,5 @@ set -e
 export COLUMNS=88
 yarn oclif-dev readme --multi --dir=../docs/command-line-interface
 yarn prettier --write ../docs/command-line-interface/*
-rm -rf ../docs/command-line-interface/*.bak
 sed -i.bak '/^- \[/d' ../docs/command-line-interface/*
+rm -rf ../docs/command-line-interface/*.bak

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "clean": "tsc -b . --clean",
     "build": "tsc -b .",
-    "docs": "export COLUMNS=88 && yarn oclif-dev readme --multi --dir=../docs/command-line-interface && yarn prettier ../docs/command-line-interface/*.md --write",
+    "docs": "./generate_docs.sh",
     "lint": "tslint -c tslint.json --project tsconfig.json",
     "prepack": "yarn run build && oclif-dev manifest && oclif-dev readme",
     "test:reset": "yarn --cwd ../protocol devchain generate-tar .tmp/devchain.tar.gz --migration_override ../dev-utils/src/migration-override.json --upto 24 --release_gold_contracts scripts/truffle/releaseGoldExampleConfigs.json",

--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -1,1 +1,2 @@
 _book/*
+command-line-interface/*.bak

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -2,32 +2,6 @@
 
 Manage your account, keys, and metadata
 
-- [`celocli account:authorize`](#celocli-accountauthorize)
-- [`celocli account:balance ADDRESS`](#celocli-accountbalance-address)
-- [`celocli account:claim-account FILE`](#celocli-accountclaim-account-file)
-- [`celocli account:claim-attestation-service-url FILE`](#celocli-accountclaim-attestation-service-url-file)
-- [`celocli account:claim-domain FILE`](#celocli-accountclaim-domain-file)
-- [`celocli account:claim-keybase FILE`](#celocli-accountclaim-keybase-file)
-- [`celocli account:claim-name FILE`](#celocli-accountclaim-name-file)
-- [`celocli account:claim-storage FILE`](#celocli-accountclaim-storage-file)
-- [`celocli account:create-metadata FILE`](#celocli-accountcreate-metadata-file)
-- [`celocli account:get-metadata ADDRESS`](#celocli-accountget-metadata-address)
-- [`celocli account:list`](#celocli-accountlist)
-- [`celocli account:lock ACCOUNT`](#celocli-accountlock-account)
-- [`celocli account:new`](#celocli-accountnew)
-- [`celocli account:offchain-read`](#celocli-accountoffchain-read)
-- [`celocli account:offchain-write`](#celocli-accountoffchain-write)
-- [`celocli account:proof-of-possession`](#celocli-accountproof-of-possession)
-- [`celocli account:recover-old`](#celocli-accountrecover-old)
-- [`celocli account:register`](#celocli-accountregister)
-- [`celocli account:register-data-encryption-key`](#celocli-accountregister-data-encryption-key)
-- [`celocli account:register-metadata`](#celocli-accountregister-metadata)
-- [`celocli account:set-name`](#celocli-accountset-name)
-- [`celocli account:show ADDRESS`](#celocli-accountshow-address)
-- [`celocli account:show-claimed-accounts ADDRESS`](#celocli-accountshow-claimed-accounts-address)
-- [`celocli account:show-metadata FILE`](#celocli-accountshow-metadata-file)
-- [`celocli account:unlock ACCOUNT`](#celocli-accountunlock-account)
-- [`celocli account:verify-proof-of-possession`](#celocli-accountverify-proof-of-possession)
 
 ## `celocli account:authorize`
 

--- a/packages/docs/command-line-interface/autocomplete.md
+++ b/packages/docs/command-line-interface/autocomplete.md
@@ -2,7 +2,6 @@
 
 display autocomplete installation instructions
 
-- [`celocli autocomplete [SHELL]`](#celocli-autocomplete-shell)
 
 ## `celocli autocomplete [SHELL]`
 

--- a/packages/docs/command-line-interface/commands.md
+++ b/packages/docs/command-line-interface/commands.md
@@ -2,7 +2,6 @@
 
 list all the commands
 
-- [`celocli commands`](#celocli-commands)
 
 ## `celocli commands`
 

--- a/packages/docs/command-line-interface/config.md
+++ b/packages/docs/command-line-interface/config.md
@@ -2,8 +2,6 @@
 
 Configure CLI options which persist across commands
 
-- [`celocli config:get`](#celocli-configget)
-- [`celocli config:set`](#celocli-configset)
 
 ## `celocli config:get`
 

--- a/packages/docs/command-line-interface/dkg.md
+++ b/packages/docs/command-line-interface/dkg.md
@@ -2,12 +2,6 @@
 
 Publish your locally computed DKG results to the blockchain
 
-- [`celocli dkg:deploy`](#celocli-dkgdeploy)
-- [`celocli dkg:get`](#celocli-dkgget)
-- [`celocli dkg:publish`](#celocli-dkgpublish)
-- [`celocli dkg:register`](#celocli-dkgregister)
-- [`celocli dkg:start`](#celocli-dkgstart)
-- [`celocli dkg:whitelist`](#celocli-dkgwhitelist)
 
 ## `celocli dkg:deploy`
 

--- a/packages/docs/command-line-interface/election.md
+++ b/packages/docs/command-line-interface/election.md
@@ -2,13 +2,6 @@
 
 Participate in and view the state of Validator Elections
 
-- [`celocli election:activate`](#celocli-electionactivate)
-- [`celocli election:current`](#celocli-electioncurrent)
-- [`celocli election:list`](#celocli-electionlist)
-- [`celocli election:revoke`](#celocli-electionrevoke)
-- [`celocli election:run`](#celocli-electionrun)
-- [`celocli election:show ADDRESS`](#celocli-electionshow-address)
-- [`celocli election:vote`](#celocli-electionvote)
 
 ## `celocli election:activate`
 

--- a/packages/docs/command-line-interface/exchange.md
+++ b/packages/docs/command-line-interface/exchange.md
@@ -2,10 +2,6 @@
 
 Exchange Celo Dollars and CELO via the stability mechanism
 
-- [`celocli exchange:celo`](#celocli-exchangecelo)
-- [`celocli exchange:dollars`](#celocli-exchangedollars)
-- [`celocli exchange:gold`](#celocli-exchangegold)
-- [`celocli exchange:show`](#celocli-exchangeshow)
 
 ## `celocli exchange:celo`
 

--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -2,22 +2,6 @@
 
 Interact with on-chain governance proposals and hotfixes
 
-- [`celocli governance:build-proposal`](#celocli-governancebuild-proposal)
-- [`celocli governance:dequeue`](#celocli-governancedequeue)
-- [`celocli governance:execute`](#celocli-governanceexecute)
-- [`celocli governance:executehotfix`](#celocli-governanceexecutehotfix)
-- [`celocli governance:hashhotfix`](#celocli-governancehashhotfix)
-- [`celocli governance:list`](#celocli-governancelist)
-- [`celocli governance:preparehotfix`](#celocli-governancepreparehotfix)
-- [`celocli governance:propose`](#celocli-governancepropose)
-- [`celocli governance:revokeupvote`](#celocli-governancerevokeupvote)
-- [`celocli governance:show`](#celocli-governanceshow)
-- [`celocli governance:upvote`](#celocli-governanceupvote)
-- [`celocli governance:view`](#celocli-governanceview)
-- [`celocli governance:viewhotfix`](#celocli-governanceviewhotfix)
-- [`celocli governance:vote`](#celocli-governancevote)
-- [`celocli governance:whitelisthotfix`](#celocli-governancewhitelisthotfix)
-- [`celocli governance:withdraw`](#celocli-governancewithdraw)
 
 ## `celocli governance:build-proposal`
 

--- a/packages/docs/command-line-interface/help.md
+++ b/packages/docs/command-line-interface/help.md
@@ -2,7 +2,6 @@
 
 display help for celocli
 
-- [`celocli help [COMMAND]`](#celocli-help-command)
 
 ## `celocli help [COMMAND]`
 

--- a/packages/docs/command-line-interface/identity.md
+++ b/packages/docs/command-line-interface/identity.md
@@ -2,10 +2,6 @@
 
 Interact with ODIS and the attestations service
 
-- [`celocli identity:current-attestation-services`](#celocli-identitycurrent-attestation-services)
-- [`celocli identity:identifier`](#celocli-identityidentifier)
-- [`celocli identity:test-attestation-service`](#celocli-identitytest-attestation-service)
-- [`celocli identity:withdraw-attestation-rewards`](#celocli-identitywithdraw-attestation-rewards)
 
 ## `celocli identity:current-attestation-services`
 

--- a/packages/docs/command-line-interface/lockedgold.md
+++ b/packages/docs/command-line-interface/lockedgold.md
@@ -2,10 +2,6 @@
 
 View and manage locked CELO
 
-- [`celocli lockedgold:lock`](#celocli-lockedgoldlock)
-- [`celocli lockedgold:show ACCOUNT`](#celocli-lockedgoldshow-account)
-- [`celocli lockedgold:unlock`](#celocli-lockedgoldunlock)
-- [`celocli lockedgold:withdraw`](#celocli-lockedgoldwithdraw)
 
 ## `celocli lockedgold:lock`
 

--- a/packages/docs/command-line-interface/multisig.md
+++ b/packages/docs/command-line-interface/multisig.md
@@ -2,8 +2,6 @@
 
 Shows information about multi-sig contract
 
-- [`celocli multisig:show ADDRESS`](#celocli-multisigshow-address)
-- [`celocli multisig:transfer ADDRESS`](#celocli-multisigtransfer-address)
 
 ## `celocli multisig:show ADDRESS`
 

--- a/packages/docs/command-line-interface/network.md
+++ b/packages/docs/command-line-interface/network.md
@@ -2,9 +2,6 @@
 
 View details about the network, like contracts and parameters
 
-- [`celocli network:contracts`](#celocli-networkcontracts)
-- [`celocli network:info`](#celocli-networkinfo)
-- [`celocli network:parameters`](#celocli-networkparameters)
 
 ## `celocli network:contracts`
 

--- a/packages/docs/command-line-interface/node.md
+++ b/packages/docs/command-line-interface/node.md
@@ -2,8 +2,6 @@
 
 Manage your Celo node
 
-- [`celocli node:accounts`](#celocli-nodeaccounts)
-- [`celocli node:synced`](#celocli-nodesynced)
 
 ## `celocli node:accounts`
 

--- a/packages/docs/command-line-interface/oracle.md
+++ b/packages/docs/command-line-interface/oracle.md
@@ -2,10 +2,6 @@
 
 List oracle addresses for a given token
 
-- [`celocli oracle:list TOKEN`](#celocli-oraclelist-token)
-- [`celocli oracle:remove-expired-reports TOKEN`](#celocli-oracleremove-expired-reports-token)
-- [`celocli oracle:report TOKEN`](#celocli-oraclereport-token)
-- [`celocli oracle:reports TOKEN`](#celocli-oraclereports-token)
 
 ## `celocli oracle:list TOKEN`
 

--- a/packages/docs/command-line-interface/releasegold.md
+++ b/packages/docs/command-line-interface/releasegold.md
@@ -2,21 +2,6 @@
 
 View and manage Release Gold contracts
 
-- [`celocli releasegold:authorize`](#celocli-releasegoldauthorize)
-- [`celocli releasegold:create-account`](#celocli-releasegoldcreate-account)
-- [`celocli releasegold:locked-gold`](#celocli-releasegoldlocked-gold)
-- [`celocli releasegold:refund-and-finalize`](#celocli-releasegoldrefund-and-finalize)
-- [`celocli releasegold:revoke`](#celocli-releasegoldrevoke)
-- [`celocli releasegold:revoke-votes`](#celocli-releasegoldrevoke-votes)
-- [`celocli releasegold:set-account`](#celocli-releasegoldset-account)
-- [`celocli releasegold:set-account-wallet-address`](#celocli-releasegoldset-account-wallet-address)
-- [`celocli releasegold:set-beneficiary`](#celocli-releasegoldset-beneficiary)
-- [`celocli releasegold:set-can-expire`](#celocli-releasegoldset-can-expire)
-- [`celocli releasegold:set-liquidity-provision`](#celocli-releasegoldset-liquidity-provision)
-- [`celocli releasegold:set-max-distribution`](#celocli-releasegoldset-max-distribution)
-- [`celocli releasegold:show`](#celocli-releasegoldshow)
-- [`celocli releasegold:transfer-dollars`](#celocli-releasegoldtransfer-dollars)
-- [`celocli releasegold:withdraw`](#celocli-releasegoldwithdraw)
 
 ## `celocli releasegold:authorize`
 

--- a/packages/docs/command-line-interface/reserve.md
+++ b/packages/docs/command-line-interface/reserve.md
@@ -2,8 +2,6 @@
 
 Shows information about reserve
 
-- [`celocli reserve:status`](#celocli-reservestatus)
-- [`celocli reserve:transfergold`](#celocli-reservetransfergold)
 
 ## `celocli reserve:status`
 

--- a/packages/docs/command-line-interface/rewards.md
+++ b/packages/docs/command-line-interface/rewards.md
@@ -2,7 +2,6 @@
 
 Show rewards information about a voter, registered Validator, or Validator Group
 
-- [`celocli rewards:show`](#celocli-rewardsshow)
 
 ## `celocli rewards:show`
 

--- a/packages/docs/command-line-interface/transfer.md
+++ b/packages/docs/command-line-interface/transfer.md
@@ -2,9 +2,6 @@
 
 Transfer CELO and Celo Dollars
 
-- [`celocli transfer:celo`](#celocli-transfercelo)
-- [`celocli transfer:dollars`](#celocli-transferdollars)
-- [`celocli transfer:gold`](#celocli-transfergold)
 
 ## `celocli transfer:celo`
 

--- a/packages/docs/command-line-interface/validator.md
+++ b/packages/docs/command-line-interface/validator.md
@@ -2,19 +2,6 @@
 
 View and manage Validators
 
-- [`celocli validator:affiliate GROUPADDRESS`](#celocli-validatoraffiliate-groupaddress)
-- [`celocli validator:deaffiliate`](#celocli-validatordeaffiliate)
-- [`celocli validator:deregister`](#celocli-validatorderegister)
-- [`celocli validator:downtime-slash`](#celocli-validatordowntime-slash)
-- [`celocli validator:force-deaffiliate`](#celocli-validatorforce-deaffiliate)
-- [`celocli validator:list`](#celocli-validatorlist)
-- [`celocli validator:register`](#celocli-validatorregister)
-- [`celocli validator:requirements`](#celocli-validatorrequirements)
-- [`celocli validator:set-bitmaps`](#celocli-validatorset-bitmaps)
-- [`celocli validator:show VALIDATORADDRESS`](#celocli-validatorshow-validatoraddress)
-- [`celocli validator:signed-blocks`](#celocli-validatorsigned-blocks)
-- [`celocli validator:status`](#celocli-validatorstatus)
-- [`celocli validator:update-bls-public-key`](#celocli-validatorupdate-bls-public-key)
 
 ## `celocli validator:affiliate GROUPADDRESS`
 

--- a/packages/docs/command-line-interface/validatorgroup.md
+++ b/packages/docs/command-line-interface/validatorgroup.md
@@ -2,13 +2,6 @@
 
 View and manage Validator Groups
 
-- [`celocli validatorgroup:commission`](#celocli-validatorgroupcommission)
-- [`celocli validatorgroup:deregister`](#celocli-validatorgroupderegister)
-- [`celocli validatorgroup:list`](#celocli-validatorgrouplist)
-- [`celocli validatorgroup:member VALIDATORADDRESS`](#celocli-validatorgroupmember-validatoraddress)
-- [`celocli validatorgroup:register`](#celocli-validatorgroupregister)
-- [`celocli validatorgroup:reset-slashing-multiplier GROUPADDRESS`](#celocli-validatorgroupreset-slashing-multiplier-groupaddress)
-- [`celocli validatorgroup:show GROUPADDRESS`](#celocli-validatorgroupshow-groupaddress)
 
 ## `celocli validatorgroup:commission`
 

--- a/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_string_.md
+++ b/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_string_.md
@@ -5,6 +5,7 @@
 ### References
 
 * [appendPath](_packages_sdk_utils_src_string_.md#appendpath)
+* [normalizeAccents](_packages_sdk_utils_src_string_.md#normalizeaccents)
 
 ### Object literals
 
@@ -15,6 +16,12 @@
 ###  appendPath
 
 • **appendPath**:
+
+___
+
+###  normalizeAccents
+
+• **normalizeAccents**:
 
 ## Object literals
 
@@ -32,6 +39,6 @@
 
 ###  normalizeAccents
 
-• **normalizeAccents**: *any*
+• **normalizeAccents**: *normalizeAccents*
 
 *Defined in [packages/sdk/utils/src/string.ts:7](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/string.ts#L7)*


### PR DESCRIPTION
### Description

Hack to remove header of each CLI command readme which contains broken links
               
### Tested

With `yarn preview`