### PR TITLE
Tag discord users from metadata-crawler

### DIFF
--- a/packages/metadata-crawler/src/crawler.ts
+++ b/packages/metadata-crawler/src/crawler.ts
@@ -220,6 +220,7 @@ async function processAttestationServiceStatusForValidator(
       status.state === AttestationServiceStatusState.Valid
 
     if (!currentValid) {
+      // see: https://discord.com/developers/docs/reference#message-formatting
       const content =
         `:no_mobile_phones: **Problem with Attestation Service!** @${status.name}\n` +
         `For validator \`${validator.address}\` in group \`${validator.affiliation}\`\n` +

--- a/packages/metadata-crawler/src/crawler.ts
+++ b/packages/metadata-crawler/src/crawler.ts
@@ -221,7 +221,7 @@ async function processAttestationServiceStatusForValidator(
 
     if (!currentValid) {
       const content =
-        `:no_mobile_phones: **Problem with Attestation Service!** ${status.name} \n` +
+        `:no_mobile_phones: **Problem with Attestation Service!** @${status.name}\n` +
         `For validator \`${validator.address}\` in group \`${validator.affiliation}\`\n` +
         `\`${status.state}\` ${status.attestationServiceURL ?? ''}${
           status.error ? '\n`' + (status.error.message ?? status.error) + '`' : ''

--- a/packages/metadata-crawler/src/members.html
+++ b/packages/metadata-crawler/src/members.html
@@ -1,0 +1,531 @@
+<h2 class="membersGroup-v9BXpm container-2ax-kl" aria-label="Validators ✅, 37 members">
+    <span aria-hidden="true">Validators ✅—37</span>
+</h2>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6831" aria-expanded="false" tabindex="-1" index="5" role="listitem" data-list-item-id="members-781618644899332146___5">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="20/20, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/323931408861102081/a_e8f55227904dfd680d340efc0c771a89.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">20/20 | Virtual Hive</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6846" aria-expanded="false" tabindex="-1" index="6" role="listitem" data-list-item-id="members-781618644899332146___6">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Adrian | moonlet.io, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/363166153130115073/329efa8be6bdaae50b00ac24840895d7.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Adrian | moonlet.io</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6832" aria-expanded="false" tabindex="-1" index="7" role="listitem" data-list-item-id="members-781618644899332146___7">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="ag, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/392575408610213898/f45a4c7a70f2411fca2deeff1f5527eb.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">ag</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6833" aria-expanded="false" tabindex="-1" index="8" role="listitem" data-list-item-id="members-781618644899332146___8">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Alesh, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/710438356802207804/70665fccb2852cf230df1e5df7561784.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Alesh | TrustWorks.io</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6834" aria-expanded="false" tabindex="-1" index="9" role="listitem" data-list-item-id="members-781618644899332146___9">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Alex [Masternode24], Do Not Disturb" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/551955825422499854/7028a9d59e3687a2764d19e02317897c.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#f04747" mask="url(#svg-mask-status-dnd)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Alex [Masternode24]</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6824" aria-expanded="false" tabindex="-1" index="10" role="listitem" data-list-item-id="members-781618644899332146___10">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="andreisid, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="/assets/1cbd08c76f8af6dddce02c5138971129.png" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">andreisid</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6825" aria-expanded="false" tabindex="-1" index="11" role="listitem" data-list-item-id="members-781618644899332146___11">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Bmass | goods-and-services, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/194360837169872896/b6bf8f9152c2abdbc3de16533548f57c.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Bmass | Goods &amp; Services</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6826" aria-expanded="false" tabindex="-1" index="12" role="listitem" data-list-item-id="members-781618644899332146___12">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="bgeihsgt, Online via mobile" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-mobile-32)">
+                        <img src="https://cdn.discordapp.com/avatars/614342366731698180/58fdcdc81b55bd904409cfe813f94dfe.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="15" x="22" y="17" fill="#43b581" mask="url(#svg-mask-status-online-mobile)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">brian | stakevalley.com</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6827" aria-expanded="false" tabindex="-1" index="13" role="listitem" data-list-item-id="members-781618644899332146___13">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Cathy | Bi23, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="/assets/dd4dbc0016779df1378e7812eabaa04d.png" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Cathy | Bi23</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6828" aria-expanded="false" tabindex="-1" index="14" role="listitem" data-list-item-id="members-781618644899332146___14">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="chorus-joe, Do Not Disturb" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="/assets/0e291f67c9274a1abdddeb3fd919cbaa.png" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#f04747" mask="url(#svg-mask-status-dnd)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">chorus-joe</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6829" aria-expanded="false" tabindex="-1" index="15" role="listitem" data-list-item-id="members-781618644899332146___15">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="chris | projecttent, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/666714661303091221/578546877439645d936c33d63fd81c17.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">chris | projecttent</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6818" aria-expanded="false" tabindex="-1" index="16" role="listitem" data-list-item-id="members-781618644899332146___16">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="daithi, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/439383515944058881/0bca1b0b14aaf2804fc950a5118d2ed8.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">daithi</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6820" aria-expanded="false" tabindex="-1" index="17" role="listitem" data-list-item-id="members-781618644899332146___17">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Dee | Usopp.club, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="/assets/0e291f67c9274a1abdddeb3fd919cbaa.png" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Dee | Usopp.club</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6821" aria-expanded="false" tabindex="-1" index="18" role="listitem" data-list-item-id="members-781618644899332146___18">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="edescourtis, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/636641853906878504/c0a9c408c970ebd34a3eea0f4b2c9c44.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">edescourtis | stake.fish</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6822" aria-expanded="false" tabindex="-1" index="19" role="listitem" data-list-item-id="members-781618644899332146___19">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Francesco | Simply VC, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/417781353409413122/c4a18cc108b95747b958762ad5b4bd8a.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Francesco | Simply VC</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6823" aria-expanded="false" tabindex="-1" index="20" role="listitem" data-list-item-id="members-781618644899332146___20">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Gavin | figment.io, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/294676197823217674/ce6eac9936004cbd4b25fb2ccced6202.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Gavin | figment.io</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6812" aria-expanded="false" tabindex="-1" index="21" role="listitem" data-list-item-id="members-781618644899332146___21">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="gunray, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="/assets/322c936a8c8be1b803cd94861bdfa868.png" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">gunray</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6838" aria-expanded="false" tabindex="-1" index="22" role="listitem" data-list-item-id="members-781618644899332146___22">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="james | censusworks, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/653402011571716106/0d883b3a8f4e77b1b192aa170bdd3176.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">james | censusworks</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6839" aria-expanded="false" tabindex="-1" index="23" role="listitem" data-list-item-id="members-781618644899332146___23">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="jiyun | DSRV, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/570549101922615316/461c7e29a8d5eaaad2f6a768d932db57.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">jiyun | DSRV | celowhale.com</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6840" aria-expanded="false" tabindex="-1" index="24" role="listitem" data-list-item-id="members-781618644899332146___24">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Kasper | Newroad, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/603296132197646391/610c59748238a23e2494142c02375704.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Kasper | Newroad</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6841" aria-expanded="false" tabindex="-1" index="25" role="listitem" data-list-item-id="members-781618644899332146___25">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="keefertaylor, Idle" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/403811901613670401/66a04da61057a67676f85052ed87f1a9.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#faa61a" mask="url(#svg-mask-status-idle)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Keefer | Tessellated Geometry</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="member-3-YXUe container-2Pjhx- clickable-1JJAn8" aria-controls="popout_6842" aria-expanded="false" tabindex="-1" index="26" role="listitem" data-list-item-id="members-781618644899332146___26">
+    <div class="layout-2DM8Md">
+        <div class="avatar-3uk_u9">
+            <div class="wrapper-3t9DeA" role="img" aria-label="Keir, Online" aria-hidden="false" style="width: 32px; height: 32px;">
+                <svg width="40" height="32" viewBox="0 0 40 32" class="mask-1l8v16 svg-2V3M55" aria-hidden="true">
+                    <foreignObject x="0" y="0" width="32" height="32" mask="url(#svg-mask-avatar-status-round-32)">
+                        <img src="https://cdn.discordapp.com/avatars/630638403326574594/5a83535818a4ec91fe742d1b85a8280f.png?size=512" alt=" " class="avatar-VxgULZ" aria-hidden="true">
+                    </foreignObject>
+                    <rect width="10" height="10" x="22" y="22" fill="#43b581" mask="url(#svg-mask-status-online)" class="pointerEvents-2zdfdO">
+                    </rect>
+                </svg>
+            </div>
+        </div>
+        <div class="content-3QAtGj">
+            <div class="nameAndDecorators-5FJ2dg">
+                <div class="name-uJV0GL">
+                    <span class="roleColor-rz2vM0" style="color: rgb(52, 152, 219);">Keir</span>
+                </div>
+            </div>
+            <div class="subText-1KtqkB">
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### Description

Tag validators in discord in the #mainnet-alerts channel so cap members don't have to

TODO:
- [ ] use `members.html` from discord to populate `username => userid` mapping
- [ ] lookup `status.name` in mapping and tag `userid` in `postToDiscord`

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._