### PR TITLE
Parse version numbers correctly from Buffer

### DIFF
--- a/packages/protocol/lib/compatibility/version.ts
+++ b/packages/protocol/lib/compatibility/version.ts
@@ -38,12 +38,12 @@ export class ContractVersion {
       throw new Error(`Invalid version buffer: ${version.toString('hex')}`)
     }
     const versions = [
-      version.slice(0, 32),  // Storage
-      version.slice(32, 64), // Major
-      version.slice(64, 96), // Minor
-      version.slice(96, 128) // Patch
+      version.toString('hex', 0, 32),  // Storage
+      version.toString('hex', 32, 64), // Major
+      version.toString('hex', 64, 96), // Minor
+      version.toString('hex', 96, 128) // Patch
     ]
-    return ContractVersion.fromString(versions.map((x) => x.toString('hex')).join('.'))
+    return ContractVersion.fromString(versions.map((x) => parseInt(x, 16)).join('.'))
   }
 
   constructor(

--- a/packages/protocol/test/compatibility/version.ts
+++ b/packages/protocol/test/compatibility/version.ts
@@ -46,6 +46,20 @@ describe('#version()', () => {
         const version = ContractVersion.fromGetVersionNumberReturnValue(buffer)
         assert.equal(version.toString(), '1.2.3.4')
       })
+
+      it('parses larger hex digits correctly', () => {
+        const zeros = '0'.repeat(63)
+        const buffer = Buffer.from(`${zeros}a${zeros}b${zeros}c${zeros}d`, 'hex')
+        const version = ContractVersion.fromGetVersionNumberReturnValue(buffer)
+        assert.equal(version.toString(), '10.11.12.13')
+      })
+
+      it('parses larger hex numbers correctly', () => {
+        const zeros = '0'.repeat(62)
+        const buffer = Buffer.from(`${zeros}10${zeros}11${zeros}fe${zeros}ff`, 'hex')
+        const version = ContractVersion.fromGetVersionNumberReturnValue(buffer)
+        assert.equal(version.toString(), '16.17.254.255')
+      })
     })
   })
 


### PR DESCRIPTION
### Description

The `fromGetVersionNumberReturnValue` incorrectly passed base-16 encoded numbers to `ContractVersion.fromString`, which would have led to errors thrown for any version number component greater than 9. This PR ensures the numbers are correctly converted to base-10.

### Tested

Added unit tests.

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/719