### PR TITLE
doc: Add Celo Signal page

### DIFF
--- a/packages/docs/SUMMARY.md
+++ b/packages/docs/SUMMARY.md
@@ -45,6 +45,7 @@
 - [Running Proxies](validator-guide/proxy.md)
 - [Validator Explorer](validator-guide/validator-explorer.md)
 - [Celo Foundation Voting Policy](validator-guide/celo-foundation-voting-policy.md)
+- [Celo Signal](validator-guide/celo-signal.md)
 
 ## Developer Guide
 

--- a/packages/docs/validator-guide/celo-signal.md
+++ b/packages/docs/validator-guide/celo-signal.md
@@ -1,0 +1,26 @@
+# Celo Signal
+
+Celo Signal is a mailing list for everything that involves the core community of Celo as well as Celo owners who participate in governance.
+
+If you are a:
+* Validator
+* Node Operator
+* Dapp Running Its Own Node 
+* Exchange or Custodian
+* Owner who is Staking + Participating in Governance
+* Core Developer or Contributor
+
+Then Celo Signal Mailing List is a great way to keep up with everything happening in Celo's core community.
+
+Updates include information on following events:
+* Celo All-Core Dev Call (where Celo Platform enhancements and proposals are discussed in the community)
+* Celo Governance Call (where governance proposals are discussed prior to submission on-chain)
+* Celo Foundation Voting Program updates
+* celo-blockchain node and attestation service release updates
+* Hardfork Updates
+* Celo Core Contract Release schedule
+* Core Community Happy Hour
+
+If you would like to keep up-to-date with all the news happening in the Celo community, including validation, node operation and governance, please sign up to our [Celo Signal mailing list here](https://celo.activehosted.com/f/15).
+
+You can add the [Celo Signal public calendar](https://calendar.google.com/calendar/u/0/embed?src=c_9su6ich1uhmetr4ob3sij6kaqs@group.calendar.google.com) as well which has relevant dates.


### PR DESCRIPTION
Adds a page for Celo Signal to have a 1-stop location to sign up for it.