### PR TITLE
Fix @ledgerhq package version in CK and CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "@celo/wallet-local": "1.0.0-dev",
     "@celo/wallet-hsm-azure": "1.0.0-dev",
     "@celo/wallet-ledger": "1.0.0-dev",
-    "@ledgerhq/hw-transport-node-hid": "^5.11.0",
+    "@ledgerhq/hw-transport-node-hid": "~5.11.0",
     "@oclif/command": "^1.6.0",
     "@oclif/config": "^1.6.0",
     "@oclif/plugin-help": "^1.2.4",

--- a/packages/sdk/wallets/wallet-ledger/package.json
+++ b/packages/sdk/wallets/wallet-ledger/package.json
@@ -26,8 +26,8 @@
     "eth-lib": "^0.2.8",
     "ethereumjs-util": "^5.2.0",
     "debug": "^4.1.1",
-    "@ledgerhq/hw-app-eth": "^5.11.0",
-    "@ledgerhq/hw-transport": "^5.11.0"
+    "@ledgerhq/hw-app-eth": "~5.11.0",
+    "@ledgerhq/hw-transport": "~5.11.0"
   },
   "devDependencies": {
     "@celo/connect": "1.0.0-dev"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4267,7 +4267,7 @@
     "@ledgerhq/errors" "^4.64.0"
     "@ledgerhq/hw-transport" "^4.64.0"
 
-"@ledgerhq/hw-app-eth@^5.11.0":
+"@ledgerhq/hw-app-eth@~5.11.0":
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.11.0.tgz#5db6abe0ddf5b5266ed09868de12021f59c1a33e"
   integrity sha512-qgpPwZzM8UMHYMC5+9xYV2O+8kgkDAl9+38w9JiBksaGmUFqcS4najsB1nj6AWf2rGEuXdKMb2WEYRskVypJrA==
@@ -4311,7 +4311,7 @@
     node-hid "^0.7.9"
     usb "^1.6.0"
 
-"@ledgerhq/hw-transport-node-hid@^5.11.0":
+"@ledgerhq/hw-transport-node-hid@~5.11.0":
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.11.0.tgz#f2d3e0edc25840de4f452cf427a0482c65be8e86"
   integrity sha512-J/hP3IqcgZn/sTGblELkwZcH68Gbv3ZeaRWdhei6K2dAuxae4dxoVUf6PoOcupEOcXT5XzJBNMc5800AwFeOgg==
@@ -4342,7 +4342,7 @@
     "@ledgerhq/errors" "^4.64.0"
     events "^3.0.0"
 
-"@ledgerhq/hw-transport@^5.11.0":
+"@ledgerhq/hw-transport@^5.11.0", "@ledgerhq/hw-transport@~5.11.0":
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.11.0.tgz#f5c45a34d9b68d81fd2f6641b49815527720364b"
   integrity sha512-z56iwv0DZZu20T5q9sNMHFQNVuRKYqzCuNFhY9woWSpmOQkyVHCRiEgOQbN5h6kVri6fkfPkDzqqcsYjJlnT9g==


### PR DESCRIPTION
### Description

The `RangeError` was coming when users used the CLI with a Ledger, and had @ledgerhq packages with versions >= `5.36.0`.  This is because of [this PR ](https://github.com/LedgerHQ/ledgerjs/pull/551)in the Ledger package. When we RLP encode Celo txns, the [chainID is at index 9](https://github.com/celo-org/celo-monorepo/blob/6148646a29e5e719df9a1b32d1580ea7e6e61be8/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L103). But the @ledgerhq/hw-app-eth package, after the 5.36.0 version, gets the chainID [from index 6](https://github.com/LedgerHQ/ledgerjs/blob/ebd5e9c4d97cb3e83c6d90ab004d28dbac1d188f/packages/hw-app-eth/src/Eth.js#L208), since it is optimized for ethereum txns.

So for now, we're fixing the version of that dependency to 5.11.0; but longer term we plan on creating our own Celo-specific library for this. See the issue to track this [here](https://github.com/celo-org/celo-monorepo/issues/6495). 

### Other changes

n/a

### Tested

Tested some previously failing cli commands using a Ledger.

### Related issues

- Fixes #6274 

### Backwards compatibility

n/a