### PR TITLE
[Wallet] Make providers on providers selection screen clickable

### DIFF
--- a/packages/mobile/locales/es-419/fiatExchangeFlow.json
+++ b/packages/mobile/locales/es-419/fiatExchangeFlow.json
@@ -25,7 +25,7 @@
   "receiveOnAddress": "Dirección de cUSD/CELO",
   "receiveWithPonto": "GCash (con Ponto)",
   "receiveWithKotani": "M-PESA (con Kotani Pay)",
-  "receiveWithBidali": "Tarjetas de reglao y recargas móviles",
+  "receiveWithBidali": "Tarjetas de regalo y recargas móviles",
   "fundingEducationDialog": {
     "title": "Fondeando {{appName}}",
     "body": "{{appName}} corre sobre la Red Celo. {{appName}} funciona con Celo Dólares (cUSD), una moneda digital estable vinculada al dólar estadounidense.\n\nPara agregar fondos a {{appName}}, compra cUSD de uno de los proveedores disponibles en tu ubicación. Para más información por favor visita <0>{{link}}</0>",

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.test.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.test.tsx
@@ -1,8 +1,12 @@
+import { CURRENCY_ENUM } from '@celo/utils'
 import * as React from 'react'
-import { render } from 'react-native-testing-library'
+import { fireEvent, render } from 'react-native-testing-library'
 import { Provider } from 'react-redux'
 import ProviderOptionsScreen from 'src/fiatExchanges/ProviderOptionsScreen'
+import { LocalCurrencyCode } from 'src/localCurrency/consts'
+import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { navigateToURI } from 'src/utils/linking'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 
 const mockScreenProps = (isCashIn: boolean) =>
@@ -10,13 +14,48 @@ const mockScreenProps = (isCashIn: boolean) =>
     isCashIn,
   })
 
+const mockStore = createMockStore({
+  account: {
+    defaultCountryCode: '+54',
+  },
+  localCurrency: {
+    preferredCurrencyCode: LocalCurrencyCode.BRL,
+  },
+})
+
 describe('ProviderOptionsScreen', () => {
   it('renders correctly', () => {
     const { toJSON } = render(
-      <Provider store={createMockStore({})}>
+      <Provider store={mockStore}>
         <ProviderOptionsScreen {...mockScreenProps(true)} />
       </Provider>
     )
     expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('opens Simplex correctly', () => {
+    const { getByTestId } = render(
+      <Provider store={mockStore}>
+        <ProviderOptionsScreen {...mockScreenProps(true)} />
+      </Provider>
+    )
+
+    fireEvent.press(getByTestId('Provider/Simplex'))
+    expect(navigateToURI).toHaveBeenCalled()
+  })
+
+  it('opens MoonPay correctly', () => {
+    const { getByTestId } = render(
+      <Provider store={mockStore}>
+        <ProviderOptionsScreen {...mockScreenProps(true)} />
+      </Provider>
+    )
+
+    fireEvent.press(getByTestId('Provider/Moonpay'))
+    expect(navigate).toHaveBeenCalledWith(Screens.MoonPay, {
+      localAmount: 0,
+      currencyCode: LocalCurrencyCode.BRL,
+      currencyToBuy: CURRENCY_ENUM.DOLLAR,
+    })
   })
 })

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -106,6 +106,7 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
       isCashIn,
       provider: provider.name,
     })
+    provider.onSelected()
   }
 
   return (
@@ -122,6 +123,7 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
                     key={provider.name}
                     onPress={providerOnPress(provider)}
                     style={styles.provider}
+                    testID={`Provider/${provider.name}`}
                   >
                     {provider.image}
                   </TouchableOpacity>

--- a/packages/mobile/src/fiatExchanges/__snapshots__/ProviderOptionsScreen.test.tsx.snap
+++ b/packages/mobile/src/fiatExchanges/__snapshots__/ProviderOptionsScreen.test.tsx.snap
@@ -59,6 +59,52 @@ exports[`ProviderOptionsScreen renders correctly 1`] = `
               },
             ]
           }
+          testID="Provider/Moonpay"
+        >
+          <Image
+            resizeMode="contain"
+            source={
+              Object {
+                "testUri": "../../../packages/mobile/src/images/moonpay.png",
+              }
+            }
+            style={
+              Object {
+                "height": 30,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#EDEEEF",
+              "height": 1,
+              "width": "100%",
+            }
+          }
+        />
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "marginVertical": 24,
+              },
+              Object {
+                "opacity": 1,
+              },
+            ]
+          }
+          testID="Provider/Simplex"
         >
           <Image
             resizeMode="contain"


### PR DESCRIPTION
### Description

The provider list screen when cashing in was not responding to taps since it was not calling the necessary method.

### Other changes

Fixed an incorrect translation.
Added tests for the screen.

### Tested

Manually on simulator

### Related issues

- Fixes #6622

### Backwards compatibility

N/A