### PR TITLE
Remove cEUR from contractkit

### DIFF
--- a/packages/protocol/scripts/build.ts
+++ b/packages/protocol/scripts/build.ts
@@ -18,7 +18,6 @@ export const ProxyContracts = [
   'ElectionProxy',
   'EpochRewardsProxy',
   'EscrowProxy',
-  'ExchangeEURProxy',
   'ExchangeProxy',
   'FeeCurrencyWhitelistProxy',
   'GasPriceMinimumProxy',
@@ -31,7 +30,6 @@ export const ProxyContracts = [
   'RegistryProxy',
   'ReserveProxy',
   'ReserveSpenderMultiSigProxy',
-  'StableTokenEURProxy',
   'StableTokenProxy',
   'SortedOraclesProxy',
 ]
@@ -68,11 +66,9 @@ export const CoreContracts = [
 
   // stability
   'Exchange',
-  'ExchangeEUR',
   'Reserve',
   'ReserveSpenderMultiSig',
   'StableToken',
-  'StableTokenEUR',
   'SortedOracles',
 ]
 

--- a/packages/sdk/contractkit/src/base.ts
+++ b/packages/sdk/contractkit/src/base.ts
@@ -8,7 +8,6 @@ export enum CeloContract {
   EpochRewards = 'EpochRewards',
   Escrow = 'Escrow',
   Exchange = 'Exchange',
-  ExchangeEUR = 'ExchangeEUR',
   FeeCurrencyWhitelist = 'FeeCurrencyWhitelist',
   Freezer = 'Freezer',
   GasPriceMinimum = 'GasPriceMinimum',
@@ -23,16 +22,15 @@ export enum CeloContract {
   Reserve = 'Reserve',
   SortedOracles = 'SortedOracles',
   StableToken = 'StableToken',
-  StableTokenEUR = 'StableTokenEUR',
   TransferWhitelist = 'TransferWhitelist',
   Validators = 'Validators',
 }
 
 export const ProxyContracts = Object.keys(CeloContract).map((c) => `${c}Proxy`)
 
-export type StableTokenContract = CeloContract.StableToken | CeloContract.StableTokenEUR
+export type StableTokenContract = CeloContract.StableToken
 
-export type ExchangeContract = CeloContract.Exchange | CeloContract.ExchangeEUR
+export type ExchangeContract = CeloContract.Exchange
 
 export type CeloTokenContract = StableTokenContract | CeloContract.GoldToken
 /**

--- a/packages/sdk/contractkit/src/celo-tokens.ts
+++ b/packages/sdk/contractkit/src/celo-tokens.ts
@@ -6,7 +6,6 @@ import { StableTokenWrapper } from './wrappers/StableTokenWrapper'
 
 export enum StableToken {
   cUSD = 'cUSD',
-  cEUR = 'cEUR',
 }
 
 export enum Token {
@@ -39,11 +38,6 @@ const stableTokenInfos: {
     contract: CeloContract.StableToken,
     exchangeContract: CeloContract.Exchange,
     symbol: StableToken.cUSD,
-  },
-  [StableToken.cEUR]: {
-    contract: CeloContract.StableTokenEUR,
-    exchangeContract: CeloContract.ExchangeEUR,
-    symbol: StableToken.cEUR,
   },
 }
 

--- a/packages/sdk/contractkit/src/contract-cache.test.ts
+++ b/packages/sdk/contractkit/src/contract-cache.test.ts
@@ -6,9 +6,7 @@ import { newKitFromWeb3 } from './kit'
 const TestedWrappers: ValidWrappers[] = [
   CeloContract.GoldToken,
   CeloContract.StableToken,
-  CeloContract.StableTokenEUR,
   CeloContract.Exchange,
-  CeloContract.ExchangeEUR,
   CeloContract.Validators,
   CeloContract.LockedGold,
 ]

--- a/packages/sdk/contractkit/src/contract-cache.ts
+++ b/packages/sdk/contractkit/src/contract-cache.ts
@@ -33,7 +33,6 @@ const WrapperFactories = {
   // [CeloContract.EpochRewards]?: EpochRewardsWrapper,
   [CeloContract.Escrow]: EscrowWrapper,
   [CeloContract.Exchange]: ExchangeWrapper,
-  [CeloContract.ExchangeEUR]: ExchangeWrapper,
   // [CeloContract.FeeCurrencyWhitelist]: FeeCurrencyWhitelistWrapper,
   [CeloContract.Freezer]: FreezerWrapper,
   [CeloContract.GasPriceMinimum]: GasPriceMinimumWrapper,
@@ -48,7 +47,6 @@ const WrapperFactories = {
   [CeloContract.Reserve]: ReserveWrapper,
   [CeloContract.SortedOracles]: SortedOraclesWrapper,
   [CeloContract.StableToken]: StableTokenWrapper,
-  [CeloContract.StableTokenEUR]: StableTokenWrapper,
   [CeloContract.Validators]: ValidatorsWrapper,
 }
 
@@ -65,7 +63,6 @@ interface WrapperCacheMap {
   // [CeloContract.EpochRewards]?: EpochRewardsWrapper
   [CeloContract.Escrow]?: EscrowWrapper
   [CeloContract.Exchange]?: ExchangeWrapper
-  [CeloContract.ExchangeEUR]?: ExchangeWrapper
   // [CeloContract.FeeCurrencyWhitelist]?: FeeCurrencyWhitelistWrapper,
   [CeloContract.Freezer]?: FreezerWrapper
   [CeloContract.GasPriceMinimum]?: GasPriceMinimumWrapper
@@ -80,7 +77,6 @@ interface WrapperCacheMap {
   [CeloContract.Reserve]?: ReserveWrapper
   [CeloContract.SortedOracles]?: SortedOraclesWrapper
   [CeloContract.StableToken]?: StableTokenWrapper
-  [CeloContract.StableTokenEUR]?: StableTokenWrapper
   [CeloContract.Validators]?: ValidatorsWrapper
 }
 

--- a/packages/sdk/contractkit/src/kit.ts
+++ b/packages/sdk/contractkit/src/kit.ts
@@ -56,7 +56,6 @@ export function newKitFromWeb3(web3: Web3, wallet: ReadOnlyWallet = new LocalWal
 export interface NetworkConfig {
   election: ElectionConfig
   exchange: ExchangeConfig
-  exchangeEUR: ExchangeConfig
   attestations: AttestationsConfig
   governance: GovernanceConfig
   lockedGold: LockedGoldConfig
@@ -64,7 +63,6 @@ export interface NetworkConfig {
   gasPriceMinimum: GasPriceMinimumConfig
   reserve: ReserveConfig
   stableToken: StableTokenConfig
-  stableTokenEUR: StableTokenConfig
   validators: ValidatorsConfig
   downtimeSlasher: DowntimeSlasherConfig
   blockchainParameters: BlockchainParametersConfig
@@ -125,7 +123,6 @@ export class ContractKit {
     // have to explicitly cast it to just any type and discard type information.
     const promises: Array<Promise<any>> = [
       this.contracts.getExchange(StableToken.cUSD),
-      this.contracts.getExchange(StableToken.cEUR),
       this.contracts.getElection(),
       this.contracts.getAttestations(),
       this.contracts.getGovernance(),
@@ -134,7 +131,6 @@ export class ContractKit {
       this.contracts.getGasPriceMinimum(),
       this.contracts.getReserve(),
       this.contracts.getStableToken(StableToken.cUSD),
-      this.contracts.getStableToken(StableToken.cEUR),
       this.contracts.getValidators(),
       this.contracts.getDowntimeSlasher(),
       this.contracts.getBlockchainParameters(),
@@ -143,8 +139,8 @@ export class ContractKit {
     const res = await Promise.all([
       contracts[0].getConfig(),
       contracts[1].getConfig(),
-      contracts[2].getConfig(),
-      contracts[3].getConfig(Object.values(celoTokenAddresses)),
+      contracts[2].getConfig(Object.values(celoTokenAddresses)),
+      contracts[3].getConfig(),
       contracts[4].getConfig(),
       contracts[5].getConfig(),
       contracts[6].getConfig(),
@@ -153,24 +149,20 @@ export class ContractKit {
       contracts[9].getConfig(),
       contracts[10].getConfig(),
       contracts[11].getConfig(),
-      contracts[12].getConfig(),
-      contracts[13].getConfig(),
     ])
     return {
       exchange: res[0],
-      exchangeEUR: res[1],
-      election: res[2],
-      attestations: res[3],
-      governance: res[4],
-      lockedGold: res[5],
-      sortedOracles: res[6],
-      gasPriceMinimum: res[7],
-      reserve: res[8],
-      stableToken: res[9],
-      stableTokenEUR: res[10],
-      validators: res[11],
-      downtimeSlasher: res[12],
-      blockchainParameters: res[13],
+      election: res[1],
+      attestations: res[2],
+      governance: res[3],
+      lockedGold: res[4],
+      sortedOracles: res[5],
+      gasPriceMinimum: res[6],
+      reserve: res[7],
+      stableToken: res[8],
+      validators: res[9],
+      downtimeSlasher: res[10],
+      blockchainParameters: res[11],
     }
   }
 
@@ -180,7 +172,6 @@ export class ContractKit {
     )
     const promises: Array<Promise<any>> = [
       this.contracts.getExchange(StableToken.cUSD),
-      this.contracts.getExchange(StableToken.cEUR),
       this.contracts.getElection(),
       this.contracts.getAttestations(),
       this.contracts.getGovernance(),
@@ -189,7 +180,6 @@ export class ContractKit {
       this.contracts.getGasPriceMinimum(),
       this.contracts.getReserve(),
       this.contracts.getStableToken(StableToken.cUSD),
-      this.contracts.getStableToken(StableToken.cEUR),
       this.contracts.getValidators(),
       this.contracts.getDowntimeSlasher(),
       this.contracts.getBlockchainParameters(),
@@ -197,35 +187,31 @@ export class ContractKit {
     const contracts = await Promise.all(promises)
     const res = await Promise.all([
       contracts[0].getHumanReadableConfig(),
-      contracts[1].getHumanReadableConfig(),
-      contracts[2].getConfig(),
-      contracts[3].getHumanReadableConfig(Object.values(celoTokenAddresses)),
+      contracts[1].getConfig(),
+      contracts[2].getHumanReadableConfig(Object.values(celoTokenAddresses)),
+      contracts[3].getHumanReadableConfig(),
       contracts[4].getHumanReadableConfig(),
       contracts[5].getHumanReadableConfig(),
-      contracts[6].getHumanReadableConfig(),
+      contracts[6].getConfig(),
       contracts[7].getConfig(),
-      contracts[8].getConfig(),
+      contracts[8].getHumanReadableConfig(),
       contracts[9].getHumanReadableConfig(),
       contracts[10].getHumanReadableConfig(),
-      contracts[11].getHumanReadableConfig(),
-      contracts[12].getHumanReadableConfig(),
-      contracts[13].getConfig(),
+      contracts[11].getConfig(),
     ])
     return {
       exchange: res[0],
-      exchangeEUR: res[1],
-      election: res[2],
-      attestations: res[3],
-      governance: res[4],
-      lockedGold: res[5],
-      sortedOracles: res[6],
-      gasPriceMinimum: res[7],
-      reserve: res[8],
-      stableToken: res[9],
-      stableTokenEUR: res[10],
-      validators: res[11],
-      downtimeSlasher: res[12],
-      blockchainParameters: res[13],
+      election: res[1],
+      attestations: res[2],
+      governance: res[3],
+      lockedGold: res[4],
+      sortedOracles: res[5],
+      gasPriceMinimum: res[6],
+      reserve: res[7],
+      stableToken: res[8],
+      validators: res[9],
+      downtimeSlasher: res[10],
+      blockchainParameters: res[11],
     }
   }
 

--- a/packages/sdk/contractkit/src/proxy.ts
+++ b/packages/sdk/contractkit/src/proxy.ts
@@ -101,7 +101,6 @@ const initializeAbiMap = {
   EpochRewardsProxy: findInitializeAbi(EpochRewardsABI),
   EscrowProxy: findInitializeAbi(EscrowABI),
   ExchangeProxy: findInitializeAbi(ExchangeABI),
-  ExchangeEURProxy: findInitializeAbi(ExchangeABI),
   FeeCurrencyWhitelistProxy: findInitializeAbi(FeeCurrencyWhitelistABI),
   FreezerProxy: findInitializeAbi(FreezerABI),
   GasPriceMinimumProxy: findInitializeAbi(GasPriceMinimumABI),
@@ -117,7 +116,6 @@ const initializeAbiMap = {
   ReserveProxy: findInitializeAbi(ReserveABI),
   SortedOraclesProxy: findInitializeAbi(SortedOraclesABI),
   StableTokenProxy: findInitializeAbi(StableTokenABI),
-  StableTokenEURProxy: findInitializeAbi(StableTokenABI),
   TransferWhitelistProxy: findInitializeAbi(TransferWhitelistABI),
   ValidatorsProxy: findInitializeAbi(ValidatorsABI),
 }

--- a/packages/sdk/contractkit/src/web3-contract-cache.ts
+++ b/packages/sdk/contractkit/src/web3-contract-cache.ts
@@ -10,7 +10,6 @@ import { newElection } from './generated/Election'
 import { newEpochRewards } from './generated/EpochRewards'
 import { newEscrow } from './generated/Escrow'
 import { newExchange } from './generated/Exchange'
-import { newExchangeEur } from './generated/ExchangeEUR'
 import { newFeeCurrencyWhitelist } from './generated/FeeCurrencyWhitelist'
 import { newFreezer } from './generated/Freezer'
 import { newGasPriceMinimum } from './generated/GasPriceMinimum'
@@ -42,7 +41,6 @@ export const ContractFactories = {
   [CeloContract.EpochRewards]: newEpochRewards,
   [CeloContract.Escrow]: newEscrow,
   [CeloContract.Exchange]: newExchange,
-  [CeloContract.ExchangeEUR]: newExchangeEur,
   [CeloContract.FeeCurrencyWhitelist]: newFeeCurrencyWhitelist,
   [CeloContract.Freezer]: newFreezer,
   [CeloContract.GasPriceMinimum]: newGasPriceMinimum,
@@ -57,7 +55,6 @@ export const ContractFactories = {
   [CeloContract.Reserve]: newReserve,
   [CeloContract.SortedOracles]: newSortedOracles,
   [CeloContract.StableToken]: newStableToken,
-  [CeloContract.StableTokenEUR]: newStableToken,
   [CeloContract.TransferWhitelist]: newTransferWhitelist,
   [CeloContract.Validators]: newValidators,
 }

--- a/packages/sdk/contractkit/src/wrappers/SortedOracles.ts
+++ b/packages/sdk/contractkit/src/wrappers/SortedOracles.ts
@@ -301,9 +301,7 @@ export class SortedOraclesWrapper extends BaseWrapper<SortedOracles> {
     } else if (isValidAddress(target)) {
       return target
     } else {
-      throw new Error(
-        `${target} is neither CeloContract.StableToken, CeloContract.StableTokenEUR or a valid Address`
-      )
+      throw new Error(`${target} is neither a StableToken or a valid Address`)
     }
   }
 }

--- a/packages/sdk/contractkit/src/wrappers/StableToken.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/StableToken.test.ts
@@ -20,11 +20,6 @@ testWithGanache('StableToken Wrapper', async (web3) => {
       name: 'Celo Dollar',
       symbol: 'cUSD',
     },
-    [StableToken.cEUR]: {
-      stableToken: StableToken.cEUR,
-      name: 'Celo Euro',
-      symbol: 'cEUR',
-    },
   }
 
   for (const stableTokenInfo of Object.values(stableTokenInfos)) {


### PR DESCRIPTION
### Description

Removes cEUR from contractkit to preserve backward compatibility with mainnet. We can undo this removal after cEUR goes live.

### Other changes

n/a

### Tested

Unit tests

### Related issues

n/a

### Backwards compatibility

Removes cEUR support, but preserves backward compatibility for mainnet