### PR TITLE
Only verify deployed bytecode of contracts which have known compiled bytecode

### DIFF
--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -1,5 +1,5 @@
 // tslint:disable: no-console
-import { ensureLeading0x, NULL_ADDRESS } from '@celo/base/lib/address'
+import { ensureLeading0x } from '@celo/base/lib/address'
 import {
   LibraryAddresses,
   LibraryPositions,
@@ -114,7 +114,6 @@ const dfsStep = async (queue: string[], visited: Set<string>, context: Verificat
 
   // check implementation deployment
   const sourceBytecode = getSourceBytecode(contract, context)
-  console.log('sourceBytecode', sourceBytecode.slice(0, 50))
   const sourceLibraryPositions = new LibraryPositions(sourceBytecode)
 
   let implementationAddress: string
@@ -124,10 +123,6 @@ const dfsStep = async (queue: string[], visited: Set<string>, context: Verificat
     implementationAddress = ensureLeading0x(context.libraryAddresses.addresses[contract])
   } else {
     const proxyAddress = await context.registry.getAddressForString(contract)
-    if (proxyAddress === NULL_ADDRESS) {
-      console.error(`WARNING: ${contract} not found in registry, skipping verification`)
-      return
-    }
     const proxy = await context.Proxy.at(proxyAddress) // necessary await
     implementationAddress = await proxy._getImplementation()
   }
@@ -232,7 +227,11 @@ export const verifyBytecodes = async (
   assertValidProposalTransactions(proposal)
   assertValidInitializationData(artifacts, proposal, _web3, initializationData)
 
-  const queue = contracts.filter((contract) => !ignoredContracts.includes(contract))
+  const compiledContracts = artifacts.listArtifacts().map((a) => a.contractName)
+
+  const queue = contracts.filter(
+    (contract) => !ignoredContracts.includes(contract) && compiledContracts.includes(contract)
+  )
   const visited: Set<string> = new Set(queue)
 
   // truffle web3 version does not have getProof

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -1,5 +1,5 @@
 // tslint:disable: no-console
-import { ensureLeading0x } from '@celo/base/lib/address'
+import { ensureLeading0x, NULL_ADDRESS } from '@celo/base/lib/address'
 import {
   LibraryAddresses,
   LibraryPositions,
@@ -114,6 +114,7 @@ const dfsStep = async (queue: string[], visited: Set<string>, context: Verificat
 
   // check implementation deployment
   const sourceBytecode = getSourceBytecode(contract, context)
+  console.log('sourceBytecode', sourceBytecode.slice(0, 50))
   const sourceLibraryPositions = new LibraryPositions(sourceBytecode)
 
   let implementationAddress: string
@@ -123,6 +124,10 @@ const dfsStep = async (queue: string[], visited: Set<string>, context: Verificat
     implementationAddress = ensureLeading0x(context.libraryAddresses.addresses[contract])
   } else {
     const proxyAddress = await context.registry.getAddressForString(contract)
+    if (proxyAddress === NULL_ADDRESS) {
+      console.error(`WARNING: ${contract} not found in registry, skipping verification`)
+      return
+    }
     const proxy = await context.Proxy.at(proxyAddress) // necessary await
     implementationAddress = await proxy._getImplementation()
   }

--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -6,14 +6,18 @@ function build_tag() {
 
   echo " - Checkout contracts source code at $BRANCH"
   BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
-  git checkout $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
+  git checkout --no-overlay $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
 
-  echo " - Build contract artifacts at $BUILD_DIR"
-  mv build/contracts build/contracts_tmp
-  yarn build:sol >> $LOG_FILE
-  rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-  mv build/contracts $BUILD_DIR
-  mv build/contracts_tmp build/contracts
+  [ -d "build/contracts" ] && mv build/contracts build/contracts_tmp
+  if [ ! -d $BUILD_DIR ]; then
+    echo " - Build contract artifacts at $BUILD_DIR"
+    yarn build:sol >> $LOG_FILE
+    rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+    mv build/contracts $BUILD_DIR
+  else
+    echo " - Contract artifacts already built at $BUILD_DIR"
+  fi
+  [ -d "build/contracts_tmp" ] && mv build/contracts_tmp build/contracts
 
   git checkout - -- contracts 2>>$LOG_FILE >> $LOG_FILE
 }

--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -6,7 +6,8 @@ function build_tag() {
 
   echo " - Checkout contracts source code at $BRANCH"
   BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))
-  git checkout --no-overlay $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
+  rm -r contracts
+  git checkout $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
 
   [ -d "build/contracts" ] && mv build/contracts build/contracts_tmp
   if [ ! -d $BUILD_DIR ]; then
@@ -19,5 +20,6 @@ function build_tag() {
   fi
   [ -d "build/contracts_tmp" ] && mv build/contracts_tmp build/contracts
 
+  rm -r contracts
   git checkout - -- contracts 2>>$LOG_FILE >> $LOG_FILE
 }

--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -9,16 +9,12 @@ function build_tag() {
   rm -r contracts
   git checkout $BRANCH -- contracts 2>>$LOG_FILE >> $LOG_FILE
 
-  [ -d "build/contracts" ] && mv build/contracts build/contracts_tmp
-  if [ ! -d $BUILD_DIR ]; then
-    echo " - Build contract artifacts at $BUILD_DIR"
-    yarn build:sol >> $LOG_FILE
-    rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-    mv build/contracts $BUILD_DIR
-  else
-    echo " - Contract artifacts already built at $BUILD_DIR"
-  fi
-  [ -d "build/contracts_tmp" ] && mv build/contracts_tmp build/contracts
+  echo " - Build contract artifacts at $BUILD_DIR"
+  mv build/contracts build/contracts_tmp
+  yarn build:sol >> $LOG_FILE
+  rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+  mv build/contracts $BUILD_DIR
+  mv build/contracts_tmp build/contracts
 
   rm -r contracts
   git checkout - -- contracts 2>>$LOG_FILE >> $LOG_FILE


### PR DESCRIPTION
### Description

Use target build artifacts list of contract names to filter the DFS tree

### Tested

`yarn verify-deployed -n mainnet -b celo-core-contracts-v2.mainnet -f`

### Related issues

- Fixes #6615 

### Backwards compatibility

Yes