### PR TITLE
Fix bootnode flag geth argument in testnets

### DIFF
--- a/packages/helm-charts/common/templates/_helpers.tpl
+++ b/packages/helm-charts/common/templates/_helpers.tpl
@@ -183,7 +183,7 @@ fi
     exec geth \
       --port $PORT  \
 {{- if not (contains "rc1" .Release.Name) }}
-      "$BOOTNODE_FLAG" \
+      $BOOTNODE_FLAG \
 {{- end }}
       --light.serve={{- if kindIs "invalid" .light_serve -}}90{{- else -}}{{- .light_serve -}}{{- end }} \
       --light.maxpeers={{- if kindIs "invalid" .light_maxpeers -}}1000{{- else -}}{{- .light_maxpeers -}}{{- end }} \


### PR DESCRIPTION
### Description

Fixed testnet error produced by the quoutes as $BOOTNODE_FLAG has the bootnode flag and network id.
```
{"enode":"enode://f1acc5e79e47b26a3257697ae9640662fd8e01f3edcf590676132bc12a653d04916f269a075063be79ab0079271882688e478c51ded4e9a63aadc72f454b8c37@10.3.250.4:30301 --networkid=1101","err":"parse \"enode://f1acc5e79e47b26a3257697ae9640662fd8e01f3edcf590676132bc12a653d04916f269a075063be79ab0079271882688e478c51ded4e9a63aadc72f454b8c37@10.3.250.4:30301 --networkid=1101\": invalid port \":30301 --networkid=1101\" after host","msg":"Bootstrap URL invalid","severity":"critical","timestamp":"2021-03-12T11:06:18.792164144Z"}
```

### Tested

Tested in a testnet with the problem
