### PR TITLE
[Wallet] Apply WebView opacity hack fix globally

### DIFF
--- a/packages/mobile/src/account/Licenses.tsx
+++ b/packages/mobile/src/account/Licenses.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { WithTranslation } from 'react-i18next'
 import { Platform, StyleSheet, View } from 'react-native'
-import { WebView } from 'react-native-webview'
+import WebView from 'src/components/WebView'
 import i18n, { Namespaces, withTranslation } from 'src/i18n'
 import { headerWithBackButton } from 'src/navigator/Headers'
 
@@ -36,7 +36,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   licensesWebView: {
-    opacity: 0.99,
     marginHorizontal: 20,
   },
 })

--- a/packages/mobile/src/account/__snapshots__/Licenses.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Licenses.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`Licenses renders correctly 1`] = `
           },
           Object {
             "marginHorizontal": 20,
-            "opacity": 0.99,
           },
         ]
       }

--- a/packages/mobile/src/app/WebViewScreen.tsx
+++ b/packages/mobile/src/app/WebViewScreen.tsx
@@ -1,11 +1,11 @@
 import colors from '@celo/react-components/styles/colors'
 import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
-import { Platform, StyleSheet, View } from 'react-native'
-import { WebView } from 'react-native-webview'
+import { StyleSheet, View } from 'react-native'
 import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
 import { useDispatch } from 'react-redux'
 import { openDeepLink } from 'src/app/actions'
+import WebView from 'src/components/WebView'
 import i18n from 'src/i18n'
 import { emptyHeader } from 'src/navigator/Headers'
 import { navigateBack } from 'src/navigator/NavigationService'
@@ -32,13 +32,6 @@ export const webViewScreenNavOptions = ({ route }: RouteProps) => {
   }
 }
 
-const shouldUseOpacityHack = () => {
-  if (Platform.OS === 'ios') {
-    return false
-  }
-  return Platform.Version >= 28
-}
-
 function WebViewScreen({ route }: Props) {
   const { uri } = route.params
   const dispatch = useDispatch()
@@ -54,7 +47,6 @@ function WebViewScreen({ route }: Props) {
   return (
     <View style={styles.container}>
       <WebView
-        style={shouldUseOpacityHack() ? styles.webView : {}}
         originWhitelist={['https://*', 'celo://*']}
         onShouldStartLoadWithRequest={handleLoadRequest}
         setSupportMultipleWindows={false}
@@ -69,9 +61,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     flex: 1,
     justifyContent: 'center',
-  },
-  webView: {
-    opacity: 0.99,
   },
   close: {
     color: colors.dark,

--- a/packages/mobile/src/components/WebView.tsx
+++ b/packages/mobile/src/components/WebView.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Platform, StyleSheet } from 'react-native'
+import { WebView as RNWebView, WebViewProps } from 'react-native-webview'
+
+// This is to prevent a crash on specific Android versions,
+// see https://github.com/react-native-webview/react-native-webview/issues/429
+const SHOULD_USE_OPACITY_HACK = Platform.OS === 'android' && Platform.Version >= 28
+
+export default function WebView({ style, ...passThroughProps }: WebViewProps) {
+  return (
+    <RNWebView
+      {...passThroughProps}
+      style={SHOULD_USE_OPACITY_HACK ? [style, styles.opacityHack] : style}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  opacityHack: {
+    opacity: 0.99,
+  },
+})

--- a/packages/mobile/src/fiatExchanges/LocalProviderCashOut.tsx
+++ b/packages/mobile/src/fiatExchanges/LocalProviderCashOut.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
 import { StyleSheet, View } from 'react-native'
-import { WebView } from 'react-native-webview'
+import WebView from 'src/components/WebView'
 import i18n from 'src/i18n'
 import { emptyHeader } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
@@ -27,7 +27,7 @@ function LocalProviderCashOut({ route }: Props) {
 
   return (
     <View style={styles.container}>
-      <WebView style={styles.exchangeWebView} source={{ uri }} />
+      <WebView source={{ uri }} />
     </View>
   )
 }
@@ -37,9 +37,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     flex: 1,
     justifyContent: 'center',
-  },
-  exchangeWebView: {
-    opacity: 0.99,
   },
 })
 

--- a/packages/mobile/src/fiatExchanges/MoonPay.tsx
+++ b/packages/mobile/src/fiatExchanges/MoonPay.tsx
@@ -2,10 +2,10 @@ import colors from '@celo/react-components/styles/colors'
 import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
-import { WebView } from 'react-native-webview'
 import { useSelector } from 'react-redux'
 import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import WebView from 'src/components/WebView'
 import config from 'src/geth/networkConfig'
 import i18n from 'src/i18n'
 import { emptyHeader } from 'src/navigator/Headers'
@@ -64,7 +64,7 @@ function FiatExchangeWeb({ route }: Props) {
       {uri === '' ? (
         <ActivityIndicator size="large" color={colors.greenBrand} />
       ) : (
-        <WebView style={styles.exchangeWebView} source={{ uri }} />
+        <WebView source={{ uri }} />
       )}
     </View>
   )
@@ -75,9 +75,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     flex: 1,
     justifyContent: 'center',
-  },
-  exchangeWebView: {
-    opacity: 0.99,
   },
 })
 

--- a/packages/mobile/src/verify/safety/GoogleReCaptcha.tsx
+++ b/packages/mobile/src/verify/safety/GoogleReCaptcha.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import WebView from 'react-native-webview'
+import WebView from 'src/components/WebView'
 
 interface Props {
   onMessage: (any: any) => void


### PR DESCRIPTION
### Description

Wrap the `opacity: 0.99` hack into our own `WebView`, so we can apply it everywhere we use a `WebView`, instead of duplicating it without an explanation.

See https://github.com/react-native-webview/react-native-webview/issues/429

### Tested

- Ran tests

### Related issues

N/A

### Backwards compatibility

Yes