### PR TITLE
Fix dependencies to work on standalone installations and in environments without Git

### DIFF
--- a/packages/sdk/connect/package.json
+++ b/packages/sdk/connect/package.json
@@ -21,6 +21,8 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@types/debug": "^4.1.5",
+    "@types/utf8": "^2.1.6",
     "@celo/utils": "1.0.0-dev",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
@@ -28,8 +30,6 @@
   },
   "devDependencies": {
     "@celo/flake-tracker": "0.0.1-dev",
-    "@types/debug": "^4.1.5",
-    "@types/utf8": "^2.1.6",
     "web3": "1.3.0",
     "web3-core": "1.3.0",
     "web3-eth": "1.3.0",

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -26,6 +26,7 @@
     "lint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
+    "@types/debug": "^4.1.5",
     "@celo/base": "1.0.0-dev",
     "@celo/connect": "1.0.0-dev",
     "@celo/utils": "1.0.0-dev",

--- a/packages/sdk/explorer/package.json
+++ b/packages/sdk/explorer/package.json
@@ -22,12 +22,13 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@types/debug": "^4.1.5",
     "@celo/base": "1.0.0-dev",
     "@celo/connect": "1.0.0-dev",
-    "@celo/contractkit": "1.0.0-dev"
+    "@celo/contractkit": "1.0.0-dev",
+    "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@types/debug": "^4.1.5",
     "web3": "1.3.0"
   },
   "engines": {

--- a/packages/sdk/governance/package.json
+++ b/packages/sdk/governance/package.json
@@ -26,13 +26,12 @@
     "@celo/connect": "1.0.0-dev",
     "@celo/contractkit": "1.0.0-dev",
     "@celo/explorer": "1.0.0-dev",
-    "ethereumjs-util": "^5.2.0",
-    "inquirer": "^7.0.5"
-  },
-  "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/inquirer": "^6.5.0",
-    "@types/ethereumjs-util": "^5.2.0"
+    "@types/ethereumjs-util": "^5.2.0",
+    "ethereumjs-util": "^5.2.0",
+    "inquirer": "^7.0.5",
+    "debug": "^4.1.1"
   },
   "engines": {
     "node": ">=8.13.0"

--- a/packages/sdk/identity/package.json
+++ b/packages/sdk/identity/package.json
@@ -28,6 +28,7 @@
     "@celo/base": "1.0.0-dev",
     "@celo/utils": "1.0.0-dev",
     "@celo/contractkit": "1.0.0-dev",
+    "@types/debug": "^4.1.5",
     "bignumber.js": "^9.0.0",
     "blind-threshold-bls": "https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a",
     "cross-fetch": "3.0.4",
@@ -39,7 +40,6 @@
   "devDependencies": {
     "@celo/dev-utils": "0.0.1-dev",
     "@celo/wallet-local": "1.0.0-dev",
-    "@types/debug": "^4.1.5",
     "fetch-mock": "9.10.4",
     "@types/elliptic": "^6.4.12",
     "@celo/flake-tracker": "0.0.1-dev",

--- a/packages/sdk/network-utils/package.json
+++ b/packages/sdk/network-utils/package.json
@@ -22,12 +22,12 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@types/debug": "^4.1.5",
     "cross-fetch": "3.0.4",
     "debug": "^4.1.1"
   },
   "devDependencies": {
     "@celo/dev-utils": "0.0.1-dev",
-    "@types/debug": "^4.1.5",
     "fetch-mock": "9.10.4",
     "@celo/flake-tracker": "0.0.1-dev"
   },

--- a/packages/sdk/transactions-uri/package.json
+++ b/packages/sdk/transactions-uri/package.json
@@ -24,6 +24,8 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@types/debug": "^4.1.5",
+    "@types/qrcode": "^1.3.4",
     "@celo/base": "1.0.0-dev",
     "@celo/connect": "1.0.0-dev",
     "bn.js": "4.11.8",
@@ -33,8 +35,6 @@
   "devDependencies": {
     "@celo/dev-utils": "0.0.1-dev",
     "@celo/contractkit": "1.0.0-dev",
-    "@types/debug": "^4.1.5",
-    "@types/qrcode": "^1.3.4",
     "dotenv": "^8.2.0",
     "@celo/flake-tracker": "0.0.1-dev"
   },

--- a/packages/sdk/utils/package.json
+++ b/packages/sdk/utils/package.json
@@ -20,7 +20,14 @@
   ],
   "dependencies": {
     "@celo/base": "1.0.0-dev",
-    "@umpirsky/country-list": "git://github.com/umpirsky/country-list#05fda51",
+    "@umpirsky/country-list": "https://github.com/umpirsky/country-list#05fda51",
+    "@types/country-data": "^0.0.0",
+    "@types/elliptic": "^6.4.9",
+    "@types/ethereumjs-util": "^5.2.0",
+    "@types/google-libphonenumber": "^7.4.17",
+    "@types/lodash": "^4.14.136",
+    "@types/node": "^10.12.18",
+    "@types/randombytes": "^2.0.0",
     "bigi": "^1.1.0",
     "bignumber.js": "^9.0.0",
     "bip32": "2.0.5",
@@ -43,14 +50,7 @@
   },
   "devDependencies": {
     "@celo/flake-tracker": "0.0.1-dev",
-    "@celo/typescript": "0.0.1",
-    "@types/country-data": "^0.0.0",
-    "@types/elliptic": "^6.4.9",
-    "@types/ethereumjs-util": "^5.2.0",
-    "@types/google-libphonenumber": "^7.4.17",
-    "@types/lodash": "^4.14.136",
-    "@types/node": "^10.12.18",
-    "@types/randombytes": "^2.0.0"
+    "@celo/typescript": "0.0.1"
   },
   "resolutions": {
     "elliptic/bn.js": "4.11.8",

--- a/packages/sdk/wallets/wallet-base/package.json
+++ b/packages/sdk/wallets/wallet-base/package.json
@@ -20,15 +20,15 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@celo/connect": "1.0.0-dev",
     "@celo/base": "1.0.0-dev",
     "@celo/utils": "1.0.0-dev",
+    "@types/ethereumjs-util": "^5.2.0",
+    "@types/debug": "^4.1.5",
     "bignumber.js": "^9.0.0",
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0",
     "debug": "^4.1.1"
-  },
-  "devDependencies": {
-    "@celo/connect": "1.0.0-dev"
   },
   "engines": {
     "node": ">=8.13.0"

--- a/packages/sdk/wallets/wallet-hsm-aws/package.json
+++ b/packages/sdk/wallets/wallet-hsm-aws/package.json
@@ -24,6 +24,8 @@
     "@celo/wallet-base": "1.0.0-dev",
     "@celo/wallet-remote": "1.0.0-dev",
     "@celo/wallet-hsm": "1.0.0-dev",
+    "@types/debug": "^4.1.5",
+    "@types/secp256k1": "^4.0.0",
     "aws-sdk": "^2.705.0",
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0",
@@ -33,7 +35,6 @@
   },
   "devDependencies": {
     "@celo/connect": "1.0.0-dev",
-    "@types/secp256k1": "^4.0.0",
     "elliptic": "6.5.3",
     "web3": "1.3.0"
   },

--- a/packages/sdk/wallets/wallet-hsm-azure/package.json
+++ b/packages/sdk/wallets/wallet-hsm-azure/package.json
@@ -27,6 +27,8 @@
     "@celo/wallet-base": "1.0.0-dev",
     "@celo/wallet-remote": "1.0.0-dev",
     "@celo/wallet-hsm": "1.0.0-dev",
+    "@celo/connect": "1.0.0-dev",
+    "@types/secp256k1": "^4.0.0",
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0",
     "bignumber.js": "^9.0.0",
@@ -34,8 +36,6 @@
     "secp256k1": "^4.0.0"
   },
   "devDependencies": {
-    "@celo/connect": "1.0.0-dev",
-    "@types/secp256k1": "^4.0.0",
     "dotenv": "^8.2.0",
     "elliptic": "6.5.2",
     "web3": "1.3.0"

--- a/packages/sdk/wallets/wallet-hsm/package.json
+++ b/packages/sdk/wallets/wallet-hsm/package.json
@@ -21,6 +21,9 @@
   },
   "dependencies": {
     "@celo/base": "1.0.0-dev",
+    "@types/asn1js": "^0.0.2",
+    "@types/secp256k1": "^4.0.0",
+    "@types/debug": "^4.1.5",
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0",
     "asn1js": "^2.0.26",
@@ -28,9 +31,7 @@
     "secp256k1": "^4.0.0"
   },
   "devDependencies": {
-    "@celo/connect": "1.0.0-dev",
-    "@types/asn1js": "^0.0.2",
-    "@types/secp256k1": "^4.0.0"
+    "@celo/connect": "1.0.0-dev"
   },
   "engines": {
     "node": ">=8.13.0"

--- a/packages/sdk/wallets/wallet-hsm/package.json
+++ b/packages/sdk/wallets/wallet-hsm/package.json
@@ -30,9 +30,6 @@
     "elliptic": "6.5.3",
     "secp256k1": "^4.0.0"
   },
-  "devDependencies": {
-    "@celo/connect": "1.0.0-dev"
-  },
   "engines": {
     "node": ">=8.13.0"
   }

--- a/packages/sdk/wallets/wallet-ledger/package.json
+++ b/packages/sdk/wallets/wallet-ledger/package.json
@@ -23,14 +23,13 @@
     "@celo/utils": "1.0.0-dev",
     "@celo/wallet-base": "1.0.0-dev",
     "@celo/wallet-remote": "1.0.0-dev",
+    "@celo/connect": "1.0.0-dev",
+    "@types/ethereumjs-util": "^5.2.0",
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0",
     "debug": "^4.1.1",
     "@ledgerhq/hw-app-eth": "^5.11.0",
     "@ledgerhq/hw-transport": "^5.11.0"
-  },
-  "devDependencies": {
-    "@celo/connect": "1.0.0-dev"
   },
   "engines": {
     "node": ">=8.13.0"

--- a/packages/sdk/wallets/wallet-local/package.json
+++ b/packages/sdk/wallets/wallet-local/package.json
@@ -21,12 +21,13 @@
   },
   "dependencies": {
     "@celo/utils": "1.0.0-dev",
+    "@celo/connect": "1.0.0-dev",
     "@celo/wallet-base": "1.0.0-dev",
+    "@types/ethereumjs-util": "^5.2.0",
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0"
   },
   "devDependencies": {
-    "@celo/connect": "1.0.0-dev"
   },
   "engines": {
     "node": ">=8.13.0"

--- a/packages/sdk/wallets/wallet-remote/package.json
+++ b/packages/sdk/wallets/wallet-remote/package.json
@@ -20,13 +20,15 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@celo/connect": "1.0.0-dev",
     "@celo/utils": "1.0.0-dev",
     "@celo/wallet-base": "1.0.0-dev",
+    "@types/ethereumjs-util": "^5.2.0",
+    "@types/debug": "^4.1.5",
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0"
   },
   "devDependencies": {
-    "@celo/connect": "1.0.0-dev"
   },
   "engines": {
     "node": ">=8.13.0"

--- a/packages/sdk/wallets/wallet-rpc/package.json
+++ b/packages/sdk/wallets/wallet-rpc/package.json
@@ -20,6 +20,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@celo/connect": "1.0.0-dev",
     "@celo/utils": "1.0.0-dev",
     "@celo/wallet-base": "1.0.0-dev",
     "@celo/wallet-remote": "1.0.0-dev",
@@ -28,7 +29,6 @@
   },
   "devDependencies": {
     "@celo/dev-utils": "0.0.1-dev",
-    "@celo/connect": "1.0.0-dev",
     "@celo/contractkit": "1.0.0-dev"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7677,6 +7677,11 @@
   version "1.0.0"
   resolved "git://github.com/umpirsky/country-list#05fda51cd97b3294e8175ffed06104c44b3c71d7"
 
+"@umpirsky/country-list@https://github.com/umpirsky/country-list#05fda51":
+  version "1.0.0"
+  uid "05fda51cd97b3294e8175ffed06104c44b3c71d7"
+  resolved "https://github.com/umpirsky/country-list#05fda51cd97b3294e8175ffed06104c44b3c71d7"
+
 "@ungap/url-search-params@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/url-search-params/-/url-search-params-0.1.2.tgz#8ba8c0527543fe675d1c29ae0a2daca842e8ee4f"


### PR DESCRIPTION
This pull request fixes several issues with the individual SDK module dependencies:

- When publishing a repository with declaration files, the `@types/*` dependencies need to be included. Otherwise TypeScript users will get many compilation errors in `node_modules/@celo/*` repositories and have to hunt down the proper `@types` module and - more difficult - version that was being used and install them manually.
- `@celo/connect` should be a `dependency` and not a `devDependency` for the wallets modules since it is used in their code. Otherwise you will get an error when trying to use e.g. `@celo/wallet-local` individually
- Git URLs (specifically `git://github.com/umpirsky/country-list#05fda51`) will not work with e.g. CI build systems that do not have Git+SSH set up. Using HTTPS should work everywhere.