### PR TITLE
[N04] Missing docstring

### DIFF
--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -307,7 +307,7 @@ contract Reserve is
    * @param spender The address that is to be no longer allowed to spend Reserve funds.
    */
   function removeSpender(address spender) external onlyOwner {
-    isSpender[spender] = false;
+    delete isSpender[spender];
     emit SpenderRemoved(spender);
   }
 

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -307,7 +307,7 @@ contract Reserve is
    * @param spender The address that is to be no longer allowed to spend Reserve funds.
    */
   function removeSpender(address spender) external onlyOwner {
-    delete isSpender[spender];
+    isSpender[spender] = false;
     emit SpenderRemoved(spender);
   }
 

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -311,6 +311,10 @@ contract Reserve is
     emit SpenderRemoved(spender);
   }
 
+  /**
+   * @notice Checks if an address is able to spend as an exchange.
+   * @param spender The address to checked.
+   */
   function isAllowedToSpendExchange(address spender) public view returns (bool) {
     return
       isExchangeSpender[spender] || (registry.getAddressForOrDie(EXCHANGE_REGISTRY_ID) == spender);

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -313,7 +313,7 @@ contract Reserve is
 
   /**
    * @notice Checks if an address is able to spend as an exchange.
-   * @param spender The address to checked.
+   * @param spender The address to be checked.
    */
   function isAllowedToSpendExchange(address spender) public view returns (bool) {
     return


### PR DESCRIPTION
### Description

Added docstring to `isAllowedToSpendExchange`.

### Other changes

- 

### Tested

- 

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/798

### Backwards compatibility

- 