### PR TITLE
Add dynamic download link to Valora invite texts

### DIFF
--- a/packages/mobile/.env.alfajores
+++ b/packages/mobile/.env.alfajores
@@ -16,6 +16,7 @@ APP_STORE_ID=1482389446
 APP_DISPLAY_NAME=Alfajores
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.alfajores.plist
 DYNAMIC_LINK_DOMAIN=https://l.celo.org
+DYNAMIC_DOWNLOAD_LINK=https://vlra.app/download
 GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution

--- a/packages/mobile/.env.alfajoresdev
+++ b/packages/mobile/.env.alfajoresdev
@@ -18,6 +18,7 @@ APP_STORE_ID=1482389446
 APP_DISPLAY_NAME=Alfajores (dev)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.alfajoresdev.plist
 DYNAMIC_LINK_DOMAIN=https://l.celo.org
+DYNAMIC_DOWNLOAD_LINK=https://vlra.app/download
 GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution

--- a/packages/mobile/.env.mainnet
+++ b/packages/mobile/.env.mainnet
@@ -16,6 +16,7 @@ APP_STORE_ID=1520414263
 APP_DISPLAY_NAME=Valora
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.mainnet.plist
 DYNAMIC_LINK_DOMAIN=https://vlra.app
+DYNAMIC_DOWNLOAD_LINK=https://vlra.app/download
 GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution

--- a/packages/mobile/.env.mainnetdev
+++ b/packages/mobile/.env.mainnetdev
@@ -18,6 +18,7 @@ APP_STORE_ID=1520414263
 APP_DISPLAY_NAME=Valora (dev)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.mainnetdev.plist
 DYNAMIC_LINK_DOMAIN=https://vlra.app
+DYNAMIC_DOWNLOAD_LINK=https://vlra.app/download
 GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -160,3 +160,4 @@ export const KOTANI_URI = 'https://kotanipay.com/partners/valora'
 
 export const APP_STORE_ID = Config.APP_STORE_ID
 export const DYNAMIC_LINK_DOMAIN = Config.DYNAMIC_LINK_DOMAIN
+export const DYNAMIC_DOWNLOAD_LINK = Config.DYNAMIC_DOWNLOAD_LINK

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -183,7 +183,6 @@ export function* sendInvite(
     const temporaryAddress = temporaryWalletAccount.address
     const inviteCode = createInviteCode(temporaryWalletAccount.privateKey)
 
-    console.log(DYNAMIC_DOWNLOAD_LINK)
     const link = features.ESCROW_WITHOUT_CODE
       ? DYNAMIC_DOWNLOAD_LINK
       : yield call(generateInviteLink, inviteCode)

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -23,8 +23,7 @@ import { showError, showMessage } from 'src/alert/actions'
 import { InviteEvents, OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { WEB_LINK } from 'src/brandingConfig'
-import { APP_STORE_ID } from 'src/config'
+import { APP_STORE_ID, DYNAMIC_DOWNLOAD_LINK } from 'src/config'
 import { transferEscrowedPayment } from 'src/escrow/actions'
 import { calculateFee } from 'src/fees/saga'
 import { generateShortInviteLink } from 'src/firebase/dynamicLinks'
@@ -184,8 +183,9 @@ export function* sendInvite(
     const temporaryAddress = temporaryWalletAccount.address
     const inviteCode = createInviteCode(temporaryWalletAccount.privateKey)
 
+    console.log(DYNAMIC_DOWNLOAD_LINK)
     const link = features.ESCROW_WITHOUT_CODE
-      ? WEB_LINK
+      ? DYNAMIC_DOWNLOAD_LINK
       : yield call(generateInviteLink, inviteCode)
 
     const messageProp = amount


### PR DESCRIPTION
### Description
Add a dynamic link to invites. This should either link to the Valora app on the invitees device or link to the appropriate app store (either App Store or Play Store) when clicked.

Purposefully linking both the Alfajores and Mainnet apps to the production app store as it does not work (and is useless) to try to link to non-mainnet builds that do no exist in App Stores.

Note: Linking into the App Store seems to be inconsistent on iOS. I believe this to be an issue with the Firebase Dynamic Link functionality and have submitted a support request to address this.

### Other changes
N/A

### Tested
Manually

### Related issues
- Fixes  #6271

### Backwards compatibility
Yes