### PR TITLE
[Wallet] Add "On Valora" recipients to RecipientPicker

### DIFF
--- a/packages/mobile/locales/en-US/sendFlow7.json
+++ b/packages/mobile/locales/en-US/sendFlow7.json
@@ -7,6 +7,7 @@
   "sendOrRequest": "Send or Request",
   "recent": "Recent",
   "contacts": "Contacts",
+  "onValora": "On Valora",
   "characterLimitExceeded": "{{max}} Character Limit Exceeded",
   "invite": "Invite",
   "payRequest": "Pay Request",

--- a/packages/mobile/locales/es-419/sendFlow7.json
+++ b/packages/mobile/locales/es-419/sendFlow7.json
@@ -9,6 +9,7 @@
   "payRequest": "Pagar La Solicitud",
   "recent": "Recientes",
   "contacts": "Contactos",
+  "onValora": "En Valora",
   "invite": "Invitar",
   "sendTo": "Enviar a",
   "celoDollarAmount": "<0></0> Celo Dólar",

--- a/packages/mobile/locales/pt-BR/sendFlow7.json
+++ b/packages/mobile/locales/pt-BR/sendFlow7.json
@@ -7,6 +7,7 @@
   "sendOrRequest": "Enviar ou solicitar",
   "recent": "Recente",
   "contacts": "Contatos",
+  "onValora": "Em Valora",
   "characterLimitExceeded": "Limite de caracteres de {{max}} excedido",
   "invite": "Convidar",
   "payRequest": "Solicitação de pagamento",

--- a/packages/mobile/src/components/ContactCircle.tsx
+++ b/packages/mobile/src/components/ContactCircle.tsx
@@ -2,7 +2,7 @@ import fontStyles from '@celo/react-components/styles/fonts'
 import * as React from 'react'
 import { Image, StyleSheet, Text, View, ViewStyle } from 'react-native'
 import DefaultAvatar from 'src/icons/DefaultAvatar'
-import { Recipient, recipientHasAddress } from 'src/recipients/recipient'
+import { Recipient, recipientHasAddress, recipientHasNumber } from 'src/recipients/recipient'
 
 interface Props {
   style?: ViewStyle
@@ -20,8 +20,9 @@ const getNameInitial = (name: string) => name.charAt(0).toLocaleUpperCase()
 
 function ContactCircle({ size, recipient, style }: Props) {
   const address = recipientHasAddress(recipient) && recipient.address
+  const number = recipientHasNumber(recipient) && recipient.e164PhoneNumber
   const iconSize = size || DEFAULT_ICON_SIZE
-  const iconBackgroundColor = getAddressBackgroundColor(address || '0x0')
+  const iconBackgroundColor = getAddressBackgroundColor(address || number || '0x0')
 
   const renderThumbnail = () => {
     if (recipient.thumbnailPath) {
@@ -37,7 +38,7 @@ function ContactCircle({ size, recipient, style }: Props) {
       )
     }
 
-    const fontColor = getAddressForegroundColor(address || '0x0')
+    const fontColor = getAddressForegroundColor(address || number || '0x0')
     if (recipient.name) {
       const initials = getNameInitial(recipient.name)
       return (

--- a/packages/mobile/src/icons/Valora.tsx
+++ b/packages/mobile/src/icons/Valora.tsx
@@ -1,0 +1,32 @@
+import colors from '@celo/react-components/styles/colors'
+import * as React from 'react'
+import Svg, { Path } from 'svgs'
+
+interface Props {
+  size?: number
+  color?: string
+}
+
+export default class Valora extends React.PureComponent<Props> {
+  static defaultProps = {
+    size: 17,
+    color: colors.greenBrand,
+  }
+
+  render() {
+    return (
+      <Svg
+        width="17"
+        height="14"
+        viewBox="0 0 17 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <Path
+          d="M10.4936 13.7327C11.1636 8.50665 13.6203 5.53224 17.3333 2.83582L15.4349 0.333984C13.0061 2.19646 10.354 4.83729 9.1256 8.47885C8.12058 5.50444 6.02677 2.89142 2.64876 0.333984L0.666626 2.89142C4.88216 5.89362 7.00388 9.2572 7.59015 13.7327H10.4936Z"
+          fill={this.props.color}
+        />
+      </Svg>
+    )
+  }
+}

--- a/packages/mobile/src/recipients/RecipientItem.tsx
+++ b/packages/mobile/src/recipients/RecipientItem.tsx
@@ -7,7 +7,13 @@ import { WithTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import ContactCircle from 'src/components/ContactCircle'
 import { Namespaces, withTranslation } from 'src/i18n'
-import { getDisplayDetail, getDisplayName, Recipient } from 'src/recipients/recipient'
+import Valora from 'src/icons/Valora'
+import {
+  getDisplayDetail,
+  getDisplayName,
+  Recipient,
+  recipientHasAddress,
+} from 'src/recipients/recipient'
 
 interface OwnProps {
   recipient: Recipient
@@ -32,10 +38,11 @@ class RecipientItem extends React.PureComponent<Props> {
             <Text numberOfLines={1} ellipsizeMode={'tail'} style={styles.name}>
               {getDisplayName(recipient, t)}
             </Text>
-            {!recipient.name ? (
+            {recipient.name ? (
               <Text style={styles.phone}>{getDisplayDetail(recipient)}</Text>
             ) : null}
           </View>
+          {recipientHasAddress(recipient) ? <Valora /> : null}
         </View>
       </Touchable>
     )

--- a/packages/mobile/src/recipients/recipient.ts
+++ b/packages/mobile/src/recipients/recipient.ts
@@ -61,7 +61,7 @@ export function getDisplayName(recipient: Recipient, t: TFunction) {
   } else if (recipientHasNumber(recipient)) {
     return recipient.e164PhoneNumber
   } else {
-    return t('global:account') + ' ' + formatShortenedAddress(recipient.address)
+    return t('walletFlow5:feedItemAddress', { address: formatShortenedAddress(recipient.address) })
   }
 }
 
@@ -69,7 +69,7 @@ export function getDisplayDetail(recipient: Recipient) {
   if (recipientHasNumber(recipient)) {
     return recipient.displayNumber
   } else {
-    return recipient.address
+    return formatShortenedAddress(recipient.address)
   }
 }
 


### PR DESCRIPTION
### Description

When choosing a recipient to send/request money, there is now an additional section that includes all recipients the user has received a transaction from (currently only receive, as for now we don't grant profile access to people who have sent us transactions)

### Tested

![146087788_138080708154940_1199630987965174731_n](https://user-images.githubusercontent.com/15326838/106812617-f25ab080-663d-11eb-9daf-53e700605cbc.jpg)
contact phone numbers removed from screenshot for privacy

### Related issues

- Fixes part of #6101

