### PR TITLE
[Wallet] Ask PIN immediately on BackupForceScreen

### DIFF
--- a/packages/mobile/src/backup/BackupForceScreen.tsx
+++ b/packages/mobile/src/backup/BackupForceScreen.tsx
@@ -13,9 +13,12 @@ import DelayButton from 'src/backup/DelayButton'
 import { Namespaces } from 'src/i18n'
 import Logo from 'src/icons/Logo'
 import { emptyHeader } from 'src/navigator/Headers'
-import { navigate } from 'src/navigator/NavigationService'
+import { ensurePincode, navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
+import Logger from 'src/utils/Logger'
+
+const TAG = 'BackupForceScreen'
 
 type Props = StackScreenProps<StackParamList, Screens.BackupForceScreen>
 
@@ -24,7 +27,15 @@ function BackupForceScreen({ navigation }: Props) {
 
   const startBackup = () => {
     ValoraAnalytics.track(OnboardingEvents.backup_start)
-    navigate(Screens.AccountKeyEducation)
+    ensurePincode()
+      .then((pinIsCorrect) => {
+        if (pinIsCorrect) {
+          navigate(Screens.AccountKeyEducation)
+        }
+      })
+      .catch((error) => {
+        Logger.error(`${TAG}@onPress`, 'PIN ensure error', error)
+      })
   }
 
   // Prevent back button on Android


### PR DESCRIPTION
### Description

Users are not being prompted for the PIN on the `BackupForceScreen` when pressing the "Set Up Now" button, so when they are prompted for it afterwards on the Account Key screen, if they press the back button they see the Account Key screen with an empty mnemonic. With this change they are prompted for their PIN right away on the `BackupForceScreen` so that pressing the back button leaves you where you started.

### Tested

Yes, on the simulator

### Related issues

- Fixes #6477

### Backwards compatibility

N/A