### PR TITLE
Increase block wait time to 600 on notification-service

### DIFF
--- a/packages/notification-service/src/blockscout/transfers.ts
+++ b/packages/notification-service/src/blockscout/transfers.ts
@@ -8,7 +8,7 @@ import { decodeLogs } from './decode'
 import { formatNativeTransfers } from './nativeTransfersFormatter'
 
 export const WEI_PER_GOLD = 1000000000000000000.0
-export const MAX_BLOCKS_TO_WAIT = 120
+export const MAX_BLOCKS_TO_WAIT = 600
 
 export enum Currencies {
   GOLD = 'gold',


### PR DESCRIPTION
### Description

We have a cache of processed blocks so we query from `now-cache_size` to now. `cache_size`  used to be 120and this PR increases it to 600.

This is because we've seen missing notifications in periods of high load. Not sure if this will fix the issue, but it's unlikely to hurt either.

### Other changes

N/A

### Tested

N/A

### Related issues

N/A

### Backwards compatibility

N/A