### PR TITLE
Split etherbase: geth validators flags for e2e tests

### DIFF
--- a/packages/celotool/src/e2e-tests/governance_tests.ts
+++ b/packages/celotool/src/e2e-tests/governance_tests.ts
@@ -923,6 +923,7 @@ describe('governance tests', () => {
           wsport: 8559,
           rpcport: 9559,
           privateKey: rotation0PrivateKey.slice(2),
+          minerValidator: privateKeyToAddress(rotation0PrivateKey.slice(2)),
         },
         {
           name: 'validator2KeyRotation1',
@@ -933,6 +934,7 @@ describe('governance tests', () => {
           wsport: 8561,
           rpcport: 9561,
           privateKey: rotation1PrivateKey.slice(2),
+          minerValidator: privateKeyToAddress(rotation1PrivateKey.slice(2)),
         },
       ]
 

--- a/packages/celotool/src/e2e-tests/replica_tests.ts
+++ b/packages/celotool/src/e2e-tests/replica_tests.ts
@@ -1,5 +1,6 @@
 import { BlockHeader } from '@celo/connect'
 import { DefaultRpcCaller, RpcCaller } from '@celo/connect/lib/utils/rpc-caller'
+import { privateKeyToAddress } from '@celo/utils/lib/address'
 import { bitIsSet, parseBlockExtraData } from '@celo/utils/lib/istanbul'
 import { assert } from 'chai'
 import Web3 from 'web3'
@@ -138,6 +139,7 @@ describe('replica swap tests', () => {
         port: 30315,
         rpcport: 8555,
         privateKey: gethConfig.instances[0].privateKey,
+        minerValidator: privateKeyToAddress(gethConfig.instances[0].privateKey!),
         proxy: 'validator0-proxy0',
         isProxied: true,
         proxyport: 30304,

--- a/packages/celotool/src/e2e-tests/transfer_tests.ts
+++ b/packages/celotool/src/e2e-tests/transfer_tests.ts
@@ -244,7 +244,7 @@ describe('Transfer tests', function(this: any) {
     rpcport: 8547,
     // We need to set an etherbase here so that the full node will accept transactions from
     // light clients.
-    minerValidator: validatorAddress,
+    minerValidator: FeeRecipientAddress,
     txFeeRecipient: FeeRecipientAddress,
   }
 

--- a/packages/celotool/src/e2e-tests/transfer_tests.ts
+++ b/packages/celotool/src/e2e-tests/transfer_tests.ts
@@ -244,7 +244,7 @@ describe('Transfer tests', function(this: any) {
     rpcport: 8547,
     // We need to set an etherbase here so that the full node will accept transactions from
     // light clients.
-    etherbase: FeeRecipientAddress,
+    txFeeRecipient: FeeRecipientAddress,
   }
 
   const restartWithCleanNodes = async () => {

--- a/packages/celotool/src/e2e-tests/transfer_tests.ts
+++ b/packages/celotool/src/e2e-tests/transfer_tests.ts
@@ -244,6 +244,7 @@ describe('Transfer tests', function(this: any) {
     rpcport: 8547,
     // We need to set an etherbase here so that the full node will accept transactions from
     // light clients.
+    minerValidator: validatorAddress,
     txFeeRecipient: FeeRecipientAddress,
   }
 

--- a/packages/celotool/src/e2e-tests/utils.ts
+++ b/packages/celotool/src/e2e-tests/utils.ts
@@ -271,7 +271,7 @@ export function getContext(gethConfig: GethRunConfig, verbose: boolean = verbose
         proxyIndex++
       }
 
-      if (!instance.minerValidator) {
+      if (!instance.minerValidator && (instance.validating || instance.isProxied)) {
         instance.minerValidator = privateKeyToAddress(instance.privateKey!)
       }
     }

--- a/packages/celotool/src/e2e-tests/utils.ts
+++ b/packages/celotool/src/e2e-tests/utils.ts
@@ -270,6 +270,10 @@ export function getContext(gethConfig: GethRunConfig, verbose: boolean = verbose
         instance.privateKey = instance.privateKey || proxyPrivateKeys[proxyIndex]
         proxyIndex++
       }
+
+      if (!instance.minerValidator) {
+        instance.minerValidator = privateKeyToAddress(validatorPrivateKeys[validatorIndex])
+      }
     }
 
     // The proxies will need to know their proxied validator's address

--- a/packages/celotool/src/e2e-tests/utils.ts
+++ b/packages/celotool/src/e2e-tests/utils.ts
@@ -272,7 +272,7 @@ export function getContext(gethConfig: GethRunConfig, verbose: boolean = verbose
       }
 
       if (!instance.minerValidator) {
-        instance.minerValidator = privateKeyToAddress(validatorPrivateKeys[validatorIndex])
+        instance.minerValidator = privateKeyToAddress(instance.privateKey!)
       }
     }
 

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -885,7 +885,9 @@ export async function startGeth(
 
   const privateKey = instance.privateKey || ''
   const lightserv = instance.lightserv || false
-  const etherbase = instance.etherbase || ''
+  // const etherbase = instance.etherbase || ''
+  const minerValidator = instance.minerValidator!
+  const txFeeRecipient = instance.txFeeRecipient || minerValidator
   const verbosity = gethConfig.verbosity ? gethConfig.verbosity : '3'
   let blocktime: number = 1
 
@@ -917,6 +919,10 @@ export async function startGeth(
     '--gcmode=archive', // Needed to retrieve historical state
     '--istanbul.blockperiod',
     blocktime.toString(),
+    '--miner.validator',
+    minerValidator,
+    '--tx-fee-recipient',
+    txFeeRecipient
   ]
 
   if (rpcport) {
@@ -937,10 +943,6 @@ export async function startGeth(
       wsport.toString(),
       '--wsapi=eth,net,web3,debug,admin,personal,txpool,istanbul'
     )
-  }
-
-  if (etherbase) {
-    gethArgs.push('--etherbase', etherbase)
   }
 
   if (lightserv) {

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -885,9 +885,12 @@ export async function startGeth(
 
   const privateKey = instance.privateKey || ''
   const lightserv = instance.lightserv || false
-  // const etherbase = instance.etherbase || ''
-  const minerValidator = instance.minerValidator!
-  const txFeeRecipient = instance.txFeeRecipient || minerValidator
+  const minerValidator = instance.minerValidator
+  if (!minerValidator) {
+    throw new Error('miner.validator address from the instance is required')
+  }
+  // TODO(ponti): add flag after Donut fork
+  // const txFeeRecipient = instance.txFeeRecipient || minerValidator
   const verbosity = gethConfig.verbosity ? gethConfig.verbosity : '3'
   let blocktime: number = 1
 
@@ -919,10 +922,11 @@ export async function startGeth(
     '--gcmode=archive', // Needed to retrieve historical state
     '--istanbul.blockperiod',
     blocktime.toString(),
-    '--miner.validator',
+    '--etherbase', //TODO(ponti): change to '--miner.validator' after deprecating the 'etherbase' flag
     minerValidator,
-    '--tx-fee-recipient',
-    txFeeRecipient
+    // TODO(ponti): add flag after Donut fork
+    // '--tx-fee-recipient',
+    //txFeeRecipient
   ]
 
   if (rpcport) {

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -886,7 +886,7 @@ export async function startGeth(
   const privateKey = instance.privateKey || ''
   const lightserv = instance.lightserv || false
   const minerValidator = instance.minerValidator
-  if (!minerValidator) {
+  if (instance.validating && !minerValidator) {
     throw new Error('miner.validator address from the instance is required')
   }
   // TODO(ponti): add flag after Donut fork
@@ -921,13 +921,18 @@ export async function startGeth(
     '--allow-insecure-unlock', // geth1.9 to use http w/unlocking
     '--gcmode=archive', // Needed to retrieve historical state
     '--istanbul.blockperiod',
-    blocktime.toString(),
-    '--etherbase', // TODO(ponti): change to '--miner.validator' after deprecating the 'etherbase' flag
-    minerValidator,
+    blocktime.toString()
+  ]
+
+  if (minerValidator) {
+    gethArgs.push(
+      '--etherbase', // TODO(ponti): change to '--miner.validator' after deprecating the 'etherbase' flag
+      minerValidator
+    )
     // TODO(ponti): add flag after Donut fork
     // '--tx-fee-recipient',
     // txFeeRecipient
-  ]
+  }
 
   if (rpcport) {
     gethArgs.push(

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -922,11 +922,11 @@ export async function startGeth(
     '--gcmode=archive', // Needed to retrieve historical state
     '--istanbul.blockperiod',
     blocktime.toString(),
-    '--etherbase', //TODO(ponti): change to '--miner.validator' after deprecating the 'etherbase' flag
+    '--etherbase', // TODO(ponti): change to '--miner.validator' after deprecating the 'etherbase' flag
     minerValidator,
     // TODO(ponti): add flag after Donut fork
     // '--tx-fee-recipient',
-    //txFeeRecipient
+    // txFeeRecipient
   ]
 
   if (rpcport) {

--- a/packages/celotool/src/lib/interfaces/geth-instance-config.ts
+++ b/packages/celotool/src/lib/interfaces/geth-instance-config.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js'
+import BigNumber from 'bignumber.js';
 
 export interface GethInstanceConfig {
   name: string
@@ -12,7 +12,8 @@ export interface GethInstanceConfig {
   wsport?: number
   lightserv?: boolean
   privateKey?: string
-  etherbase?: string
+  minerValidator?: string
+  txFeeRecipient?: string
   proxies?: Array<string[2]>
   pid?: number
   isProxied?: boolean


### PR DESCRIPTION
### Description

Add required flags to run a validator, that are needed since the split etherbase change in the blockchain

### Backwards compatibility

No. Works only for the instances of geth that already have the etherbase split (since the donut fork)