### PR TITLE
Fix phone number search on Send Screen

### DIFF
--- a/packages/mobile/src/recipients/recipient.ts
+++ b/packages/mobile/src/recipients/recipient.ts
@@ -185,11 +185,13 @@ const SCORE_THRESHOLD = -6000
 const fuzzysortOptions = {
   keys: ['displayName', 'e164PhoneNumber', 'address'],
   threshold: SCORE_THRESHOLD,
+  allowTypo: false,
 }
 
 const fuzzysortPreparedOptions = {
   keys: ['displayPrepared', 'phonePrepared', 'addressPrepared'],
   threshold: SCORE_THRESHOLD,
+  allowTypo: false,
 }
 
 function fuzzysortToRecipients(


### PR DESCRIPTION
### Description
The `fuzzysort` search options we had were too permissive. For example, using the Send search bar and entering`310` returned matches for all numbers that had a `3`, `1`, or `0` instead of only numbers that start with `310`. Disallowing typos fixes this issue.

### Other changes
None

### Tested
Manually

### Related issues
- Fixes #6009

### Backwards compatibility
Yes