### PR TITLE
Fix verifying the previous release on a network

### DIFF
--- a/packages/protocol/lib/registry-utils.ts
+++ b/packages/protocol/lib/registry-utils.ts
@@ -1,3 +1,11 @@
+/**
+ * Be careful when adding to this file or relying on this file.
+ * The verification tooling uses the CeloContractName enum as a
+ * source of truth for what contracts are considered "core" and
+ * need to be checked for backwards compatability and bytecode on
+ * an environment.
+ */
+
 export const celoRegistryAddress = '0x000000000000000000000000000000000000ce10'
 
 export enum CeloContractName {

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -35,13 +35,21 @@ git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*
 git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
 echo "- Build contract artifacts"
 rm -rf build/contracts
-yarn build >> $LOG_FILE
+yarn build:sol >> $LOG_FILE
 rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
 mv build/contracts $BUILD_DIR
-
-echo "- Run verification script"
-yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts $FORNO
+cp lib/registry-utils.ts $BUILD_DIR/
 
 # Move back to branch from which we started
 echo "- Return to original git commit"
 git checkout - >> $LOG_FILE
+
+cp $BUILD_DIR/registry-utils.ts lib/
+
+echo "- Build verification script"
+yarn build >> $LOG_FILE
+
+echo "- Run verification script"
+yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts $FORNO
+
+git checkout lib/registry-utils.ts

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -35,15 +35,13 @@ git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*
 git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
 echo "- Build contract artifacts"
 rm -rf build/contracts
-yarn build:sol >> $LOG_FILE
+yarn build >> $LOG_FILE
 rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
 mv build/contracts $BUILD_DIR
-# Move back to branch from which we started
-echo "- Return to original git commit"
-git checkout - >> $LOG_FILE
-
-echo "- Build verification script"
-yarn build >> $LOG_FILE
 
 echo "- Run verification script"
 yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts $FORNO
+
+# Move back to branch from which we started
+echo "- Return to original git commit"
+git checkout - >> $LOG_FILE

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -40,11 +40,17 @@ rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
 mv build/contracts $BUILD_DIR
 cp lib/registry-utils.ts $BUILD_DIR/
 
+
 # Move back to branch from which we started
 echo "- Return to original git commit"
 git checkout - >> $LOG_FILE
 
 cp $BUILD_DIR/registry-utils.ts lib/
+
+# Hack since v1 did not yet expose celoRegistryAddress
+if ! cat lib/registry-utils.ts | grep -q "celoRegistryAddress"; then
+  echo "export const celoRegistryAddress = '0x000000000000000000000000000000000000ce10'" >> lib/registry-utils.ts
+fi
 
 echo "- Build verification script"
 yarn build >> $LOG_FILE


### PR DESCRIPTION
### Description

This PR fixes the [step from the docs that verifies the previous release on a network](https://docs.celo.org/community/release-process/smart-contracts#verify-the-previous-release-on-the-network)

The problem was that `CeloContractName` in `lib/registry-utils.ts` was being relied upon as an enumeration of all Celo Core Contracts. When new contracts are added later on, as of that commit, the tooling would fail as it does not know what to do with the new contract.

This intermediary fix for this problem is to copy over the target's `lib/registry-utils.ts` and effectively going forward treat that file as a source of truth. In the long-run, some more effective configuration of this should envisioned, as copying source code around is not ideal.


### Tested

- Ran `yarn verify-deployed -n mainnet -b celo-core-contracts-v1.mainnet -f` which previously failed

### Related issues

- Fixes #6615 

### Backwards compatibility

This PR effectively restores backwards compatibility, though may make it hard to do refactors in a backwards compatible way in the future. 