### PR TITLE
celocli releasegold:show should succeed w/o account registration

### DIFF
--- a/packages/cli/src/commands/releasegold/show.ts
+++ b/packages/cli/src/commands/releasegold/show.ts
@@ -21,11 +21,14 @@ export default class Show extends ReleaseGoldBaseCommand {
       currentReleasedTotalAmount: await this.releaseGoldWrapper.getCurrentReleasedTotalAmount(),
     }
     const accounts = await this.kit.contracts.getAccounts()
-    const authorizedSigners = {
-      voter: await accounts.getVoteSigner(this.releaseGoldWrapper.address),
-      validator: await accounts.getValidatorSigner(this.releaseGoldWrapper.address),
-      attestations: await accounts.getAttestationSigner(this.releaseGoldWrapper.address),
-    }
+    const isAccount = await accounts.isAccount(this.releaseGoldWrapper.address)
+    const authorizedSigners = isAccount
+      ? {
+          voter: await accounts.getVoteSigner(this.releaseGoldWrapper.address),
+          validator: await accounts.getValidatorSigner(this.releaseGoldWrapper.address),
+          attestations: await accounts.getAttestationSigner(this.releaseGoldWrapper.address),
+        }
+      : { voter: null, validator: null, attestations: null }
     const releaseGoldInfo = {
       releaseGoldWrapperAddress: this.releaseGoldWrapper.address,
       beneficiary: await this.releaseGoldWrapper.getBeneficiary(),


### PR DESCRIPTION
### Description

Only fetch signers if the contract is a registered account

### Related issues

- Partially addresses #7091
