### PR TITLE
Fix Azure HSM Wallet PublicKey to Address conversion

### DIFF
--- a/packages/sdk/utils/src/address.ts
+++ b/packages/sdk/utils/src/address.ts
@@ -8,7 +8,6 @@ import {
   toChecksumAddress,
 } from 'ethereumjs-util'
 import * as Web3Utils from 'web3-utils'
-import { isCompressed } from './ecdh'
 
 // Exports moved to @celo/base, forwarding them
 // here for backwards compatibility
@@ -38,9 +37,7 @@ export const privateKeyToPublicKey = (privateKey: string) =>
 
 export const publicKeyToAddress = (publicKey: string) =>
   toChecksumAddress(
-    ensureLeading0x(
-      pubToAddress(toBuffer(ensureLeading0x(publicKey)), isCompressed(publicKey)).toString('hex')
-    )
+    ensureLeading0x(pubToAddress(toBuffer(ensureLeading0x(publicKey)), true).toString('hex'))
   )
 
 export const isValidPrivateKey = (privateKey: string) =>

--- a/packages/sdk/utils/src/address.ts
+++ b/packages/sdk/utils/src/address.ts
@@ -4,6 +4,7 @@ import {
   privateToAddress,
   privateToPublic,
   pubToAddress,
+  toBuffer,
   toChecksumAddress,
 } from 'ethereumjs-util'
 import * as Web3Utils from 'web3-utils'
@@ -37,7 +38,9 @@ export const privateKeyToPublicKey = (privateKey: string) =>
 
 export const publicKeyToAddress = (publicKey: string) =>
   toChecksumAddress(
-    ensureLeading0x(pubToAddress(hexToBuffer(publicKey), isCompressed(publicKey)).toString('hex'))
+    ensureLeading0x(
+      pubToAddress(toBuffer(ensureLeading0x(publicKey)), isCompressed(publicKey)).toString('hex')
+    )
   )
 
 export const isValidPrivateKey = (privateKey: string) =>

--- a/packages/sdk/utils/src/ecdh.ts
+++ b/packages/sdk/utils/src/ecdh.ts
@@ -15,7 +15,10 @@ export function isCompressed(publicKey: string) {
   if (noLeading0x.length === 64) {
     return true
   }
-  return noLeading0x.length === 66 && (noLeading0x.startsWith('02') || noLeading0x.startsWith('03'))
+  return (
+    noLeading0x.length === 66 &&
+    (noLeading0x.startsWith('02') || noLeading0x.startsWith('03') || noLeading0x.startsWith('04'))
+  )
 }
 
 export function ensureCompressed(publicKey: string): string {

--- a/packages/sdk/utils/src/ecdh.ts
+++ b/packages/sdk/utils/src/ecdh.ts
@@ -15,10 +15,7 @@ export function isCompressed(publicKey: string) {
   if (noLeading0x.length === 64) {
     return true
   }
-  return (
-    noLeading0x.length === 66 &&
-    (noLeading0x.startsWith('02') || noLeading0x.startsWith('03') || noLeading0x.startsWith('04'))
-  )
+  return noLeading0x.length === 66 && (noLeading0x.startsWith('02') || noLeading0x.startsWith('03'))
 }
 
 export function ensureCompressed(publicKey: string): string {

--- a/packages/sdk/wallets/wallet-hsm-azure/src/azure-hsm-wallet.test.ts
+++ b/packages/sdk/wallets/wallet-hsm-azure/src/azure-hsm-wallet.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@celo/utils/lib/address'
 import { verifySignature } from '@celo/utils/lib/signatureUtils'
 import { recoverTransaction, verifyEIP712TypedDataSigner } from '@celo/wallet-base'
-import { Signature } from '@celo/wallet-hsm'
+import { publicKeyPrefix, Signature } from '@celo/wallet-hsm'
 import { BigNumber } from 'bignumber.js'
 import * as ethUtil from 'ethereumjs-util'
 import Web3 from 'web3'
@@ -118,7 +118,10 @@ describe('AzureHSMWallet class', () => {
                 throw new Error(`A key with (name/id) ${keyName} was not found in this key vault`)
               }
               const privKey = keyVaultAddresses.get(keyName)!.privateKey
-              const pubKey = ethUtil.privateToPublic(ethUtil.toBuffer(privKey))
+              const pubKey = Buffer.concat([
+                Buffer.from(new Uint8Array([publicKeyPrefix])),
+                ethUtil.privateToPublic(ethUtil.toBuffer(privKey)),
+              ])
               return new BigNumber(ensureLeading0x(pubKey.toString('hex')))
             },
             signMessage: async (message: Buffer, keyName: string): Promise<Signature> => {

--- a/packages/sdk/wallets/wallet-hsm-azure/src/azure-hsm-wallet.test.ts
+++ b/packages/sdk/wallets/wallet-hsm-azure/src/azure-hsm-wallet.test.ts
@@ -48,8 +48,6 @@ const keyVaultAddresses: Map<string, { address: string; privateKey: string }> = 
   ],
 ])
 
-console.log(keyVaultAddresses)
-
 // Sample data from the official EIP-712 example:
 // https://github.com/ethereum/EIPs/blob/master/assets/eip-712/Example.js
 const TYPED_DATA = {

--- a/packages/sdk/wallets/wallet-hsm-azure/src/azure-hsm-wallet.test.ts
+++ b/packages/sdk/wallets/wallet-hsm-azure/src/azure-hsm-wallet.test.ts
@@ -48,6 +48,8 @@ const keyVaultAddresses: Map<string, { address: string; privateKey: string }> = 
   ],
 ])
 
+console.log(keyVaultAddresses)
+
 // Sample data from the official EIP-712 example:
 // https://github.com/ethereum/EIPs/blob/master/assets/eip-712/Example.js
 const TYPED_DATA = {


### PR DESCRIPTION
### Description

Some more context in issue #6807

Summary is that latest version of `sdk` (post-refactor) introduces some issues in how we interpret the Azure HSM KeyVault keys. Specifically how we convert the public key (EC x and y terms) into an ethereum address. 
This came to light when trying to run Komenci on staging based on the latest master and the issue exhibited itself as the service complaining that the wallet doesn't contain the address that it should.
This lead me to find that if I initialise a Wallet and I run `getAccounts()` using the same key vault but different versions of the codebase, it results in different accounts. But diving deeper into the code I see that the same public key is being manipulated.

I identified two separate issues in the flow which are causing the malformation.

#### 1. Using Buffer.from on arbitrary hex

In `azure-hsm-wallet.ts` we're converting a public key into an address by calling:
```typescript
const publicKey = await this.keyVaultClient!.getPublicKey(keyName)
return publicKeyToAddress(publicKey.toString(16))
```

Here `publicKey` is a BigNumber that's then turned into a hex string using `toString`. But this method has a little gotcha.
The public key is prefixed with `04` to inform that it is an uncompressed key. But because it's converted to a BigNumber the `0` at the front is actually dropped and we get something like `4<... other 128 chars / 64 bytes>` having a total of 129 chars. 

In `utils/src/address` the `publicKeyToAddress` function relied on `hexToBuffer` which is implemented as:
```typescript
export const hexToBuffer = (input: string) => Buffer.from(trimLeading0x(input), 'hex')
```

Here the usage of `Buffer.from` is a problem because with uneven hex strings it results in dropping a char at the tail:
```typescript
> Buffer.from('42236', 'hex')
<Buffer 42 23>
``` 

And because the above logic which uses BigNumbers to compute the public key, and the fact that there's `04` prefix, our keys are _always_ uneven and instead of being parsed as `<Buffer 04 .. .. .. ..>` we get `<Buffer 4. .. .. ..>` and we lose the last octet. 

In the PR I've reverted to using the `toBuffer` method from `ethereumjs-utils` because that properly handles this case, but we might also want to fix our own implementation. 

#### 2. Passing `isCompressed` to the `santize` parameter

The [pubToAddress](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L251-L260) method takes an optional `sanitize` param that takes care of different formats in which a public key can be passed.

This is where I'm not sure what the intention was. From my current understanding we have two options here:

1. Always pass `true` for `sanitize` (as I did in the PR and was before on master).
2. Pass `isCompressed` but when `isCompressed` is false we need to also do a `trimUncompressedPrefix` to get rid of the `04` prefix.

(2) seams superfluous as that's exactly the point of `sanitize` here. But here I might be missing some info.

### Tested

This issue wasn't picked up by the specs because we were mocking the keyvault client in way that wasn't true to how it worked. We weren't returning a public key with the `04` prefix. I updated the tests to reflect that.

### Related issues

- Fixes #6807 

### Backwards compatibility

Fixes a regression.