### PR TITLE
Update the condition for detect non-proxied validators

### DIFF
--- a/packages/helm-charts/testnet/templates/validators.service.yaml
+++ b/packages/helm-charts/testnet/templates/validators.service.yaml
@@ -2,7 +2,7 @@
 
 {{ range $index, $e := until (.Values.geth.validators | int) }}
 
-{{ if (ge $index (len $.Values.geth.proxiesPerValidator)) }}
+{{ if (eq (index $.Values.geth.proxiesPerValidator $index | int) 0) }}
 
 {{ $loadBalancerIP := index $.Values.geth.validatorsIPAddressArray $index }}
 


### PR DESCRIPTION
### Description

Update the condition used in the validator service to determine if which validators have not any proxy associated, and in that case create a service to expose port 30303.

### Tested

Tested in alfajores migration