### PR TITLE
Bump StableToken transfer gas cost

### DIFF
--- a/packages/celotool/src/e2e-tests/transfer_tests.ts
+++ b/packages/celotool/src/e2e-tests/transfer_tests.ts
@@ -119,7 +119,7 @@ const ADDITIONAL_INTRINSIC_TX_GAS_COST = 50000
 // Gas refund for resetting to the original non-zero value
 const sstoreCleanRefundEIP2200 = 4200
 // Transfer cost of a stable token transfer, accounting for the refund above.
-const stableTokenTransferGasCost = 23631
+const stableTokenTransferGasCost = 23653
 
 /** Helper to watch balance changes over accounts */
 interface BalanceWatcher {


### PR DESCRIPTION
### Description

During the audit response for R3 we found that the StableToken transfer costs have increased due to a new branch statement, this PR bumps the number expected by 22 wei.  

### Tested

By running in CI.