### PR TITLE
[Wallet] Enable multidex

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -160,6 +160,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode appVersionCode
         versionName "1.9.2"
+        multiDexEnabled true
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         resValue "string", "app_name", project.env.get("APP_DISPLAY_NAME")
@@ -194,7 +195,6 @@ android {
     }
     buildTypes {
         debug {
-            multiDexEnabled true
             signingConfig signingConfigs.debug
         }
 


### PR DESCRIPTION
### Description

This PR enables multidex on Android. We recently hit the single dex limit and decided this was the way to go for now.
See [discussion thread](https://celo-org.slack.com/archives/CL7BVQPHB/p1612561369198000).

### Tested

Release build works.

### Related issues

- Fixes #7026

### Backwards compatibility

Yes.