### PR TITLE
Add support for genesis generation using mycelo in e2e tests

### DIFF
--- a/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
+++ b/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
@@ -79,14 +79,16 @@ describe('Blockchain parameters tests', function(this: any) {
     it('changing the block gas limit', async () => {
       this.timeout(0)
       await parameters.setBlockGasLimit(23000000).send({ from: validatorAddress })
-      await sleep(5)
+      await sleep(2)
       const res = await parameters.getBlockGasLimit()
       assert.equal(0, res.comparedTo(23000000))
     })
     it('should exit when minimum version is updated', async () => {
       this.timeout(0)
       await setMinimumClientVersion(1, 9, 99)
-      await sleep(120, true)
+      // The client checks every 60 seconds and then waits 10 seconds before quitting, so we
+      // may have to wait a little over 70 seconds
+      await sleep(75, true)
       try {
         // It should have exited by now, call RPC to trigger error
         await kit.connection.getBlockNumber()

--- a/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
+++ b/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
@@ -16,7 +16,7 @@ describe('Blockchain parameters tests', function(this: any) {
   let parameters: BlockchainParametersWrapper
 
   const gethConfig: GethRunConfig = {
-    migrateTo: 20,
+    useMycelo: true,
     runPath: TMP_PATH,
     keepData: false,
     networkId: 1101,

--- a/packages/celotool/src/lib/generate_utils.ts
+++ b/packages/celotool/src/lib/generate_utils.ts
@@ -451,7 +451,15 @@ export const generateGenesisWithMigrations = async ({
   const myceloBinaryPath = path.join(gethRepoPath!, '/build/bin/mycelo')
   await spawnCmdWithExitOnFailure(
     myceloBinaryPath,
-    ['genesis-config', '--template', 'monorepo', '--mnemonic', mnemonic],
+    [
+      'genesis-config',
+      '--template',
+      'monorepo',
+      '--mnemonic',
+      mnemonic,
+      '--validators',
+      numValidators.toString(),
+    ],
     {
       silent: true,
       cwd: tmpDir,

--- a/packages/celotool/src/lib/generate_utils.ts
+++ b/packages/celotool/src/lib/generate_utils.ts
@@ -500,9 +500,15 @@ export const generateGenesisWithMigrations = async ({
   fs.writeFileSync(configFile, JSON.stringify(mcConfig, undefined, 2))
 
   // Generate the genesis file, and return its contents
-  await spawnCmdWithExitOnFailure(myceloBinaryPath, ['genesis-from-config', tmpDir], {
-    silent: true,
-  })
+  const contractsBuildPath = path.resolve(monorepoRoot, 'packages/protocol/build/contracts/')
+  await spawnCmdWithExitOnFailure(
+    myceloBinaryPath,
+    ['genesis-from-config', tmpDir, '--buildpath', contractsBuildPath],
+    {
+      silent: true,
+      cwd: tmpDir,
+    }
+  )
   const genesis = fs.readFileSync(path.join(tmpDir, 'genesis.json')).toString()
   // Clean up the tmp dir as it's no longer needed
   await spawnCmd('rm', ['-rf', tmpDir], { silent: true })

--- a/packages/celotool/src/lib/generate_utils.ts
+++ b/packages/celotool/src/lib/generate_utils.ts
@@ -13,7 +13,7 @@ import * as rlp from 'rlp'
 import { MyceloGenesisConfig } from 'src/lib/interfaces/mycelo-genesis-config'
 import { CurrencyPair } from 'src/lib/k8s-oracle/base'
 import Web3 from 'web3'
-import { spawnCmdWithExitOnFailure } from './cmd-utils'
+import { spawnCmd, spawnCmdWithExitOnFailure } from './cmd-utils'
 import { envVar, fetchEnv, fetchEnvOrFallback, monorepoRoot } from './env-utils'
 import {
   CONTRACT_OWNER_STORAGE_LOCATION,
@@ -499,8 +499,12 @@ export const generateGenesisWithMigrations = async ({
 
   fs.writeFileSync(configFile, JSON.stringify(mcConfig, undefined, 2))
 
+  // Generate the genesis file, and return its contents
   await spawnCmdWithExitOnFailure(myceloBinaryPath, ['genesis-from-config', tmpDir], {
     silent: true,
   })
-  return fs.readFileSync(path.join(tmpDir, 'genesis.json')).toString()
+  const genesis = fs.readFileSync(path.join(tmpDir, 'genesis.json')).toString()
+  // Clean up the tmp dir as it's no longer needed
+  await spawnCmd('rm', ['-rf', tmpDir], { silent: true })
+  return genesis
 }

--- a/packages/celotool/src/lib/interfaces/geth-run-config.ts
+++ b/packages/celotool/src/lib/interfaces/geth-run-config.ts
@@ -8,6 +8,10 @@ export interface GethRunConfig {
   migrateTo?: number
   migrationOverrides?: any
   keepData?: boolean
+  // Whether to use the mycelo tool to generate the genesis.json
+  useMycelo?: boolean
+  // Skip compiling the smart contracts (e.g. during dev if they're already compiled and you want to save 10 seconds)
+  myceloSkipCompilingContracts?: boolean
   // genesis config
   genesisConfig?: GenesisConfig
   // network

--- a/packages/celotool/src/lib/interfaces/mycelo-genesis-config.ts
+++ b/packages/celotool/src/lib/interfaces/mycelo-genesis-config.ts
@@ -1,0 +1,9 @@
+import { GenesisConfig } from 'src/lib/interfaces/genesis-config'
+
+export interface MyceloGenesisConfig {
+  genesisConfig: GenesisConfig
+  numValidators: number // used in place of genesisConfig.validators
+  mnemonic: string
+  gethRepoPath: string
+  migrationOverrides?: any
+}


### PR DESCRIPTION
### Description

This PR adds support in the e2e tests for using mycelo to generate a genesis file with the core contracts already deployed and migrated.  It switched the blockchain parameters test to use mycelo.  Work that's left for the future:

1. Make the other e2e tests use mycelo.  Some of them fail if you do, need to figure out why.  The transfer test failing is because of https://github.com/celo-org/celo-blockchain/issues/1419, but it's unclear why using mycelo exposes that while it doesn't happen as is
2. Add support for using the typescript migrations config object (with any overrides).  This may be necessary for some of the tests
3. (Not specific to e2e tests) Make celotool's testnet commands also support using mycelo for genesis generation.

### Other changes

Tweaked the sleep values in the blockchain parameters test to bring them lower while still being above what they need to do.

### Tested

Blockchain parameters e2e test uses mycelo by default and passes consistently.

### Backwards compatibility

Doesn't affect e2e tests unless the `GethRunConfig` specifies `useMycelo: true` (except for the sleep changes mentioned above).