### PR TITLE
Use smaller amounts on exchange and transfer env-tests

### DIFF
--- a/packages/env-tests/src/scaffold.ts
+++ b/packages/env-tests/src/scaffold.ts
@@ -97,7 +97,9 @@ export async function clearAllFundsToRoot(context: EnvTestContext, stableTokensT
     context.kit.connection.addAccount(account.privateKey)
 
     const celoBalance = await goldToken.balanceOf(account.address)
-    if (celoBalance.gt(ONE)) {
+    // Exchange and transfer tests move ~0.5, so setting the threshold slightly below
+    const maxBalanceBeforeCollecting = ONE.times(0.4)
+    if (celoBalance.gt(maxBalanceBeforeCollecting)) {
       await goldToken
         .transfer(
           root.address,
@@ -119,7 +121,7 @@ export async function clearAllFundsToRoot(context: EnvTestContext, stableTokensT
     for (const stableToken of stableTokensToClear) {
       const stableTokenInstance = await initStableTokenFromRegistry(stableToken, context.kit)
       const balance = await stableTokenInstance.balanceOf(account.address)
-      if (balance.gt(ONE)) {
+      if (balance.gt(maxBalanceBeforeCollecting)) {
         await stableTokenInstance
           .transfer(
             root.address,

--- a/packages/env-tests/src/tests/exchange.ts
+++ b/packages/env-tests/src/tests/exchange.ts
@@ -17,7 +17,13 @@ export function runExchangeTest(context: EnvTestContext, stableTokensToTest: str
 
     for (const stableToken of stableTokensToTest) {
       test(`exchange ${stableToken} for CELO`, async () => {
-        await fundAccountWithStableToken(context, TestAccounts.Exchange, ONE.times(10), stableToken)
+        const stableTokenAmountToFund = ONE
+        await fundAccountWithStableToken(
+          context,
+          TestAccounts.Exchange,
+          stableTokenAmountToFund,
+          stableToken
+        )
         const stableTokenInstance = await initStableTokenFromRegistry(stableToken, context.kit)
 
         const from = await getKey(context.mnemonic, TestAccounts.Exchange)
@@ -28,17 +34,20 @@ export function runExchangeTest(context: EnvTestContext, stableTokensToTest: str
 
         const exchange = await initExchangeFromRegistry(stableToken, context.kit)
         const previousGoldBalance = await goldToken.balanceOf(from.address)
-        const goldAmount = await exchange.getBuyTokenAmount(ONE, false)
+        const stableTokenAmountToSell = stableTokenAmountToFund.times(0.5)
+        const goldAmount = await exchange.getBuyTokenAmount(stableTokenAmountToSell, false)
         logger.debug(
           { rate: goldAmount.toString(), stabletoken: stableToken },
           `quote selling ${stableToken}`
         )
 
-        const approveTx = await stableTokenInstance.approve(exchange.address, ONE.toString()).send()
+        const approveTx = await stableTokenInstance
+          .approve(exchange.address, stableTokenAmountToSell.toString())
+          .send()
         await approveTx.waitReceipt()
         const sellTx = await exchange
           .sell(
-            ONE,
+            stableTokenAmountToSell,
             // Allow 5% deviation from the quoted price
             goldAmount
               .times(0.95)
@@ -51,7 +60,6 @@ export function runExchangeTest(context: EnvTestContext, stableTokensToTest: str
         const receipt = await sellTx.waitReceipt()
         logger.debug({ stabletoken: stableToken, receipt }, `Sold ${stableToken}`)
 
-        // Sell more to receive at least 1 cUSD / cEUR back
         const goldAmountToSell = (await goldToken.balanceOf(from.address)).minus(
           previousGoldBalance
         )
@@ -73,8 +81,9 @@ export function runExchangeTest(context: EnvTestContext, stableTokensToTest: str
         const sellGoldTx = await exchange
           .sellGold(
             goldAmountToSell,
-            // Assume wee can get at least 80 cents back
-            ONE.times(0.8)
+            // Assume we can get at least 80 % back
+            stableTokenAmountToSell
+              .times(0.8)
               .integerValue(BigNumber.ROUND_DOWN)
               .toString()
           )

--- a/packages/env-tests/src/tests/transfer.ts
+++ b/packages/env-tests/src/tests/transfer.ts
@@ -15,10 +15,11 @@ export function runTransfersTest(context: EnvTestContext, stableTokensToTest: st
 
     for (const stableToken of stableTokensToTest) {
       test(`transfer ${stableToken}`, async () => {
+        const stableTokenAmountToFund = ONE
         await fundAccountWithStableToken(
           context,
           TestAccounts.TransferFrom,
-          ONE.times(10),
+          stableTokenAmountToFund,
           stableToken
         )
         const stableTokenInstance = await initStableTokenFromRegistry(stableToken, context.kit)
@@ -36,8 +37,9 @@ export function runTransfersTest(context: EnvTestContext, stableTokensToTest: st
           `Get ${stableToken} Balance Before`
         )
 
+        const stableTokenAmountToTransfer = ONE.times(0.5)
         const receipt = await stableTokenInstance
-          .transfer(to.address, ONE.toString())
+          .transfer(to.address, stableTokenAmountToTransfer.toString())
           .sendAndWaitForReceipt({ from: from.address })
 
         logger.debug({ stabletoken: stableToken, receipt }, `Transferred ${stableToken}`)
@@ -52,13 +54,15 @@ export function runTransfersTest(context: EnvTestContext, stableTokensToTest: st
           { stabletoken: stableToken, balance: toBalanceAfter.toString(), account: to.address },
           `Get ${stableToken} Balance After`
         )
-        expect(toBalanceAfter.minus(toBalanceBefore).isEqualTo(ONE)).toBeTruthy()
+        expect(
+          toBalanceAfter.minus(toBalanceBefore).isEqualTo(stableTokenAmountToTransfer)
+        ).toBeTruthy()
         // check whether difference of balance of 'from' account before/after - transfer amount
         // is equal to transaction fee
         expect(
           fromBalanceBefore
             .minus(fromBalanceAfter)
-            .minus(ONE)
+            .minus(stableTokenAmountToTransfer)
             .isEqualTo(transactionFee)
         ).toBeTruthy()
       })


### PR DESCRIPTION
### Description

Currently the exchange and transfer env-tests are transferring 10 units of stableToken from the RootAccount as the initial funding before doing the respective tests, which is mostly fine on test networks where the accounts have large balances, but this is not the case on mainnet (the RootAccount has ~3 CELO and 11 cUSD).

In order to avoid having to add more funds to the RootAccount for us to be able to test cEUR once it lands on mainnet, this instead reduces the amount transferred and traded in the tests.

### Tested

Ran the transfer and exchange env-tests on all three networks to ensure all of them are still passing

### Related issues

This is slightly related to https://github.com/celo-org/celo-monorepo/issues/7442 (not fixing it completely) as I noticed this when looking into it.

### Backwards compatibility

This only changes the amounts, so everything works as before.