### PR TITLE
Bump resource_class for general-test from M->L

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,6 +392,7 @@ jobs:
 
   general-test:
     <<: *defaults
+    resource_class: large
     steps:
       - attach_workspace:
           at: ~/app


### PR DESCRIPTION
Tiny PR to try to address why `general_test` fails sometimes with error code 137, per [this discussion](https://celo-org.slack.com/archives/CP5V8KF51/p1613140803128200?thread_ts=1613058289.071800&cid=CP5V8KF51)