### PR TITLE
[Wallet] Deduce providers names and add them to the feed

### DIFF
--- a/packages/mobile/locales/en-US/fiatExchangeFlow.json
+++ b/packages/mobile/locales/en-US/fiatExchangeFlow.json
@@ -45,6 +45,6 @@
   "youCanTransfer": "You can transfer {{currency}} to or from the following exchanges. You'll need your Account Number (also known as an address) - tap below to copy.",
   "useBalanceWithMerchants": "Use your balance with supporting merchants",
   "findMerchants": "Find local merchants near you",
-  "celoDeposit": "CELO Deposit",
-  "cUsdDeposit": "cUSD Deposit"
+  "celoDeposit": "CELO Purchase",
+  "cUsdDeposit": "cUSD Purchase"
 }

--- a/packages/mobile/locales/en-US/fiatExchangeFlow.json
+++ b/packages/mobile/locales/en-US/fiatExchangeFlow.json
@@ -44,5 +44,7 @@
   "otherFundingOptions": "For more ways to add and withdraw funds, visit <0>How to fund your account</0>",
   "youCanTransfer": "You can transfer {{currency}} to or from the following exchanges. You'll need your Account Number (also known as an address) - tap below to copy.",
   "useBalanceWithMerchants": "Use your balance with supporting merchants",
-  "findMerchants": "Find local merchants near you"
+  "findMerchants": "Find local merchants near you",
+  "celoDeposit": "CELO Deposit",
+  "cUsdDeposit": "cUSD Deposit"
 }

--- a/packages/mobile/locales/es-419/fiatExchangeFlow.json
+++ b/packages/mobile/locales/es-419/fiatExchangeFlow.json
@@ -44,5 +44,7 @@
   "otherFundingOptions": "Para conocer más formas de agregar y retirar fondos, a <0>Cómo depositar fondos en mi cuenta</0>",
   "youCanTransfer": "Puedes transferir {{currency}} desde/hacia los siguientes exchanges utilizando tu Número de Cuenta (también conocido como dirección de Celo) - toca abajo para copiar.",
   "useBalanceWithMerchants": "Usa tu balance con comercios asociados",
-  "findMerchants": "Encuentra comercios asociados cerca de ti"
+  "findMerchants": "Encuentra comercios asociados cerca de ti",
+  "celoDeposit": "Depósito de CELO",
+  "cUsdDeposit": "Depósito de cUSD"
 }

--- a/packages/mobile/locales/es-419/fiatExchangeFlow.json
+++ b/packages/mobile/locales/es-419/fiatExchangeFlow.json
@@ -45,6 +45,6 @@
   "youCanTransfer": "Puedes transferir {{currency}} desde/hacia los siguientes exchanges utilizando tu Número de Cuenta (también conocido como dirección de Celo) - toca abajo para copiar.",
   "useBalanceWithMerchants": "Usa tu balance con comercios asociados",
   "findMerchants": "Encuentra comercios asociados cerca de ti",
-  "celoDeposit": "Depósito de CELO",
-  "cUsdDeposit": "Depósito de cUSD"
+  "celoDeposit": "Compra de CELO",
+  "cUsdDeposit": "Compra de cUSD"
 }

--- a/packages/mobile/locales/pt-BR/fiatExchangeFlow.json
+++ b/packages/mobile/locales/pt-BR/fiatExchangeFlow.json
@@ -44,5 +44,7 @@
   "otherFundingOptions": "Para conhecer mais maneiras de adicionar e sacar fundos, visite <0>Como adicionar fundos à sua conta</0>",
   "youCanTransfer": "Você pode transferir {{currency}} de ou para os seguintes exchanges. Você precisará do seu Número da Conta (também conhecido como endereço) – toque abaixo para copiar.",
   "useBalanceWithMerchants": "Use seu saldo com comerciantes apoiadores",
-  "findMerchants": "Encontre comerciantes locais perto de você"
+  "findMerchants": "Encontre comerciantes locais perto de você",
+  "celoDeposit": "Depósito de CELO",
+  "cUsdDeposit": "Depósito de cUSD"
 }

--- a/packages/mobile/locales/pt-BR/fiatExchangeFlow.json
+++ b/packages/mobile/locales/pt-BR/fiatExchangeFlow.json
@@ -45,6 +45,6 @@
   "youCanTransfer": "Você pode transferir {{currency}} de ou para os seguintes exchanges. Você precisará do seu Número da Conta (também conhecido como endereço) – toque abaixo para copiar.",
   "useBalanceWithMerchants": "Use seu saldo com comerciantes apoiadores",
   "findMerchants": "Encontre comerciantes locais perto de você",
-  "celoDeposit": "Depósito de CELO",
-  "cUsdDeposit": "Depósito de cUSD"
+  "celoDeposit": "Compra de CELO",
+  "cUsdDeposit": "Compra de cUSD"
 }

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -304,6 +304,7 @@ export enum FiatExchangeEvents {
 
   cico_option_chosen = 'cico_option_chosen',
   provider_chosen = 'provider_chosen',
+  cash_in_success = 'cash_in_success',
 }
 
 export enum GethEvents {

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -724,6 +724,10 @@ interface FiatExchangeEventsProperties {
     isCashIn: boolean
     provider: string
   }
+  [FiatExchangeEvents.cash_in_success]: {
+    provider: string
+    currency: string
+  }
 }
 
 interface GethEventsProperties {

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -7,10 +7,12 @@ import { StackScreenProps } from '@react-navigation/stack'
 import React, { useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { useDispatch } from 'react-redux'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import Dialog from 'src/components/Dialog'
+import { selectProvider } from 'src/fiatExchanges/actions'
 import { openMoonpay, openRamp, openSimplex } from 'src/fiatExchanges/utils'
 import { CURRENCY_ENUM } from 'src/geth/consts'
 import i18n, { Namespaces } from 'src/i18n'
@@ -44,6 +46,7 @@ ProviderOptionsScreen.navigationOptions = ({
 interface Provider {
   name: string
   enabled: boolean
+  icon: string
   image?: React.ReactNode
   onSelected: () => void
 }
@@ -60,6 +63,8 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
   const isCashIn = route.params?.isCashIn ?? true
   const { MOONPAY_DISABLED } = useCountryFeatures()
   const selectedCurrency = route.params.currency || CURRENCY_ENUM.DOLLAR
+
+  const dispatch = useDispatch()
 
   useLayoutEffect(() => {
     const showExplanation = () => setShowExplanation(true)
@@ -84,18 +89,24 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
       {
         name: 'Moonpay',
         enabled: !MOONPAY_DISABLED,
+        icon:
+          'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fmoonpay.png?alt=media&token=3617af49-7762-414d-a4d0-df05fbc49b97',
         image: <Image source={moonpayLogo} style={styles.logo} resizeMode={'contain'} />,
         onSelected: () => openMoonpay(localCurrency || FALLBACK_CURRENCY, selectedCurrency),
       },
       {
         name: 'Simplex',
         enabled: true,
+        icon:
+          'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media&token=6037b2f9-9d76-4076-b29e-b7e0de0b3f34',
         image: <Image source={simplexLogo} style={styles.logo} resizeMode={'contain'} />,
         onSelected: () => openSimplex(account),
       },
       {
         name: 'Ramp',
         enabled: true,
+        icon:
+          'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media&token=548ab5b9-7b03-49a2-a196-198f45958852',
         onSelected: () => openRamp(localCurrency || FALLBACK_CURRENCY, selectedCurrency),
       },
     ],
@@ -106,6 +117,7 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
       isCashIn,
       provider: provider.name,
     })
+    dispatch(selectProvider(provider.name, provider.icon))
     provider.onSelected()
   }
 

--- a/packages/mobile/src/fiatExchanges/actions.ts
+++ b/packages/mobile/src/fiatExchanges/actions.ts
@@ -1,5 +1,7 @@
 export enum Actions {
   BIDALI_PAYMENT_REQUESTED = 'FIAT_EXCHANGES/BIDALI_PAYMENT_REQUESTED',
+  SELECT_PROVIDER = 'FIAT_EXCHANGES/SELECT_PROVIDER',
+  ASSIGN_PROVIDER_TO_TX_HASH = 'FIAT_EXCHANGES/ASSIGN_PROVIDER_TO_TX_HASH',
 }
 
 export interface BidaliPaymentRequestedAction {
@@ -12,8 +14,6 @@ export interface BidaliPaymentRequestedAction {
   onPaymentSent: () => void
   onCancelled: () => void
 }
-
-export type ActionTypes = BidaliPaymentRequestedAction
 
 export const bidaliPaymentRequested = (
   address: string,
@@ -33,3 +33,35 @@ export const bidaliPaymentRequested = (
   onPaymentSent,
   onCancelled,
 })
+
+export interface SelectProviderAction {
+  type: Actions.SELECT_PROVIDER
+  name: string
+  icon: string
+}
+
+export const selectProvider = (name: string, icon: string): SelectProviderAction => ({
+  type: Actions.SELECT_PROVIDER,
+  name,
+  icon,
+})
+
+export interface AssignProviderToTxHashAction {
+  type: Actions.ASSIGN_PROVIDER_TO_TX_HASH
+  txHash: string
+  currencyCode: string
+}
+
+export const assignProviderToTxHash = (
+  txHash: string,
+  currencyCode: string
+): AssignProviderToTxHashAction => ({
+  type: Actions.ASSIGN_PROVIDER_TO_TX_HASH,
+  txHash,
+  currencyCode,
+})
+
+export type ActionTypes =
+  | BidaliPaymentRequestedAction
+  | SelectProviderAction
+  | AssignProviderToTxHashAction

--- a/packages/mobile/src/fiatExchanges/reducer.test.ts
+++ b/packages/mobile/src/fiatExchanges/reducer.test.ts
@@ -1,0 +1,87 @@
+import { Actions } from 'src/fiatExchanges/actions'
+import { initialState, reducer } from 'src/fiatExchanges/reducer'
+
+describe('fiat exchange reducer', () => {
+  it('should return the initial state', () => {
+    // @ts-ignore
+    expect(reducer(undefined, {})).toEqual(initialState)
+  })
+  const mockProvider1 = {
+    name: 'Provider 1 name',
+    icon: 'https://provider1.iconUrl',
+  }
+  const mockProvider2 = {
+    name: 'Provider 2 name',
+    icon: 'https://provider2.iconUrl',
+  }
+
+  it('SELECT_PROVIDER should override the provider', () => {
+    let updatedState = reducer(undefined, {
+      type: Actions.SELECT_PROVIDER,
+      name: mockProvider1.name,
+      icon: mockProvider1.icon,
+    })
+    expect(updatedState).toEqual({
+      ...initialState,
+      lastUsedProvider: mockProvider1,
+    })
+
+    updatedState = reducer(updatedState, {
+      type: Actions.SELECT_PROVIDER,
+      name: mockProvider2.name,
+      icon: mockProvider2.icon,
+    })
+    expect(updatedState).toEqual({
+      ...initialState,
+      lastUsedProvider: mockProvider2,
+    })
+  })
+
+  it('ASSIGN_PROVIDER_TO_TX_HASH assigns and clears last provider correctly', () => {
+    const currencyCode = 'cUSD'
+    const txHash1 = '0x4607df6d11e63bb024cf1001956de7b6bd7adc253146f8412e8b3756752b8353'
+    const txHash2 = '0x16fbd53c4871f0657f40e1b4515184be04bed8912c6e2abc2cda549e4ad8f852'
+
+    let updatedState = reducer(undefined, {
+      type: Actions.ASSIGN_PROVIDER_TO_TX_HASH,
+      txHash: txHash1,
+      currencyCode,
+    })
+
+    expect(updatedState).toEqual({
+      ...initialState,
+      txHashToProvider: {
+        [txHash1]: {
+          name: 'fiatExchangeFlow:cUsdDeposit',
+          icon: expect.any(String),
+        },
+      },
+    })
+
+    updatedState = reducer(updatedState, {
+      type: Actions.SELECT_PROVIDER,
+      name: mockProvider1.name,
+      icon: mockProvider1.icon,
+    })
+    updatedState = reducer(updatedState, {
+      type: Actions.ASSIGN_PROVIDER_TO_TX_HASH,
+      txHash: txHash2,
+      currencyCode,
+    })
+
+    expect(updatedState).toEqual({
+      ...initialState,
+      lastUsedProvider: null,
+      txHashToProvider: {
+        [txHash1]: {
+          name: 'fiatExchangeFlow:cUsdDeposit',
+          icon: expect.any(String),
+        },
+        [txHash2]: {
+          name: mockProvider1.name,
+          icon: mockProvider1.icon,
+        },
+      },
+    })
+  })
+})

--- a/packages/mobile/src/fiatExchanges/reducer.ts
+++ b/packages/mobile/src/fiatExchanges/reducer.ts
@@ -1,0 +1,65 @@
+import { RehydrateAction } from 'redux-persist'
+import { Actions, ActionTypes } from 'src/fiatExchanges/actions'
+import { CURRENCIES, CURRENCY_ENUM } from 'src/geth/consts'
+import i18n from 'src/i18n'
+import { getRehydratePayload, REHYDRATE } from 'src/redux/persist-helper'
+import { RootState } from 'src/redux/reducers'
+
+interface ProviderFeedInfo {
+  name: string
+  icon: string
+}
+
+export interface State {
+  lastUsedProvider: ProviderFeedInfo | null
+  txHashToProvider: { [txHash: string]: ProviderFeedInfo | undefined }
+}
+
+export const initialState = {
+  lastUsedProvider: null,
+  txHashToProvider: {},
+}
+
+export const reducer = (state: State = initialState, action: ActionTypes | RehydrateAction) => {
+  switch (action.type) {
+    case REHYDRATE: {
+      return {
+        ...state,
+        ...getRehydratePayload(action, 'fiatExchanges'),
+      }
+    }
+    case Actions.SELECT_PROVIDER:
+      return {
+        ...state,
+        lastUsedProvider: {
+          name: action.name,
+          icon: action.icon,
+        },
+      }
+    case Actions.ASSIGN_PROVIDER_TO_TX_HASH:
+      let providerToAssign = state.lastUsedProvider
+      if (!providerToAssign) {
+        const nameKey =
+          action.currencyCode === CURRENCIES[CURRENCY_ENUM.GOLD].code
+            ? 'fiatExchangeFlow:celoDeposit'
+            : 'fiatExchangeFlow:cUsdDeposit'
+        providerToAssign = {
+          name: i18n.t(nameKey),
+          icon:
+            'https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media',
+        }
+      }
+      return {
+        ...state,
+        lastUsedProvider: null,
+        txHashToProvider: {
+          ...state.txHashToProvider,
+          [action.txHash]: providerToAssign,
+        },
+      }
+    default:
+      return state
+  }
+}
+
+export const txHashToFeedInfoSelector = (state: RootState) => state.fiatExchanges.txHashToProvider

--- a/packages/mobile/src/fiatExchanges/reducer.ts
+++ b/packages/mobile/src/fiatExchanges/reducer.ts
@@ -1,4 +1,6 @@
 import { RehydrateAction } from 'redux-persist'
+import { FiatExchangeEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { Actions, ActionTypes } from 'src/fiatExchanges/actions'
 import { CURRENCIES, CURRENCY_ENUM } from 'src/geth/consts'
 import i18n from 'src/i18n'
@@ -38,6 +40,10 @@ export const reducer = (state: State = initialState, action: ActionTypes | Rehyd
       }
     case Actions.ASSIGN_PROVIDER_TO_TX_HASH:
       let providerToAssign = state.lastUsedProvider
+      ValoraAnalytics.track(FiatExchangeEvents.cash_in_success, {
+        provider: providerToAssign?.name || 'unknown',
+        currency: action.currencyCode,
+      })
       if (!providerToAssign) {
         const nameKey =
           action.currencyCode === CURRENCIES[CURRENCY_ENUM.GOLD].code

--- a/packages/mobile/src/fiatExchanges/saga.test.ts
+++ b/packages/mobile/src/fiatExchanges/saga.test.ts
@@ -1,11 +1,13 @@
 import BigNumber from 'bignumber.js'
 import { expectSaga } from 'redux-saga-test-plan'
+import { select } from 'redux-saga/effects'
 import { SendOrigin } from 'src/analytics/types'
-import { TokenTransactionType } from 'src/apollo/types'
+import { TokenTransactionType, TransactionFeedFragment } from 'src/apollo/types'
 import { activeScreenChanged } from 'src/app/actions'
-import { bidaliPaymentRequested } from 'src/fiatExchanges/actions'
-import { watchBidaliPaymentRequests } from 'src/fiatExchanges/saga'
+import { assignProviderToTxHash, bidaliPaymentRequested } from 'src/fiatExchanges/actions'
+import { searchNewItemsForProviderTxs, watchBidaliPaymentRequests } from 'src/fiatExchanges/saga'
 import { Actions as IdentityActions, updateKnownAddresses } from 'src/identity/actions'
+import { providerAddressesSelector } from 'src/identity/reducer'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { RecipientKind, RecipientWithAddress } from 'src/recipients/recipient'
@@ -14,6 +16,7 @@ import {
   sendPaymentOrInviteFailure,
   sendPaymentOrInviteSuccess,
 } from 'src/send/actions'
+import { mockAccount } from 'test/values'
 
 const now = Date.now()
 Date.now = jest.fn(() => now)
@@ -153,5 +156,56 @@ describe(watchBidaliPaymentRequests, () => {
     expect(navigate).not.toHaveBeenCalled()
     expect(onPaymentSent).not.toHaveBeenCalled()
     expect(onCancelled).not.toHaveBeenCalled()
+  })
+})
+
+describe(searchNewItemsForProviderTxs, () => {
+  const mockAmount = {
+    __typename: 'MoneyAmount',
+    value: '-0.2',
+    currencyCode: 'cUSD',
+    localAmount: {
+      __typename: 'LocalMoneyAmount',
+      value: '-0.2',
+      currencyCode: 'USD',
+      exchangeRate: '1',
+    },
+  }
+
+  it('assigns new txs to known providers', async () => {
+    const providerTransferHash =
+      '0x4607df6d11e63bb024cf1001956de7b6bd7adc253146f8412e8b3756752b8353'
+    const exchangeHash = '0x16fbd53c4871f0657f40e1b4515184be04bed8912c6e2abc2cda549e4ad8f852'
+    const nonProviderTransferHash =
+      '0x28147e5953639687915e9b152173076611cc9e51e8634fad3850374ccc87d7aa'
+    const mockProviderAccount = '0x30d5ca2a263e0c0d11e7a668ccf30b38f1482251'
+    const transactions: TransactionFeedFragment[] = [
+      {
+        __typename: 'TokenTransfer',
+        type: TokenTransactionType.Received,
+        hash: providerTransferHash,
+        amount: mockAmount,
+        timestamp: 1578530538,
+        address: mockProviderAccount,
+      },
+      {
+        __typename: 'TokenExchange',
+        type: TokenTransactionType.Exchange,
+        hash: exchangeHash,
+      } as any,
+      {
+        __typename: 'TokenTransfer',
+        type: TokenTransactionType.Received,
+        hash: nonProviderTransferHash,
+        amount: mockAmount,
+        timestamp: 1578530602,
+        address: mockAccount,
+      },
+    ]
+
+    await expectSaga(searchNewItemsForProviderTxs, { transactions })
+      .provide([[select(providerAddressesSelector), [mockProviderAccount]]])
+      .put(assignProviderToTxHash(providerTransferHash, 'cUSD'))
+      .run()
   })
 })

--- a/packages/mobile/src/fiatExchanges/saga.ts
+++ b/packages/mobile/src/fiatExchanges/saga.ts
@@ -100,7 +100,7 @@ function* bidaliPaymentRequest({
   }
 }
 
-function* searchNewItemsForProviderTxs({ transactions }: NewTransactionsInFeedAction) {
+export function* searchNewItemsForProviderTxs({ transactions }: NewTransactionsInFeedAction) {
   try {
     if (!transactions || !transactions.length) {
       return

--- a/packages/mobile/src/identity/reducer.ts
+++ b/packages/mobile/src/identity/reducer.ts
@@ -50,6 +50,7 @@ export interface AddressInfoToDisplay {
   name: string
   imageUrl: string | null
   isCeloRewardSender?: boolean
+  isProviderAddress?: boolean
 }
 
 export interface AddressToDisplayNameType {
@@ -692,4 +693,10 @@ export const tryFeelessOnboardingSelector = ({
 }: RootState) => {
   const { errorTimestamps } = feelessVerificationState.komenci
   return !hasExceededKomenciErrorQuota(errorTimestamps) && features.KOMENCI
+}
+
+export const providerAddressesSelector = ({ identity: { addressToDisplayName } }: RootState) => {
+  return Object.entries(addressToDisplayName)
+    .filter(([_, info]) => info?.isProviderAddress)
+    .map(([address, _]) => address)
 }

--- a/packages/mobile/src/redux/reducers.ts
+++ b/packages/mobile/src/redux/reducers.ts
@@ -7,6 +7,7 @@ import { appReducer as app, State as AppState } from 'src/app/reducers'
 import { escrowReducer as escrow, State as EscrowState } from 'src/escrow/reducer'
 import { reducer as exchange, State as ExchangeState } from 'src/exchange/reducer'
 import { reducer as fees, State as FeesState } from 'src/fees/reducer'
+import { reducer as fiatExchanges, State as FiatExchangesState } from 'src/fiatExchanges/reducer'
 import { gethReducer as geth, State as GethState } from 'src/geth/reducer'
 import { reducer as goldToken, State as GoldTokenState } from 'src/goldToken/reducer'
 import { homeReducer as home, State as HomeState } from 'src/home/reducers'
@@ -43,6 +44,7 @@ const appReducer = combineReducers({
   localCurrency,
   imports,
   paymentRequest,
+  fiatExchanges,
 }) as (state: RootState | undefined, action: Action) => RootState
 
 const rootReducer = (state: RootState | undefined, action: Action): RootState => {
@@ -86,6 +88,7 @@ export interface RootState {
   localCurrency: LocalCurrencyState
   imports: ImportState
   paymentRequest: PaymentRequestState
+  fiatExchanges: FiatExchangesState
 }
 
 export interface PersistedRootState {
@@ -102,4 +105,5 @@ export interface PersistedRootState {
   invite: InviteState
   escrow: EscrowState
   localCurrency: LocalCurrencyState
+  fiatExchanges: FiatExchangesState
 }

--- a/packages/mobile/src/transactions/CeloTransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/CeloTransferFeedItem.tsx
@@ -14,6 +14,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { TransferItemFragment } from 'src/apollo/types'
 import CurrencyDisplay from 'src/components/CurrencyDisplay'
 import { formatShortenedAddress } from 'src/components/ShortenedAddress'
+import { txHashToFeedInfoSelector } from 'src/fiatExchanges/reducer'
 import { Namespaces } from 'src/i18n'
 import { addressToDisplayNameSelector } from 'src/identity/reducer'
 import { navigateToPaymentTransferReview } from 'src/transactions/actions'
@@ -27,7 +28,9 @@ type Props = TransferItemFragment & {
 export function CeloTransferFeedItem(props: Props) {
   const { t, i18n } = useTranslation(Namespaces.walletFlow5)
   const addressToDisplayName = useSelector(addressToDisplayNameSelector)
-  const { address, amount, comment, status, timestamp, type } = props
+  const txHashToFeedInfo = useSelector(txHashToFeedInfoSelector)
+  const { address, amount, hash, comment, status, timestamp, type } = props
+  const txInfo = txHashToFeedInfo[hash]
 
   const onPress = () => {
     ValoraAnalytics.track(CeloExchangeEvents.celo_transaction_select)
@@ -49,7 +52,8 @@ export function CeloTransferFeedItem(props: Props) {
   const dateTimeFormatted = getDatetimeDisplayString(timestamp, i18n)
   const isPending = status === TransactionStatus.Pending
   const isWithdrawal = new BigNumber(amount.value).isNegative()
-  const displayName = addressToDisplayName[address]?.name || formatShortenedAddress(address)
+  const displayName =
+    txInfo?.name || addressToDisplayName[address]?.name || formatShortenedAddress(address)
 
   return (
     <Touchable onPress={onPress}>

--- a/packages/mobile/src/transactions/TransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux'
 import { HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { TokenTransactionType, TransferItemFragment } from 'src/apollo/types'
+import { txHashToFeedInfoSelector } from 'src/fiatExchanges/reducer'
 import { Namespaces } from 'src/i18n'
 import {
   addressToDisplayNameSelector,
@@ -70,6 +71,7 @@ function navigateToTransactionReview({
 export function TransferFeedItem(props: Props) {
   const { t } = useTranslation(Namespaces.walletFlow5)
   const addressToDisplayName = useSelector(addressToDisplayNameSelector)
+  const txHashToFeedInfo = useSelector(txHashToFeedInfoSelector)
 
   const onPress = () => {
     navigateToTransactionReview({ ...props, addressToDisplayName })
@@ -81,6 +83,7 @@ export function TransferFeedItem(props: Props) {
     address,
     timestamp,
     type,
+    hash,
     comment,
     commentKey,
     status,
@@ -89,21 +92,22 @@ export function TransferFeedItem(props: Props) {
     recentTxRecipientsCache,
     invitees,
   } = props
+  const txInfo = txHashToFeedInfo[hash]
 
   const { title, info, recipient } = getTransferFeedParams(
     type,
     t,
     recipientCache,
     recentTxRecipientsCache,
+    txInfo?.name || addressToDisplayName[address]?.name,
     address,
     addressToE164Number,
-    addressToDisplayName,
     comment,
     commentKey,
     timestamp,
     invitees
   )
-  const imageUrl = addressToDisplayName[address]?.imageUrl ?? null
+  const imageUrl = (txInfo?.icon || addressToDisplayName[address]?.imageUrl) ?? null
 
   return (
     <TransactionFeedItem

--- a/packages/mobile/src/transactions/transferFeedUtils.ts
+++ b/packages/mobile/src/transactions/transferFeedUtils.ts
@@ -9,7 +9,7 @@ import {
 import { formatShortenedAddress } from 'src/components/ShortenedAddress'
 import { DEFAULT_TESTNET } from 'src/config'
 import { decryptComment } from 'src/identity/commentEncryption'
-import { AddressToDisplayNameType, AddressToE164NumberType } from 'src/identity/reducer'
+import { AddressToE164NumberType } from 'src/identity/reducer'
 import { InviteDetails } from 'src/invite/actions'
 import { NumberToRecipient } from 'src/recipients/recipient'
 import { KnownFeedTransactionsType } from 'src/transactions/reducer'
@@ -74,9 +74,9 @@ export function getTransferFeedParams(
   t: TFunction,
   recipientCache: NumberToRecipient,
   recentTxRecipientsCache: NumberToRecipient,
+  name: string | undefined,
   address: string,
   addressToE164Number: AddressToE164NumberType,
-  addressToDisplayName: AddressToDisplayNameType,
   rawComment: string | null,
   commentKey: string | null,
   timestamp: number,
@@ -91,8 +91,7 @@ export function getTransferFeedParams(
     timestamp,
     invitees
   )
-  const nameOrNumber =
-    recipient?.displayName || addressToDisplayName[address]?.name || e164PhoneNumber
+  const nameOrNumber = name || recipient?.displayName || e164PhoneNumber
   const displayName =
     nameOrNumber ||
     t('feedItemAddress', {

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -483,6 +483,10 @@ export const v7Schema = {
     loading: false,
     notifications: {},
   },
+  fiatExchanges: {
+    lastUsedProvider: null,
+    txHashToProvider: {},
+  },
 }
 
 export function getLatestSchema(): Partial<RootState> {


### PR DESCRIPTION
### Description

Transfers coming from Simplex and Moonpay are both routed through a Bittrex address causing them to appear to come from the same provider. This PR adds a mechanism to guess where the transaction comes from to include on the feed with a generic default option.

The solution I ended up going with is to save the last provider the user clicked on and if we then see an incoming tx from an address that we know belongs to a provider we assign it to the one the user clicked on. If a tx comes in from a provider address but the user didn't click on any provider, we show a generic 'cUSD Purchase' or 'CELO Purshase'.

To do this, I added an optional `isProviderAddress` field to the known addresses on Firebase.

### Other changes

- Added a new analytics event when we see a new tx that belongs to a provider.

### Tested

Locally, there are some unit tests as well.

### Related issues

- Fixes #7005

### Backwards compatibility

N/A