### PR TITLE
Fix broken link in Celo Docs homepage

### DIFF
--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -115,7 +115,7 @@ Try Celo out:
 
 Read the Whitepapers:
 
-- [Main Celo Whitepaper](https://celo.org/papers/Celo_A_Multi_Asset_Cryptographic_Protocol_for_Decentralized_Social_Payments.pdf) and [introductory blog post](https://medium.com/celohq/a-look-at-the-celo-whitepaper-c0061118ffd4)
+- [Main Celo Whitepaper](https://celo.org/papers/whitepaper) and [introductory blog post](https://medium.com/celohq/a-look-at-the-celo-whitepaper-c0061118ffd4)
 - [Stability Analysis Whitepaper](https://celo.org/papers/Celo_Stability_Analysis.pdf) and [blog post](https://medium.com/celohq/a-look-at-the-celo-stability-analysis-white-paper-part-1-23edd5ef8b5)
 - [BFTree \(Longer Term Consensus Plan\)](https://storage.googleapis.com/celo_whitepapers/BFTree%20-%20Scaling%20HotStuff%20to%20Millions%20of%20Validators.pdf)
 


### PR DESCRIPTION
Fixes a broken link in Celo Docs homepage to the main whitepaper.