### PR TITLE
Fix wallet url to play store in getting started doc.

### DIFF
--- a/packages/docs/getting-started/using-the-wallet.md
+++ b/packages/docs/getting-started/using-the-wallet.md
@@ -14,7 +14,7 @@ If you already have an account \(and the corresponding seed phrase\), you can do
 
 ### Downloading the Celo Wallet
 
-To download the app on the Play Store, go [here](https://play.google.com/store/apps/details?id=org.celo.mobile.alfajores). Note that you will need an account or an invitation code to use the wallet.
+To download the app on the Play Store, go [here](https://play.google.com/apps/testing/org.celo.mobile.alfajores). Note that you will need an account or an invitation code to use the wallet.
 
 ### Running the Celo Wallet Locally
 


### PR DESCRIPTION
### Description

Fixes a invalid URL to the google play store. New URL is taken from https://celo.org/developers/wallet

### Other changes

none

### Tested

yes, clicked the link and it opened the wallt in the play store

### Related issues

- Fixes #6856 

### Backwards compatibility

not sure.