### PR TITLE
Fix wallets-test

### DIFF
--- a/packages/sdk/wallets/wallet-hsm-aws/package.json
+++ b/packages/sdk/wallets/wallet-hsm-aws/package.json
@@ -40,5 +40,8 @@
   },
   "engines": {
     "node": ">=8.13.0"
+  },
+  "resolutions": {
+    "secp256k1": "^4.0.0"
   }
 }


### PR DESCRIPTION
### Description

Tried to fix this [previously](https://github.com/celo-org/celo-monorepo/pull/6432) but no dice. This fix pins the `secp256k1` version for our `aws-hsm-wallet` package.