### PR TITLE
Build all of protocol during make-release

### DIFF
--- a/packages/protocol/scripts/bash/make-release.sh
+++ b/packages/protocol/scripts/bash/make-release.sh
@@ -50,7 +50,7 @@ mv build/contracts $BUILD_DIR
 cp migrationsConfig.js $BUILD_DIR/
 git checkout -
 cp $BUILD_DIR/migrationsConfig.js ./
-yarn build:ts
+yarn build
 
 yarn run truffle exec ./scripts/truffle/make-release.js \
   --network $NETWORK \


### PR DESCRIPTION
### Description

Just building the typescript will not build the truffle types from the artifacts and will cause typescript then to complain if the current branch's tests are inconsistent with the last compiled types
