### PR TITLE
add install instructions for CLI readme

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,18 @@
 
 Tool for interacting with the Celo Protocol.
 
+## Installation
+
+We are currently deploying the CLI with only Node v10.x LTS support.
+
+To install globally, run:
+
+```
+npm install -g @celo/celocli
+```
+
+If you have trouble installing globally (i.e. with the `-g` flag), try installing to a local directory instead with `npm install @celo/celocli` and run with `npx celocli`.
+
 ## Development
 
 ### Build


### PR DESCRIPTION
### Description

Add install instructions to the celocli README so that it appears on the @celo/celocli npm page.

### Other changes

none