### PR TITLE
Add quicktest command

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -rf ./types/typechain && rm -rf build/* && rm -rf .0x-artifacts/* && rm -rf migrations/*.js* && rm -rf test/**/*.js* && rm -f lib/*.js* && rm -f lib/**/*.js* && rm -f scripts/*.js*",
     "pretest": "yarn run build",
     "test": "rm test/**/*.js ; node runTests.js",
+    "quicktest": "./scripts/bash/quicktest.sh",
     "test:coverage": "yarn run test --coverage",
     "test:devchain-release": "./scripts/bash/release-on-devchain.sh",
     "test:generate-old-devchain-and-build": "./scripts/bash/generate-old-devchain-and-build.sh",

--- a/packages/protocol/scripts/bash/backupmigrations.sh
+++ b/packages/protocol/scripts/bash/backupmigrations.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+if [ -d migrations.bak ]; then
+  echo Replacing migrations
+  rm -rf migrations
+  mv migrations.bak migrations
+else
+  echo Backing up migrations
+  mv migrations migrations.bak
+  mkdir migrations
+
+  # Migration 0 always needs to be present
+  cp migrations.bak/00_initial_migration.* migrations/
+
+  # Uncomment lines for whichever migrations you actually do need.
+  # Note that some migrations depend on others (for example, many contracts
+  # require libraries to have been migrated, so you might need migration 1 to be
+  # uncommented).
+  cp migrations.bak/01_libraries.* migrations/
+  # cp migrations.bak/02_registry.* migrations/
+  # cp migrations.bak/03_freezer.* migrations/
+  # cp migrations.bak/03_transferwhitelist.* migrations/
+  # cp migrations.bak/03_whitelist.* migrations/
+  # cp migrations.bak/04_goldtoken.* migrations/
+  # cp migrations.bak/05_sortedoracles.* migrations/
+  # cp migrations.bak/06_gaspriceminimum.* migrations/
+  # cp migrations.bak/07_reserve_spender_multisig.* migrations/
+  # cp migrations.bak/08_reserve.* migrations/
+  # cp migrations.bak/09_stabletoken.* migrations/
+  # cp migrations.bak/10_exchange.* migrations/
+  # cp migrations.bak/11_accounts.* migrations/
+  # cp migrations.bak/12_lockedgold.* migrations/
+  # cp migrations.bak/13_validators.* migrations/
+  # cp migrations.bak/14_election.* migrations/
+  # cp migrations.bak/15_epoch_rewards.* migrations/
+  # cp migrations.bak/16_random.* migrations/
+  # cp migrations.bak/17_attestations.* migrations/
+  # cp migrations.bak/18_escrow.* migrations/
+  # cp migrations.bak/19_blockchainparams.* migrations/
+  # cp migrations.bak/20_governance_slasher.* migrations/
+  # cp migrations.bak/21_double_signing_slasher.* migrations/
+  # cp migrations.bak/22_downtime_slasher.* migrations/
+  # cp migrations.bak/23_governance_approver_multisig.* migrations/
+  # cp migrations.bak/24_governance.* migrations/
+  # cp migrations.bak/25_elect_validators.* migrations/
+fi

--- a/packages/protocol/scripts/bash/quicktest.sh
+++ b/packages/protocol/scripts/bash/quicktest.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Use this script if you want quick test iterations.
+# Compared to the normal test command, this script will:
+# 1. not run the pretest script of building solidity (will still be run as part of truffle test)
+#    and compiling typescript. This works because truffle can run typescript "natively".
+# 2. only migrate selected migrations as set in `backupmigrations.sh` (you'll likely need at
+#    least one compilation step since truffle seems to only run compiled migrations)
+#
+
+rm test/**/*.js
+./scripts/bash/backupmigrations.sh
+node runTests.js "$@"
+./scripts/bash/backupmigrations.sh


### PR DESCRIPTION
### Description

This PR adds `quicktest` yarn command that can be used to more quickly get into a code-test-fix-retest cycle. It relies on the tried backupmigrations script by @m-chrzan 
