### PR TITLE
Add instructions for consuming contracts and ABIs via npm

### DIFF
--- a/packages/protocol/contracts/README.md
+++ b/packages/protocol/contracts/README.md
@@ -2,6 +2,8 @@
 
 Smart contracts for the Celo protocols, including identity and stability.
 
+The built contract artifacts can be browsed via [unpkg.com](https://unpkg.com/browse/@celo/contracts@latest/build/).
+
 ## Usage
 
 ### Installation

--- a/packages/protocol/contracts/README.md
+++ b/packages/protocol/contracts/README.md
@@ -4,22 +4,15 @@ Smart contracts for the Celo protocols, including identity and stability.
 
 ## Usage
 
-1. Target Release
+### Installation
 
-```
-RELEASE="celo-core-contracts-v2.mainnet"
-URL="https://gitpkg.now.sh/celo-org/celo-monorepo/packages/protocol/contracts?$RELEASE"
-```
-
-2. Installation
-
-`npm install $URL`
+`npm install @celo/contracts`
 
 or
 
-`yarn add $URL`
+`yarn add @celo/contracts`
 
-3. Development
+### Development
 
 Solidity
 
@@ -34,6 +27,20 @@ contract Example is UsingRegistry {
   }
 }
 ```
+
+Web3
+
+```javascript
+var Contract = require('web3-eth-contract');
+var jsonInterface = require('@celo/contracts/build/AddressSortedLinkedList.json');
+var contract = new Contract(jsonInterface, address);
+```
+
+For more advanced interaction with the celo core contracts, we recommend using [ContractKit](https://github.com/celo-org/celo-monorepo/tree/master/packages/sdk/contractkit).
+
+## Development
+
+Use `yarn publish --access public` to publish to the NPM registry.
 
 ## License
 

--- a/packages/protocol/contracts/README.md
+++ b/packages/protocol/contracts/README.md
@@ -4,11 +4,37 @@ Smart contracts for the Celo protocols, including identity and stability.
 
 ## Usage
 
+1. Target Release
+
 ```
 RELEASE="celo-core-contracts-v2.mainnet"
 URL="https://gitpkg.now.sh/celo-org/celo-monorepo/packages/protocol/contracts?$RELEASE"
-npm install $URL
-yarn add $URL
+```
+
+2. Installation
+
+npm
+
+`npm install $URL`
+
+Yarn
+
+`yarn add $URL`
+
+3. Development
+
+Solidity
+
+```solidity
+pragma solidity ^0.5.13;
+
+import 'celo/contracts/common/UsingRegistry.sol';
+
+contract Example is UsingRegistry {
+  constructor() {
+    require(getAccounts().createAccount());
+  }
+}
 ```
 
 ## License

--- a/packages/protocol/contracts/README.md
+++ b/packages/protocol/contracts/README.md
@@ -29,7 +29,7 @@ pragma solidity ^0.5.13;
 import '@celo/contracts/common/UsingRegistry.sol';
 
 contract Example is UsingRegistry {
-  constructor() {
+  constructor() public {
     require(getAccounts().createAccount());
   }
 }

--- a/packages/protocol/contracts/README.md
+++ b/packages/protocol/contracts/README.md
@@ -13,11 +13,9 @@ URL="https://gitpkg.now.sh/celo-org/celo-monorepo/packages/protocol/contracts?$R
 
 2. Installation
 
-npm
-
 `npm install $URL`
 
-Yarn
+or
 
 `yarn add $URL`
 
@@ -28,7 +26,7 @@ Solidity
 ```solidity
 pragma solidity ^0.5.13;
 
-import 'celo/contracts/common/UsingRegistry.sol';
+import '@celo/contracts/common/UsingRegistry.sol';
 
 contract Example is UsingRegistry {
   constructor() {

--- a/packages/protocol/contracts/README.md
+++ b/packages/protocol/contracts/README.md
@@ -1,0 +1,16 @@
+# Protocols
+
+Smart contracts for the Celo protocols, including identity and stability.
+
+## Usage
+
+```
+RELEASE="celo-core-contracts-v2.mainnet"
+URL="https://gitpkg.now.sh/celo-org/celo-monorepo/packages/protocol/contracts?$RELEASE"
+npm install $URL
+yarn add $URL
+```
+
+## License
+
+The contents of this package are licensed under the terms of the GNU Lesser Public License V3

--- a/packages/protocol/contracts/package.json
+++ b/packages/protocol/contracts/package.json
@@ -3,6 +3,14 @@
     "version": "1.0.0",
     "author": "cLabs",
     "license": "LGPL-3.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/celo-org/celo-monorepo/tree/master/packages/protocol/contracts"
+    },
+    "files": [
+        "../build/contracts",
+        "."
+    ],
     "dependencies": {
         "openzeppelin-solidity": "2.5.0",
         "solidity-bytes-utils": "0.0.7"

--- a/packages/protocol/contracts/package.json
+++ b/packages/protocol/contracts/package.json
@@ -4,7 +4,7 @@
     "author": "cLabs",
     "license": "LGPL-3.0",
     "dependencies": {
-        "openzeppelin-solidity": "^2.5.0",
+        "openzeppelin-solidity": "2.5.0",
         "solidity-bytes-utils": "0.0.7"
     }
 }

--- a/packages/protocol/contracts/package.json
+++ b/packages/protocol/contracts/package.json
@@ -1,16 +1,16 @@
 {
     "name": "@celo/contracts",
-    "version": "1.0.0",
+    "version": "0.0.8",
     "author": "cLabs",
     "license": "LGPL-3.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/celo-org/celo-monorepo/tree/master/packages/protocol/contracts"
     },
-    "files": [
-        "../build/contracts",
-        "."
-    ],
+    "scripts": {
+        "build": "yarn --cwd .. build:sol",
+        "prepublish": "rm -r ../build && yarn build && rm -r ./build && cp -r ../build/contracts ./build"
+    },
     "dependencies": {
         "openzeppelin-solidity": "2.5.0",
         "solidity-bytes-utils": "0.0.7"

--- a/packages/protocol/contracts/package.json
+++ b/packages/protocol/contracts/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@celo/contracts",
+    "version": "1.0.0",
+    "author": "cLabs",
+    "license": "LGPL-3.0",
+    "dependencies": {
+        "openzeppelin-solidity": "^2.5.0",
+        "solidity-bytes-utils": "0.0.7"
+    }
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -72,7 +72,7 @@
     "lodash": "^4.17.14",
     "mathjs": "^5.0.4",
     "node-fetch": "^2.6.1",
-    "openzeppelin-solidity": "^2.5.0",
+    "openzeppelin-solidity": "2.5.0",
     "prompts": "^2.0.1",
     "solhint": "^2.3.1",
     "solidity-bytes-utils": "0.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19867,7 +19867,7 @@ opener@~1.4.3:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
   integrity sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=
 
-openzeppelin-solidity@^2.5.0:
+openzeppelin-solidity@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-2.5.0.tgz#829a9bcfc928619dd96c44bd893b180044ff51aa"
   integrity sha512-I0yRC3nff9Kn2LDWuz02fuw0EuomVQ9Z8lHzdqh8P9BiOUzIk8frQRxn/a1Kva3StF6hwPP+Dh3/SQ2ily1Pow==


### PR DESCRIPTION
### Description

Adds instructions for consuming `@celo/contracts` via npm

### Other changes

Makes `protocol/contracts` a separate NPM package for simplicity

### Related issues

- Fixes #7554
- Fixes #6702

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._