### PR TITLE
Added the account field

### DIFF
--- a/packages/blockchain-api/src/blockscout.ts
+++ b/packages/blockchain-api/src/blockscout.ts
@@ -41,6 +41,8 @@ export interface BlockscoutTransferTx {
 export interface BlockscoutCeloTransfer {
   fromAddressHash: string
   toAddressHash: string
+  fromAccountHash: string
+  toAccountHash: string
   token: string
   value: string
 }
@@ -80,6 +82,8 @@ export class BlockscoutAPI extends RESTDataSource {
                     node {
                       fromAddressHash
                       toAddressHash
+                      fromAccountHash
+                      toAccountHash
                       value
                       token
                     }

--- a/packages/blockchain-api/src/events/EscrowReceived.ts
+++ b/packages/blockchain-api/src/events/EscrowReceived.ts
@@ -23,7 +23,8 @@ export class EscrowReceived extends TransactionType {
       transaction,
       transfer,
       EventTypes.ESCROW_RECEIVED,
-      transfer.fromAddressHash
+      transfer.fromAddressHash,
+      transfer.fromAccountHash
     )
   }
 

--- a/packages/blockchain-api/src/events/EscrowSent.ts
+++ b/packages/blockchain-api/src/events/EscrowSent.ts
@@ -24,6 +24,7 @@ export class EscrowSent extends TransactionType {
       transfer,
       EventTypes.ESCROW_SENT,
       transfer.toAddressHash,
+      transfer.toAccountHash,
       transaction.fees
     )
   }

--- a/packages/blockchain-api/src/events/Faucet.ts
+++ b/packages/blockchain-api/src/events/Faucet.ts
@@ -19,7 +19,8 @@ export class Faucet extends TransactionType {
       transaction,
       transfer,
       EventTypes.FAUCET,
-      transfer.fromAddressHash
+      transfer.fromAddressHash,
+      transfer.fromAccountHash
     )
   }
 

--- a/packages/blockchain-api/src/events/TokenReceived.ts
+++ b/packages/blockchain-api/src/events/TokenReceived.ts
@@ -22,7 +22,8 @@ export class TokenReceived extends TransactionType {
       transaction,
       transfer,
       EventTypes.RECEIVED,
-      transfer.fromAddressHash
+      transfer.fromAddressHash,
+      transfer.fromAccountHash
     )
   }
 

--- a/packages/blockchain-api/src/events/TokenSent.ts
+++ b/packages/blockchain-api/src/events/TokenSent.ts
@@ -23,6 +23,7 @@ export class TokenSent extends TransactionType {
       transfer,
       EventTypes.SENT,
       transfer.toAddressHash,
+      transfer.toAccountHash,
       transaction.fees
     )
   }

--- a/packages/blockchain-api/src/events/Verification.ts
+++ b/packages/blockchain-api/src/events/Verification.ts
@@ -24,6 +24,7 @@ export class Verification extends TransactionType {
       transfer,
       EventTypes.VERIFICATION_FEE,
       transfer.toAddressHash,
+      transfer.toAccountHash,
       transaction.fees
     )
   }

--- a/packages/blockchain-api/src/helpers/EventBuilder.ts
+++ b/packages/blockchain-api/src/helpers/EventBuilder.ts
@@ -11,6 +11,7 @@ export class EventBuilder {
     transfer: BlockscoutCeloTransfer,
     eventType: string,
     address: string,
+    account?: string,
     fees?: Fee[]
   ) {
     const hash = transaction.transactionHash
@@ -27,6 +28,7 @@ export class EventBuilder {
       comment,
       hash,
       address,
+      account: account ? account : address,
       amount: {
         // Signed amount relative to the account currency
         value: new BigNumber(transfer.value)

--- a/packages/blockchain-api/src/schema.ts
+++ b/packages/blockchain-api/src/schema.ts
@@ -43,6 +43,7 @@ export interface TransferEvent {
   block: number
   value: number
   address: string
+  account: string
   comment: string
   symbol: string
   hash: string
@@ -171,6 +172,7 @@ export const typeDefs = gql`
     # signed amount (+/-)
     amount: MoneyAmount!
     address: Address!
+    account: Address!
     comment: String
     token: Token!
     hash: String!

--- a/packages/blockchain-api/test/blockscout.test.ts
+++ b/packages/blockchain-api/test/blockscout.test.ts
@@ -160,6 +160,7 @@ describe('Blockscout', () => {
           "type": "EXCHANGE",
         },
         Object {
+          "account": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
           "address": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
           "amount": Object {
             "currencyCode": "cUSD",
@@ -191,6 +192,7 @@ describe('Blockscout', () => {
           "type": "SENT",
         },
         Object {
+          "account": "0xa12a699c641cc875a7ca57495861c79c33d293b4",
           "address": "0xa12a699c641cc875a7ca57495861c79c33d293b4",
           "amount": Object {
             "currencyCode": "cUSD",
@@ -222,6 +224,7 @@ describe('Blockscout', () => {
           "type": "SENT",
         },
         Object {
+          "account": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
           "address": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
           "amount": Object {
             "currencyCode": "cUSD",
@@ -253,6 +256,7 @@ describe('Blockscout', () => {
           "type": "SENT",
         },
         Object {
+          "account": "0xf4314cb9046bece6aa54bb9533155434d0c76910",
           "address": "0xf4314cb9046bece6aa54bb9533155434d0c76909",
           "amount": Object {
             "currencyCode": "cUSD",
@@ -266,6 +270,7 @@ describe('Blockscout', () => {
           "type": "RECEIVED",
         },
         Object {
+          "account": "0x0000000000000000000000000000000000a77327",
           "address": "0x0000000000000000000000000000000000a77327",
           "amount": Object {
             "currencyCode": "cUSD",
@@ -289,6 +294,7 @@ describe('Blockscout', () => {
           "type": "ESCROW_SENT",
         },
         Object {
+          "account": "0x0000000000000000000000000000000000a77357",
           "address": "0x0000000000000000000000000000000000a77357",
           "amount": Object {
             "currencyCode": "cUSD",
@@ -312,6 +318,7 @@ describe('Blockscout', () => {
           "type": "VERIFICATION_FEE",
         },
         Object {
+          "account": "0x0000000000000000000000000000000000007E57",
           "address": "0x0000000000000000000000000000000000007E57",
           "amount": Object {
             "currencyCode": "cUSD",
@@ -455,6 +462,7 @@ describe('Blockscout', () => {
           "type": "EXCHANGE",
         },
         Object {
+          "account": "0xf4314cb9046bece6aa54bb9533155434d0c76909",
           "address": "0xf4314cb9046bece6aa54bb9533155434d0c76909",
           "amount": Object {
             "currencyCode": "cGLD",
@@ -486,6 +494,7 @@ describe('Blockscout', () => {
           "type": "SENT",
         },
         Object {
+          "account": "0xf4314cb9046bece6aa54bb9533155434d0c76910",
           "address": "0xf4314cb9046bece6aa54bb9533155434d0c76909",
           "amount": Object {
             "currencyCode": "cGLD",
@@ -509,6 +518,7 @@ describe('Blockscout', () => {
           "type": "SENT",
         },
         Object {
+          "account": "0xf4314cb9046bece6aa54bb9533155434d0c76909",
           "address": "0xf4314cb9046bece6aa54bb9533155434d0c76909",
           "amount": Object {
             "currencyCode": "cGLD",
@@ -522,6 +532,7 @@ describe('Blockscout', () => {
           "type": "RECEIVED",
         },
         Object {
+          "account": "0x0000000000000000000000000000000000f40c37",
           "address": "0x0000000000000000000000000000000000f40c37",
           "amount": Object {
             "currencyCode": "cGLD",

--- a/packages/blockchain-api/test/mockTokenTxs.ts
+++ b/packages/blockchain-api/test/mockTokenTxs.ts
@@ -358,6 +358,7 @@ const mockTokenTxs = {
                 {
                   node: {
                     fromAddressHash: '0xf4314cb9046bece6aa54bb9533155434d0c76909',
+                    fromAccountHash: '0xf4314cb9046bece6aa54bb9533155434d0c76910', // this should go to the `account` field
                     toAddressHash: '0x0000000000000000000000000000000000007E57',
                     token: 'cUSD',
                     value: '10000000000000000000',
@@ -367,6 +368,7 @@ const mockTokenTxs = {
                   node: {
                     fromAddressHash: '0xf4314cb9046bece6aa54bb9533155434d0c76909',
                     toAddressHash: '0xa12a699c641cc875a7ca57495861c79c33d293b4',
+                    toAccountHash: null,
                     token: 'cUSD',
                     value: '1297230000000000',
                   },
@@ -375,6 +377,7 @@ const mockTokenTxs = {
                   node: {
                     fromAddressHash: '0xf4314cb9046bece6aa54bb9533155434d0c76909',
                     toAddressHash: '0x2a43f97f8bf959e31f69a894ebd80a88572c8553',
+                    toAccountHash: null,
                     token: 'cUSD',
                     value: '5188920000000000',
                   },
@@ -383,6 +386,7 @@ const mockTokenTxs = {
                   node: {
                     fromAddressHash: '0xf4314cb9046bece6aa54bb9533155434d0c76909',
                     toAddressHash: '0xfcf7fc2f0c1f06fb6314f9fa2a53e9805aa863e0',
+                    toAccountHash: null,
                     token: 'cUSD',
                     value: '0',
                   },
@@ -409,6 +413,7 @@ const mockTokenTxs = {
                   node: {
                     fromAddressHash: '0x0000000000000000000000000000000000007E57',
                     toAddressHash: '0xf4314cb9046bece6aa54bb9533155434d0c76909',
+                    toAccountHash: '0xf4314cb9046bece6aa54bb9533155434d0c76910', // this should go to the `account` field
                     token: 'cGLD',
                     value: '1000000000000000000',
                   },


### PR DESCRIPTION
### Description

Adds the new `account` field that exposes the account address associated with the wallet address currently returned in the `address` field.

### Related issues

Fixes #6268 and https://github.com/celo-org/blockscout/pull/171
Relevant blockscout changes: https://github.com/celo-org/blockscout/pull/178

### Backwards compatibility

Yes.