### PR TITLE
Adjust dequeued expired proposal check

### DIFF
--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -544,7 +544,10 @@ contract Governance is
       return
         isQueuedProposalExpired(proposalId) ? Proposals.Stage.Expiration : Proposals.Stage.Queued;
     } else {
-      return proposals[proposalId].getDequeuedStage(stageDurations);
+      return
+        isDequeuedProposalExpired(proposalId)
+          ? Proposals.Stage.Expiration
+          : proposals[proposalId].getDequeuedStage(stageDurations);
     }
   }
 
@@ -646,6 +649,7 @@ contract Governance is
     emit ProposalVoted(proposalId, account, uint256(value), weight);
     return true;
   }
+
   /* solhint-enable code-complexity */
 
   /**
@@ -1090,7 +1094,6 @@ contract Governance is
   function isDequeuedProposalExpired(uint256 proposalId) external view returns (bool) {
     Proposals.Proposal storage proposal = proposals[proposalId];
     return _isDequeuedProposalExpired(proposal, proposal.getDequeuedStage(stageDurations));
-
   }
 
   /**

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -187,7 +187,7 @@ contract Governance is
    * @return The storage, major, minor, and patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 2, 0, 2);
+    return (1, 2, 0, 3);
   }
 
   /**

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -540,14 +540,14 @@ contract Governance is
   function getProposalStage(uint256 proposalId) external view returns (Proposals.Stage) {
     if (proposalId == 0 || proposalId > proposalCount) {
       return Proposals.Stage.None;
-    } else if (isQueued(proposalId)) {
+    }
+    Proposals.Proposal storage proposal = proposals[proposalId];
+    if (isQueued(proposalId)) {
       return
-        isQueuedProposalExpired(proposalId) ? Proposals.Stage.Expiration : Proposals.Stage.Queued;
+        _isQueuedProposalExpired(proposal) ? Proposals.Stage.Expiration : Proposals.Stage.Queued;
     } else {
-      return
-        isDequeuedProposalExpired(proposalId)
-          ? Proposals.Stage.Expiration
-          : proposals[proposalId].getDequeuedStage(stageDurations);
+      Proposals.Stage stage = proposal.getDequeuedStage(stageDurations);
+      return _isDequeuedProposalExpired(proposal, stage) ? Proposals.Stage.Expiration : stage;
     }
   }
 

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -9,7 +9,7 @@ import "./interfaces/IGovernance.sol";
 import "./Proposals.sol";
 import "../common/interfaces/IAccounts.sol";
 import "../common/ExtractFunctionSignature.sol";
-import "../common/Initializable.sol";
+import "../common/InitializableV2.sol";
 import "../common/FixidityLib.sol";
 import "../common/linkedlists/IntegerSortedLinkedList.sol";
 import "../common/UsingRegistry.sol";
@@ -24,7 +24,7 @@ contract Governance is
   IGovernance,
   ICeloVersionedContract,
   Ownable,
-  Initializable,
+  InitializableV2,
   ReentrancyGuard,
   UsingRegistry,
   UsingPrecompiles
@@ -177,6 +177,12 @@ contract Governance is
     require(msg.sender == approver, "msg.sender not approver");
     _;
   }
+
+  /**
+   * @notice Sets initialized == true on implementation contracts
+   * @param test Set to true to skip implementation initialization
+   */
+  constructor(bool test) public InitializableV2(test) {}
 
   function() external payable {
     require(msg.data.length == 0, "unknown method");

--- a/packages/protocol/contracts/governance/test/GovernanceTest.sol
+++ b/packages/protocol/contracts/governance/test/GovernanceTest.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.13;
 
 import "../Governance.sol";
 
-contract GovernanceTest is Governance {
+contract GovernanceTest is Governance(true) {
   address[] validatorSet;
 
   // Minimally override core functions from UsingPrecompiles

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -2482,7 +2482,7 @@ contract('Governance', (accounts: string[]) => {
     })
   })
 
-  describe.only('#getProposalStage()', () => {
+  describe('#getProposalStage()', () => {
     const proposalId = 1
     const expectStage = async (expected: Stage, _proposalId?: number) => {
       const stage = await governance.getProposalStage(_proposalId ?? proposalId)
@@ -2496,7 +2496,6 @@ contract('Governance', (accounts: string[]) => {
 
     describe('when proposal exists', () => {
       beforeEach(async () => {
-        await accountsInstance.createAccount()
         await governance.propose(
           [transactionSuccess1.value],
           [transactionSuccess1.destination],
@@ -2561,7 +2560,6 @@ contract('Governance', (accounts: string[]) => {
           beforeEach(async () => {
             await governance.approve(proposalId, index)
             await timeTravel(approvalStageDuration, web3)
-            await mockLockedGold.setAccountTotalLockedGold(account, 100)
             await governance.vote(proposalId, index, VoteValue.Yes)
             const passing = await governance.isProposalPassing(proposalId)
             assert.isTrue(passing, 'proposal not passing')

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -67,6 +67,15 @@ enum VoteValue {
   Yes,
 }
 
+enum Stage {
+  None = 0,
+  Queued,
+  Approval,
+  Referendum,
+  Execution,
+  Expiration,
+}
+
 interface Transaction {
   value: number
   destination: string
@@ -2469,6 +2478,103 @@ contract('Governance', (accounts: string[]) => {
       it('should return false', async () => {
         const passing = await governance.isProposalPassing(proposalId)
         assert.isFalse(passing)
+      })
+    })
+  })
+
+  describe.only('#getProposalStage()', () => {
+    const proposalId = 1
+    const expectStage = async (expected: Stage, _proposalId?: number) => {
+      const stage = await governance.getProposalStage(_proposalId ?? proposalId)
+      assertEqualBN(stage, expected)
+    }
+
+    it('should return None stage when proposal doesnt exist', async () => {
+      expectStage(Stage.None, 0)
+      expectStage(Stage.None)
+    })
+
+    describe('when proposal exists', () => {
+      beforeEach(async () => {
+        await accountsInstance.createAccount()
+        await governance.propose(
+          [transactionSuccess1.value],
+          [transactionSuccess1.destination],
+          // @ts-ignore bytes type
+          transactionSuccess1.data,
+          [transactionSuccess1.data.length],
+          descriptionUrl,
+          // @ts-ignore: TODO(mcortesi) fix typings for TransactionDetails
+          { value: minDeposit }
+        )
+        const exists = await governance.proposalExists(proposalId)
+        assert.isTrue(exists, 'proposal does not exist')
+      })
+
+      describe('when proposal is queued', () => {
+        beforeEach(async () => {
+          const queued = await governance.isQueued(proposalId)
+          assert.isTrue(queued, 'proposal not queued')
+        })
+
+        it('should return Queued when not expired', () => expectStage(Stage.Queued))
+
+        it('should return Expiration when expired', async () => {
+          await timeTravel(queueExpiry, web3)
+          expectStage(Stage.Expiration)
+        })
+      })
+
+      describe('when proposal is dequeued', () => {
+        const index = 0
+        beforeEach(async () => {
+          await timeTravel(dequeueFrequency, web3)
+          await governance.dequeueProposalsIfReady()
+          const dequeued = await governance.isDequeuedProposal(proposalId, index)
+          assert.isTrue(dequeued, 'proposal not dequeued')
+        })
+
+        describe('when in approval stage', () => {
+          it('should return Approval when not expired', () => expectStage(Stage.Approval))
+
+          it('should return Expiration when expired', async () => {
+            await timeTravel(approvalStageDuration, web3)
+            expectStage(Stage.Expiration)
+          })
+        })
+
+        describe('when in referendum stage', () => {
+          beforeEach(async () => {
+            await governance.approve(proposalId, index)
+            await timeTravel(approvalStageDuration, web3)
+          })
+
+          it('should return Referendum when not expired', () => expectStage(Stage.Referendum))
+
+          it('should return Expiration when expired', async () => {
+            await timeTravel(referendumStageDuration, web3)
+            expectStage(Stage.Expiration)
+          })
+        })
+
+        describe('when in execution stage', () => {
+          beforeEach(async () => {
+            await governance.approve(proposalId, index)
+            await timeTravel(approvalStageDuration, web3)
+            await mockLockedGold.setAccountTotalLockedGold(account, 100)
+            await governance.vote(proposalId, index, VoteValue.Yes)
+            const passing = await governance.isProposalPassing(proposalId)
+            assert.isTrue(passing, 'proposal not passing')
+            await timeTravel(referendumStageDuration, web3)
+          })
+
+          it('should return Execution when not expired', () => expectStage(Stage.Execution))
+
+          it('should return Expiration when expired', async () => {
+            await timeTravel(executionStageDuration, web3)
+            expectStage(Stage.Expiration)
+          })
+        })
       })
     })
   })

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -2483,18 +2483,18 @@ contract('Governance', (accounts: string[]) => {
   })
 
   describe('#getProposalStage()', () => {
-    const proposalId = 1
-    const expectStage = async (expected: Stage, _proposalId?: number) => {
-      const stage = await governance.getProposalStage(_proposalId ?? proposalId)
+    const expectStage = async (expected: Stage, _proposalId: number) => {
+      const stage = await governance.getProposalStage(_proposalId)
       assertEqualBN(stage, expected)
     }
 
     it('should return None stage when proposal doesnt exist', async () => {
       await expectStage(Stage.None, 0)
-      await expectStage(Stage.None)
+      await expectStage(Stage.None, 1)
     })
 
     describe('when proposal exists', () => {
+      let proposalId: number
       beforeEach(async () => {
         await governance.propose(
           [transactionSuccess1.value],
@@ -2503,9 +2503,9 @@ contract('Governance', (accounts: string[]) => {
           transactionSuccess1.data,
           [transactionSuccess1.data.length],
           descriptionUrl,
-          // @ts-ignore: TODO(mcortesi) fix typings for TransactionDetails
           { value: minDeposit }
         )
+        proposalId = 1
         const exists = await governance.proposalExists(proposalId)
         assert.isTrue(exists, 'proposal does not exist')
       })
@@ -2516,11 +2516,11 @@ contract('Governance', (accounts: string[]) => {
           assert.isTrue(queued, 'proposal not queued')
         })
 
-        it('should return Queued when not expired', () => expectStage(Stage.Queued))
+        it('should return Queued when not expired', () => expectStage(Stage.Queued, proposalId))
 
         it('should return Expiration when expired', async () => {
           await timeTravel(queueExpiry, web3)
-          await expectStage(Stage.Expiration)
+          await expectStage(Stage.Expiration, proposalId)
         })
       })
 
@@ -2534,11 +2534,12 @@ contract('Governance', (accounts: string[]) => {
         })
 
         describe('when in approval stage', () => {
-          it('should return Approval when not expired', () => expectStage(Stage.Approval))
+          it('should return Approval when not expired', () =>
+            expectStage(Stage.Approval, proposalId))
 
           it('should return Expiration when expired', async () => {
             await timeTravel(approvalStageDuration, web3)
-            await expectStage(Stage.Expiration)
+            await expectStage(Stage.Expiration, proposalId)
           })
         })
 
@@ -2548,11 +2549,12 @@ contract('Governance', (accounts: string[]) => {
             await timeTravel(approvalStageDuration, web3)
           })
 
-          it('should return Referendum when not expired', () => expectStage(Stage.Referendum))
+          it('should return Referendum when not expired', () =>
+            expectStage(Stage.Referendum, proposalId))
 
           it('should return Expiration when expired', async () => {
             await timeTravel(referendumStageDuration, web3)
-            await expectStage(Stage.Expiration)
+            await expectStage(Stage.Expiration, proposalId)
           })
         })
 
@@ -2566,11 +2568,12 @@ contract('Governance', (accounts: string[]) => {
             await timeTravel(referendumStageDuration, web3)
           })
 
-          it('should return Execution when not expired', () => expectStage(Stage.Execution))
+          it('should return Execution when not expired', () =>
+            expectStage(Stage.Execution, proposalId))
 
           it('should return Expiration when expired', async () => {
             await timeTravel(executionStageDuration, web3)
-            await expectStage(Stage.Expiration)
+            await expectStage(Stage.Expiration, proposalId)
           })
         })
       })

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -2490,8 +2490,8 @@ contract('Governance', (accounts: string[]) => {
     }
 
     it('should return None stage when proposal doesnt exist', async () => {
-      expectStage(Stage.None, 0)
-      expectStage(Stage.None)
+      await expectStage(Stage.None, 0)
+      await expectStage(Stage.None)
     })
 
     describe('when proposal exists', () => {
@@ -2520,7 +2520,7 @@ contract('Governance', (accounts: string[]) => {
 
         it('should return Expiration when expired', async () => {
           await timeTravel(queueExpiry, web3)
-          expectStage(Stage.Expiration)
+          await expectStage(Stage.Expiration)
         })
       })
 
@@ -2538,7 +2538,7 @@ contract('Governance', (accounts: string[]) => {
 
           it('should return Expiration when expired', async () => {
             await timeTravel(approvalStageDuration, web3)
-            expectStage(Stage.Expiration)
+            await expectStage(Stage.Expiration)
           })
         })
 
@@ -2552,7 +2552,7 @@ contract('Governance', (accounts: string[]) => {
 
           it('should return Expiration when expired', async () => {
             await timeTravel(referendumStageDuration, web3)
-            expectStage(Stage.Expiration)
+            await expectStage(Stage.Expiration)
           })
         })
 
@@ -2570,7 +2570,7 @@ contract('Governance', (accounts: string[]) => {
 
           it('should return Expiration when expired', async () => {
             await timeTravel(executionStageDuration, web3)
-            expectStage(Stage.Expiration)
+            await expectStage(Stage.Expiration)
           })
         })
       })


### PR DESCRIPTION
### Description

- Adjust `Governance.getProposalStage` behavior to handle expiration in `queue` and `dequeue` correctly
- Add unit tests for `#getProposalStage`

### Other changes

- `getVersionNumber` updated accordingly

### Tested

- Unit tests

### Related issues

- Fixes #7111

### Backwards compatibility

- Governance patch bump