### PR TITLE
[Wallet] Disable 8 digit codes verification

### DIFF
--- a/packages/mobile/src/flags.ts
+++ b/packages/mobile/src/flags.ts
@@ -11,7 +11,7 @@ export const features = {
   PNP_USE_DEK_FOR_AUTH: true,
   KOMENCI: true,
   ESCROW_WITHOUT_CODE: true,
-  SHORT_VERIFICATION_CODES: true,
+  SHORT_VERIFICATION_CODES: false,
 }
 
 export const pausedFeatures = {


### PR DESCRIPTION
### Description
Disable 8 digit codes verification until all validators on mainnet have proper configurations and UX issues are resolved.

### Tested

Android devices, complete verification on mainnet and alfajores

### Backwards compatibility

Yes