### PR TITLE
Shouldn't import from src folder in peer package

### DIFF
--- a/packages/sdk/contractkit/src/wrappers/SortedOracles.ts
+++ b/packages/sdk/contractkit/src/wrappers/SortedOracles.ts
@@ -1,7 +1,7 @@
 import { eqAddress, NULL_ADDRESS } from '@celo/base/lib/address'
 import { Address, CeloTransactionObject, toTransactionObject } from '@celo/connect'
+import { isValidAddress } from '@celo/utils/lib/address'
 import { fromFixed, toFixed } from '@celo/utils/lib/fixidity'
-import { isValidAddress } from '@celo/utils/src/address'
 import BigNumber from 'bignumber.js'
 import { CeloContract } from '../base'
 import { SortedOracles } from '../generated/SortedOracles'


### PR DESCRIPTION
### Description

🤦 - There's an import from `@celo/utils/src/...` inside of contractkit which causes a runtime error.
This means the that the current `1.0.2-beta-1` is broken.

In the long run it would be smart to add tolling to protect us from these sort of issues by checking import paths.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Yes