### PR TITLE
Add check for signer or registered account

### DIFF
--- a/packages/cli/src/commands/account/show.ts
+++ b/packages/cli/src/commands/account/show.ts
@@ -1,4 +1,5 @@
 import { BaseCommand } from '../../base'
+import { newCheckBuilder } from '../../utils/checks'
 import { printValueMapRecursive } from '../../utils/cli'
 import { Args } from '../../utils/command'
 
@@ -16,7 +17,9 @@ export default class Show extends BaseCommand {
 
   async run() {
     const { args } = this.parse(Show)
-
+    await newCheckBuilder(this, args.address)
+      .isSignerOrAccount()
+      .runChecks()
     const accounts = await this.kit.contracts.getAccounts()
     const address = await accounts.signerToAccount(args.address)
     printValueMapRecursive(await accounts.getAccountSummary(address))

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -268,7 +268,8 @@ class CheckBuilder {
         const res =
           (await accounts.isAccount(this.signer!)) || (await accounts.isSigner(this.signer!))
         return res
-      })
+      }),
+      `${this.signer} is not a signer or registered as an account. Try authorizing as a signer or running account:register.`
     )
 
   isVoteSignerOrAccount = () =>


### PR DESCRIPTION
# Description
- Add a check that an address is a signer or registered account when running `account:show`
- Add a helpful warning message for if this check fails 

# Related issues
- Partially addresses #7091