### PR TITLE
ContractKit Reserve unfrozen balance methods

### DIFF
--- a/packages/sdk/contractkit/src/wrappers/Reserve.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Reserve.test.ts
@@ -29,7 +29,7 @@ testWithGanache('Reserve Wrapper', (web3) => {
 
   test('can get sum of reserve unfrozen balance + other reserve address balances', async () => {
     const balanceWithOtherAddresses = await reserve.getUnfrozenReserveCeloBalance()
-    expect(balanceWithOtherAddresses).toEqBigNumber('1e+26')
+    expect(balanceWithOtherAddresses).toEqBigNumber('3e+26')
   })
 
   test('test is spender', async () => {

--- a/packages/sdk/contractkit/src/wrappers/Reserve.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Reserve.test.ts
@@ -22,6 +22,16 @@ testWithGanache('Reserve Wrapper', (web3) => {
     reserveSpenderMultiSig = await kit.contracts.getMultiSig(multiSigAddress)
   })
 
+  test('can get reserve unfrozen balance ', async () => {
+    const balance = await reserve.getUnfrozenBalance()
+    expect(balance).toEqBigNumber('1e+26')
+  })
+
+  test('can get sum of reserve unfrozen balance + other reserve address balances', async () => {
+    const balanceWithOtherAddresses = await reserve.getUnfrozenReserveCeloBalance()
+    expect(balanceWithOtherAddresses).toEqBigNumber('1e+26')
+  })
+
   test('test is spender', async () => {
     const tx = await reserve.isSpender(reserveSpenderMultiSig.address)
     expect(tx).toBeTruthy()

--- a/packages/sdk/contractkit/src/wrappers/Reserve.ts
+++ b/packages/sdk/contractkit/src/wrappers/Reserve.ts
@@ -55,7 +55,7 @@ export class ReserveWrapper extends BaseWrapper<Reserve> {
   )
 
   /**
-    @alias {getReserveGoldBalance}
+   * @alias {getReserveGoldBalance}
    */
   getReserveGoldBalance = proxyCall(
     this.contract.methods.getReserveGoldBalance,

--- a/packages/sdk/contractkit/src/wrappers/Reserve.ts
+++ b/packages/sdk/contractkit/src/wrappers/Reserve.ts
@@ -53,11 +53,45 @@ export class ReserveWrapper extends BaseWrapper<Reserve> {
     undefined,
     valueToBigNumber
   )
+
+  /**
+    @alias {getReserveGoldBalance}
+   */
   getReserveGoldBalance = proxyCall(
     this.contract.methods.getReserveGoldBalance,
     undefined,
     valueToBigNumber
   )
+
+  /**
+   * @notice Returns the amount of CELO included in the reserve
+   * @return {BigNumber} The CELO amount included in the reserve.
+   */
+  getReserveCeloBalance = this.getReserveGoldBalance
+
+  /**
+   * @notice Returns the amount of unfrozen CELO in the Reserve contract.
+   * @see {getUnfrozenReserveCeloBalance}
+   * @return {BigNumber} amount in wei
+   */
+  getUnfrozenBalance = proxyCall(
+    this.contract.methods.getUnfrozenBalance,
+    undefined,
+    valueToBigNumber
+  )
+
+  /**
+   * @notice Returns the amount of unfrozen CELO included in the reserve
+   *  contract and in other reserve addresses.
+   * @see {getUnfrozenBalance}
+   * @return {BigNumber} amount in wei
+   */
+  getUnfrozenReserveCeloBalance = proxyCall(
+    this.contract.methods.getUnfrozenReserveGoldBalance,
+    undefined,
+    valueToBigNumber
+  )
+
   getOtherReserveAddresses = proxyCall(this.contract.methods.getOtherReserveAddresses)
 
   /**


### PR DESCRIPTION
### Description

adds `getUnfrozenBalance` 
adds `getUnfrozenReserveCeloBalance` 

### Other changes

Added an alias for getReserveGoldBalance as getReserveCeloBalance

also adds documentation which was taken from the underlying Reserve.sol but modified to be more clear about the difference between the two unfrozen methods

### Tested

added tests to the ReserveWrapper.test file

### Related issues

Motivation Behind this is to enabled Celoreserve.org to use contractKit to get live numbers

### Backwards compatibility
yes because no existing methods were changed