### PR TITLE
Update README.md

### DIFF
--- a/packages/sdk/contractkit/README.md
+++ b/packages/sdk/contractkit/README.md
@@ -75,7 +75,7 @@ const celoToken = await kit.contracts.getGoldToken()
 // get the cUSD contract
 const stableToken = await kit.contracts.getStableToken()
 
-const celoBalance = await goldToken.balanceOf(someAddress)
+const celoBalance = await celoToken.balanceOf(someAddress)
 const cusdBalance = await stableToken.balanceOf(someAddress)
 ```
 


### PR DESCRIPTION
s/goldToken/celoToken

was declared as `celoToken` but later used as `goldToken`

### Description

fix small flaw in the docu.
### Other changes