### PR TITLE
Simplify contracts release tooling git gymnastics

### DIFF
--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -38,9 +38,9 @@ git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*
 
 source scripts/bash/release-lib.sh
 
-build_tag $OLD_BRANCH
+build_tag $OLD_BRANCH $LOG_FILE
 BUILD_DIR_1=$BUILD_DIR
-build_tag $NEW_BRANCH
+build_tag $NEW_BRANCH $LOG_FILE
 BUILD_DIR_2=$BUILD_DIR
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -33,22 +33,10 @@ if [ ! -z "$REPORT" ]; then
   REPORT_FLAG="--output_file "$REPORT
 fi
 
-function build_tag() {
-  BRANCH="$1"
-
-  echo " - Checkout contracts source code at $BRANCH"
-  BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
-  git checkout --no-overlay $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
-
-  echo " - Build contract artifacts at $BUILD_DIR"
-  rm -rf build/contracts
-  yarn build:sol >> $LOG_FILE
-  rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-  mv build/contracts $BUILD_DIR
-}
-
 # fetch tags
 git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' >> $LOG_FILE
+
+source scripts/bash/release-lib.sh
 
 build_tag $OLD_BRANCH
 BUILD_DIR_1=$BUILD_DIR

--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -28,37 +28,32 @@ done
 [ -z "$OLD_BRANCH" ] && echo "Need to set the old branch via the -a flag" && exit 1;
 [ -z "$NEW_BRANCH" ] && echo "Need to set the new branch via the -b flag" && exit 1;
 
-ORIGINAL_GIT_REF=$(git symbolic-ref --short HEAD)
-echo " - Checkout source code of old branch at $OLD_BRANCH"
-BUILD_DIR_1=$(echo build/$(echo $OLD_BRANCH | sed -e 's/\//_/g'))
-git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' >> $LOG_FILE
-git checkout $OLD_BRANCH 2>>$LOG_FILE >> $LOG_FILE
-rm -rf build/contracts
-yarn install
-
-echo " - Build contract artifacts ..."
-# TODO: Move to yarn build:sol after the next contract release.
-yarn build >> $LOG_FILE
-rm -rf $BUILD_DIR_1 && mkdir -p $BUILD_DIR_1
-mv build/contracts $BUILD_DIR_1
-
-echo " - Checkout source code of new branch at $NEW_BRANCH"
-BUILD_DIR_2=$(echo build/$(echo $NEW_BRANCH | sed -e 's/\//_/g'))
-git checkout $NEW_BRANCH 2>>$LOG_FILE >> $LOG_FILE
-rm -rf build/contracts
-yarn install
-echo " - Build contract artifacts ..."
-yarn build:sol >> $LOG_FILE
-rm -rf $BUILD_DIR_2 && mkdir -p $BUILD_DIR_2
-mv build/contracts $BUILD_DIR_2
-
 REPORT_FLAG=""
 if [ ! -z "$REPORT" ]; then
   REPORT_FLAG="--output_file "$REPORT
 fi
 
-echo " - Return to original git ref"
-git checkout $ORIGINAL_GIT_REF >> $LOG_FILE
+function build_tag() {
+  BRANCH="$1"
+
+  echo " - Checkout contracts source code at $BRANCH"
+  BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
+  git checkout --no-overlay $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
+
+  echo " - Build contract artifacts at $BUILD_DIR"
+  rm -rf build/contracts
+  yarn build:sol >> $LOG_FILE
+  rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+  mv build/contracts $BUILD_DIR
+}
+
+# fetch tags
+git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' >> $LOG_FILE
+
+build_tag $OLD_BRANCH
+BUILD_DIR_1=$BUILD_DIR
+build_tag $NEW_BRANCH
+BUILD_DIR_2=$BUILD_DIR
 
 # Exclude test contracts, mock contracts, contract interfaces, Proxy contracts, inlined libraries,
 # MultiSig contracts, and the ReleaseGold contract.

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -28,7 +28,7 @@ done
 [ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'));
 
 source scripts/bash/release-lib.sh
-build_tag $BRANCH
+build_tag $BRANCH $LOG_FILE
 
 # TODO: Move to yarn build:sol after the next contract release.
 echo "- Create local network"

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -27,14 +27,8 @@ done
 [ -z "$BRANCH" ] && echo "Need to set the branch via the -b flag" && exit 1;
 [ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'));
 
-echo "- Checkout source code at $BRANCH"
-git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' 2>>$LOG_FILE >> $LOG_FILE
-git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
-
-echo "- Build contract artifacts"
-rm -rf build/contracts
-yarn install >> $LOG_FILE
-yarn build >> $LOG_FILE
+source scripts/bash/release-lib.sh
+build_tag $BRANCH
 
 # TODO: Move to yarn build:sol after the next contract release.
 echo "- Create local network"

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -27,8 +27,14 @@ done
 [ -z "$BRANCH" ] && echo "Need to set the branch via the -b flag" && exit 1;
 [ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'));
 
-source scripts/bash/release-lib.sh
-build_tag $BRANCH $LOG_FILE
+echo "- Checkout source code at $BRANCH"
+git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' 2>>$LOG_FILE >> $LOG_FILE
+git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
+
+echo "- Build contract artifacts"
+rm -rf build/contracts
+yarn install >> $LOG_FILE
+yarn build >> $LOG_FILE
 
 # TODO: Move to yarn build:sol after the next contract release.
 echo "- Create local network"

--- a/packages/protocol/scripts/bash/make-release.sh
+++ b/packages/protocol/scripts/bash/make-release.sh
@@ -41,7 +41,7 @@ done
 [ -z "$REPORT" ] && echo "Need to set the compatibility report input via the -r flag" && exit 1;
 
 source scripts/bash/release-lib.sh
-build_tag $BRANCH
+build_tag $BRANCH "/dev/null"
 
 yarn run truffle exec ./scripts/truffle/make-release.js \
   --network $NETWORK \

--- a/packages/protocol/scripts/bash/make-release.sh
+++ b/packages/protocol/scripts/bash/make-release.sh
@@ -40,17 +40,8 @@ done
 [ -z "$INITIALIZE_DATA" ] && echo "Need to set the initialization data via the -i flag" && exit 1;
 [ -z "$REPORT" ] && echo "Need to set the compatibility report input via the -r flag" && exit 1;
 
-BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
-git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*'
-git checkout $BRANCH
-rm -rf build/contracts
-yarn build
-rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-mv build/contracts $BUILD_DIR
-cp migrationsConfig.js $BUILD_DIR/
-git checkout -
-cp $BUILD_DIR/migrationsConfig.js ./
-yarn build
+source scripts/bash/release-lib.sh
+build_tag $BRANCH
 
 yarn run truffle exec ./scripts/truffle/make-release.js \
   --network $NETWORK \
@@ -59,5 +50,3 @@ yarn run truffle exec ./scripts/truffle/make-release.js \
   --proposal $PROPOSAL \
   --from $FROM \
   --initialize_data $INITIALIZE_DATA $DRYRUN
-
-git checkout migrationsConfig.js

--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function build_tag() {
+  BRANCH="$1"
+
+  echo " - Checkout contracts source code at $BRANCH"
+  BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
+  git checkout --no-overlay $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
+
+  echo " - Build contract artifacts at $BUILD_DIR"
+  mv build/contracts build/contracts_tmp
+  yarn build:sol >> $LOG_FILE
+  rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+  mv build/contracts $BUILD_DIR
+  mv build/contracts_tmp build/contracts
+
+  git checkout contracts 2>>$LOG_FILE >> $LOG_FILE
+}

--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -2,6 +2,7 @@
 
 function build_tag() {
   BRANCH="$1"
+  LOG_FILE="$2"
 
   echo " - Checkout contracts source code at $BRANCH"
   BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
@@ -14,5 +15,5 @@ function build_tag() {
   mv build/contracts $BUILD_DIR
   mv build/contracts_tmp build/contracts
 
-  git checkout contracts 2>>$LOG_FILE >> $LOG_FILE
+  git checkout - -- contracts 2>>$LOG_FILE >> $LOG_FILE
 }

--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -6,7 +6,7 @@ function build_tag() {
 
   echo " - Checkout contracts source code at $BRANCH"
   BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
-  git checkout --no-overlay $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
+  git checkout $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
 
   echo " - Build contract artifacts at $BUILD_DIR"
   mv build/contracts build/contracts_tmp

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -30,6 +30,6 @@ done
 [ -z "$NETWORK" ] && echo "Need to set the NETWORK via the -n flag" && exit 1;
 
 source scripts/bash/release-lib.sh
-build_tag $BRANCH
+build_tag $BRANCH $LOG_FILE
 
 yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts $FORNO

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -29,33 +29,7 @@ done
 [ -z "$BRANCH" ] && echo "Need to set the branch via the -b flag" && exit 1;
 [ -z "$NETWORK" ] && echo "Need to set the NETWORK via the -n flag" && exit 1;
 
-echo "- Checkout source code at $BRANCH"
-BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
-git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' 2>>$LOG_FILE >> $LOG_FILE
-git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
-echo "- Build contract artifacts"
-rm -rf build/contracts
-yarn build:sol >> $LOG_FILE
-rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-mv build/contracts $BUILD_DIR
-cp lib/registry-utils.ts $BUILD_DIR/
+source scripts/bash/release-lib.sh
+build_tag $BRANCH
 
-
-# Move back to branch from which we started
-echo "- Return to original git commit"
-git checkout - >> $LOG_FILE
-
-cp $BUILD_DIR/registry-utils.ts lib/
-
-# Hack since v1 did not yet expose celoRegistryAddress
-if ! cat lib/registry-utils.ts | grep -q "celoRegistryAddress"; then
-  echo "export const celoRegistryAddress = '0x000000000000000000000000000000000000ce10'" >> lib/registry-utils.ts
-fi
-
-echo "- Build verification script"
-yarn build >> $LOG_FILE
-
-echo "- Run verification script"
 yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts $FORNO
-
-git checkout lib/registry-utils.ts

--- a/packages/protocol/scripts/bash/verify-release.sh
+++ b/packages/protocol/scripts/bash/verify-release.sh
@@ -40,6 +40,6 @@ done
 git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' >> $LOG_FILE
 
 source scripts/bash/release-lib.sh
-build_tag $BRANCH
+build_tag $BRANCH $LOG_FILE
 
 yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts --proposal $PROPOSAL $FORNO $INITIALIZE_DATA

--- a/packages/protocol/scripts/bash/verify-release.sh
+++ b/packages/protocol/scripts/bash/verify-release.sh
@@ -37,32 +37,9 @@ done
 [ -z "$NETWORK" ] && echo "Need to set the network via the -n flag" && exit 1;
 [ -z "$PROPOSAL" ] && echo "Need to set the proposal via the -p flag" && exit 1;
 
-BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
 git fetch origin +'refs/tags/celo-core-contracts*:refs/tags/celo-core-contracts*' >> $LOG_FILE
-echo " - Checkout source code at $BRANCH"
-git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
-rm -rf build/contracts
-# TODO: Move to yarn build:sol after the next contract release.
-echo " - Build contract artifacts ..."
-yarn build >> $LOG_FILE
-rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-mv build/contracts $BUILD_DIR
-cp lib/registry-utils.ts $BUILD_DIR/
 
-echo " - Return to original git ref"
-# Move back to branch from which we started
-git checkout - >> $LOG_FILE
+source scripts/bash/release-lib.sh
+build_tag $BRANCH
 
-cp $BUILD_DIR/registry-utils.ts lib/
-
-# Hack since v1 did not yet expose celoRegistryAddress
-if ! cat lib/registry-utils.ts | grep -q "celoRegistryAddress"; then
-  echo "export const celoRegistryAddress = '0x000000000000000000000000000000000000ce10'" >> lib/registry-utils.ts
-fi
-
-echo " - Build verification script ..."
-yarn build >> $LOG_FILE
-echo " - Run verification script ..."
 yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts --proposal $PROPOSAL $FORNO $INITIALIZE_DATA
-
-git checkout lib/registry-utils.ts

--- a/packages/protocol/scripts/build.ts
+++ b/packages/protocol/scripts/build.ts
@@ -102,12 +102,18 @@ function compile() {
   exec(`yarn run --silent truffle compile --build_directory=${BUILD_DIR}`)
 
   for (const contractName of ImplContracts) {
-    const fileStr = getArtifact(contractName)
-    if (hasEmptyBytecode(fileStr)) {
+    try {
+      const fileStr = getArtifact(contractName)
+      if (hasEmptyBytecode(fileStr)) {
+        console.error(
+          `${contractName} has empty bytecode. Maybe you forgot to fully implement an interface?`
+        )
+        process.exit(1)
+      }
+    } catch (e) {
       console.error(
-        `${contractName} has empty bytecode. Maybe you forgot to fully implement an interface?`
+        `WARNING: ${contractName} artifact could not be fetched. Maybe it doesn't exist?`
       )
-      process.exit(1)
     }
   }
 }


### PR DESCRIPTION
### Description

`git checkout -- contracts` to avoid headaches with other monorepo files/build systems/tools

### Other changes

Define `build_tag` bash function to be used across bash scripts

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #7310

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._