### PR TITLE
Disable Ramp CICO for US users

### DIFF
--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -58,7 +58,7 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
   const account = useSelector(currentAccountSelector)
   const localCurrency = useSelector(getLocalCurrencyCode)
   const isCashIn = route.params?.isCashIn ?? true
-  const { MOONPAY_DISABLED } = useCountryFeatures()
+  const { MOONPAY_DISABLED, RAMP_DISABLED } = useCountryFeatures()
   const selectedCurrency = route.params.currency || CURRENCY_ENUM.DOLLAR
 
   useLayoutEffect(() => {
@@ -95,7 +95,7 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
       },
       {
         name: 'Ramp',
-        enabled: true,
+        enabled: !RAMP_DISABLED,
         onSelected: () => openRamp(localCurrency || FALLBACK_CURRENCY, selectedCurrency),
       },
     ],

--- a/packages/mobile/src/flags.ts
+++ b/packages/mobile/src/flags.ts
@@ -35,6 +35,9 @@ export const countryFeatures = {
   MOONPAY_DISABLED: {
     US: true,
   },
+  RAMP_DISABLED: {
+    US: true,
+  },
   PONTO_SUPPORTED: {
     PH: true,
   },

--- a/packages/mobile/src/utils/countryFeatures.test.ts
+++ b/packages/mobile/src/utils/countryFeatures.test.ts
@@ -16,6 +16,7 @@ describe(getCountryFeaturesSelector, () => {
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": true,
         "PONTO_SUPPORTED": false,
+        "RAMP_DISABLED": true,
         "RESTRICTED_CP_DOTO": false,
         "SANCTIONED_COUNTRY": false,
       }
@@ -35,6 +36,7 @@ describe(getCountryFeaturesSelector, () => {
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": false,
         "PONTO_SUPPORTED": true,
+        "RAMP_DISABLED": false,
         "RESTRICTED_CP_DOTO": true,
         "SANCTIONED_COUNTRY": false,
       }
@@ -54,6 +56,7 @@ describe(getCountryFeaturesSelector, () => {
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": false,
         "PONTO_SUPPORTED": false,
+        "RAMP_DISABLED": false,
         "RESTRICTED_CP_DOTO": true,
         "SANCTIONED_COUNTRY": false,
       }
@@ -73,6 +76,7 @@ describe(getCountryFeaturesSelector, () => {
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": false,
         "PONTO_SUPPORTED": false,
+        "RAMP_DISABLED": false,
         "RESTRICTED_CP_DOTO": false,
         "SANCTIONED_COUNTRY": true,
       }


### PR DESCRIPTION
### Description
This PR hides the Ramp CICO provider from the options list for users with a US phone number. This is a stopgap solution while we develop a more comprehensive design to guide users through the provider selection process.

### Tested
Yes

### Related issues
- Part of #6055 

### Backwards compatibility
Yes