### PR TITLE
Test exchange.sol initialization with zero address for stableToken

### DIFF
--- a/packages/protocol/test/stability/exchange.ts
+++ b/packages/protocol/test/stability/exchange.ts
@@ -155,6 +155,18 @@ contract('Exchange', (accounts: string[]) => {
       assert.equal(expectedOwner, accounts[0])
     })
 
+    it('should allow empty stableToken address', async () => {
+      const exchange2 = await Exchange.new()
+      await exchange2.initialize(
+        registry.address,
+        '0x0000000000000000000000000000000000000000',
+        spread,
+        reserveFraction,
+        updateFrequency,
+        minimumReports
+      )
+    })
+
     it('should not be callable again', async () => {
       await assertRevert(
         exchange.initialize(


### PR DESCRIPTION
### Description

For CR3, we need to initialize exchange.sol with a zero address for stableToken, as stableTokenEUR address wont be available at the time of proposing.

### Other changes

- 

### Tested

Added tests

### Related issues

- #7171 

### Backwards compatibility

-