### PR TITLE
Update pre-deploy script

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -30,7 +30,7 @@
     "test:e2e:packager": "export CELO_TEST_CONFIG=e2e && yarn react-native start",
     "test:verify-locales": "./scripts/verify_locales.sh",
     "pre-deploy": "./scripts/pre-deploy.sh",
-    "deploy:update-disclaimer": "yarn licenses generate-disclaimer > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh",
+    "deploy:update-disclaimer": "yarn reset && git fetch —tags -f && yarn && yarn licenses generate-disclaimer > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh",
     "postinstall": "./scripts/sync_branding.sh && ./scripts/copy_license_to_android_assets.sh"
   },
   "rnpm": {


### PR DESCRIPTION
### Description
Update `pre-deploy` script to avoid tag errors that may be encountered while the licensing page is being updated by resetting the yarn cache and explicitly fetching tags from remote. This change also runs `yarn` to ensure packages are updated prior to updating the licenses, which are reliant on our dependencies.

### Other changes
No

### Tested
Yes on this current release

### Related issues
N/A

### Backwards compatibility
Yes