### PR TITLE
doc(web-dapp): add an important config step to the walkthrough

### DIFF
--- a/packages/docs/developer-resources/walkthroughs/web-dapp.md
+++ b/packages/docs/developer-resources/walkthroughs/web-dapp.md
@@ -19,13 +19,32 @@ touch tsconfig.json
 yarn add --dev typescript @types/react @types/node
 ```
 
-Now running `yarn dev` should open up our new Next.js website on `localhost:3000`.
-
 Next we'll need to add a few Celo specific dependencies so we can work with our core contracts.
 
 ```bash
 yarn add @celo/contractkit @celo-tools/use-contractkit bignumber.js
 ```
+
+Finally, we'll need to add this configuration below to `next.config.js` so [@celo-tools/use-contractkit](https://github.com/celo-tools/use-contractkit) can work properly on the client side
+
+```javascript
+module.exports = {
+  target: 'serverless',
+  webpack: (config, { webpack }) => {
+    config.node = {
+      fs: 'empty',
+      net: 'empty',
+      child_process: 'empty',
+      readline: 'empty',
+    };
+    config.plugins.push(new webpack.IgnorePlugin(/^electron$/));
+
+    return config;
+  },
+};
+```
+
+Now running `yarn dev` should open up our new Next.js website on `localhost:3000`.
 
 Here's what we'll be using each of these packages for:
 


### PR DESCRIPTION
### Description

Currently, if node packages like `fs and child_process` are not disabled on the client side, you'll keep getting the error `Module fs or child_process not found`, but now, I added an extra step in the walkthrough with a sample config that can be copied into `next.config.js` to avoid the node module errors

### Tested

It does not need to be tested because it is a walkthrough

### Backwards compatibility

It is a walkthrough update, so yes it is