### PR TITLE
[Wallet] Disable keyboard suggestion when entering the account key

### DIFF
--- a/packages/mobile/locales/en-US/onboarding.json
+++ b/packages/mobile/locales/en-US/onboarding.json
@@ -67,7 +67,7 @@
     "dismiss": "Dismiss"
   },
   "importExistingKey": {
-    "explanation": "Your Account Key is a 24-word phrase that you wrote down and saved when you set up your account. Please enter it here to restore your account.\n\nNote that your language preference must match the language used when you created your account.",
+    "explanation": "Your Account Key is a 24-word phrase that you wrote down and saved when you set up your account. Please enter it here to restore your account.",
     "keyPlaceholder": "horse leopard dog monkey ..."
   },
   "verificationInput": {

--- a/packages/mobile/locales/es-419/onboarding.json
+++ b/packages/mobile/locales/es-419/onboarding.json
@@ -67,7 +67,7 @@
     "dismiss": "Descartar"
   },
   "importExistingKey": {
-    "explanation": "La clave de tu cuenta es una frase de 24 palabras que escribiste y guardaste cuando configuraste tu cuenta. Por favor ingrésala aquí para restaurar tu cuenta.\n\nRecuerda que tu elección de idioma debe coincidir con el lenguaje usado al crear la cuenta.",
+    "explanation": "La clave de tu cuenta es una frase de 24 palabras que escribiste y guardaste cuando configuraste tu cuenta. Por favor ingrésala aquí para restaurar tu cuenta.",
     "keyPlaceholder": "horse leopard dog monkey ..."
   },
   "verificationInput": {

--- a/packages/mobile/locales/pt-BR/onboarding.json
+++ b/packages/mobile/locales/pt-BR/onboarding.json
@@ -67,7 +67,7 @@
     "dismiss": "Ignorar"
   },
   "importExistingKey": {
-    "explanation": "Sua Chave de Conta é uma frase de 24 palavras que você anotou e salvou ao configurar sua conta. Insira-a aqui para restaurar sua conta.\n\nObserve que sua preferência de idioma deve corresponder ao idioma escolhido quando você criou sua conta.",
+    "explanation": "Sua Chave de Conta é uma frase de 24 palavras que você anotou e salvou ao configurar sua conta. Insira-a aqui para restaurar sua conta.",
     "keyPlaceholder": "cavalo leopardo cachorro macaco..."
   },
   "verificationInput": {

--- a/packages/mobile/src/components/CodeInput.test.tsx
+++ b/packages/mobile/src/components/CodeInput.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import 'react-native'
+import { TextInput } from 'react-native'
 import { render } from 'react-native-testing-library'
 import CodeInput, { CodeInputStatus } from 'src/components/CodeInput'
 
@@ -24,5 +24,22 @@ describe('CodeInput', () => {
       )
       expect(toJSON()).toMatchSnapshot()
     })
+  })
+
+  it('disables auto correct / suggestion when in input mode', () => {
+    const { toJSON, getByType } = render(
+      <CodeInput
+        label="label"
+        status={CodeInputStatus.INPUTTING}
+        inputValue={'test'}
+        inputPlaceholder={'placeholder'}
+        onInputChange={jest.fn()}
+        shouldShowClipboard={jest.fn()}
+      />
+    )
+
+    expect(getByType(TextInput).props.autoCorrect).toBe(false)
+    expect(getByType(TextInput).props.autoCapitalize).toBe('none')
+    expect(getByType(TextInput).props.keyboardType).toBe('visible-password')
   })
 })

--- a/packages/mobile/src/components/CodeInput.test.tsx
+++ b/packages/mobile/src/components/CodeInput.test.tsx
@@ -27,7 +27,7 @@ describe('CodeInput', () => {
   })
 
   it('disables auto correct / suggestion when in input mode', () => {
-    const { toJSON, getByType } = render(
+    const { getByType } = render(
       <CodeInput
         label="label"
         status={CodeInputStatus.INPUTTING}

--- a/packages/mobile/src/components/CodeInput.tsx
+++ b/packages/mobile/src/components/CodeInput.tsx
@@ -1,5 +1,5 @@
 import Card from '@celo/react-components/components/Card'
-import TextInput from '@celo/react-components/components/TextInput'
+import TextInput, { LINE_HEIGHT } from '@celo/react-components/components/TextInput'
 import Checkmark from '@celo/react-components/icons/Checkmark'
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
@@ -106,12 +106,14 @@ export default function CodeInput({
                 // and has the unfortunate drawback of breaking multiline autosize.
                 // We use numberOfLines to workaround this last problem.
                 keyboardType={Platform.OS === 'android' ? 'visible-password' : undefined}
-                // numberOfLines doesn't work for multiline TextInput on iOS
+                // numberOfLines is currently Android only on TextInput
                 // workaround is to set the minHeight on iOS :/
                 numberOfLines={Platform.OS === 'ios' ? undefined : numberOfLines}
                 inputStyle={{
                   minHeight:
-                    Platform.OS === 'ios' && numberOfLines ? 20 * numberOfLines : undefined,
+                    Platform.OS === 'ios' && numberOfLines
+                      ? LINE_HEIGHT * numberOfLines
+                      : undefined,
                 }}
                 autoCapitalize="none"
                 testID={testID}

--- a/packages/mobile/src/components/CodeInput.tsx
+++ b/packages/mobile/src/components/CodeInput.tsx
@@ -109,12 +109,13 @@ export default function CodeInput({
                 // numberOfLines is currently Android only on TextInput
                 // workaround is to set the minHeight on iOS :/
                 numberOfLines={Platform.OS === 'ios' ? undefined : numberOfLines}
-                inputStyle={{
-                  minHeight:
-                    Platform.OS === 'ios' && numberOfLines
-                      ? LINE_HEIGHT * numberOfLines
-                      : undefined,
-                }}
+                inputStyle={
+                  Platform.OS === 'ios' && numberOfLines
+                    ? {
+                        minHeight: LINE_HEIGHT * numberOfLines,
+                      }
+                    : undefined
+                }
                 autoCapitalize="none"
                 testID={testID}
               />

--- a/packages/mobile/src/components/CodeInput.tsx
+++ b/packages/mobile/src/components/CodeInput.tsx
@@ -8,6 +8,7 @@ import React, { useLayoutEffect } from 'react'
 import {
   ActivityIndicator,
   LayoutAnimation,
+  Platform,
   StyleProp,
   StyleSheet,
   Text,
@@ -34,6 +35,7 @@ export interface Props {
   onInputChange: (value: string) => void
   shouldShowClipboard: (value: string) => boolean
   multiline?: boolean
+  numberOfLines?: number
   testID?: string
   style?: StyleProp<ViewStyle>
 }
@@ -47,6 +49,7 @@ export default function CodeInput({
   onInputChange,
   shouldShowClipboard,
   multiline,
+  numberOfLines,
   testID,
   style,
 }: Props) {
@@ -93,6 +96,24 @@ export default function CodeInput({
                 }
                 onChangeText={onInputChange}
                 multiline={multiline}
+                // This disables keyboard suggestions on iOS, but unfortunately NOT on Android
+                // Though `InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS` is correctly set on the native input,
+                // most Android keyboards ignore it :/
+                autoCorrect={false}
+                // On Android, the only known hack for now to disable keyboard suggestions
+                // is to set the keyboard type to 'visible-password' which sets `InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD`
+                // on the native input. Though it doesn't work in all cases (see https://stackoverflow.com/a/33227237/158525)
+                // and has the unfortunate drawback of breaking multiline autosize.
+                // We use numberOfLines to workaround this last problem.
+                keyboardType={Platform.OS === 'android' ? 'visible-password' : undefined}
+                // numberOfLines doesn't work for multiline TextInput on iOS
+                // workaround is to set the minHeight on iOS :/
+                numberOfLines={Platform.OS === 'ios' ? undefined : numberOfLines}
+                inputStyle={{
+                  minHeight:
+                    Platform.OS === 'ios' && numberOfLines ? 20 * numberOfLines : undefined,
+                }}
+                autoCapitalize="none"
                 testID={testID}
               />
             ) : (

--- a/packages/mobile/src/components/__snapshots__/CodeInput.test.tsx.snap
+++ b/packages/mobile/src/components/__snapshots__/CodeInput.test.tsx.snap
@@ -163,6 +163,9 @@ exports[`CodeInput renders correctly for all CodeInputStatus states 2`] = `
         >
           <TextInput
             allowFontScaling={true}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="visible-password"
             onBlur={[Function]}
             onChangeText={[MockFunction]}
             onFocus={[Function]}

--- a/packages/mobile/src/import/ImportWallet.tsx
+++ b/packages/mobile/src/import/ImportWallet.tsx
@@ -8,7 +8,7 @@ import { HeaderHeightContext, StackScreenProps } from '@react-navigation/stack'
 import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { Trans, WithTranslation } from 'react-i18next'
-import { Keyboard, StyleSheet, Text, View } from 'react-native'
+import { Dimensions, Keyboard, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { hideAlert } from 'src/alert/actions'
@@ -32,6 +32,11 @@ import TopBarTextButtonOnboarding from 'src/onboarding/TopBarTextButtonOnboardin
 import UseBackToWelcomeScreen from 'src/onboarding/UseBackToWelcomeScreen'
 import { RootState } from 'src/redux/reducers'
 import { isAppConnected } from 'src/redux/selectors'
+
+const AVERAGE_WORD_WIDTH = 80
+const AVERAGE_SEED_WIDTH = AVERAGE_WORD_WIDTH * 24
+// Estimated number of lines needed to enter the account key
+const NUMBER_OF_LINES = Math.ceil(AVERAGE_SEED_WIDTH / Dimensions.get('window').width)
 
 interface State {
   keyboardVisible: boolean
@@ -172,6 +177,7 @@ export class ImportWallet extends React.Component<Props, State> {
                     inputValue={backupPhrase}
                     inputPlaceholder={t('importExistingKey.keyPlaceholder')}
                     multiline={true}
+                    numberOfLines={NUMBER_OF_LINES}
                     onInputChange={this.setBackupPhrase}
                     shouldShowClipboard={this.shouldShowClipboard}
                     testID="ImportWalletBackupKeyInputField"

--- a/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
+++ b/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
@@ -102,7 +102,11 @@ exports[`ImportWallet renders correctly and is disabled with no text 1`] = `
               >
                 <TextInput
                   allowFontScaling={true}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="visible-password"
                   multiline={true}
+                  numberOfLines={3}
                   onBlur={[Function]}
                   onChangeText={[Function]}
                   onFocus={[Function]}

--- a/packages/mobile/src/verify/__snapshots__/VerificationInputScreen.test.tsx.snap
+++ b/packages/mobile/src/verify/__snapshots__/VerificationInputScreen.test.tsx.snap
@@ -154,6 +154,9 @@ exports[`VerificationInputScreen renders correctly 1`] = `
                   >
                     <TextInput
                       allowFontScaling={true}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      keyboardType="visible-password"
                       onBlur={[Function]}
                       onChangeText={[Function]}
                       onFocus={[Function]}

--- a/packages/react-components/components/TextInput.tsx
+++ b/packages/react-components/components/TextInput.tsx
@@ -18,6 +18,8 @@ import {
   ViewStyle,
 } from 'react-native'
 
+export const LINE_HEIGHT = Platform.select({ android: 22, default: 20 })
+
 type Props = Omit<RNTextInputProps, 'style'> & {
   style?: StyleProp<ViewStyle>
   inputStyle?: RNTextInputProps['style']
@@ -116,7 +118,7 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingVertical: 12,
     paddingHorizontal: 0,
-    lineHeight: Platform.select({ android: 22, ios: 20 }), // vertical align = center
+    lineHeight: LINE_HEIGHT, // vertical align = center
   },
   icon: {
     marginLeft: 8,


### PR DESCRIPTION
### Description

This disables keyboard suggestion when entering the account key. We saw in #602 that the keyboard started learning the words after entering it a few times.

### Details

Went in a little rabbit hole to disable keyboard suggestions on Android when entering the account key.
I naively thought well `autoCorrect={false}`  and done...

...and I was wrong.

Though setting this attribute, correctly sets `InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS` on the underlying native text input, the keyboard now ignores this on some devices (emulator included).
Workaround is to set `keyboardType={Platform.OS === 'android' ? 'visible-password' : undefined}` which sets `InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD` on the native input.

This seems to work on the first look, but breaks multiline autoresize. Only workaround sofar is to set the number of lines :confused:

And lastly according to [this comment](https://stackoverflow.com/a/33227237/158525) it breaks Korean input to only ascii (which is ok I guess for us given we don't support Korean in the app for now).

### Other changes

- Removed obsolete wording about language requirements of the Account Key.

### Tested

**before/after iOS**

<img src="https://user-images.githubusercontent.com/57791/106456299-9cdfa180-648d-11eb-907c-5c5bb749147f.png" width="50%" /><img src="https://user-images.githubusercontent.com/57791/106455714-d95ecd80-648c-11eb-93cb-a30477134c98.png" width="50%" />

**before/after Android**

<img src="https://user-images.githubusercontent.com/57791/106455992-42dedc00-648d-11eb-927a-c576d6d3f83f.png" width="50%" /><img src="https://user-images.githubusercontent.com/57791/106455675-cd730b80-648c-11eb-9e7f-733590c1c06e.png" width="50%" />

### Related issues

- Fixes #602
- Fixes #6812

### Backwards compatibility

Yes.