### PR TITLE
Write transfer and transferFrom commands for MultiSig contract

### DIFF
--- a/packages/cli/src/commands/multisig/transfer.ts
+++ b/packages/cli/src/commands/multisig/transfer.ts
@@ -1,0 +1,47 @@
+import { flags } from '@oclif/command'
+import { BigNumber } from 'bignumber.js'
+import { BaseCommand } from '../../base'
+import { displaySendTx } from '../../utils/cli'
+import { Args, Flags } from '../../utils/command'
+
+export default class MultiSigTransfer extends BaseCommand {
+  static description = 'Ability approve CELO transfers to and from multisig'
+
+  static flags = {
+    ...BaseCommand.flags,
+    to: Flags.address({ required: true, description: 'Recipient of transfer' }),
+    amount: flags.string({ required: true, description: 'Amount to transfer, e.g. 10e18' }),
+    transferFrom: flags.boolean({ description: 'Perform transferFrom instead of transfer' }),
+    sender: Flags.address({ description: 'Identify sender if performing transferFrom' }),
+    from: Flags.address({ required: true, description: 'account performing transaction' }),
+  }
+
+  static args = [Args.address('address')]
+
+  static examples = [
+    'transfer <multiSigAddr> --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18',
+    'transfer <multiSigAddr> --transferFrom --sender 0x123abc --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18',
+  ]
+
+  async run() {
+    const {
+      args,
+      flags: { to, sender, from, amount, transferFrom },
+    } = this.parse(MultiSigTransfer)
+    const amountBN = new BigNumber(amount)
+    const celoToken = await this.kit.contracts.getGoldToken()
+    const multisig = await this.kit.contracts.getMultiSig(args.address)
+
+    let transferTx
+    if (transferFrom) {
+      if (!sender) this.error("Must submit 'sender' when submitting TransferFrom tx")
+      // @ts-ignore - function will accept BigNumber
+      transferTx = celoToken.transferFrom(sender, to, amountBN)
+    } else {
+      // @ts-ignore - function will accept BigNumber
+      transferTx = celoToken.transfer(to, amountBN)
+    }
+    let multiSigTx = await multisig.submitOrConfirmTransaction(celoToken.address, transferTx.txo)
+    await displaySendTx<any>('submitOrApproveTransfer', multiSigTx, { from }, 'tx Sent')
+  }
+}

--- a/packages/cli/src/commands/multisig/transfer.ts
+++ b/packages/cli/src/commands/multisig/transfer.ts
@@ -5,7 +5,8 @@ import { displaySendTx } from '../../utils/cli'
 import { Args, Flags } from '../../utils/command'
 
 export default class MultiSigTransfer extends BaseCommand {
-  static description = 'Ability approve CELO transfers to and from multisig'
+  static description =
+    'Ability to approve CELO transfers to and from multisig. Submit transaction or approve a matching existing transaction'
 
   static flags = {
     ...BaseCommand.flags,
@@ -19,8 +20,8 @@ export default class MultiSigTransfer extends BaseCommand {
   static args = [Args.address('address')]
 
   static examples = [
-    'transfer <multiSigAddr> --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18',
-    'transfer <multiSigAddr> --transferFrom --sender 0x123abc --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18',
+    'transfer <multiSigAddr> --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18 --from 0x123abc',
+    'transfer <multiSigAddr> --transferFrom --sender 0x123abc --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18 --from 0x123abc',
   ]
 
   async run() {
@@ -41,7 +42,7 @@ export default class MultiSigTransfer extends BaseCommand {
       // @ts-ignore - function will accept BigNumber
       transferTx = celoToken.transfer(to, amountBN)
     }
-    let multiSigTx = await multisig.submitOrConfirmTransaction(celoToken.address, transferTx.txo)
+    const multiSigTx = await multisig.submitOrConfirmTransaction(celoToken.address, transferTx.txo)
     await displaySendTx<any>('submitOrApproveTransfer', multiSigTx, { from }, 'tx Sent')
   }
 }

--- a/packages/docs/SUMMARY.md
+++ b/packages/docs/SUMMARY.md
@@ -706,6 +706,7 @@
       - [packages/sdk/utils/src/solidity](developer-resources/utils/reference/modules/_packages_sdk_utils_src_solidity_.md)
       - [packages/sdk/utils/src/string](developer-resources/utils/reference/modules/_packages_sdk_utils_src_string_.md)
       - [packages/sdk/utils/src/task](developer-resources/utils/reference/modules/_packages_sdk_utils_src_task_.md)
+      - [packages/sdk/utils/src/typed-data-constructors](developer-resources/utils/reference/modules/_packages_sdk_utils_src_typed_data_constructors_.md)
     - [Classes]()
       - [F](developer-resources/utils/reference/classes/_node_modules_bls12377js_src_f_.f.md)
       - [F2](developer-resources/utils/reference/classes/_node_modules_bls12377js_src_f2_.f2.md)

--- a/packages/docs/command-line-interface/multisig.md
+++ b/packages/docs/command-line-interface/multisig.md
@@ -3,6 +3,7 @@
 Shows information about multi-sig contract
 
 - [`celocli multisig:show ADDRESS`](#celocli-multisigshow-address)
+- [`celocli multisig:transfer ADDRESS`](#celocli-multisigtransfer-address)
 
 ## `celocli multisig:show ADDRESS`
 
@@ -28,3 +29,38 @@ EXAMPLES
 ```
 
 _See code: [src/commands/multisig/show.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/multisig/show.ts)_
+
+## `celocli multisig:transfer ADDRESS`
+
+Ability approve CELO transfers to and from multisig
+
+```
+Ability approve CELO transfers to and from multisig
+
+USAGE
+  $ celocli multisig:transfer ADDRESS
+
+OPTIONS
+  --amount=amount                                      (required) Amount to transfer,
+                                                       e.g. 10e18
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) account performing
+                                                       transaction
+
+  --sender=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Identify sender if performing
+                                                       transferFrom
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Recipient of transfer
+
+  --transferFrom                                       Perform transferFrom instead of
+                                                       transfer
+
+EXAMPLES
+  transfer <multiSigAddr> --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount
+  200000e18
+
+  transfer <multiSigAddr> --transferFrom --sender 0x123abc --to
+  0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18
+```
+
+_See code: [src/commands/multisig/transfer.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/multisig/transfer.ts)_

--- a/packages/docs/command-line-interface/multisig.md
+++ b/packages/docs/command-line-interface/multisig.md
@@ -32,10 +32,10 @@ _See code: [src/commands/multisig/show.ts](https://github.com/celo-org/celo-mono
 
 ## `celocli multisig:transfer ADDRESS`
 
-Ability approve CELO transfers to and from multisig
+Ability to approve CELO transfers to and from multisig. Submit transaction or approve a matching existing transaction
 
 ```
-Ability approve CELO transfers to and from multisig
+Ability to approve CELO transfers to and from multisig. Submit transaction or approve a matching existing transaction
 
 USAGE
   $ celocli multisig:transfer ADDRESS
@@ -57,10 +57,10 @@ OPTIONS
 
 EXAMPLES
   transfer <multiSigAddr> --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount
-  200000e18
+  200000e18 --from 0x123abc
 
   transfer <multiSigAddr> --transferFrom --sender 0x123abc --to
-  0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18
+  0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18 --from 0x123abc
 ```
 
 _See code: [src/commands/multisig/transfer.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/multisig/transfer.ts)_

--- a/packages/docs/developer-resources/base/reference/modules/_string_.md
+++ b/packages/docs/developer-resources/base/reference/modules/_string_.md
@@ -5,6 +5,7 @@
 ### Functions
 
 * [appendPath](_string_.md#appendpath)
+* [normalizeAccents](_string_.md#normalizeaccents)
 
 ### Object literals
 
@@ -27,16 +28,38 @@ Name | Type |
 
 **Returns:** *string*
 
+___
+
+###  normalizeAccents
+
+▸ **normalizeAccents**(`str`: string): *string*
+
+*Defined in [packages/sdk/base/src/string.ts:10](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/base/src/string.ts#L10)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`str` | string |
+
+**Returns:** *string*
+
 ## Object literals
 
 ### `Const` StringBase
 
 ### ▪ **StringBase**: *object*
 
-*Defined in [packages/sdk/base/src/string.ts:9](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/base/src/string.ts#L9)*
+*Defined in [packages/sdk/base/src/string.ts:14](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/base/src/string.ts#L14)*
 
 ###  appendPath
 
 • **appendPath**: *[appendPath](_string_.md#appendpath)*
 
-*Defined in [packages/sdk/base/src/string.ts:10](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/base/src/string.ts#L10)*
+*Defined in [packages/sdk/base/src/string.ts:15](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/base/src/string.ts#L15)*
+
+###  normalizeAccents
+
+• **normalizeAccents**: *[normalizeAccents](_string_.md#normalizeaccents)*
+
+*Defined in [packages/sdk/base/src/string.ts:16](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/base/src/string.ts#L16)*

--- a/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
@@ -115,13 +115,13 @@ core contract's address registry
 
 • **get defaultAccount**(): *Address | undefined*
 
-*Defined in [contractkit/src/kit.ts:291](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L291)*
+*Defined in [contractkit/src/kit.ts:290](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L290)*
 
 **Returns:** *Address | undefined*
 
 • **set defaultAccount**(`address`: Address | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:287](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L287)*
+*Defined in [contractkit/src/kit.ts:286](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L286)*
 
 **Parameters:**
 
@@ -137,13 +137,13 @@ ___
 
 • **get defaultFeeCurrency**(): *undefined | string*
 
-*Defined in [contractkit/src/kit.ts:315](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L315)*
+*Defined in [contractkit/src/kit.ts:314](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L314)*
 
 **Returns:** *undefined | string*
 
 • **set defaultFeeCurrency**(`address`: Address | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:311](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L311)*
+*Defined in [contractkit/src/kit.ts:310](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L310)*
 
 **Parameters:**
 
@@ -159,13 +159,13 @@ ___
 
 • **get gasInflationFactor**(): *number*
 
-*Defined in [contractkit/src/kit.ts:299](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L299)*
+*Defined in [contractkit/src/kit.ts:298](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L298)*
 
 **Returns:** *number*
 
 • **set gasInflationFactor**(`factor`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:295](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L295)*
+*Defined in [contractkit/src/kit.ts:294](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L294)*
 
 **Parameters:**
 
@@ -181,13 +181,13 @@ ___
 
 • **get gasPrice**(): *number*
 
-*Defined in [contractkit/src/kit.ts:307](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L307)*
+*Defined in [contractkit/src/kit.ts:306](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L306)*
 
 **Returns:** *number*
 
 • **set gasPrice**(`price`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:303](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L303)*
+*Defined in [contractkit/src/kit.ts:302](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L302)*
 
 **Parameters:**
 
@@ -203,7 +203,7 @@ ___
 
 • **get web3**(): *Web3‹›*
 
-*Defined in [contractkit/src/kit.ts:353](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L353)*
+*Defined in [contractkit/src/kit.ts:352](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L352)*
 
 **Returns:** *Web3‹›*
 
@@ -213,7 +213,7 @@ ___
 
 ▸ **addAccount**(`privateKey`: string): *void*
 
-*Defined in [contractkit/src/kit.ts:283](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L283)*
+*Defined in [contractkit/src/kit.ts:282](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L282)*
 
 **Parameters:**
 
@@ -229,7 +229,7 @@ ___
 
 ▸ **fillGasPrice**(`tx`: CeloTx): *Promise‹CeloTx›*
 
-*Defined in [contractkit/src/kit.ts:327](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L327)*
+*Defined in [contractkit/src/kit.ts:326](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L326)*
 
 **Parameters:**
 
@@ -245,7 +245,7 @@ ___
 
 ▸ **getEpochNumberOfBlock**(`blockNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:268](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L268)*
+*Defined in [contractkit/src/kit.ts:267](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L267)*
 
 **Parameters:**
 
@@ -261,7 +261,7 @@ ___
 
 ▸ **getEpochSize**(): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:241](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L241)*
+*Defined in [contractkit/src/kit.ts:240](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L240)*
 
 **Returns:** *Promise‹number›*
 
@@ -271,7 +271,7 @@ ___
 
 ▸ **getFirstBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:248](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L248)*
+*Defined in [contractkit/src/kit.ts:247](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L247)*
 
 **Parameters:**
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **getHumanReadableNetworkConfig**(): *Promise‹object›*
 
-*Defined in [contractkit/src/kit.ts:172](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L172)*
+*Defined in [contractkit/src/kit.ts:171](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L171)*
 
 **Returns:** *Promise‹object›*
 
@@ -297,7 +297,7 @@ ___
 
 ▸ **getLastBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:258](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L258)*
+*Defined in [contractkit/src/kit.ts:257](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L257)*
 
 **Parameters:**
 
@@ -313,7 +313,7 @@ ___
 
 ▸ **getNetworkConfig**(): *Promise‹[NetworkConfig](../interfaces/_kit_.networkconfig.md)›*
 
-*Defined in [contractkit/src/kit.ts:121](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L121)*
+*Defined in [contractkit/src/kit.ts:120](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L120)*
 
 **Returns:** *Promise‹[NetworkConfig](../interfaces/_kit_.networkconfig.md)›*
 
@@ -349,7 +349,7 @@ ___
 
 ▸ **isListening**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:319](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L319)*
+*Defined in [contractkit/src/kit.ts:318](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -359,7 +359,7 @@ ___
 
 ▸ **isSyncing**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:323](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L323)*
+*Defined in [contractkit/src/kit.ts:322](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -369,7 +369,7 @@ ___
 
 ▸ **sendTransaction**(`tx`: CeloTx): *Promise‹TransactionResult›*
 
-*Defined in [contractkit/src/kit.ts:334](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L334)*
+*Defined in [contractkit/src/kit.ts:333](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L333)*
 
 **Parameters:**
 
@@ -385,7 +385,7 @@ ___
 
 ▸ **sendTransactionObject**(`txObj`: CeloTxObject‹any›, `tx?`: Omit‹CeloTx, "data"›): *Promise‹TransactionResult›*
 
-*Defined in [contractkit/src/kit.ts:338](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L338)*
+*Defined in [contractkit/src/kit.ts:337](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L337)*
 
 **Parameters:**
 
@@ -402,7 +402,7 @@ ___
 
 ▸ **setFeeCurrency**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹void›*
 
-*Defined in [contractkit/src/kit.ts:224](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L224)*
+*Defined in [contractkit/src/kit.ts:223](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L223)*
 
 Set CeloToken to use to pay for gas fees
 
@@ -420,7 +420,7 @@ ___
 
 ▸ **signTypedData**(`signer`: string, `typedData`: EIP712TypedData): *Promise‹Signature›*
 
-*Defined in [contractkit/src/kit.ts:345](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L345)*
+*Defined in [contractkit/src/kit.ts:344](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L344)*
 
 **Parameters:**
 
@@ -437,7 +437,7 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [contractkit/src/kit.ts:349](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L349)*
+*Defined in [contractkit/src/kit.ts:348](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L348)*
 
 **Returns:** *void*
 
@@ -447,7 +447,7 @@ ___
 
 ▸ **updateGasPriceInConnectionLayer**(`currency`: Address): *Promise‹void›*
 
-*Defined in [contractkit/src/kit.ts:234](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L234)*
+*Defined in [contractkit/src/kit.ts:233](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L233)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_kit_.contractkit.md
@@ -115,13 +115,13 @@ core contract's address registry
 
 • **get defaultAccount**(): *Address | undefined*
 
-*Defined in [contractkit/src/kit.ts:290](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L290)*
+*Defined in [contractkit/src/kit.ts:291](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L291)*
 
 **Returns:** *Address | undefined*
 
 • **set defaultAccount**(`address`: Address | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:286](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L286)*
+*Defined in [contractkit/src/kit.ts:287](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L287)*
 
 **Parameters:**
 
@@ -137,13 +137,13 @@ ___
 
 • **get defaultFeeCurrency**(): *undefined | string*
 
-*Defined in [contractkit/src/kit.ts:314](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L314)*
+*Defined in [contractkit/src/kit.ts:315](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L315)*
 
 **Returns:** *undefined | string*
 
 • **set defaultFeeCurrency**(`address`: Address | undefined): *void*
 
-*Defined in [contractkit/src/kit.ts:310](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L310)*
+*Defined in [contractkit/src/kit.ts:311](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L311)*
 
 **Parameters:**
 
@@ -159,13 +159,13 @@ ___
 
 • **get gasInflationFactor**(): *number*
 
-*Defined in [contractkit/src/kit.ts:298](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L298)*
+*Defined in [contractkit/src/kit.ts:299](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L299)*
 
 **Returns:** *number*
 
 • **set gasInflationFactor**(`factor`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:294](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L294)*
+*Defined in [contractkit/src/kit.ts:295](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L295)*
 
 **Parameters:**
 
@@ -181,13 +181,13 @@ ___
 
 • **get gasPrice**(): *number*
 
-*Defined in [contractkit/src/kit.ts:306](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L306)*
+*Defined in [contractkit/src/kit.ts:307](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L307)*
 
 **Returns:** *number*
 
 • **set gasPrice**(`price`: number): *void*
 
-*Defined in [contractkit/src/kit.ts:302](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L302)*
+*Defined in [contractkit/src/kit.ts:303](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L303)*
 
 **Parameters:**
 
@@ -203,7 +203,7 @@ ___
 
 • **get web3**(): *Web3‹›*
 
-*Defined in [contractkit/src/kit.ts:352](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L352)*
+*Defined in [contractkit/src/kit.ts:353](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L353)*
 
 **Returns:** *Web3‹›*
 
@@ -213,7 +213,7 @@ ___
 
 ▸ **addAccount**(`privateKey`: string): *void*
 
-*Defined in [contractkit/src/kit.ts:282](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L282)*
+*Defined in [contractkit/src/kit.ts:283](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L283)*
 
 **Parameters:**
 
@@ -229,7 +229,7 @@ ___
 
 ▸ **fillGasPrice**(`tx`: CeloTx): *Promise‹CeloTx›*
 
-*Defined in [contractkit/src/kit.ts:326](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L326)*
+*Defined in [contractkit/src/kit.ts:327](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L327)*
 
 **Parameters:**
 
@@ -245,7 +245,7 @@ ___
 
 ▸ **getEpochNumberOfBlock**(`blockNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:267](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L267)*
+*Defined in [contractkit/src/kit.ts:268](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L268)*
 
 **Parameters:**
 
@@ -261,7 +261,7 @@ ___
 
 ▸ **getEpochSize**(): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:240](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L240)*
+*Defined in [contractkit/src/kit.ts:241](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L241)*
 
 **Returns:** *Promise‹number›*
 
@@ -271,7 +271,7 @@ ___
 
 ▸ **getFirstBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:247](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L247)*
+*Defined in [contractkit/src/kit.ts:248](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L248)*
 
 **Parameters:**
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **getHumanReadableNetworkConfig**(): *Promise‹object›*
 
-*Defined in [contractkit/src/kit.ts:171](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L171)*
+*Defined in [contractkit/src/kit.ts:172](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L172)*
 
 **Returns:** *Promise‹object›*
 
@@ -297,7 +297,7 @@ ___
 
 ▸ **getLastBlockNumberForEpoch**(`epochNumber`: number): *Promise‹number›*
 
-*Defined in [contractkit/src/kit.ts:257](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L257)*
+*Defined in [contractkit/src/kit.ts:258](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L258)*
 
 **Parameters:**
 
@@ -313,7 +313,7 @@ ___
 
 ▸ **getNetworkConfig**(): *Promise‹[NetworkConfig](../interfaces/_kit_.networkconfig.md)›*
 
-*Defined in [contractkit/src/kit.ts:120](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L120)*
+*Defined in [contractkit/src/kit.ts:121](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L121)*
 
 **Returns:** *Promise‹[NetworkConfig](../interfaces/_kit_.networkconfig.md)›*
 
@@ -349,7 +349,7 @@ ___
 
 ▸ **isListening**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:318](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L318)*
+*Defined in [contractkit/src/kit.ts:319](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L319)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -359,7 +359,7 @@ ___
 
 ▸ **isSyncing**(): *Promise‹boolean›*
 
-*Defined in [contractkit/src/kit.ts:322](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L322)*
+*Defined in [contractkit/src/kit.ts:323](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L323)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -369,7 +369,7 @@ ___
 
 ▸ **sendTransaction**(`tx`: CeloTx): *Promise‹TransactionResult›*
 
-*Defined in [contractkit/src/kit.ts:333](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L333)*
+*Defined in [contractkit/src/kit.ts:334](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L334)*
 
 **Parameters:**
 
@@ -385,7 +385,7 @@ ___
 
 ▸ **sendTransactionObject**(`txObj`: CeloTxObject‹any›, `tx?`: Omit‹CeloTx, "data"›): *Promise‹TransactionResult›*
 
-*Defined in [contractkit/src/kit.ts:337](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L337)*
+*Defined in [contractkit/src/kit.ts:338](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L338)*
 
 **Parameters:**
 
@@ -402,7 +402,7 @@ ___
 
 ▸ **setFeeCurrency**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹void›*
 
-*Defined in [contractkit/src/kit.ts:223](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L223)*
+*Defined in [contractkit/src/kit.ts:224](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L224)*
 
 Set CeloToken to use to pay for gas fees
 
@@ -420,7 +420,7 @@ ___
 
 ▸ **signTypedData**(`signer`: string, `typedData`: EIP712TypedData): *Promise‹Signature›*
 
-*Defined in [contractkit/src/kit.ts:344](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L344)*
+*Defined in [contractkit/src/kit.ts:345](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L345)*
 
 **Parameters:**
 
@@ -437,7 +437,7 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [contractkit/src/kit.ts:348](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L348)*
+*Defined in [contractkit/src/kit.ts:349](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L349)*
 
 **Returns:** *void*
 
@@ -447,7 +447,7 @@ ___
 
 ▸ **updateGasPriceInConnectionLayer**(`currency`: Address): *Promise‹void›*
 
-*Defined in [contractkit/src/kit.ts:233](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L233)*
+*Defined in [contractkit/src/kit.ts:234](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L234)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_attestations_.attestationswrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_attestations_.attestationswrapper.md
@@ -83,7 +83,7 @@ Name | Type |
 
 • **approveTransfer**: *function* = proxySend(this.kit, this.contract.methods.approveTransfer)
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:521](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L521)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:522](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L522)*
 
 Updates sender's approval status on whether to allow an attestation identifier
 mapping to be transfered from one address to another.
@@ -118,7 +118,7 @@ ___
     valueToInt
   )
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:106](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L106)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:107](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L107)*
 
  Returns the time an attestation can be completable before it is considered expired
 
@@ -142,7 +142,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:117](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L117)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:118](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L118)*
 
 Returns the attestation request fee in a given currency.
 
@@ -189,7 +189,7 @@ ___
 
 • **getAttestationIssuers**: *function* = proxyCall(this.contract.methods.getAttestationIssuers)
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:190](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L190)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:191](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L191)*
 
 Returns the issuers of attestations for a phoneNumber/account combo
 
@@ -217,7 +217,7 @@ ___
     (stat) => ({ completed: valueToInt(stat[0]), total: valueToInt(stat[1]) })
   )
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:212](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L212)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:213](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L213)*
 
 Returns the attestation stats of a identifer/account pair
 
@@ -246,7 +246,7 @@ ___
     (state) => ({ attestationState: valueToInt(state[0]) })
   )
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:197](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L197)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:198](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L198)*
 
 Returns the attestation state of a phone number/account/issuer tuple
 
@@ -276,7 +276,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:380](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L380)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:381](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L381)*
 
 Returns the attestation signer for the specified account.
 
@@ -311,7 +311,7 @@ ___
     })
   )
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:134](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L134)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:135](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L135)*
 
 **`notice`** Returns the unselected attestation request for an identifier/account pair, if any.
 
@@ -335,7 +335,7 @@ ___
 
 • **lookupAccountsForIdentifier**: *function* = proxyCall(this.contract.methods.lookupAccountsForIdentifier)
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:457](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L457)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:458](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L458)*
 
 Returns the list of accounts associated with an identifier.
 
@@ -383,7 +383,7 @@ ___
     valueToInt
   )
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:123](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L123)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:124](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L124)*
 
 #### Type declaration:
 
@@ -401,7 +401,7 @@ ___
 
 • **withdraw**: *function* = proxySend(this.kit, this.contract.methods.withdraw)
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:390](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L390)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:391](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L391)*
 
 Allows issuers to withdraw accumulated attestation rewards
 
@@ -437,7 +437,7 @@ Contract address
 
 ▸ **approveAttestationFee**(`attestationsRequested`: number): *Promise‹CeloTransactionObject‹boolean››*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:259](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L259)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:260](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L260)*
 
 Approves the necessary amount of StableToken to request Attestations
 
@@ -455,7 +455,7 @@ ___
 
 ▸ **complete**(`identifier`: string, `account`: Address, `issuer`: Address, `code`: string): *Promise‹CeloTransactionObject‹void››*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:356](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L356)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:357](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L357)*
 
 Completes an attestation with the corresponding code
 
@@ -476,7 +476,7 @@ ___
 
 ▸ **findMatchingIssuer**(`identifier`: string, `account`: Address, `code`: string, `issuers`: string[]): *Promise‹string | null›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:399](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L399)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:400](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L400)*
 
 Given a list of issuers, finds the matching issuer for a given code
 
@@ -497,7 +497,7 @@ ___
 
 ▸ **getActionableAttestations**(`identifier`: string, `account`: Address, `tries`: number): *Promise‹[ActionableAttestation](../interfaces/_wrappers_attestations_.actionableattestation.md)[]›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:271](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L271)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:272](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L272)*
 
 Returns an array of attestations that can be completed, along with the issuers' attestation
 service urls
@@ -518,7 +518,7 @@ ___
 
 ▸ **getAttestationFeeRequired**(`attestationsRequested`: number): *Promise‹BigNumber‹››*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:249](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L249)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:250](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L250)*
 
 Calculates the amount of StableToken required to request Attestations
 
@@ -534,9 +534,9 @@ ___
 
 ###  getAttestationForSecurityCode
 
-▸ **getAttestationForSecurityCode**(`serviceURL`: string, `requestBody`: GetAttestationRequest): *Promise‹Response›*
+▸ **getAttestationForSecurityCode**(`serviceURL`: string, `requestBody`: GetAttestationRequest): *Promise‹string›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:593](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L593)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:594](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L594)*
 
 Returns attestation code for provided security code from validator's attestation service
 
@@ -547,7 +547,7 @@ Name | Type |
 `serviceURL` | string |
 `requestBody` | GetAttestationRequest |
 
-**Returns:** *Promise‹Response›*
+**Returns:** *Promise‹string›*
 
 ___
 
@@ -555,7 +555,7 @@ ___
 
 ▸ **getAttestationServiceStatus**(`validator`: [Validator](../interfaces/_wrappers_validators_.validator.md)): *Promise‹[AttestationServiceStatusResponse](../interfaces/_wrappers_attestations_.attestationservicestatusresponse.md)›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:645](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L645)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:671](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L671)*
 
 Gets the relevant attestation service status for a validator
 
@@ -573,7 +573,7 @@ ___
 
 ▸ **getConfig**(`tokens`: string[]): *Promise‹[AttestationsConfig](../interfaces/_wrappers_attestations_.attestationsconfig.md)›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:428](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L428)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:429](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L429)*
 
 Returns the current configuration parameters for the contract.
 
@@ -593,7 +593,7 @@ ___
 
 ▸ **getHumanReadableConfig**(`tokens`: string[]): *Promise‹object›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:445](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L445)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:446](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L446)*
 
 **`dev`** Returns human readable configuration of the attestations contract
 
@@ -613,7 +613,7 @@ ___
 
 ▸ **getNonCompliantIssuers**(`identifier`: string, `account`: Address, `tries`: number): *Promise‹Address[]›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:294](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L294)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:295](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L295)*
 
 Returns an array of issuer addresses that were found to not run the attestation service
 
@@ -654,7 +654,7 @@ ___
 
 ▸ **getRevealStatus**(`phoneNumber`: string, `account`: Address, `issuer`: Address, `serviceURL`: string, `pepper?`: undefined | string): *Promise‹Response›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:569](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L569)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:570](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L570)*
 
 Returns reveal status from validator's attestation service
 
@@ -676,7 +676,7 @@ ___
 
 ▸ **getVerifiedStatus**(`identifier`: string, `account`: Address, `numAttestationsRequired?`: undefined | number, `attestationThreshold?`: undefined | number): *Promise‹AttestationsStatus›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:231](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L231)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:232](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L232)*
 
 Returns the verified status of an identifier/account pair indicating whether the attestation
 stats for a given pair are completed beyond a certain threshold of confidence (aka "verified")
@@ -698,7 +698,7 @@ ___
 
 ▸ **isAttestationExpired**(`attestationRequestBlockNumber`: number): *Promise‹boolean›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:148](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L148)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:149](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L149)*
 
 **`notice`** Checks if attestation request is expired.
 
@@ -716,7 +716,7 @@ ___
 
 ▸ **lookupIdentifiers**(`identifiers`: string[]): *Promise‹[IdentifierLookupResult](../modules/_wrappers_attestations_.md#identifierlookupresult)›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:463](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L463)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:464](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L464)*
 
 Lookup mapped wallet addresses for a given list of identifiers
 
@@ -734,7 +734,7 @@ ___
 
 ▸ **request**(`identifier`: string, `attestationsRequested`: number): *Promise‹CeloTransactionObject‹void››*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:504](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L504)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:505](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L505)*
 
 Requests a new attestation
 
@@ -753,7 +753,7 @@ ___
 
 ▸ **revealPhoneNumberToIssuer**(`serviceURL`: string, `requestBody`: AttestationRequest): *Promise‹Response›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:551](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L551)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:552](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L552)*
 
 Reveal phone number to issuer
 
@@ -772,7 +772,7 @@ ___
 
 ▸ **revoke**(`identifer`: string, `account`: Address): *Promise‹CeloTransactionObject‹void››*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:757](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L757)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:783](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L783)*
 
 **Parameters:**
 
@@ -789,7 +789,7 @@ ___
 
 ▸ **selectIssuers**(`identifier`: string): *CeloTransactionObject‹void›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:527](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L527)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:528](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L528)*
 
 Selects the issuers for previously requested attestations for a phone number
 
@@ -807,7 +807,7 @@ ___
 
 ▸ **selectIssuersAfterWait**(`identifier`: string, `account`: string, `timeoutSeconds?`: undefined | number, `pollDurationSeconds?`: undefined | number): *Promise‹CeloTransactionObject‹void››*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:536](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L536)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:537](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L537)*
 
 Waits appropriate number of blocks, then selects issuers for previously requested phone number attestations
 
@@ -828,7 +828,7 @@ ___
 
 ▸ **validateAttestationCode**(`identifier`: string, `account`: Address, `issuer`: Address, `code`: string): *Promise‹boolean›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:618](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L618)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:644](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L644)*
 
 Validates a given code by the issuer on-chain
 
@@ -849,7 +849,7 @@ ___
 
 ▸ **waitForSelectingIssuers**(`identifier`: string, `account`: Address, `timeoutSeconds`: number, `pollDurationSeconds`: number): *Promise‹void›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:160](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L160)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:161](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L161)*
 
 **`notice`** Waits for appropriate block numbers for before issuer can be selected
 

--- a/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_sortedoracles_.sortedoracleswrapper.md
+++ b/packages/docs/developer-resources/contractkit/reference/classes/_wrappers_sortedoracles_.sortedoracleswrapper.md
@@ -118,7 +118,7 @@ ___
     valueToBigNumber
   )
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:102](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L102)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:146](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L146)*
 
 Returns the report expiry parameter.
 
@@ -154,7 +154,7 @@ Contract address
 
 ▸ **getConfig**(): *Promise‹[SortedOraclesConfig](../interfaces/_wrappers_sortedoracles_.sortedoraclesconfig.md)›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:190](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L190)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:234](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L234)*
 
 Returns current configuration parameters.
 
@@ -166,7 +166,7 @@ ___
 
 ▸ **getHumanReadableConfig**(): *Promise‹object›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:200](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L200)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:244](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L244)*
 
 **`dev`** Returns human readable configuration of the sortedoracles contract
 
@@ -178,17 +178,17 @@ ___
 
 ###  getOracles
 
-▸ **getOracles**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹Address[]›*
+▸ **getOracles**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹Address[]›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:93](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L93)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:137](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L137)*
 
-Returns the list of whitelisted oracles for a given token.
+Returns the list of whitelisted oracles for a given target
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) |
+Name | Type | Description |
+------ | ------ | ------ |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair |
 
 **Returns:** *Promise‹Address[]›*
 
@@ -219,9 +219,9 @@ ___
 
 ###  getRates
 
-▸ **getRates**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹[OracleRate](../interfaces/_wrappers_sortedoracles_.oraclerate.md)[]›*
+▸ **getRates**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹[OracleRate](../interfaces/_wrappers_sortedoracles_.oraclerate.md)[]›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:219](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L219)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:262](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L262)*
 
 Gets all elements from the doubly linked list.
 
@@ -229,7 +229,7 @@ Gets all elements from the doubly linked list.
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The CeloToken representing the token for which the Celo   Gold exchange rate is being reported. Example: CeloContract.StableToken |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair in question |
 
 **Returns:** *Promise‹[OracleRate](../interfaces/_wrappers_sortedoracles_.oraclerate.md)[]›*
 
@@ -239,15 +239,15 @@ ___
 
 ###  getReports
 
-▸ **getReports**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹[OracleReport](../interfaces/_wrappers_sortedoracles_.oraclereport.md)[]›*
+▸ **getReports**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹[OracleReport](../interfaces/_wrappers_sortedoracles_.oraclereport.md)[]›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:255](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L255)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:297](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L297)*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) |
 
 **Returns:** *Promise‹[OracleReport](../interfaces/_wrappers_sortedoracles_.oraclereport.md)[]›*
 
@@ -257,7 +257,7 @@ ___
 
 ▸ **getStableTokenRates**(): *Promise‹[OracleRate](../interfaces/_wrappers_sortedoracles_.oraclerate.md)[]›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:211](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L211)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:255](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L255)*
 
 Helper function to get the rates for StableToken, by passing the address
 of StableToken to `getRates`.
@@ -268,9 +268,9 @@ ___
 
 ###  getTimestamps
 
-▸ **getTimestamps**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹[OracleTimestamp](../interfaces/_wrappers_sortedoracles_.oracletimestamp.md)[]›*
+▸ **getTimestamps**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹[OracleTimestamp](../interfaces/_wrappers_sortedoracles_.oracletimestamp.md)[]›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:240](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L240)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:282](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L282)*
 
 Gets all elements from the doubly linked list.
 
@@ -278,7 +278,7 @@ Gets all elements from the doubly linked list.
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The CeloToken representing the token for which the Celo   Gold exchange rate is being reported. Example: CeloContract.StableToken |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair in question |
 
 **Returns:** *Promise‹[OracleTimestamp](../interfaces/_wrappers_sortedoracles_.oracletimestamp.md)[]›*
 
@@ -288,17 +288,17 @@ ___
 
 ###  getTokenReportExpirySeconds
 
-▸ **getTokenReportExpirySeconds**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹BigNumber›*
+▸ **getTokenReportExpirySeconds**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹BigNumber›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:113](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L113)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:157](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L157)*
 
-Returns the expiry for the token if exists, if not the default.
+Returns the expiry for the target if exists, if not the default.
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The address of the token. |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair |
 
 **Returns:** *Promise‹BigNumber›*
 
@@ -308,17 +308,17 @@ ___
 
 ###  isOldestReportExpired
 
-▸ **isOldestReportExpired**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹[boolean, Address]›*
+▸ **isOldestReportExpired**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹[boolean, Address]›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:123](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L123)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:167](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L167)*
 
-Checks if the oldest report for a given token is expired
+Checks if the oldest report for a given target is expired
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The token for which to check reports  |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair  |
 
 **Returns:** *Promise‹[boolean, Address]›*
 
@@ -326,17 +326,17 @@ ___
 
 ###  isOracle
 
-▸ **isOracle**(`token`: [CeloToken](../modules/_base_.md#celotoken), `oracle`: Address): *Promise‹boolean›*
+▸ **isOracle**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget), `oracle`: Address): *Promise‹boolean›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:84](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L84)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:127](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L127)*
 
-Checks if the given address is whitelisted as an oracle for the token
+Checks if the given address is whitelisted as an oracle for the target
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The CeloToken token |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair |
 `oracle` | Address | The address that we're checking the oracle status of |
 
 **Returns:** *Promise‹boolean›*
@@ -347,17 +347,17 @@ ___
 
 ###  medianRate
 
-▸ **medianRate**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹[MedianRate](../interfaces/_wrappers_sortedoracles_.medianrate.md)›*
+▸ **medianRate**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹[MedianRate](../interfaces/_wrappers_sortedoracles_.medianrate.md)›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:70](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L70)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:113](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L113)*
 
-Returns the median rate for the given token
+Returns the median rate for the given target
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The CeloToken token for which the CELO exchange rate is being reported. |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair |
 
 **Returns:** *Promise‹[MedianRate](../interfaces/_wrappers_sortedoracles_.medianrate.md)›*
 
@@ -368,17 +368,17 @@ ___
 
 ###  numRates
 
-▸ **numRates**(`token`: [CeloToken](../modules/_base_.md#celotoken)): *Promise‹number›*
+▸ **numRates**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget)): *Promise‹number›*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:58](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L58)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:101](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L101)*
 
-Gets the number of rates that have been reported for the given token
+Gets the number of rates that have been reported for the given target
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The CeloToken token for which the CELO exchange rate is being reported. |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair |
 
 **Returns:** *Promise‹number›*
 
@@ -388,9 +388,9 @@ ___
 
 ###  removeExpiredReports
 
-▸ **removeExpiredReports**(`token`: [CeloToken](../modules/_base_.md#celotoken), `numReports?`: undefined | number): *Promise‹CeloTransactionObject‹void››*
+▸ **removeExpiredReports**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget), `numReports?`: undefined | number): *Promise‹CeloTransactionObject‹void››*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:136](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L136)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:180](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L180)*
 
 Removes expired reports, if any exist
 
@@ -398,7 +398,7 @@ Removes expired reports, if any exist
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The token to remove reports for |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair |
 `numReports?` | undefined &#124; number | The upper-limit of reports to remove. For example, if there are 2 expired reports, and this param is 5, it will only remove the 2 that are expired.  |
 
 **Returns:** *Promise‹CeloTransactionObject‹void››*
@@ -407,9 +407,9 @@ ___
 
 ###  report
 
-▸ **report**(`token`: [CeloToken](../modules/_base_.md#celotoken), `value`: BigNumber.Value, `oracleAddress`: Address): *Promise‹CeloTransactionObject‹void››*
+▸ **report**(`target`: [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget), `value`: BigNumber.Value, `oracleAddress`: Address): *Promise‹CeloTransactionObject‹void››*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:155](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L155)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:199](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L199)*
 
 Updates an oracle value and the median.
 
@@ -417,7 +417,7 @@ Updates an oracle value and the median.
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`token` | [CeloToken](../modules/_base_.md#celotoken) | The token for which the CELO exchange rate is being reported. |
+`target` | [ReportTarget](../modules/_wrappers_sortedoracles_.md#reporttarget) | The ReportTarget, either CeloToken or currency pair |
 `value` | BigNumber.Value | The amount of `token` equal to one CELO.  |
 `oracleAddress` | Address | - |
 
@@ -429,7 +429,7 @@ ___
 
 ▸ **reportStableToken**(`value`: BigNumber.Value, `oracleAddress`: Address): *Promise‹CeloTransactionObject‹void››*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:180](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L180)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:224](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L224)*
 
 Updates an oracle value and the median.
 

--- a/packages/docs/developer-resources/contractkit/reference/enums/_wrappers_attestations_.attestationservicestatusstate.md
+++ b/packages/docs/developer-resources/contractkit/reference/enums/_wrappers_attestations_.attestationservicestatusstate.md
@@ -21,7 +21,7 @@
 
 • **InvalidMetadata**: = "InvalidMetadata"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:770](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L770)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:796](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L796)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **MetadataTimeout**: = "MetadataTimeout"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:777](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L777)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:803](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L803)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **NoAttestationServiceURL**: = "NoAttestationServiceURL"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:771](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L771)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:797](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L797)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **NoAttestationSigner**: = "NoAttestationSigner"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:768](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L768)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:794](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L794)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **NoMetadataURL**: = "NoMetadataURL"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:769](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L769)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:795](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L795)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **Unhealthy**: = "Unhealthy"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:775](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L775)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:801](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L801)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **UnreachableAttestationService**: = "UnreachableAttestationService"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:772](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L772)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:798](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L798)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **UnreachableHealthz**: = "UnreachableHealthz"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:774](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L774)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:800](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L800)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **Valid**: = "Valid"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:773](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L773)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:799](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L799)*
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 • **WrongAccount**: = "WrongAccount"
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:776](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L776)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:802](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L802)*

--- a/packages/docs/developer-resources/contractkit/reference/enums/_wrappers_attestations_.attestationstate.md
+++ b/packages/docs/developer-resources/contractkit/reference/enums/_wrappers_attestations_.attestationstate.md
@@ -16,7 +16,7 @@ Contract for managing identities
 
 • **Complete**:
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:57](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L57)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:58](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L58)*
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 • **Incomplete**:
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L56)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:57](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L57)*
 
 ___
 
@@ -32,4 +32,4 @@ ___
 
 • **None**:
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:55](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L55)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:56](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L56)*

--- a/packages/docs/developer-resources/contractkit/reference/enums/_wrappers_sortedoracles_.medianrelation.md
+++ b/packages/docs/developer-resources/contractkit/reference/enums/_wrappers_sortedoracles_.medianrelation.md
@@ -15,7 +15,7 @@
 
 • **Equal**:
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:20](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L20)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:23](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L23)*
 
 ___
 
@@ -23,7 +23,7 @@ ___
 
 • **Greater**:
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:19](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L19)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:22](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L22)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **Lesser**:
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:18](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L18)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:21](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L21)*
 
 ___
 
@@ -39,4 +39,4 @@ ___
 
 • **Undefined**:
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:17](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L17)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:20](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L20)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.actionableattestation.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.actionableattestation.md
@@ -19,7 +19,7 @@
 
 • **attestationServiceURL**: *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:63](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L63)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:64](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L64)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:62](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L62)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:63](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L63)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **issuer**: *Address*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:61](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L61)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:62](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L62)*
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 • **name**: *string | undefined*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:64](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L64)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:65](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L65)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationsconfig.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationsconfig.md
@@ -17,7 +17,7 @@
 
 • **attestationExpiryBlocks**: *number*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:47](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L47)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:48](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L48)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **attestationRequestFees**: *[AttestationsToken](_wrappers_attestations_.attestationstoken.md)[]*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:48](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L48)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:49](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L49)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationservicestatusresponse.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationservicestatusresponse.md
@@ -34,7 +34,7 @@
 
 • **address**: *Address*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:781](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L781)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:807](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L807)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • **affiliation**: *string | null*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:784](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L784)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:810](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L810)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • **ageOfLatestBlock**: *number | null*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:798](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L798)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:824](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L824)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • **attestationServiceURL**: *string | null*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:788](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L788)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:814](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L814)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • **attestationSigner**: *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:787](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L787)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:813](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L813)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 • **blacklistedRegionCodes**: *string[] | null*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:793](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L793)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:819](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L819)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • **blsPublicKey**: *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:783](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L783)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:809](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L809)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 • **ecdsaPublicKey**: *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:782](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L782)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:808](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L808)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 • **error**: *null | Error*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:791](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L791)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:817](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L817)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 • **hasAttestationSigner**: *boolean*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:786](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L786)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:812](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L812)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 • **metadataURL**: *string | null*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:789](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L789)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:815](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L815)*
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:780](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L780)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:806](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L806)*
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 • **okStatus**: *boolean*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:790](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L790)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:816](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L816)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 • **rightAccount**: *boolean*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:794](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L794)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:820](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L820)*
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 • **score**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:785](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L785)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:811](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L811)*
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 • **signer**: *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:795](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L795)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:821](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L821)*
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 • **smsProviders**: *string[]*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:792](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L792)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:818](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L818)*
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 • **state**: *[AttestationServiceStatusState](../enums/_wrappers_attestations_.attestationservicestatusstate.md)*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:796](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L796)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:822](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L822)*
 
 ___
 
@@ -178,4 +178,4 @@ ___
 
 • **version**: *string | null*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:797](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L797)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:823](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L823)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationstat.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationstat.md
@@ -17,7 +17,7 @@
 
 • **completed**: *number*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:33](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L33)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:34](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L34)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **total**: *number*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:34](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L34)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:35](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L35)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationstateforissuer.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationstateforissuer.md
@@ -16,4 +16,4 @@
 
 • **attestationState**: *[AttestationState](../enums/_wrappers_attestations_.attestationstate.md)*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:38](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L38)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:39](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L39)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationstoken.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.attestationstoken.md
@@ -17,7 +17,7 @@
 
 • **address**: *Address*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L42)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L43)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **fee**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L43)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L44)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.unselectedrequest.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_attestations_.unselectedrequest.md
@@ -18,7 +18,7 @@
 
 • **attestationRequestFeeToken**: *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L74)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:75](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L75)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **attestationsRequested**: *number*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:73](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L73)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L74)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:72](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L72)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:73](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L73)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.medianrate.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.medianrate.md
@@ -16,4 +16,4 @@
 
 • **rate**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:46](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L46)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:49](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L49)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.oraclerate.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.oraclerate.md
@@ -18,7 +18,7 @@
 
 • **address**: *Address*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:28](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L28)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:31](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L31)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **medianRelation**: *[MedianRelation](../enums/_wrappers_sortedoracles_.medianrelation.md)*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:30](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L30)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:33](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L33)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **rate**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:29](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L29)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:32](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L32)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.oraclereport.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.oraclereport.md
@@ -18,7 +18,7 @@
 
 • **address**: *Address*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:40](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L40)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:43](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L43)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **rate**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:41](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L41)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:44](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L44)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **timestamp**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:42](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L42)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:45](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L45)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.oracletimestamp.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.oracletimestamp.md
@@ -18,7 +18,7 @@
 
 • **address**: *Address*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:34](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L34)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:37](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L37)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **medianRelation**: *[MedianRelation](../enums/_wrappers_sortedoracles_.medianrelation.md)*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:36](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L36)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:39](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L39)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **timestamp**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:35](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L35)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:38](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L38)*

--- a/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.sortedoraclesconfig.md
+++ b/packages/docs/developer-resources/contractkit/reference/interfaces/_wrappers_sortedoracles_.sortedoraclesconfig.md
@@ -16,4 +16,4 @@
 
 • **reportExpirySeconds**: *BigNumber*
 
-*Defined in [contractkit/src/wrappers/SortedOracles.ts:24](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L24)*
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:27](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L27)*

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_attestations_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_attestations_.md
@@ -35,7 +35,7 @@
 
 Ƭ **IdentifierLookupResult**: *Record‹string, Record‹Address, [AttestationStat](../interfaces/_wrappers_attestations_.attestationstat.md) | undefined› | undefined›*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:78](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L78)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:79](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L79)*
 
 ## Functions
 
@@ -43,7 +43,7 @@
 
 ▸ **getSecurityCodePrefix**(`issuerAddress`: Address): *string*
 
-*Defined in [contractkit/src/wrappers/Attestations.ts:28](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L28)*
+*Defined in [contractkit/src/wrappers/Attestations.ts:29](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/Attestations.ts#L29)*
 
 **Parameters:**
 

--- a/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_sortedoracles_.md
+++ b/packages/docs/developer-resources/contractkit/reference/modules/_wrappers_sortedoracles_.md
@@ -17,3 +17,73 @@
 * [OracleReport](../interfaces/_wrappers_sortedoracles_.oraclereport.md)
 * [OracleTimestamp](../interfaces/_wrappers_sortedoracles_.oracletimestamp.md)
 * [SortedOraclesConfig](../interfaces/_wrappers_sortedoracles_.sortedoraclesconfig.md)
+
+### Type aliases
+
+* [CurrencyPairIdentifier](_wrappers_sortedoracles_.md#currencypairidentifier)
+* [ReportTarget](_wrappers_sortedoracles_.md#reporttarget)
+
+### Functions
+
+* [pairIdentifier](_wrappers_sortedoracles_.md#const-pairidentifier)
+
+### Object literals
+
+* [OracleCurrencyPair](_wrappers_sortedoracles_.md#const-oraclecurrencypair)
+
+## Type aliases
+
+###  CurrencyPairIdentifier
+
+Ƭ **CurrencyPairIdentifier**: *Branded‹Address, "PairIdentifier"›*
+
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:52](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L52)*
+
+___
+
+###  ReportTarget
+
+Ƭ **ReportTarget**: *[CeloToken](_base_.md#celotoken) | [CurrencyPairIdentifier](_wrappers_sortedoracles_.md#currencypairidentifier)*
+
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:82](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L82)*
+
+## Functions
+
+### `Const` pairIdentifier
+
+▸ **pairIdentifier**(`pair`: string): *[CurrencyPairIdentifier](_wrappers_sortedoracles_.md#currencypairidentifier)*
+
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:61](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L61)*
+
+Used to construct the pair identifier from a pair label (e.g. CELO/BTC)
+The pair identifier needs to be a valid ethereum address, thus we
+truncate a keccak of the pair label.
+This function returns a branded type which can be fed into the wrapper.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`pair` | string | a string  |
+
+**Returns:** *[CurrencyPairIdentifier](_wrappers_sortedoracles_.md#currencypairidentifier)*
+
+## Object literals
+
+### `Const` OracleCurrencyPair
+
+### ▪ **OracleCurrencyPair**: *object*
+
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:77](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L77)*
+
+###  CELOBTC
+
+• **CELOBTC**: *Branded‹string, "PairIdentifier"›* = pairIdentifier('CELO/BTC')
+
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:78](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L78)*
+
+###  CELOUSD
+
+• **CELOUSD**: *[StableToken](../enums/_base_.celocontract.md#stabletoken)* = CeloContract.StableToken
+
+*Defined in [contractkit/src/wrappers/SortedOracles.ts:79](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/SortedOracles.ts#L79)*

--- a/packages/docs/developer-resources/utils/reference/SUMMARY.md
+++ b/packages/docs/developer-resources/utils/reference/SUMMARY.md
@@ -64,6 +64,7 @@
   * [packages/sdk/utils/src/solidity](modules/_packages_sdk_utils_src_solidity_.md)
   * [packages/sdk/utils/src/string](modules/_packages_sdk_utils_src_string_.md)
   * [packages/sdk/utils/src/task](modules/_packages_sdk_utils_src_task_.md)
+  * [packages/sdk/utils/src/typed-data-constructors](modules/_packages_sdk_utils_src_typed_data_constructors_.md)
 * [Classes]()
   * [F](classes/_node_modules_bls12377js_src_f_.f.md)
   * [F2](classes/_node_modules_bls12377js_src_f2_.f2.md)

--- a/packages/docs/developer-resources/utils/reference/globals.md
+++ b/packages/docs/developer-resources/utils/reference/globals.md
@@ -41,3 +41,4 @@
 * ["packages/sdk/utils/src/solidity"](modules/_packages_sdk_utils_src_solidity_.md)
 * ["packages/sdk/utils/src/string"](modules/_packages_sdk_utils_src_string_.md)
 * ["packages/sdk/utils/src/task"](modules/_packages_sdk_utils_src_task_.md)
+* ["packages/sdk/utils/src/typed-data-constructors"](modules/_packages_sdk_utils_src_typed_data_constructors_.md)

--- a/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_account_.md
+++ b/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_account_.md
@@ -12,6 +12,7 @@
 
 ### Functions
 
+* [formatNonAccentedCharacters](_packages_sdk_utils_src_account_.md#formatnonaccentedcharacters)
 * [generateDeterministicInviteCode](_packages_sdk_utils_src_account_.md#generatedeterministicinvitecode)
 * [generateKeys](_packages_sdk_utils_src_account_.md#generatekeys)
 * [generateKeysFromSeed](_packages_sdk_utils_src_account_.md#generatekeysfromseed)
@@ -55,11 +56,27 @@ ___
 
 ## Functions
 
+###  formatNonAccentedCharacters
+
+▸ **formatNonAccentedCharacters**(`mnemonic`: string): *string*
+
+*Defined in [packages/sdk/utils/src/account.ts:69](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L69)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`mnemonic` | string |
+
+**Returns:** *string*
+
+___
+
 ###  generateDeterministicInviteCode
 
 ▸ **generateDeterministicInviteCode**(`recipientPhoneHash`: string, `recipientPepper`: string, `addressIndex`: number, `changeIndex`: number, `derivationPath`: string): *object*
 
-*Defined in [packages/sdk/utils/src/account.ts:87](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L87)*
+*Defined in [packages/sdk/utils/src/account.ts:139](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L139)*
 
 **Parameters:**
 
@@ -83,7 +100,7 @@ ___
 
 ▸ **generateKeys**(`mnemonic`: string, `password?`: undefined | string, `changeIndex`: number, `addressIndex`: number, `bip39ToUse`: Bip39, `derivationPath`: string): *Promise‹object›*
 
-*Defined in [packages/sdk/utils/src/account.ts:75](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L75)*
+*Defined in [packages/sdk/utils/src/account.ts:127](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L127)*
 
 **Parameters:**
 
@@ -104,7 +121,7 @@ ___
 
 ▸ **generateKeysFromSeed**(`seed`: Buffer, `changeIndex`: number, `addressIndex`: number, `derivationPath`: string): *object*
 
-*Defined in [packages/sdk/utils/src/account.ts:115](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L115)*
+*Defined in [packages/sdk/utils/src/account.ts:167](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L167)*
 
 **Parameters:**
 
@@ -129,7 +146,7 @@ ___
 
 ▸ **generateMnemonic**(`strength`: [MnemonicStrength](_packages_sdk_utils_src_account_.md#mnemonicstrength), `language?`: [MnemonicLanguages](_packages_sdk_utils_src_account_.md#mnemoniclanguages), `bip39ToUse`: Bip39): *Promise‹string›*
 
-*Defined in [packages/sdk/utils/src/account.ts:49](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L49)*
+*Defined in [packages/sdk/utils/src/account.ts:50](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L50)*
 
 **Parameters:**
 
@@ -147,7 +164,7 @@ ___
 
 ▸ **generateSeed**(`mnemonic`: string, `password?`: undefined | string, `bip39ToUse`: Bip39, `keyByteLength`: number): *Promise‹Buffer›*
 
-*Defined in [packages/sdk/utils/src/account.ts:100](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L100)*
+*Defined in [packages/sdk/utils/src/account.ts:152](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L152)*
 
 **Parameters:**
 
@@ -164,16 +181,15 @@ ___
 
 ###  validateMnemonic
 
-▸ **validateMnemonic**(`mnemonic`: string, `defaultLanguage?`: [MnemonicLanguages](_packages_sdk_utils_src_account_.md#mnemoniclanguages), `bip39ToUse`: Bip39): *boolean*
+▸ **validateMnemonic**(`mnemonic`: string, `bip39ToUse`: Bip39): *boolean*
 
-*Defined in [packages/sdk/utils/src/account.ts:57](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L57)*
+*Defined in [packages/sdk/utils/src/account.ts:58](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L58)*
 
 **Parameters:**
 
 Name | Type | Default |
 ------ | ------ | ------ |
 `mnemonic` | string | - |
-`defaultLanguage?` | [MnemonicLanguages](_packages_sdk_utils_src_account_.md#mnemoniclanguages) | - |
 `bip39ToUse` | Bip39 | bip39Wrapper |
 
 **Returns:** *boolean*
@@ -184,34 +200,34 @@ Name | Type | Default |
 
 ### ▪ **AccountUtils**: *object*
 
-*Defined in [packages/sdk/utils/src/account.ts:171](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L171)*
+*Defined in [packages/sdk/utils/src/account.ts:235](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L235)*
 
 ###  generateKeys
 
 • **generateKeys**: *[generateKeys](_packages_sdk_utils_src_account_.md#generatekeys)*
 
-*Defined in [packages/sdk/utils/src/account.ts:174](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L174)*
+*Defined in [packages/sdk/utils/src/account.ts:238](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L238)*
 
 ###  generateKeysFromSeed
 
 • **generateKeysFromSeed**: *[generateKeysFromSeed](_packages_sdk_utils_src_account_.md#generatekeysfromseed)*
 
-*Defined in [packages/sdk/utils/src/account.ts:176](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L176)*
+*Defined in [packages/sdk/utils/src/account.ts:240](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L240)*
 
 ###  generateMnemonic
 
 • **generateMnemonic**: *[generateMnemonic](_packages_sdk_utils_src_account_.md#generatemnemonic)*
 
-*Defined in [packages/sdk/utils/src/account.ts:172](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L172)*
+*Defined in [packages/sdk/utils/src/account.ts:236](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L236)*
 
 ###  generateSeed
 
 • **generateSeed**: *[generateSeed](_packages_sdk_utils_src_account_.md#generateseed)*
 
-*Defined in [packages/sdk/utils/src/account.ts:175](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L175)*
+*Defined in [packages/sdk/utils/src/account.ts:239](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L239)*
 
 ###  validateMnemonic
 
 • **validateMnemonic**: *[validateMnemonic](_packages_sdk_utils_src_account_.md#validatemnemonic)*
 
-*Defined in [packages/sdk/utils/src/account.ts:173](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L173)*
+*Defined in [packages/sdk/utils/src/account.ts:237](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/account.ts#L237)*

--- a/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_attestations_.md
+++ b/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_attestations_.md
@@ -16,6 +16,7 @@
 ### Functions
 
 * [attestToIdentifier](_packages_sdk_utils_src_attestations_.md#attesttoidentifier)
+* [extractSecurityCodeWithPrefix](_packages_sdk_utils_src_attestations_.md#extractsecuritycodewithprefix)
 * [getAttestationMessageToSignFromIdentifier](_packages_sdk_utils_src_attestations_.md#getattestationmessagetosignfromidentifier)
 * [getAttestationMessageToSignFromPhoneNumber](_packages_sdk_utils_src_attestations_.md#getattestationmessagetosignfromphonenumber)
 * [hashIdentifier](_packages_sdk_utils_src_attestations_.md#hashidentifier)
@@ -92,6 +93,22 @@ Name | Type |
 
 ___
 
+###  extractSecurityCodeWithPrefix
+
+▸ **extractSecurityCodeWithPrefix**(`message`: string): *null | string*
+
+*Defined in [packages/sdk/utils/src/attestations.ts:66](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L66)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`message` | string |
+
+**Returns:** *null | string*
+
+___
+
 ###  getAttestationMessageToSignFromIdentifier
 
 ▸ **getAttestationMessageToSignFromIdentifier**(`identifier`: string, `account`: string): *string*
@@ -149,70 +166,76 @@ Name | Type |
 
 ### ▪ **AttestationUtils**: *object*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:66](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L66)*
+*Defined in [packages/sdk/utils/src/attestations.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L74)*
 
 ###  IdentifierType
 
 • **IdentifierType**: *IdentifierType*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:67](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L67)*
+*Defined in [packages/sdk/utils/src/attestations.ts:75](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L75)*
 
 ###  attestToIdentifier
 
 • **attestToIdentifier**: *[attestToIdentifier](_packages_sdk_utils_src_attestations_.md#attesttoidentifier)*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:73](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L73)*
+*Defined in [packages/sdk/utils/src/attestations.ts:81](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L81)*
 
 ###  base64ToHex
 
 • **base64ToHex**: *base64ToHex*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:72](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L72)*
+*Defined in [packages/sdk/utils/src/attestations.ts:80](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L80)*
 
 ###  extractAttestationCodeFromMessage
 
 • **extractAttestationCodeFromMessage**: *extractAttestationCodeFromMessage*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:76](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L76)*
+*Defined in [packages/sdk/utils/src/attestations.ts:84](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L84)*
+
+###  extractSecurityCodeWithPrefix
+
+• **extractSecurityCodeWithPrefix**: *[extractSecurityCodeWithPrefix](_packages_sdk_utils_src_attestations_.md#extractsecuritycodewithprefix)*
+
+*Defined in [packages/sdk/utils/src/attestations.ts:86](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L86)*
 
 ###  getAttestationMessageToSignFromIdentifier
 
 • **getAttestationMessageToSignFromIdentifier**: *[getAttestationMessageToSignFromIdentifier](_packages_sdk_utils_src_attestations_.md#getattestationmessagetosignfromidentifier)*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:70](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L70)*
+*Defined in [packages/sdk/utils/src/attestations.ts:78](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L78)*
 
 ###  getAttestationMessageToSignFromPhoneNumber
 
 • **getAttestationMessageToSignFromPhoneNumber**: *[getAttestationMessageToSignFromPhoneNumber](_packages_sdk_utils_src_attestations_.md#getattestationmessagetosignfromphonenumber)*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:71](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L71)*
+*Defined in [packages/sdk/utils/src/attestations.ts:79](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L79)*
 
 ###  getIdentifierPrefix
 
 • **getIdentifierPrefix**: *getIdentifierPrefix*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:68](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L68)*
+*Defined in [packages/sdk/utils/src/attestations.ts:76](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L76)*
 
 ###  hashIdentifier
 
 • **hashIdentifier**: *[hashIdentifier](_packages_sdk_utils_src_attestations_.md#hashidentifier)*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:69](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L69)*
+*Defined in [packages/sdk/utils/src/attestations.ts:77](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L77)*
 
 ###  isAccountConsideredVerified
 
 • **isAccountConsideredVerified**: *isAccountConsideredVerified*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:77](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L77)*
+*Defined in [packages/sdk/utils/src/attestations.ts:85](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L85)*
 
 ###  messageContainsAttestationCode
 
 • **messageContainsAttestationCode**: *messageContainsAttestationCode*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:75](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L75)*
+*Defined in [packages/sdk/utils/src/attestations.ts:83](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L83)*
 
 ###  sanitizeMessageBase64
 
 • **sanitizeMessageBase64**: *sanitizeMessageBase64*
 
-*Defined in [packages/sdk/utils/src/attestations.ts:74](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L74)*
+*Defined in [packages/sdk/utils/src/attestations.ts:82](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/attestations.ts#L82)*

--- a/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_bn_.md
+++ b/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_bn_.md
@@ -10,7 +10,7 @@
 
 ###  compareBN
 
-▸ **compareBN**(`a`: BN, `b`: BN): *0 | 1 | -1*
+▸ **compareBN**(`a`: BN, `b`: BN): *1 | 0 | -1*
 
 *Defined in [packages/sdk/utils/src/bn.ts:3](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/bn.ts#L3)*
 
@@ -21,4 +21,4 @@ Name | Type |
 `a` | BN |
 `b` | BN |
 
-**Returns:** *0 | 1 | -1*
+**Returns:** *1 | 0 | -1*

--- a/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_signatureutils_.md
+++ b/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_signatureutils_.md
@@ -23,6 +23,7 @@
 * [signMessage](_packages_sdk_utils_src_signatureutils_.md#signmessage)
 * [signMessageWithoutPrefix](_packages_sdk_utils_src_signatureutils_.md#signmessagewithoutprefix)
 * [signedMessageToPublicKey](_packages_sdk_utils_src_signatureutils_.md#signedmessagetopublickey)
+* [verifyEIP712TypedDataSigner](_packages_sdk_utils_src_signatureutils_.md#verifyeip712typeddatasigner)
 * [verifySignature](_packages_sdk_utils_src_signatureutils_.md#verifysignature)
 
 ### Object literals
@@ -106,7 +107,7 @@ ___
 
 ▸ **guessSigner**(`message`: string, `signature`: string): *string*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:148](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L148)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:166](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L166)*
 
 **Parameters:**
 
@@ -283,6 +284,24 @@ Name | Type |
 
 ___
 
+###  verifyEIP712TypedDataSigner
+
+▸ **verifyEIP712TypedDataSigner**(`typedData`: [EIP712TypedData](../interfaces/_packages_sdk_utils_src_sign_typed_data_utils_.eip712typeddata.md), `signature`: string, `signer`: string): *boolean*
+
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:157](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L157)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typedData` | [EIP712TypedData](../interfaces/_packages_sdk_utils_src_sign_typed_data_utils_.eip712typeddata.md) |
+`signature` | string |
+`signer` | string |
+
+**Returns:** *boolean*
+
+___
+
 ###  verifySignature
 
 ▸ **verifySignature**(`message`: string, `signature`: string, `signer`: string): *boolean*
@@ -305,46 +324,58 @@ Name | Type |
 
 ### ▪ **SignatureUtils**: *object*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:195](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L195)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:213](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L213)*
 
 ###  LocalSigner
 
 • **LocalSigner**: *[LocalSigner](_packages_sdk_utils_src_signatureutils_.md#localsigner)*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:197](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L197)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:215](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L215)*
 
 ###  NativeSigner
 
 • **NativeSigner**: *NativeSigner*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:196](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L196)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:214](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L214)*
 
 ###  parseSignature
 
 • **parseSignature**: *[parseSignature](_packages_sdk_utils_src_signatureutils_.md#parsesignature)*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:200](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L200)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:218](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L218)*
 
 ###  parseSignatureWithoutPrefix
 
 • **parseSignatureWithoutPrefix**: *[parseSignatureWithoutPrefix](_packages_sdk_utils_src_signatureutils_.md#parsesignaturewithoutprefix)*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:201](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L201)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:219](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L219)*
+
+###  recoverEIP712TypedDataSigner
+
+• **recoverEIP712TypedDataSigner**: *[recoverEIP712TypedDataSigner](_packages_sdk_utils_src_signatureutils_.md#recovereip712typeddatasigner)*
+
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:221](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L221)*
 
 ###  serializeSignature
 
 • **serializeSignature**: *serializeSignature*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:202](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L202)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:220](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L220)*
 
 ###  signMessage
 
 • **signMessage**: *[signMessage](_packages_sdk_utils_src_signatureutils_.md#signmessage)*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:198](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L198)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:216](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L216)*
 
 ###  signMessageWithoutPrefix
 
 • **signMessageWithoutPrefix**: *[signMessageWithoutPrefix](_packages_sdk_utils_src_signatureutils_.md#signmessagewithoutprefix)*
 
-*Defined in [packages/sdk/utils/src/signatureUtils.ts:199](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L199)*
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:217](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L217)*
+
+###  verifyEIP712TypedDataSigner
+
+• **verifyEIP712TypedDataSigner**: *[verifyEIP712TypedDataSigner](_packages_sdk_utils_src_signatureutils_.md#verifyeip712typeddatasigner)*
+
+*Defined in [packages/sdk/utils/src/signatureUtils.ts:222](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/signatureUtils.ts#L222)*

--- a/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_string_.md
+++ b/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_string_.md
@@ -29,3 +29,9 @@
 • **appendPath**: *appendPath*
 
 *Defined in [packages/sdk/utils/src/string.ts:6](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/string.ts#L6)*
+
+###  normalizeAccents
+
+• **normalizeAccents**: *any*
+
+*Defined in [packages/sdk/utils/src/string.ts:7](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/string.ts#L7)*

--- a/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_typed_data_constructors_.md
+++ b/packages/docs/developer-resources/utils/reference/modules/_packages_sdk_utils_src_typed_data_constructors_.md
@@ -1,0 +1,23 @@
+# Module: "packages/sdk/utils/src/typed-data-constructors"
+
+## Index
+
+### Functions
+
+* [attestationSecurityCode](_packages_sdk_utils_src_typed_data_constructors_.md#attestationsecuritycode)
+
+## Functions
+
+###  attestationSecurityCode
+
+▸ **attestationSecurityCode**(`code`: string): *[EIP712TypedData](../interfaces/_packages_sdk_utils_src_sign_typed_data_utils_.eip712typeddata.md)*
+
+*Defined in [packages/sdk/utils/src/typed-data-constructors.ts:3](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/src/typed-data-constructors.ts#L3)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`code` | string |
+
+**Returns:** *[EIP712TypedData](../interfaces/_packages_sdk_utils_src_sign_typed_data_utils_.eip712typeddata.md)*


### PR DESCRIPTION
### Description

This adds the command `celocli multisig:transfer` so that there is tooling for users to manage CELO transfers with a multisig

### Other changes

N/A

### Tested

N/A cli entrypoint
### Related issues

- No Issues. This was a quick fix, so that we can test multisig transactions with our signers related to CGP-0014

### Backwards compatibility

yes.