### PR TITLE
Create gitcoin-bounty-issue.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/gitcoin-bounty-issue.md
+++ b/.github/ISSUE_TEMPLATE/gitcoin-bounty-issue.md
@@ -1,8 +1,8 @@
 ---
 name: New Gitcoin Bounty Issue
 about: Use this template to propose new Gitcoin bounties.
-title: "BOUNTY: [Bounty Title]"
-labels: bounty
+title: "[BOUNTY]: <Bounty Title>"
+labels: dog
 assignees: reachjason,critesjosh,barbaraliau,aslawson
 ---
 
@@ -16,6 +16,12 @@ assignees: reachjason,critesjosh,barbaraliau,aslawson
 [comment]: # How will we ultimately decide the winner/winners from all valid submissions? Typically clean successful PR merge? First valid submission received? Best submission meeting some criteria by the deadline? 
 [comment]: # We review the submissions as early as possible (sometimes immediately upon submission) to ensure prompt winner announcement and payout.
 
+### Prerequisites
+[comment]: # What prerequisite knowledge does this bounty require? What specific topics does someone need to know about before they can start work? Is there setup required before they can begin work? If so, what do they need to do?
+
 ### Time Expectation
+[comment]: # Given someone has the expected prerequisites and knowledge, what is the expected time investment?
 
 ### Resources
+[comment]: # Link any relevant resources (e.g. specific documentation, source code that may be useful)
+

--- a/.github/ISSUE_TEMPLATE/gitcoin-bounty-issue.md
+++ b/.github/ISSUE_TEMPLATE/gitcoin-bounty-issue.md
@@ -1,0 +1,21 @@
+---
+name: New Gitcoin Bounty Issue
+about: Use this template to propose new Gitcoin bounties.
+title: "BOUNTY: [Bounty Title]"
+labels: bounty
+assignees: reachjason,critesjosh,barbaraliau,aslawson
+---
+
+### Issue Title
+
+### Challenge Description
+[comment]: # Be as descriptive as possible about what you want to see built. Challenges should be useful to Celo, but open-ended enough to allow for creativity from hackers.
+
+### Submission Requirements
+[comment]: # What constitutes a valid/good submission to win the bounty? Would you like a demo included in the submission (Strongly Recommended)? What will help you determine whether a submission passed a threshold of acceptable quality? Please include any relevant code contribution guidelines/standards, etc. Is there any criteria?
+[comment]: # How will we ultimately decide the winner/winners from all valid submissions? Typically clean successful PR merge? First valid submission received? Best submission meeting some criteria by the deadline? 
+[comment]: # We review the submissions as early as possible (sometimes immediately upon submission) to ensure prompt winner announcement and payout.
+
+### Time Expectation
+
+### Resources


### PR DESCRIPTION
Adding a template for people to propose bounties that would later go up on Gitcoin.

### Description
Adding a template for people to propose bounties that would later go up on Gitcoin. Users will see a UI on clicking New Issue that looks like the screenshot below:
![image](https://user-images.githubusercontent.com/23431890/111364486-4afa8000-86b7-11eb-8e84-7525b0aecb3a.png)

### Tested
Tested in another repo.

### Backwards compatibility
These changes are backward compatible.