### PR TITLE
Add more support for Churrito and Donut hard forks in celotool

### DIFF
--- a/.env
+++ b/.env
@@ -81,6 +81,9 @@ BLOCK_TIME=1
 EPOCH=1000
 LOOKBACK=12
 ISTANBUL_REQUEST_TIMEOUT_MS=3000
+# Hardfork activation block numbers (also part of genesis)
+CHURRITO_BLOCK=0
+DONUT_BLOCK=0
 
 # the number of load test clients that will be given funds in the genesis & migrations
 LOAD_TEST_CLIENTS=100

--- a/packages/celotool/src/cmds/geth/start.ts
+++ b/packages/celotool/src/cmds/geth/start.ts
@@ -21,6 +21,8 @@ interface StartArgv extends GethArgv {
   syncMode: string
   mining: boolean
   blockTime: number
+  churritoBlock: number
+  donutBlock: number
   port: number
   rpcport: number
   wsport: number
@@ -36,6 +38,22 @@ interface StartArgv extends GethArgv {
   ethstats: string
   mnemonic: string
   initialAccounts: string
+}
+
+// hardForkBlockCoercer parses a hard fork activation block as follows:
+// "null" => no activation
+// "42" => activate at block 42 (and likewise for other numbers >= 0)
+const hardForkBlockCoercer = (arg: string) => {
+  if (arg === 'null') {
+    return undefined
+  } else {
+    const value = parseInt(arg, 10)
+    if (typeof value === 'number' && value >= 0) {
+      return value
+    } else {
+      throw new Error(`Invalid value for hard fork activation block: '${arg}'`)
+    }
+  }
 }
 
 export const builder = (argv: yargs.Argv) => {
@@ -109,6 +127,18 @@ export const builder = (argv: yargs.Argv) => {
       description: 'Block Time',
       default: 1,
     })
+    .option('churritoBlock', {
+      type: 'string',
+      coerce: hardForkBlockCoercer,
+      description: 'Churrito hard fork activation block number (use "null" for no activation)',
+      default: '0',
+    })
+    .option('donutBlock', {
+      type: 'string',
+      coerce: hardForkBlockCoercer,
+      description: 'Donut hard fork activation block number (use "null" for no activation)',
+      default: '0',
+    })
     .option('migrate', {
       type: 'boolean',
       description: 'Migrate contracts',
@@ -145,6 +175,8 @@ export const handler = async (argv: StartArgv) => {
   const networkId = parseInt(argv.networkId, 10)
   const syncMode = argv.syncMode
   const blockTime = argv.blockTime
+  const churritoBlock = argv.churritoBlock
+  const donutBlock = argv.donutBlock
 
   const port = argv.port
   const rpcport = argv.rpcport
@@ -184,6 +216,8 @@ export const handler = async (argv: StartArgv) => {
       blockTime,
       epoch: 17280,
       initialAccounts,
+      churritoBlock,
+      donutBlock,
     },
   }
 


### PR DESCRIPTION
### Description

This is a follow-up to #6534, which adds the following:

- Support for Churrito and Donut activation blocks in celotool's `geth start` command (with defaults of 0)
- Set `CHURRITO_BLOCK` and `DONUT_BLOCK` to 0 in `.env`, so new testnets will have Churrito and Donut enabled

I was planning to add these commits to #6534 following the feedback from @nategraf, but the PR had automerge enabled, so it's been merged already, and so I'm adding them in a new PR.

### Tested

- Verified the new argument parsing for `geth start` works and the values are included in the resulting `GethRunConfig`
- The effect of including the block numbers in `.env` was tested as part of #6534

### Backwards compatibility

This will make new testnets celotool's `geth start` or using the default `.env` have Churrito and Donut enabled.