### PR TITLE
[Wallet] Fix navigation init

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -65,6 +65,7 @@ export class App extends React.Component<Props> {
     Linking.addEventListener('url', this.handleOpenURL)
 
     const url = await Linking.getInitialURL()
+    Logger.debug('App/componentDidMount', 'initial url: ' + url)
     if (url) {
       await this.handleOpenURL({ url })
     }
@@ -95,8 +96,11 @@ export class App extends React.Component<Props> {
   }
 
   handleOpenURL = async (event: any) => {
+    Logger.debug('App/handleOpenURL', 'top event: ' + event)
     await waitUntilSagasFinishLoading()
+    Logger.debug('App/handleOpenURL', 'after wait saga')
     store.dispatch(openDeepLink(event.url))
+    Logger.debug('App/handleOpenURL', 'dispatch done')
   }
 
   render() {

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -65,7 +65,6 @@ export class App extends React.Component<Props> {
     Linking.addEventListener('url', this.handleOpenURL)
 
     const url = await Linking.getInitialURL()
-    Logger.debug('App/componentDidMount', 'initial url: ' + url)
     if (url) {
       await this.handleOpenURL({ url })
     }
@@ -96,11 +95,8 @@ export class App extends React.Component<Props> {
   }
 
   handleOpenURL = async (event: any) => {
-    Logger.debug('App/handleOpenURL', 'top event: ' + event)
     await waitUntilSagasFinishLoading()
-    Logger.debug('App/handleOpenURL', 'after wait saga')
     store.dispatch(openDeepLink(event.url))
-    Logger.debug('App/handleOpenURL', 'dispatch done')
   }
 
   render() {

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -16,6 +16,8 @@ import Logger from 'src/utils/Logger'
 
 const TAG = 'NavigationService'
 
+const NAVIGATOR_INIT_RETRIES = 5
+
 type SafeNavigate = typeof navigate
 
 export const navigationRef = createRef<NavigationContainerRef>()
@@ -23,7 +25,11 @@ export const navigatorIsReadyRef: MutableRefObject<boolean | null> = createRef()
 
 async function ensureNavigator() {
   let retries = 0
-  while (!navigationRef.current && !navigatorIsReadyRef.current && retries < 5) {
+  while (
+    !navigationRef.current &&
+    !navigatorIsReadyRef.current &&
+    retries < NAVIGATOR_INIT_RETRIES
+  ) {
     await sleep(200)
     retries++
   }

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -24,7 +24,7 @@ export const isReadyRef = createRef() // TODO: type
 async function ensureNavigator() {
   let retries = 0
   Logger.debug(`${TAG}@ensureNavigator`, `waiting for navigator`)
-  while (!navigationRef.current && isReadyRef.current && retries < 30) {
+  while (!navigationRef.current && !isReadyRef.current && retries < 30) {
     Logger.debug(`${TAG}@ensureNavigator`, `waiting for navigator try: ${retries}`)
     await sleep(200)
     retries++

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -23,7 +23,7 @@ export const isReadyRef: MutableRefObject<boolean | null> = createRef()
 
 async function ensureNavigator() {
   let retries = 0
-  while (!navigationRef.current && !isReadyRef.current && retries < 30) {
+  while (!navigationRef.current && !isReadyRef.current && retries < 5) {
     await sleep(200)
     retries++
   }

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -19,15 +19,15 @@ const TAG = 'NavigationService'
 type SafeNavigate = typeof navigate
 
 export const navigationRef = createRef<NavigationContainerRef>()
-export const isReadyRef: MutableRefObject<boolean | null> = createRef()
+export const navigatorIsReadyRef: MutableRefObject<boolean | null> = createRef()
 
 async function ensureNavigator() {
   let retries = 0
-  while (!navigationRef.current && !isReadyRef.current && retries < 5) {
+  while (!navigationRef.current && !navigatorIsReadyRef.current && retries < 5) {
     await sleep(200)
     retries++
   }
-  if (!navigationRef.current || !isReadyRef.current) {
+  if (!navigationRef.current || !navigatorIsReadyRef.current) {
     throw new Error('navigator is not initialized')
   }
 }

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -19,14 +19,17 @@ const TAG = 'NavigationService'
 type SafeNavigate = typeof navigate
 
 export const navigationRef = createRef<NavigationContainerRef>()
+export const isReadyRef = createRef() // TODO: type
 
 async function ensureNavigator() {
   let retries = 0
-  while (!navigationRef.current && retries < 3) {
+  Logger.debug(`${TAG}@ensureNavigator`, `waiting for navigator`)
+  while (!navigationRef.current && isReadyRef.current && retries < 30) {
+    Logger.debug(`${TAG}@ensureNavigator`, `waiting for navigator try: ${retries}`)
     await sleep(200)
     retries++
   }
-  if (!navigationRef.current) {
+  if (!navigationRef.current || !isReadyRef.current) {
     throw new Error('navigator is not initialized')
   }
 }

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -23,9 +23,7 @@ export const isReadyRef: MutableRefObject<boolean | null> = createRef()
 
 async function ensureNavigator() {
   let retries = 0
-  Logger.debug(`${TAG}@ensureNavigator`, `waiting for navigator`)
   while (!navigationRef.current && !isReadyRef.current && retries < 30) {
-    Logger.debug(`${TAG}@ensureNavigator`, `waiting for navigator try: ${retries}`)
     await sleep(200)
     retries++
   }

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -2,7 +2,7 @@
 
 import { NavigationActions, StackActions } from '@react-navigation/compat'
 import { CommonActions, NavigationContainerRef } from '@react-navigation/native'
-import { createRef } from 'react'
+import { createRef, MutableRefObject } from 'react'
 import sleep from 'sleep-promise'
 import { PincodeType } from 'src/account/reducer'
 import { pincodeTypeSelector } from 'src/account/selectors'
@@ -19,7 +19,7 @@ const TAG = 'NavigationService'
 type SafeNavigate = typeof navigate
 
 export const navigationRef = createRef<NavigationContainerRef>()
-export const isReadyRef = createRef() // TODO: type
+export const isReadyRef: MutableRefObject<boolean | null> = createRef()
 
 async function ensureNavigator() {
   let retries = 0

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -22,6 +22,7 @@ type SafeNavigate = typeof navigate
 
 export const navigationRef = createRef<NavigationContainerRef>()
 export const navigatorIsReadyRef: MutableRefObject<boolean | null> = createRef()
+navigatorIsReadyRef.current = false
 
 async function ensureNavigator() {
   let retries = 0

--- a/packages/mobile/src/navigator/NavigatorWrapper.tsx
+++ b/packages/mobile/src/navigator/NavigatorWrapper.tsx
@@ -94,8 +94,6 @@ export const NavigatorWrapper = () => {
         routeNameRef.current = getActiveRouteName(state)
       }
     }
-
-    navigatorIsReadyRef.current = false
   }, [])
 
   React.useEffect(() => {
@@ -133,6 +131,12 @@ export const NavigatorWrapper = () => {
       RNShake.removeEventListener('ShakeEvent')
     }
   }, [appState])
+
+  React.useEffect(() => {
+    return () => {
+      navigatorIsReadyRef.current = false
+    }
+  }, [])
 
   if (!isReady) {
     return null

--- a/packages/mobile/src/navigator/NavigatorWrapper.tsx
+++ b/packages/mobile/src/navigator/NavigatorWrapper.tsx
@@ -17,7 +17,7 @@ import { DEV_RESTORE_NAV_STATE_ON_RELOAD } from 'src/config'
 import i18n from 'src/i18n'
 import InviteFriendModal from 'src/invite/InviteFriendModal'
 import { generateInviteLink } from 'src/invite/saga'
-import { isReadyRef, navigate, navigationRef } from 'src/navigator/NavigationService'
+import { navigate, navigationRef, navigatorIsReadyRef } from 'src/navigator/NavigationService'
 import Navigator from 'src/navigator/Navigator'
 import { Screens } from 'src/navigator/Screens'
 import PincodeLock from 'src/pincode/PincodeLock'
@@ -134,7 +134,7 @@ export const NavigatorWrapper = () => {
 
   React.useEffect(() => {
     return () => {
-      isReadyRef.current = false
+      navigatorIsReadyRef.current = false
     }
   }, [])
 
@@ -179,7 +179,7 @@ export const NavigatorWrapper = () => {
   }
 
   const onReady = () => {
-    isReadyRef.current = true
+    navigatorIsReadyRef.current = true
   }
 
   return (

--- a/packages/mobile/src/navigator/NavigatorWrapper.tsx
+++ b/packages/mobile/src/navigator/NavigatorWrapper.tsx
@@ -94,6 +94,8 @@ export const NavigatorWrapper = () => {
         routeNameRef.current = getActiveRouteName(state)
       }
     }
+
+    navigatorIsReadyRef.current = false
   }, [])
 
   React.useEffect(() => {
@@ -131,12 +133,6 @@ export const NavigatorWrapper = () => {
       RNShake.removeEventListener('ShakeEvent')
     }
   }, [appState])
-
-  React.useEffect(() => {
-    return () => {
-      navigatorIsReadyRef.current = false
-    }
-  }, [])
 
   if (!isReady) {
     return null

--- a/packages/mobile/src/navigator/NavigatorWrapper.tsx
+++ b/packages/mobile/src/navigator/NavigatorWrapper.tsx
@@ -17,7 +17,7 @@ import { DEV_RESTORE_NAV_STATE_ON_RELOAD } from 'src/config'
 import i18n from 'src/i18n'
 import InviteFriendModal from 'src/invite/InviteFriendModal'
 import { generateInviteLink } from 'src/invite/saga'
-import { navigate, navigationRef } from 'src/navigator/NavigationService'
+import { isReadyRef, navigate, navigationRef } from 'src/navigator/NavigationService'
 import Navigator from 'src/navigator/Navigator'
 import { Screens } from 'src/navigator/Screens'
 import PincodeLock from 'src/pincode/PincodeLock'
@@ -132,6 +132,12 @@ export const NavigatorWrapper = () => {
     }
   }, [appState])
 
+  React.useEffect(() => {
+    return () => {
+      isReadyRef.current = false
+    }
+  }, [])
+
   if (!isReady) {
     return null
   }
@@ -175,6 +181,9 @@ export const NavigatorWrapper = () => {
   return (
     <NavigationContainer
       ref={navigationRef}
+      onReady={() => {
+        isReadyRef.current = true
+      }}
       onStateChange={handleStateChange}
       initialState={initialState}
       theme={AppTheme}

--- a/packages/mobile/src/navigator/NavigatorWrapper.tsx
+++ b/packages/mobile/src/navigator/NavigatorWrapper.tsx
@@ -178,12 +178,14 @@ export const NavigatorWrapper = () => {
     await Share.share({ message })
   }
 
+  const onReady = () => {
+    isReadyRef.current = true
+  }
+
   return (
     <NavigationContainer
       ref={navigationRef}
-      onReady={() => {
-        isReadyRef.current = true
-      }}
+      onReady={onReady}
       onStateChange={handleStateChange}
       initialState={initialState}
       theme={AppTheme}


### PR DESCRIPTION
### Description

Trying to fix the e2e test that fails on the deep link. Looking at the logs I see a navigation failure like this:

> [Wed Jan 13 2021 08:29:06.736]  INFO     NavigationService@navigate :: Navigation failure: Error: The 'navigation' object hasn't been initialized yet. This might happen if you don't have a navigator mounted, or if the navigator hasn't finished mounting. See https://reactnavigation.org/docs/navigating-without-navigation-prop#handling-initialization for more details. ::


The solution is described pretty well here: https://reactnavigation.org/docs/navigating-without-navigation-prop/

Basically we need to wait for the ready state in addition to the mounted state.

We should send some of the error messages that happen when we really don't expect them to to the backend to analyze. Maybe we can sample 1% or something like that.

### Tested

end to end DeepLinkSend.spec.js

### Related issues

- Fixes #6434 

### Backwards compatibility

Yes.
