### PR TITLE
Add proxy docs and recommend upgrade to 1.2.2

### DIFF
--- a/packages/docs/SUMMARY.md
+++ b/packages/docs/SUMMARY.md
@@ -39,6 +39,7 @@
 - [Securing Celo Nodes and Services](validator-guide/securing-nodes-and-services.md)
 - [Monitoring](validator-guide/monitoring.md)
 - [Upgrading a Node](validator-guide/node-upgrades.md)
+- [Running Proxies](validator-guide/proxy.md)
 - [Validator Explorer](validator-guide/validator-explorer.md)
 - [Celo Foundation Voting Policy](validator-guide/celo-foundation-voting-policy.md)
 

--- a/packages/docs/validator-guide/node-upgrades.md
+++ b/packages/docs/validator-guide/node-upgrades.md
@@ -4,8 +4,7 @@ When a new version of the Celo node is available, you can follow this guide to u
 
 ## Recent Releases
 
-* [Blockchain Client 1.2.0](https://github.com/celo-org/celo-blockchain/releases/tag/v1.2.0) (latest release for testnets)
-* [Blockchain Client 1.1.0](https://github.com/celo-org/celo-blockchain/releases/tag/v1.1.0) (Latest production release)
+* [Blockchain Client 1.2.0](https://github.com/celo-org/celo-blockchain/releases/tag/v1.2.2) (Latest production release)
 
 ## When an upgrade is required
 


### PR DESCRIPTION
### Description

This adds the proxy page in the validator guide to the summary so it will be included in the docs.
This also notes that the latest recommended versions for node operators is celo-blockchain 1.2.2.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._