### PR TITLE
Fix call to set gas currency in CLI base

### DIFF
--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -170,7 +170,9 @@ export abstract class BaseCommand extends Command {
 
     const setUsdGas = async () => {
       await this.kit.setFeeCurrency(CeloContract.StableToken)
-      await this.kit.updateGasPriceInConnectionLayer(CeloContract.StableToken)
+      await this.kit.updateGasPriceInConnectionLayer(
+        await this.kit.registry.addressFor(CeloContract.StableToken)
+      )
     }
     if (gasCurrencyConfig === GasOptions.cUSD) {
       await setUsdGas()


### PR DESCRIPTION
### Description

In the code to set cUSD as the gas currency for `celocli`, there is an error that sends the string
'StableToken' as an `Address` to `kit.updateGasPriceInConnectionLayer`. Instead, it should fetch the
address for the cUSD contract from the registry and pass that in, or we should update the
`kit.updateGasPriceInConnectionLayer` to take the contract identifier and complete the same
operation interanlly. This PR implements the former.

```
Error: invalid address (argument="address", value="StableToken", code=INVALID_ARGUMENT, version=address/5.0.4) (argument="tokenAddress", value="StableToken", code=INVALID_ARGUMENT, version=abi/5.0.0-beta.153)
Code: INVALID_ARGUMENT
```

### Tested

Ran a cUSD transfer command that previously failed