### PR TITLE
Fixed Global Flag Parsing in CLI

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ This package will follow the release process outlined [here](https://docs.celo.o
 
 
 ## Development (not published yet)
-### **[1.0.2--dev]**
+### **[1.0.3--dev]**
 Features
 - [one-line summary] - [link PR]
 
@@ -15,6 +15,10 @@ Bug Fixes
 Other Changes
 - [one-line summary] - [link PR]
 ## Published
+### **[1.0.2]** -- 2021-01-22
+Bug Fixes
+- Fixed Global Flag Parsing in CLI - [#6619](https://github.com/celo-org/celo-monorepo/pull/6619)
+
 ### **[1.0.1]** -- 2021-01-20
 Features
 - Pass through [oclif table flags](https://github.com/oclif/cli-ux#clitable) to commands which output tables - [#5618](https://github.com/celo-org/celo-monorepo/pull/5618)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@celo/celocli",
   "description": "CLI Tool for transacting with the Celo protocol",
-  "version": "1.0.1-dev",
+  "version": "1.0.3-dev",
   "author": "Celo",
   "license": "Apache-2.0",
   "repository": "celo-org/celo-monorepo",

--- a/packages/cli/src/commands/account/balance.ts
+++ b/packages/cli/src/commands/account/balance.ts
@@ -5,6 +5,10 @@ import { Args } from '../../utils/command'
 export default class Balance extends BaseCommand {
   static description = 'View Celo Dollar and Gold balances for an address'
 
+  static flags = {
+    ...BaseCommand.flags,
+  }
+
   static args = [Args.address('address')]
 
   static examples = ['balance 0x5409ed021d9299bf6814279a6a1411a7e866a631']

--- a/packages/cli/src/commands/account/lock.ts
+++ b/packages/cli/src/commands/account/lock.ts
@@ -5,6 +5,10 @@ import { Args } from '../../utils/command'
 export default class Lock extends BaseCommand {
   static description = 'Lock an account which was previously unlocked'
 
+  static flags = {
+    ...BaseCommand.flags,
+  }
+
   static args: IArg[] = [Args.address('account', { description: 'Account address' })]
 
   static examples = ['lock 0x5409ed021d9299bf6814279a6a1411a7e866a631']

--- a/packages/cli/src/commands/config/get.ts
+++ b/packages/cli/src/commands/config/get.ts
@@ -5,6 +5,10 @@ import { readConfig } from '../../utils/config'
 export default class Get extends BaseCommand {
   static description = 'Output network node configuration'
 
+  static flags = {
+    ...BaseCommand.flags,
+  }
+
   requireSynced = false
 
   async run() {


### PR DESCRIPTION
### Description

#5882 broke some commands' global flags. This PR brings them back
Also updated dev version in preparation for CLI 1.0.2 release.

### Other changes

n/a

### Tested

Tested locally on relevant commands; works!

### Related issues

- Fixes bug mentioned on discord [here](https://discord.com/channels/600834479145353243/600840423958904842/802241358831026176).

### Backwards compatibility

n/a