### PR TITLE
Add explicit file name for deployment script

### DIFF
--- a/packages/docs/developer-resources/walkthroughs/hello-contract-remote-node.md
+++ b/packages/docs/developer-resources/walkthroughs/hello-contract-remote-node.md
@@ -200,7 +200,7 @@ You need to compile the `HelloWorld.sol` contract using \(if it isn't already\):
 $ truffle compile
 ```
 
-This command will generate a `HelloWorld.json` file in the `./build/contracts/` directory. `HelloWorld.json` contains a lot of data about the contract, compiler and low level details. Import this file into the deployment script with:
+This command will generate a `HelloWorld.json` file in the `./build/contracts/` directory. `HelloWorld.json` contains a lot of data about the contract, compiler and low level details. Import this file into the deployment script `celo_deploy.js` with:
 
 ```javascript
 const HelloWorld = require('./build/contracts/HelloWorld.json')


### PR DESCRIPTION
### Description

Referencing the name in case users are confused about which file needs the import. I'm agnostic as to whether `./celo_deploy.js` is better than `celo_deploy.js`.

### Other changes

N/A

### Tested

N/A

### Related issues

N/A

### Backwards compatibility

N/A
