### PR TITLE
import `toTxResult` from @celo/connect

### DIFF
--- a/packages/docs/developer-resources/dappkit/usage.md
+++ b/packages/docs/developer-resources/dappkit/usage.md
@@ -61,7 +61,7 @@ Let's go from accessing account information to submitting transactions. To alter
 ([expo base template commit](https://github.com/celo-org/dappkit-base/commit/e3a1c00f2b8a6f6f6891c515a131ff66b55cb563))
 
 ```javascript
-import { toTxResult } from "@celo/connect"
+import { toTxResult } from '@celo/connect'
 import {
   requestTxSig,
   waitForSignedTxs

--- a/packages/docs/developer-resources/dappkit/usage.md
+++ b/packages/docs/developer-resources/dappkit/usage.md
@@ -61,6 +61,7 @@ Let's go from accessing account information to submitting transactions. To alter
 ([expo base template commit](https://github.com/celo-org/dappkit-base/commit/e3a1c00f2b8a6f6f6891c515a131ff66b55cb563))
 
 ```javascript
+import { toTxResult } from "@celo/connect"
 import {
   requestTxSig,
   waitForSignedTxs

--- a/packages/sdk/dappkit/README.md
+++ b/packages/sdk/dappkit/README.md
@@ -12,8 +12,6 @@ DAppKit is currently built with the excellent [Expo framework](https://expo.io) 
 
 # Usage
 
-This section walks you through the main functionalities of DAppKit. You can also find the result of this walkthrough on the [expo base template](https://github.com/celo-org/dappkit-base) on branch [`dappkit-usage`](https://github.com/celo-org/dappkit-base/tree/dappkit-usage).
-
 DAppKit uses deeplinks to communicate between your DApp and the Celo Wallet. All "requests" that your DApp makes to the Wallet needs to contain the following meta payload:
 
 - `requestId` A string you can pass to DAppKit, that you can use to listen to the response for that request
@@ -28,7 +26,7 @@ One of the first actions you will want to do as a DApp Developer is to get the a
 
 ```javascript
 import { requestAccountAddress, waitForAccountAuth } from '@celo/dappkit'
-import { Linking } from 'expo'
+import * as Linking from 'expo-linking'
 
 login = async () => {
   const requestId = 'login'


### PR DESCRIPTION
### Description

Add `import { toTxResult } from "@celo/connect"` to a docs code example.

Remove an outdated reference in the dappkit README and update an import.

### Other changes

none

### Tested

test in [this](https://github.com/critesjosh/celo-dappkit/blob/4274c17b8a5f7dff3dca61aa6a757ec4c70e9dcf/client/App.js#L12) example.