### PR TITLE
stableToken checks exchangeIdentifier exist in the registry on initialization

### DIFF
--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -139,7 +139,10 @@ contract StableToken is
       _mint(initialBalanceAddresses[i], initialBalanceValues[i]);
     }
     setRegistry(registryAddress);
+
     exchangeRegistryId = keccak256(abi.encodePacked(exchangeIdentifier));
+    // fail in case exchangeRegistryId can't be looked up in the registry
+    registry.getAddressForOrDie(getExchangeRegistryId());
   }
 
   /**

--- a/packages/protocol/test/stability/stabletoken.ts
+++ b/packages/protocol/test/stability/stabletoken.ts
@@ -37,25 +37,6 @@ contract('StableToken', (accounts: string[]) => {
   const amountToMint = 10
   const SECONDS_IN_A_WEEK = 60 * 60 * 24 * 7
 
-  // beforeAll(async () => {
-  //   const _registry = await Registry.new()
-  //   await _registry.setAddressFor(CeloContractName.Freezer, freezer.address)
-  //   const _stableToken = await StableToken.new()
-
-  //   // should fail with an invalid exchange address
-  //   await assertRevert(_stableToken.initialize(
-  //     'Celo Dollar',
-  //     'cUSD',
-  //     18,
-  //     registry.address,
-  //     fixed1,
-  //     SECONDS_IN_A_WEEK,
-  //     [],
-  //     [],
-  //     'foo' // non-existing exchange
-  //   ))
-  // })
-
   beforeEach(async () => {
     registry = await Registry.new()
     freezer = await Freezer.new()


### PR DESCRIPTION
### Description

Checks that exchangeIdentifier is valid on initialization.

### Other changes

- 

### Tested

Added unit tests.

### Related issues

- 

### Backwards compatibility

-