### PR TITLE
Update prettier version to most recent (2.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jest-snapshot": "^26.1.0",
     "lerna": "^3.16.0",
     "patch-package": "^6.2.2",
-    "prettier": "1.19.1",
+    "prettier": "^2.2.1",
     "prettier-plugin-java": "^0.6.0",
     "prettier-plugin-solidity": "1.0.0-alpha.35",
     "pretty-quick": "^2.0.1",
@@ -74,7 +74,7 @@
     "typescript-tslint-plugin": "^0.5.4"
   },
   "resolutions": {
-    "@types/prettier": "^1.19.0",
+    "@types/prettier": "^2.2.1",
     "**/axios": "0.21.1",
     "**/cross-fetch": "^3.0.2",
     "**/deep-extend": "^0.5.1",
@@ -103,7 +103,7 @@
     "npm": "^5.10.0",
     "npmi": "^4.0.0",
     "object-path": "^0.11.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.2.1",
     "randomatic": "^3.1.1",
     "react-native-flipper": "^0.70.0",
     "react-native-ntp-client": "^1.0.0",

--- a/packages/attestation-service/src/db.ts
+++ b/packages/attestation-service/src/db.ts
@@ -226,9 +226,7 @@ async function purgeExpiredRecords() {
       const rowsDeleted = await table.destroy({
         where: {
           createdAt: {
-            [Op.lte]: moment()
-              .subtract(dbRecordExpiryMins!, 'minutes')
-              .toDate(),
+            [Op.lte]: moment().subtract(dbRecordExpiryMins!, 'minutes').toDate(),
           },
         },
         transaction,

--- a/packages/attestation-service/src/models/attestation.ts
+++ b/packages/attestation-service/src/models/attestation.ts
@@ -66,16 +66,16 @@ export default (sequelize: Sequelize) => {
     completedAt: DataTypes.DATE,
   }) as AttestationStatic
 
-  model.prototype.key = function(): AttestationKey {
+  model.prototype.key = function (): AttestationKey {
     return { account: this.account, identifier: this.identifier, issuer: this.issuer }
   }
 
-  model.prototype.provider = function(): string | null {
+  model.prototype.provider = function (): string | null {
     const pl = this.providers.split(',')
     return this.providers ? pl[this.attempt % pl.length] : null
   }
 
-  model.prototype.recordError = function(error: string) {
+  model.prototype.recordError = function (error: string) {
     const errors = this.errors ? JSON.parse(this.errors) : {}
 
     errors[this.attempt] = {
@@ -85,7 +85,7 @@ export default (sequelize: Sequelize) => {
     this.errors = JSON.stringify(errors)
   }
 
-  model.prototype.failure = function(): boolean {
+  model.prototype.failure = function (): boolean {
     return (
       // tslint:disable-next-line: triple-equals
       this.status == AttestationStatus.NotSent.valueOf() ||
@@ -94,7 +94,7 @@ export default (sequelize: Sequelize) => {
     )
   }
 
-  model.prototype.currentError = function() {
+  model.prototype.currentError = function () {
     if (this.failure()) {
       const errors = this.errors ? JSON.parse(this.errors) : {}
       return errors[this.attempt]?.error ?? errors[this.attempt - 1]?.error ?? undefined

--- a/packages/celotool/src/cmds/bots/auto-vote.ts
+++ b/packages/celotool/src/cmds/bots/auto-vote.ts
@@ -302,10 +302,7 @@ function shouldChangeVote(
   scoreSensitivity: BigNumber,
   baseChangeProbability: BigNumber
 ): boolean {
-  const scoreBasedProbability = score
-    .pow(scoreSensitivity)
-    .negated()
-    .plus(1)
+  const scoreBasedProbability = score.pow(scoreSensitivity).negated().plus(1)
   const scaledProbability = scoreBasedProbability.times(baseChangeProbability.negated().plus(1))
   const totalProbability = scaledProbability.plus(baseChangeProbability)
 

--- a/packages/celotool/src/e2e-tests/attestations_tests.ts
+++ b/packages/celotool/src/e2e-tests/attestations_tests.ts
@@ -63,12 +63,12 @@ describe('attestations tests', () => {
   let contractKit: ContractKit
   let Attestations: AttestationsWrapper
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     await context.hooks.before()
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await context.hooks.after()
   })
@@ -86,12 +86,12 @@ describe('attestations tests', () => {
   }
 
   describe('Attestations', () => {
-    before(async function() {
+    before(async function () {
       this.timeout(0)
       await restart()
     })
 
-    it('requests an attestation', async function(this: any) {
+    it('requests an attestation', async function (this: any) {
       this.timeout(10000)
 
       const approve = await Attestations.approveAttestationFee(2)

--- a/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
+++ b/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
@@ -9,7 +9,7 @@ import { getHooks, sleep } from './utils'
 const TMP_PATH = '/tmp/e2e'
 const rpcURL = 'http://localhost:8545'
 
-describe('Blockchain parameters tests', function(this: any) {
+describe('Blockchain parameters tests', function (this: any) {
   this.timeout(0)
 
   let kit: ContractKit
@@ -38,12 +38,12 @@ describe('Blockchain parameters tests', function(this: any) {
 
   const hooks = getHooks(gethConfig)
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     await hooks.before()
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await hooks.after()
   })

--- a/packages/celotool/src/e2e-tests/cip35_tests.ts
+++ b/packages/celotool/src/e2e-tests/cip35_tests.ts
@@ -397,7 +397,7 @@ class TestEnv {
   }
 }
 
-describe('CIP-35 >', function(this: any) {
+describe('CIP-35 >', function (this: any) {
   this.timeout(0)
 
   describe('before activation', () => {
@@ -405,7 +405,7 @@ describe('CIP-35 >', function(this: any) {
       return
     }
     const testEnv = new TestEnv(false)
-    before(async function(this) {
+    before(async function (this) {
       this.timeout(0)
       await testEnv.before()
     })
@@ -420,7 +420,7 @@ describe('CIP-35 >', function(this: any) {
       testEnv.runReplayProtectionTests()
     }
 
-    after(async function(this: any) {
+    after(async function (this: any) {
       this.timeout(0)
       await testEnv.hooks.after()
     })
@@ -431,7 +431,7 @@ describe('CIP-35 >', function(this: any) {
       return
     }
     const testEnv = new TestEnv(true)
-    before(async function(this) {
+    before(async function (this) {
       this.timeout(0)
       await testEnv.before()
     })
@@ -446,7 +446,7 @@ describe('CIP-35 >', function(this: any) {
       testEnv.runReplayProtectionTests()
     }
 
-    after(async function(this: any) {
+    after(async function (this: any) {
       this.timeout(0)
       await testEnv.hooks.after()
     })

--- a/packages/celotool/src/e2e-tests/governance_tests.ts
+++ b/packages/celotool/src/e2e-tests/governance_tests.ts
@@ -235,13 +235,13 @@ describe('governance tests', () => {
   let accounts: any
   let kit: ContractKit
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     // Comment out the following line after a local run for a quick rerun.
     await hooks.before()
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await hooks.after()
   })
@@ -336,14 +336,7 @@ describe('governance tests', () => {
     } else {
       const difference = currentTarget.minus(previousTarget)
       // Assert equal to 9 decimal places due to rounding errors.
-      assert.equal(
-        fromFixed(difference)
-          .dp(9)
-          .toFixed(),
-        fromFixed(expected)
-          .dp(9)
-          .toFixed()
-      )
+      assert.equal(fromFixed(difference).dp(9).toFixed(), fromFixed(expected).dp(9).toFixed())
     }
   }
 
@@ -372,7 +365,7 @@ describe('governance tests', () => {
     let epoch: number
     let validatorAccounts: string[]
 
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
 
       await restart()
@@ -486,7 +479,7 @@ describe('governance tests', () => {
       }
     })
 
-    it('should always return a validator set equal to the signing keys of the group members at the end of the last epoch', async function(this: any) {
+    it('should always return a validator set equal to the signing keys of the group members at the end of the last epoch', async function (this: any) {
       this.timeout(0)
       for (const blockNumber of blockNumbers) {
         const lastEpochBlock = getLastEpochBlock(blockNumber, epoch)
@@ -522,7 +515,7 @@ describe('governance tests', () => {
       }
     })
 
-    it('should update the validator scores at the end of each epoch', async function(this: any) {
+    it('should update the validator scores at the end of each epoch', async function (this: any) {
       this.timeout(0)
       const scoreParams = await validators.methods.getValidatorScoreParameters().call()
       const exponent = new BigNumber(scoreParams[0])
@@ -592,7 +585,7 @@ describe('governance tests', () => {
       }
     })
 
-    it('should distribute epoch payments at the end of each epoch', async function(this: any) {
+    it('should distribute epoch payments at the end of each epoch', async function (this: any) {
       this.timeout(0)
       const commission = 0.1
       const targetValidatorEpochPayment = new BigNumber(
@@ -652,7 +645,7 @@ describe('governance tests', () => {
       }
     })
 
-    it('should distribute epoch rewards at the end of each epoch', async function(this: any) {
+    it('should distribute epoch rewards at the end of each epoch', async function (this: any) {
       this.timeout(0)
       const lockedGold = await kit._web3Contracts.getLockedGold()
       const governance = await kit._web3Contracts.getGovernance()
@@ -897,7 +890,7 @@ describe('governance tests', () => {
     let epoch: number
     let validatorAccounts: string[]
 
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
 
       await restart()
@@ -1055,7 +1048,7 @@ describe('governance tests', () => {
     let blockFrozen: number
     let latestBlock: number
 
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0)
       await restart()
       const validator = (await kit.connection.getAccounts())[0]
@@ -1083,7 +1076,7 @@ describe('governance tests', () => {
 
   describe('after the gold token smart contract is registered', () => {
     let goldGenesisSupply = new BigNumber(0)
-    beforeEach(async function(this: any) {
+    beforeEach(async function (this: any) {
       this.timeout(0) // Disable test timeout
       await restart()
       const genesis = await importGenesis(path.join(gethConfig.runPath, 'genesis.json'))
@@ -1092,7 +1085,7 @@ describe('governance tests', () => {
       })
     })
 
-    it('should initialize the Celo Gold total supply correctly', async function(this: any) {
+    it('should initialize the Celo Gold total supply correctly', async function (this: any) {
       const events = await registry.getPastEvents('RegistryUpdated', { fromBlock: 0 })
       let blockNumber = 0
       for (const e of events) {

--- a/packages/celotool/src/e2e-tests/replica_tests.ts
+++ b/packages/celotool/src/e2e-tests/replica_tests.ts
@@ -102,13 +102,13 @@ describe('replica swap tests', () => {
   const hooks: any = getHooks(gethConfig)
   let web3: Web3
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     // Comment out the following line after a local run for a quick rerun.
     await hooks.before()
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await hooks.after()
   })
@@ -127,7 +127,7 @@ describe('replica swap tests', () => {
     let swapBlock: number
     const missed: any = []
 
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
 
       await restart()

--- a/packages/celotool/src/e2e-tests/slashing_tests.ts
+++ b/packages/celotool/src/e2e-tests/slashing_tests.ts
@@ -91,7 +91,7 @@ async function generateValidIntervalArrays(
   return { startBlocks, endBlocks }
 }
 
-describe('slashing tests', function(this: any) {
+describe('slashing tests', function (this: any) {
   const gethConfigDown: GethRunConfig = {
     network: 'local',
     networkId: 1101,
@@ -155,13 +155,13 @@ describe('slashing tests', function(this: any) {
   let web3: Web3
   let kit: ContractKit
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     // Comment out the following line after a test run for a quick rerun.
     await hooks.before()
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await hooks.after()
   })
@@ -181,7 +181,7 @@ describe('slashing tests', function(this: any) {
   }
 
   describe('when running a network', () => {
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
       await restartWithDowntime()
     })
@@ -221,12 +221,12 @@ describe('slashing tests', function(this: any) {
   let doubleSigningBlock: any
 
   describe('test slashing for downtime', () => {
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
       await restartWithDowntime()
     })
 
-    it('slash for downtime', async function(this: any) {
+    it('slash for downtime', async function (this: any) {
       this.timeout(0) // Disable test timeout
       const slasher = await kit._web3Contracts.getDowntimeSlasher()
       const slashableDowntime = new BigNumber(await slasher.methods.slashableDowntime().call())
@@ -288,12 +288,12 @@ describe('slashing tests', function(this: any) {
   })
 
   describe('test slashing for downtime with contractkit', () => {
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
       await restartWithDowntime()
     })
 
-    it('slash for downtime with contractkit', async function(this: any) {
+    it('slash for downtime with contractkit', async function (this: any) {
       this.timeout(0) // Disable test timeout
       const slasher = await kit.contracts.getDowntimeSlasher()
       const blockNumber = await kit.connection.getBlockNumber()
@@ -327,12 +327,12 @@ describe('slashing tests', function(this: any) {
   })
 
   describe('test slashing for double signing', () => {
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
       await restart()
     })
 
-    it('slash for double signing', async function(this: any) {
+    it('slash for double signing', async function (this: any) {
       this.timeout(0) // Disable test timeout
       const slasher = await kit._web3Contracts.getDoubleSigningSlasher()
 
@@ -377,12 +377,12 @@ describe('slashing tests', function(this: any) {
   })
 
   describe('test slashing for double signing with contractkit', () => {
-    before(async function(this: any) {
+    before(async function (this: any) {
       this.timeout(0) // Disable test timeout
       await restart()
     })
 
-    it('slash for double signing with contractkit', async function(this: any) {
+    it('slash for double signing with contractkit', async function (this: any) {
       this.timeout(0) // Disable test timeout
       const slasher = await kit.contracts.getDoubleSigningSlasher()
       const election = await kit.contracts.getElection()

--- a/packages/celotool/src/e2e-tests/sync_tests.ts
+++ b/packages/celotool/src/e2e-tests/sync_tests.ts
@@ -8,7 +8,7 @@ import { getHooks, initAndSyncGethWithRetry, killInstance, waitForBlock } from '
 const TMP_PATH = '/tmp/e2e'
 const verbose = false
 
-describe('sync tests', function(this: any) {
+describe('sync tests', function (this: any) {
   this.timeout(0)
 
   const gethConfig: GethRunConfig = {
@@ -64,7 +64,7 @@ describe('sync tests', function(this: any) {
 
   const hooks = getHooks(gethConfig)
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     // Start validator nodes and migrate contracts.
     await hooks.before()
@@ -80,7 +80,7 @@ describe('sync tests', function(this: any) {
     )
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await hooks.after()
   })
@@ -133,12 +133,12 @@ describe('sync tests', function(this: any) {
     })
   }
   describe(`when a validator's data directory is deleted`, () => {
-    beforeEach(async function(this: any) {
+    beforeEach(async function (this: any) {
       this.timeout(0) // Disable test timeout
       await hooks.restart()
     })
 
-    it('should continue to block produce', async function(this: any) {
+    it('should continue to block produce', async function (this: any) {
       this.timeout(0)
       const instance: GethInstanceConfig = gethConfig.instances[1]
       await killInstance(instance)

--- a/packages/celotool/src/e2e-tests/transfer_tests.ts
+++ b/packages/celotool/src/e2e-tests/transfer_tests.ts
@@ -186,7 +186,7 @@ function assertEqualBN(value: BigNumber, expected: BigNumber) {
   assert.equal(value.toString(), expected.toString())
 }
 
-describe('Transfer tests', function(this: any) {
+describe('Transfer tests', function (this: any) {
   this.timeout(0)
 
   let kit: ContractKit
@@ -229,12 +229,12 @@ describe('Transfer tests', function(this: any) {
 
   const hooks = getHooks(gethConfig)
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     await hooks.before()
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await hooks.after()
   })

--- a/packages/celotool/src/e2e-tests/utils.ts
+++ b/packages/celotool/src/e2e-tests/utils.ts
@@ -108,10 +108,7 @@ export function assertAlmostEqual(
   if (expected.isZero()) {
     assert.equal(actual.toFixed(), expected.toFixed())
   } else {
-    const isCloseTo = actual
-      .minus(expected)
-      .abs()
-      .lte(delta)
+    const isCloseTo = actual.minus(expected).abs().lte(delta)
     assert(
       isCloseTo,
       `expected ${actual.toString()} to almost equal ${expected.toString()} +/- ${delta.toString()}`

--- a/packages/celotool/src/e2e-tests/validator_order_tests.ts
+++ b/packages/celotool/src/e2e-tests/validator_order_tests.ts
@@ -34,24 +34,24 @@ describe('governance tests', () => {
   const context: any = getContext(gethConfig)
   let web3: Web3
 
-  before(async function(this: any) {
+  before(async function (this: any) {
     this.timeout(0)
     await context.hooks.before()
   })
 
-  after(async function(this: any) {
+  after(async function (this: any) {
     this.timeout(0)
     await context.hooks.after()
   })
 
   describe('Validator ordering', () => {
-    before(async function() {
+    before(async function () {
       this.timeout(0)
       web3 = new Web3('http://localhost:8545')
       await context.hooks.restart()
     })
 
-    it('properly orders validators randomly', async function(this: any) {
+    it('properly orders validators randomly', async function (this: any) {
       this.timeout(320000 /* 320 seconds */)
       // If a consensus round fails during this test, the results are inconclusive.
       // Retry up to two times to mitigate this issue. Restarting the nodes is not needed.

--- a/packages/celotool/src/lib/cloud-storage.ts
+++ b/packages/celotool/src/lib/cloud-storage.ts
@@ -75,10 +75,7 @@ export const fileDownload = async (
   srcFileName: string,
   dstFileName: string
 ) => {
-  await client
-    .bucket(bucketName)
-    .file(srcFileName)
-    .download({
-      destination: dstFileName,
-    })
+  await client.bucket(bucketName).file(srcFileName).download({
+    destination: dstFileName,
+  })
 }

--- a/packages/celotool/src/lib/forno.ts
+++ b/packages/celotool/src/lib/forno.ts
@@ -9,9 +9,7 @@ import { deployModule, destroyModule } from './vm-testnet-utils'
 const FORNO_TERRAFORM_MODULE_NAME = 'forno'
 
 export async function deployForno(celoEnv: string) {
-  const contexts: string[] = fetchEnv(envVar.FORNO_FULL_NODE_CONTEXTS)
-    .split(',')
-    .map(coerceContext)
+  const contexts: string[] = fetchEnv(envVar.FORNO_FULL_NODE_CONTEXTS).split(',').map(coerceContext)
   console.info('Deploying Forno with full node contexts:', contexts)
   const terraformVars: TerraformVars = await getFornoTerraformVars(celoEnv, contexts)
   // This prints the global IP address for forno
@@ -22,9 +20,7 @@ export async function deployForno(celoEnv: string) {
 }
 
 export async function destroyForno(celoEnv: string) {
-  const contexts: string[] = fetchEnv(envVar.FORNO_FULL_NODE_CONTEXTS)
-    .split(',')
-    .map(coerceContext)
+  const contexts: string[] = fetchEnv(envVar.FORNO_FULL_NODE_CONTEXTS).split(',').map(coerceContext)
   console.info('DESTROYING Forno')
   const terraformVars: TerraformVars = await getFornoTerraformVars(celoEnv, contexts)
   await destroyModule(celoEnv, FORNO_TERRAFORM_MODULE_NAME, terraformVars)

--- a/packages/celotool/src/lib/helm_deploy.ts
+++ b/packages/celotool/src/lib/helm_deploy.ts
@@ -104,12 +104,8 @@ export async function createCloudSQLInstance(celoEnv: string, instanceName: stri
     `gcloud sql instances patch ${instanceName} --backup-start-time 17:00`
   )
 
-  const blockscoutDBUsername = Math.random()
-    .toString(36)
-    .slice(-8)
-  const blockscoutDBPassword = Math.random()
-    .toString(36)
-    .slice(-8)
+  const blockscoutDBUsername = Math.random().toString(36).slice(-8)
+  const blockscoutDBPassword = Math.random().toString(36).slice(-8)
 
   console.info('Creating SQL user')
   await execCmdWithExitOnFailure(

--- a/packages/celotool/src/lib/komenci.ts
+++ b/packages/celotool/src/lib/komenci.ts
@@ -196,8 +196,9 @@ async function helmParameters(celoEnv: string, context: string, useForno: boolea
     `--set onboarding.db.username=${databaseConfig.username}`,
     `--set onboarding.db.password=${databasePassword}`,
     `--set onboarding.publicHostname=${getPublicHostname(clusterConfig.regionName, celoEnv)}`,
-    `--set onboarding.publicUrl=${'https://' +
-      getPublicHostname(clusterConfig.regionName, celoEnv)}`,
+    `--set onboarding.publicUrl=${
+      'https://' + getPublicHostname(clusterConfig.regionName, celoEnv)
+    }`,
     `--set onboarding.ruleConfig.captcha.bypassEnabled=${vars.captchaBypassEnabled}`,
     `--set onboarding.ruleConfig.captcha.bypassToken=${fetchEnv(
       envVar.KOMENCI_RULE_CONFIG_CAPTCHA_BYPASS_TOKEN

--- a/packages/celotool/src/lib/testnet-utils.ts
+++ b/packages/celotool/src/lib/testnet-utils.ts
@@ -181,13 +181,10 @@ export async function uploadFileToGoogleStorage(
 
   if (makeFileWorldReadable) {
     // set the permission to be world-readable
-    await storage
-      .bucket(googleStorageBucketName)
-      .file(googleStorageFileName)
-      .acl.add({
-        entity: 'allUsers',
-        role: storage.acl.READER_ROLE,
-      })
+    await storage.bucket(googleStorageBucketName).file(googleStorageFileName).acl.add({
+      entity: 'allUsers',
+      role: storage.acl.READER_ROLE,
+    })
   }
 }
 

--- a/packages/cli/src/commands/account/register-data-encryption-key.ts
+++ b/packages/cli/src/commands/account/register-data-encryption-key.ts
@@ -29,9 +29,7 @@ export default class RegisterDataEncryptionKey extends BaseCommand {
     const res = this.parse(RegisterDataEncryptionKey)
     this.kit.defaultAccount = res.flags.from
 
-    await newCheckBuilder(this)
-      .isAccount(res.flags.from)
-      .runChecks()
+    await newCheckBuilder(this).isAccount(res.flags.from).runChecks()
 
     const publicKey = res.flags.publicKey
 

--- a/packages/cli/src/commands/account/register-metadata.ts
+++ b/packages/cli/src/commands/account/register-metadata.ts
@@ -33,9 +33,7 @@ export default class RegisterMetadata extends BaseCommand {
   async run() {
     const res = this.parse(RegisterMetadata)
 
-    await newCheckBuilder(this)
-      .isAccount(res.flags.from)
-      .runChecks()
+    await newCheckBuilder(this).isAccount(res.flags.from).runChecks()
 
     const metadataURL = res.flags.url
 

--- a/packages/cli/src/commands/account/register.ts
+++ b/packages/cli/src/commands/account/register.ts
@@ -26,9 +26,7 @@ export default class Register extends BaseCommand {
 
     const accounts = await this.kit.contracts.getAccounts()
 
-    await newCheckBuilder(this)
-      .isNotAccount(res.flags.from)
-      .runChecks()
+    await newCheckBuilder(this).isNotAccount(res.flags.from).runChecks()
     await displaySendTx('register', accounts.createAccount())
     if (res.flags.name) {
       await displaySendTx('setName', accounts.setName(res.flags.name))

--- a/packages/cli/src/commands/account/set-name.ts
+++ b/packages/cli/src/commands/account/set-name.ts
@@ -25,9 +25,7 @@ export default class SetName extends BaseCommand {
     this.kit.defaultAccount = res.flags.account
     const accounts = await this.kit.contracts.getAccounts()
 
-    await newCheckBuilder(this)
-      .isAccount(res.flags.account)
-      .runChecks()
+    await newCheckBuilder(this).isAccount(res.flags.account).runChecks()
     await displaySendTx('setName', accounts.setName(res.flags.name))
   }
 }

--- a/packages/cli/src/commands/account/show.ts
+++ b/packages/cli/src/commands/account/show.ts
@@ -17,9 +17,7 @@ export default class Show extends BaseCommand {
 
   async run() {
     const { args } = this.parse(Show)
-    await newCheckBuilder(this, args.address)
-      .isSignerOrAccount()
-      .runChecks()
+    await newCheckBuilder(this, args.address).isSignerOrAccount().runChecks()
     const accounts = await this.kit.contracts.getAccounts()
     const address = await accounts.signerToAccount(args.address)
     printValueMapRecursive(await accounts.getAccountSummary(address))

--- a/packages/cli/src/commands/election/activate.ts
+++ b/packages/cli/src/commands/election/activate.ts
@@ -23,9 +23,7 @@ export default class ElectionVote extends BaseCommand {
   async run() {
     const res = this.parse(ElectionVote)
 
-    await newCheckBuilder(this, res.flags.from)
-      .isSignerOrAccount()
-      .runChecks()
+    await newCheckBuilder(this, res.flags.from).isSignerOrAccount().runChecks()
 
     const election = await this.kit.contracts.getElection()
     const accounts = await this.kit.contracts.getAccounts()

--- a/packages/cli/src/commands/election/show.ts
+++ b/packages/cli/src/commands/election/show.ts
@@ -35,15 +35,11 @@ export default class ElectionShow extends BaseCommand {
     const election = await this.kit.contracts.getElection()
 
     if (res.flags.group) {
-      await newCheckBuilder(this)
-        .isValidatorGroup(address)
-        .runChecks()
+      await newCheckBuilder(this).isValidatorGroup(address).runChecks()
       const groupVotes = await election.getValidatorGroupVotes(address)
       printValueMapRecursive(groupVotes)
     } else if (res.flags.voter) {
-      await newCheckBuilder(this)
-        .isAccount(address)
-        .runChecks()
+      await newCheckBuilder(this).isAccount(address).runChecks()
       const voter = await election.getVoter(address)
       printValueMapRecursive(voter)
     } else {

--- a/packages/cli/src/commands/exchange/celo.ts
+++ b/packages/cli/src/commands/exchange/celo.ts
@@ -55,9 +55,7 @@ export default class ExchangeCelo extends BaseCommand {
       failWith(`The ${stableToken} token was not deployed yet`)
     }
 
-    await newCheckBuilder(this)
-      .hasEnoughCelo(res.flags.from, sellAmount)
-      .runChecks()
+    await newCheckBuilder(this).hasEnoughCelo(res.flags.from, sellAmount).runChecks()
 
     if (minBuyAmount.toNumber() === 0) {
       const check = await checkNotDangerousExchange(

--- a/packages/cli/src/commands/governance/approvehotfix.ts
+++ b/packages/cli/src/commands/governance/approvehotfix.ts
@@ -28,10 +28,7 @@ export default class ApproveHotfix extends BaseCommand {
     this.kit.defaultAccount = account
     const governance = await this.kit.contracts.getGovernance()
 
-    await newCheckBuilder(this)
-      .isApprover(account)
-      .hotfixNotExecuted(hash)
-      .runChecks()
+    await newCheckBuilder(this).isApprover(account).hotfixNotExecuted(hash).runChecks()
 
     await displaySendTx('approveTx', governance.approveHotfix(hash), {})
   }

--- a/packages/cli/src/commands/governance/revokeupvote.ts
+++ b/packages/cli/src/commands/governance/revokeupvote.ts
@@ -18,9 +18,7 @@ export default class RevokeUpvote extends BaseCommand {
     const signer = res.flags.from
     this.kit.defaultAccount = signer
 
-    await newCheckBuilder(this, signer)
-      .isVoteSignerOrAccount()
-      .runChecks()
+    await newCheckBuilder(this, signer).isVoteSignerOrAccount().runChecks()
 
     // TODO(nategraf): Check whether there are upvotes to revoke before sending transaction.
     const governance = await this.kit.contracts.getGovernance()

--- a/packages/cli/src/commands/governance/show.ts
+++ b/packages/cli/src/commands/governance/show.ts
@@ -70,9 +70,7 @@ export default class Show extends BaseCommand {
 
     const governance = await this.kit.contracts.getGovernance()
     if (id) {
-      await newCheckBuilder(this)
-        .proposalExists(id)
-        .runChecks()
+      await newCheckBuilder(this).proposalExists(id).runChecks()
 
       const record = await governance.getProposalRecord(id)
       const proposal = record.proposal

--- a/packages/cli/src/commands/governance/whitelisthotfix.ts
+++ b/packages/cli/src/commands/governance/whitelisthotfix.ts
@@ -24,9 +24,7 @@ export default class WhitelistHotfix extends BaseCommand {
     const account = res.flags.from
     this.kit.defaultAccount = account
 
-    await newCheckBuilder(this)
-      .hotfixNotExecuted(hash)
-      .runChecks()
+    await newCheckBuilder(this).hotfixNotExecuted(hash).runChecks()
 
     const governance = await this.kit.contracts.getGovernance()
     await displaySendTx(

--- a/packages/cli/src/commands/governance/withdraw.ts
+++ b/packages/cli/src/commands/governance/withdraw.ts
@@ -16,9 +16,7 @@ export default class Withdraw extends BaseCommand {
   async run() {
     const res = this.parse(Withdraw)
 
-    await newCheckBuilder(this, res.flags.from)
-      .hasRefundedDeposits(res.flags.from)
-      .runChecks()
+    await newCheckBuilder(this, res.flags.from).hasRefundedDeposits(res.flags.from).runChecks()
 
     const governance = await this.kit.contracts.getGovernance()
     await displaySendTx('withdraw', governance.withdraw(), {}, 'DepositWithdrawn')

--- a/packages/cli/src/commands/identity/identifier.ts
+++ b/packages/cli/src/commands/identity/identifier.ts
@@ -36,9 +36,7 @@ export default class IdentifierQuery extends BaseCommand {
     const { flags } = this.parse(IdentifierQuery)
     const { phoneNumber, from, context } = flags
 
-    await newCheckBuilder(this)
-      .isValidAddress(flags.from)
-      .runChecks()
+    await newCheckBuilder(this).isValidAddress(flags.from).runChecks()
 
     cli.action.start('Querying ODIS for identifier')
 

--- a/packages/cli/src/commands/identity/test-attestation-service.ts
+++ b/packages/cli/src/commands/identity/test-attestation-service.ts
@@ -36,10 +36,7 @@ export default class TestAttestationService extends BaseCommand {
     const address = flags.from
     const { phoneNumber, message, provider } = flags
 
-    await newCheckBuilder(this, flags.from)
-      .isSignerOrAccount()
-      .canSign(address)
-      .runChecks()
+    await newCheckBuilder(this, flags.from).isSignerOrAccount().canSign(address).runChecks()
 
     const accounts = await this.kit.contracts.getAccounts()
     const account = await accounts.signerToAccount(address)

--- a/packages/cli/src/commands/lockedgold/lock.ts
+++ b/packages/cli/src/commands/lockedgold/lock.ts
@@ -39,9 +39,7 @@ export default class Lock extends BaseCommand {
     const relockValue = BigNumber.minimum(pendingWithdrawalsValue, value)
     const lockValue = value.minus(relockValue)
 
-    await newCheckBuilder(this)
-      .hasEnoughCelo(address, lockValue)
-      .runChecks()
+    await newCheckBuilder(this).hasEnoughCelo(address, lockValue).runChecks()
 
     const txos = await lockedGold.relock(address, relockValue)
     for (const txo of txos) {

--- a/packages/cli/src/commands/lockedgold/show.ts
+++ b/packages/cli/src/commands/lockedgold/show.ts
@@ -20,9 +20,7 @@ export default class Show extends BaseCommand {
 
     const lockedGold = await this.kit.contracts.getLockedGold()
 
-    await newCheckBuilder(this)
-      .isAccount(args.account)
-      .runChecks()
+    await newCheckBuilder(this).isAccount(args.account).runChecks()
 
     printValueMapRecursive(await lockedGold.getAccountSummary(args.account))
   }

--- a/packages/cli/src/commands/lockedgold/withdraw.ts
+++ b/packages/cli/src/commands/lockedgold/withdraw.ts
@@ -20,9 +20,7 @@ export default class Withdraw extends BaseCommand {
     this.kit.defaultAccount = flags.from
     const lockedgold = await this.kit.contracts.getLockedGold()
 
-    await newCheckBuilder(this)
-      .isAccount(flags.from)
-      .runChecks()
+    await newCheckBuilder(this).isAccount(flags.from).runChecks()
 
     const currentTime = Math.round(new Date().getTime() / 1000)
     while (true) {

--- a/packages/cli/src/commands/releasegold/set-beneficiary.ts
+++ b/packages/cli/src/commands/releasegold/set-beneficiary.ts
@@ -38,9 +38,7 @@ export default class SetBeneficiary extends ReleaseGoldBaseCommand {
     const owner = await this.releaseGoldWrapper.getOwner()
     const releaseGoldMultiSig = await this.kit.contracts.getMultiSig(owner)
 
-    await newCheckBuilder(this)
-      .isMultiSigOwner(flags.from, releaseGoldMultiSig)
-      .runChecks()
+    await newCheckBuilder(this).isMultiSigOwner(flags.from, releaseGoldMultiSig).runChecks()
 
     if (!flags.yesreally) {
       const response = await prompts({

--- a/packages/cli/src/commands/transfer/celo.ts
+++ b/packages/cli/src/commands/transfer/celo.ts
@@ -31,9 +31,7 @@ export default class TransferCelo extends BaseCommand {
     this.kit.defaultAccount = from
     const celoToken = await this.kit.contracts.getGoldToken()
 
-    await newCheckBuilder(this)
-      .hasEnoughCelo(from, value)
-      .runChecks()
+    await newCheckBuilder(this).hasEnoughCelo(from, value).runChecks()
 
     if (res.flags.comment) {
       await displaySendTx(

--- a/packages/cli/src/commands/validator/show.ts
+++ b/packages/cli/src/commands/validator/show.ts
@@ -20,9 +20,7 @@ export default class ValidatorShow extends BaseCommand {
     const address = args.validatorAddress
     const validators = await this.kit.contracts.getValidators()
 
-    await newCheckBuilder(this)
-      .isValidator(address)
-      .runChecks()
+    await newCheckBuilder(this).isValidator(address).runChecks()
 
     const validator = await validators.getValidator(address)
     printValueMap(validator)

--- a/packages/cli/src/commands/validatorgroup/show.ts
+++ b/packages/cli/src/commands/validatorgroup/show.ts
@@ -19,9 +19,7 @@ export default class ValidatorGroupShow extends BaseCommand {
     const res = this.parse(ValidatorGroupShow)
     const validators = await this.kit.contracts.getValidators()
 
-    await newCheckBuilder(this)
-      .isValidatorGroup(res.args.groupAddress)
-      .runChecks()
+    await newCheckBuilder(this).isValidatorGroup(res.args.groupAddress).runChecks()
 
     const validatorGroup = await validators.getValidatorGroup(res.args.groupAddress)
     printValueMap(validatorGroup)

--- a/packages/docs/developer-resources/dappkit/setup.md
+++ b/packages/docs/developer-resources/dappkit/setup.md
@@ -82,7 +82,7 @@ if (typeof global.self === 'undefined') {
   global.self = global
 }
 if (typeof btoa === 'undefined') {
-  global.btoa = function(str) {
+  global.btoa = function (str) {
     return new Buffer(str, 'binary').toString('base64')
   }
 }

--- a/packages/docs/developer-resources/walkthroughs/hello-contract-remote-node.md
+++ b/packages/docs/developer-resources/walkthroughs/hello-contract-remote-node.md
@@ -80,7 +80,7 @@ After compiling the contract, you need to create a migration to deploy the contr
 ```javascript
 var HelloWorld = artifacts.require('HelloWorld')
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
   deployer.deploy(HelloWorld)
 }
 ```

--- a/packages/docs/developer-resources/walkthroughs/hellocontracts.md
+++ b/packages/docs/developer-resources/walkthroughs/hellocontracts.md
@@ -49,7 +49,7 @@ Let's create a migration to deploy the contract. For that, we need to create a f
 ```javascript
 var HelloWorld = artifacts.require('HelloWorld')
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
   deployer.deploy(HelloWorld)
 }
 ```

--- a/packages/env-tests/src/scaffold.ts
+++ b/packages/env-tests/src/scaffold.ts
@@ -103,10 +103,7 @@ export async function clearAllFundsToRoot(context: EnvTestContext, stableTokensT
       await goldToken
         .transfer(
           root.address,
-          celoBalance
-            .times(0.99)
-            .integerValue(BigNumber.ROUND_DOWN)
-            .toString()
+          celoBalance.times(0.99).integerValue(BigNumber.ROUND_DOWN).toString()
         )
         .sendAndWaitForReceipt({ from: account.address, feeCurrency: undefined })
       context.logger.debug(
@@ -123,13 +120,7 @@ export async function clearAllFundsToRoot(context: EnvTestContext, stableTokensT
       const balance = await stableTokenInstance.balanceOf(account.address)
       if (balance.gt(maxBalanceBeforeCollecting)) {
         await stableTokenInstance
-          .transfer(
-            root.address,
-            balance
-              .times(0.99)
-              .integerValue(BigNumber.ROUND_DOWN)
-              .toString()
-          )
+          .transfer(root.address, balance.times(0.99).integerValue(BigNumber.ROUND_DOWN).toString())
           .sendAndWaitForReceipt({
             feeCurrency: stableTokenInstance.address,
             from: account.address,

--- a/packages/env-tests/src/shared/attestation.ts
+++ b/packages/env-tests/src/shared/attestation.ts
@@ -311,8 +311,6 @@ export async function fetchLatestMessagesFromToday(
     to: phoneNumber,
     pageSize: count,
     // Twilio keeps track of dates in UTC so it could be yesterday too
-    dateSentAfter: moment()
-      .subtract(2, 'day')
-      .toDate(),
+    dateSentAfter: moment().subtract(2, 'day').toDate(),
   })
 }

--- a/packages/env-tests/src/tests/attestation.ts
+++ b/packages/env-tests/src/tests/attestation.ts
@@ -203,10 +203,7 @@ export function runAttestationTest(
       const stableBalanceRoot = await stableToken.balanceOf(attestationAccountAddress)
       const transferBackTx = stableToken.transfer(
         root.address,
-        stableBalanceRoot
-          .times(0.95)
-          .integerValue(BigNumber.ROUND_DOWN)
-          .toString()
+        stableBalanceRoot.times(0.95).integerValue(BigNumber.ROUND_DOWN).toString()
       )
       const transferBackTxReceipt = await transferBackTx.sendAndWaitForReceipt()
 

--- a/packages/env-tests/src/tests/exchange.ts
+++ b/packages/env-tests/src/tests/exchange.ts
@@ -49,10 +49,7 @@ export function runExchangeTest(context: EnvTestContext, stableTokensToTest: str
           .sell(
             stableTokenAmountToSell,
             // Allow 5% deviation from the quoted price
-            goldAmount
-              .times(0.95)
-              .integerValue(BigNumber.ROUND_DOWN)
-              .toString(),
+            goldAmount.times(0.95).integerValue(BigNumber.ROUND_DOWN).toString(),
             false
           )
           .send()
@@ -82,10 +79,7 @@ export function runExchangeTest(context: EnvTestContext, stableTokensToTest: str
           .sellGold(
             goldAmountToSell,
             // Assume we can get at least 80 % back
-            stableTokenAmountToSell
-              .times(0.8)
-              .integerValue(BigNumber.ROUND_DOWN)
-              .toString()
+            stableTokenAmountToSell.times(0.8).integerValue(BigNumber.ROUND_DOWN).toString()
           )
           .send()
         const sellGoldReceipt = await sellGoldTx.waitReceipt()

--- a/packages/flake-tracker/src/db.js
+++ b/packages/flake-tracker/src/db.js
@@ -98,12 +98,7 @@ const mkTmpDir = (name) => {
 
 const readFileInFlakeDir = (file) => {
   const path = join(tmpdir(), flakeDir, file)
-  return fs.existsSync(path)
-    ? fs
-        .readFileSync(path)
-        .toString()
-        .split(delim)
-    : []
+  return fs.existsSync(path) ? fs.readFileSync(path).toString().split(delim) : []
 }
 
 const fmtTestKey = (testID) => {
@@ -111,10 +106,7 @@ const fmtTestKey = (testID) => {
   // Hashing is necessary because the full test path is too long.
   const titlePath = testID.split(' -> ')
   const testTitle = titlePath[titlePath.length - 1]
-  const testKey = hashCode(testID)
-    .concat('_', testTitle)
-    .trim()
-    .replace(/(\W)/g, '_')
+  const testKey = hashCode(testID).concat('_', testTitle).trim().replace(/(\W)/g, '_')
   return testKey
 }
 

--- a/packages/flake-tracker/src/mocha/reporter.js
+++ b/packages/flake-tracker/src/mocha/reporter.js
@@ -13,17 +13,17 @@ function FlakeReporter(runner) {
   let skipped = []
   let currErrors = []
 
-  before('Fetch Flakey Tests', async function() {
+  before('Fetch Flakey Tests', async function () {
     manager = await FlakeManager.build()
     skip = shouldSkipKnownFlakes ? db.readKnownFlakes().map((i) => i.title) : []
   })
 
-  after('Process Flakey Tests', async function() {
+  after('Process Flakey Tests', async function () {
     db.writeSkippedFlakes(skipped)
     await manager.finish()
   })
 
-  runner.on('retry', function(test, err) {
+  runner.on('retry', function (test, err) {
     console.log('Retry #' + (test.currentRetry() + 1) + ' for test ' + getTestID(test))
     if (shouldLogRetryErrorsOnFailure) {
       console.log('\n' + fmtError(err) + '\n')
@@ -31,7 +31,7 @@ function FlakeReporter(runner) {
     currErrors.push(fmtError(err))
   })
 
-  runner.on('test', function(test) {
+  runner.on('test', function (test) {
     if (skip.length) {
       let testID = getTestID(test)
       if (skip.some((knownFlake) => knownFlake.includes(testID))) {
@@ -42,7 +42,7 @@ function FlakeReporter(runner) {
     }
   })
 
-  runner.on('pass', function(test) {
+  runner.on('pass', function (test) {
     if (test.currentRetry() > 0) {
       // Note that we could store these errors locally in a map and not use the db at all.
       // We use the db here for consistency with jest which must use the db, and also because
@@ -51,7 +51,7 @@ function FlakeReporter(runner) {
     }
   })
 
-  runner.on('test end', function(test) {
+  runner.on('test end', function (test) {
     currErrors = []
   })
 }

--- a/packages/phone-number-privacy/combiner/migrations/20200330212224_create-accounts-table.ts
+++ b/packages/phone-number-privacy/combiner/migrations/20200330212224_create-accounts-table.ts
@@ -3,9 +3,7 @@ import { ACCOUNTS_COLUMNS, ACCOUNTS_TABLE } from '../src/database/models/account
 
 export async function up(knex: Knex): Promise<any> {
   return knex.schema.createTable(ACCOUNTS_TABLE, (t) => {
-    t.string(ACCOUNTS_COLUMNS.address)
-      .notNullable()
-      .primary()
+    t.string(ACCOUNTS_COLUMNS.address).notNullable().primary()
     t.dateTime(ACCOUNTS_COLUMNS.createdAt).notNullable()
     t.dateTime(ACCOUNTS_COLUMNS.didMatchmaking)
   })

--- a/packages/phone-number-privacy/combiner/src/database/wrappers/account.ts
+++ b/packages/phone-number-privacy/combiner/src/database/wrappers/account.ts
@@ -8,9 +8,7 @@ function accounts() {
 }
 
 async function getAccountExists(account: string): Promise<boolean> {
-  const existingAccountRecord = await accounts()
-    .where(ACCOUNTS_COLUMNS.address, account)
-    .first()
+  const existingAccountRecord = await accounts().where(ACCOUNTS_COLUMNS.address, account).first()
   return !!existingAccountRecord
 }
 
@@ -57,8 +55,6 @@ export async function setDidMatchmaking(account: string, logger: Logger) {
 }
 
 async function insertRecord(data: Account) {
-  await accounts()
-    .insert(data)
-    .timeout(DB_TIMEOUT)
+  await accounts().insert(data).timeout(DB_TIMEOUT)
   return true
 }

--- a/packages/phone-number-privacy/signer/src/database/database.ts
+++ b/packages/phone-number-privacy/signer/src/database/database.ts
@@ -70,9 +70,7 @@ export async function initDatabase(doTestQuery = true) {
 
 async function executeTestQuery(_db: Knex) {
   logger.info('Counting accounts')
-  const result = await _db(ACCOUNTS_TABLE)
-    .count(ACCOUNTS_COLUMNS.address)
-    .first()
+  const result = await _db(ACCOUNTS_TABLE).count(ACCOUNTS_COLUMNS.address).first()
 
   if (!result) {
     throw new Error('No result from count, have migrations been run?')

--- a/packages/phone-number-privacy/signer/src/database/wrappers/account.ts
+++ b/packages/phone-number-privacy/signer/src/database/wrappers/account.ts
@@ -28,9 +28,7 @@ export async function getPerformedQueryCount(account: string, logger: Logger): P
 }
 
 async function getAccountExists(account: string): Promise<boolean> {
-  const existingAccountRecord = await accounts()
-    .where(ACCOUNTS_COLUMNS.address, account)
-    .first()
+  const existingAccountRecord = await accounts().where(ACCOUNTS_COLUMNS.address, account).first()
   return !!existingAccountRecord
 }
 
@@ -103,8 +101,6 @@ export async function setDidMatchmaking(account: string, logger: Logger) {
 }
 
 async function insertRecord(data: Account) {
-  await accounts()
-    .insert(data)
-    .timeout(DB_TIMEOUT)
+  await accounts().insert(data).timeout(DB_TIMEOUT)
   return true
 }

--- a/packages/phone-number-privacy/signer/src/database/wrappers/request.ts
+++ b/packages/phone-number-privacy/signer/src/database/wrappers/request.ts
@@ -42,9 +42,7 @@ export async function storeRequest(request: GetBlindedMessagePartialSigRequest, 
   }
   logger.debug({ request }, 'Storing salt request')
   try {
-    await requests()
-      .insert(new Request(request))
-      .timeout(DB_TIMEOUT)
+    await requests().insert(new Request(request)).timeout(DB_TIMEOUT)
     return true
   } catch (err) {
     Counters.databaseErrors.labels(Labels.update).inc()

--- a/packages/phone-number-privacy/signer/src/migrations/20200330212224_create-accounts-table.ts
+++ b/packages/phone-number-privacy/signer/src/migrations/20200330212224_create-accounts-table.ts
@@ -5,9 +5,7 @@ export async function up(knex: Knex): Promise<any> {
   // This check was necessary to switch from using .ts migrations to .js migrations.
   if (!(await knex.schema.hasTable(ACCOUNTS_TABLE))) {
     return knex.schema.createTable(ACCOUNTS_TABLE, (t) => {
-      t.string(ACCOUNTS_COLUMNS.address)
-        .notNullable()
-        .primary()
+      t.string(ACCOUNTS_COLUMNS.address).notNullable().primary()
       t.dateTime(ACCOUNTS_COLUMNS.createdAt).notNullable()
       t.integer(ACCOUNTS_COLUMNS.numLookups).unsigned()
       t.dateTime(ACCOUNTS_COLUMNS.didMatchmaking)

--- a/packages/phone-number-privacy/signer/test/index.test.ts
+++ b/packages/phone-number-privacy/signer/test/index.test.ts
@@ -210,10 +210,7 @@ describe(`POST /getBlindedMessageSignature endpoint`, () => {
         account: 'd31509C31d654056A45185ECb6',
       }
 
-      request(app)
-        .post('/getBlindedMessagePartialSig')
-        .send(mockRequestData)
-        .expect(400, done)
+      request(app).post('/getBlindedMessagePartialSig').send(mockRequestData).expect(400, done)
     })
 
     it('invalid hashedPhoneNumber returns 400', (done) => {
@@ -222,10 +219,7 @@ describe(`POST /getBlindedMessageSignature endpoint`, () => {
         hashedPhoneNumber: '+1234567890',
       }
 
-      request(app)
-        .post('/getBlindedMessagePartialSig')
-        .send(mockRequestData)
-        .expect(400, done)
+      request(app).post('/getBlindedMessagePartialSig').send(mockRequestData).expect(400, done)
     })
 
     it('expired timestamp returns 400', (done) => {
@@ -234,10 +228,7 @@ describe(`POST /getBlindedMessageSignature endpoint`, () => {
         timestamp: Date.now() - REQUEST_EXPIRY_WINDOW_MS,
       }
 
-      request(app)
-        .post('/getBlindedMessagePartialSig')
-        .send(mockRequestData)
-        .expect(400, done)
+      request(app).post('/getBlindedMessagePartialSig').send(mockRequestData).expect(400, done)
     })
 
     it('invalid blinded phone number returns 400', (done) => {
@@ -246,10 +237,7 @@ describe(`POST /getBlindedMessageSignature endpoint`, () => {
         blindedQueryPhoneNumber: '1234567890',
       }
 
-      request(app)
-        .post('/getBlindedMessagePartialSig')
-        .send(mockRequestData)
-        .expect(400, done)
+      request(app).post('/getBlindedMessagePartialSig').send(mockRequestData).expect(400, done)
     })
   })
 })

--- a/packages/protocol/migrations/08_reserve.ts
+++ b/packages/protocol/migrations/08_reserve.ts
@@ -12,17 +12,9 @@ import Web3Utils = require('web3-utils')
 
 const truffle = require('@celo/protocol/truffle-config.js')
 
-const initializeArgs = async (): Promise<[
-  string,
-  number,
-  string,
-  number,
-  number,
-  string[],
-  string[],
-  string,
-  string
-]> => {
+const initializeArgs = async (): Promise<
+  [string, number, string, number, number, string[], string[], string, string]
+> => {
   const registry: RegistryInstance = await getDeployedProxiedContract<RegistryInstance>(
     'Registry',
     artifacts
@@ -75,9 +67,10 @@ module.exports = deploymentForCoreContract<ReserveInstance>(
       }
     }
 
-    const reserveSpenderMultiSig: ReserveSpenderMultiSigInstance = await getDeployedProxiedContract<
-      ReserveSpenderMultiSigInstance
-    >(CeloContractName.ReserveSpenderMultiSig, artifacts)
+    const reserveSpenderMultiSig: ReserveSpenderMultiSigInstance = await getDeployedProxiedContract<ReserveSpenderMultiSigInstance>(
+      CeloContractName.ReserveSpenderMultiSig,
+      artifacts
+    )
     console.info(`Marking ${reserveSpenderMultiSig.address} as a reserve spender`)
     await reserve.addSpender(reserveSpenderMultiSig.address)
   }

--- a/packages/protocol/migrations/09_0_stabletoken_USD.ts
+++ b/packages/protocol/migrations/09_0_stabletoken_USD.ts
@@ -47,9 +47,10 @@ module.exports = deploymentForCoreContract<StableTokenInstance>(
       await freezer.freeze(stableToken.address)
     }
 
-    const sortedOracles: SortedOraclesInstance = await getDeployedProxiedContract<
-      SortedOraclesInstance
-    >('SortedOracles', artifacts)
+    const sortedOracles: SortedOraclesInstance = await getDeployedProxiedContract<SortedOraclesInstance>(
+      'SortedOracles',
+      artifacts
+    )
 
     for (const oracle of config.stableToken.oracles) {
       console.info(`Adding ${oracle} as an Oracle for StableToken (USD)`)
@@ -82,9 +83,10 @@ module.exports = deploymentForCoreContract<StableTokenInstance>(
     }
 
     console.info('Whitelisting StableToken (USD) as a fee currency')
-    const feeCurrencyWhitelist: FeeCurrencyWhitelistInstance = await getDeployedProxiedContract<
-      FeeCurrencyWhitelistInstance
-    >('FeeCurrencyWhitelist', artifacts)
+    const feeCurrencyWhitelist: FeeCurrencyWhitelistInstance = await getDeployedProxiedContract<FeeCurrencyWhitelistInstance>(
+      'FeeCurrencyWhitelist',
+      artifacts
+    )
     await feeCurrencyWhitelist.addToken(stableToken.address)
   }
 )

--- a/packages/protocol/migrations/09_1_stableToken_EUR.ts
+++ b/packages/protocol/migrations/09_1_stableToken_EUR.ts
@@ -47,9 +47,10 @@ module.exports = deploymentForCoreContract<StableTokenEURInstance>( // TODO add 
       )
       await freezer.freeze(stableToken.address)
     }
-    const sortedOracles: SortedOraclesInstance = await getDeployedProxiedContract<
-      SortedOraclesInstance
-    >('SortedOracles', artifacts)
+    const sortedOracles: SortedOraclesInstance = await getDeployedProxiedContract<SortedOraclesInstance>(
+      'SortedOracles',
+      artifacts
+    )
 
     for (const oracle of config.stableTokenEUR.oracles) {
       console.info(`Adding ${oracle} as an Oracle for StableToken (EUR)`)
@@ -82,9 +83,10 @@ module.exports = deploymentForCoreContract<StableTokenEURInstance>( // TODO add 
     }
 
     console.info('Whitelisting StableToken (EUR) as a fee currency')
-    const feeCurrencyWhitelist: FeeCurrencyWhitelistInstance = await getDeployedProxiedContract<
-      FeeCurrencyWhitelistInstance
-    >('FeeCurrencyWhitelist', artifacts)
+    const feeCurrencyWhitelist: FeeCurrencyWhitelistInstance = await getDeployedProxiedContract<FeeCurrencyWhitelistInstance>(
+      'FeeCurrencyWhitelist',
+      artifacts
+    )
     await feeCurrencyWhitelist.addToken(stableToken.address)
   }
 )

--- a/packages/protocol/migrations/10_1_exchange_EUR.ts
+++ b/packages/protocol/migrations/10_1_exchange_EUR.ts
@@ -15,9 +15,10 @@ import {
 } from 'types'
 
 const initializeArgs = async (): Promise<any[]> => {
-  const stableTokenEUR: StableTokenEURInstance = await getDeployedProxiedContract<
-    StableTokenEURInstance
-  >('StableTokenEUR', artifacts)
+  const stableTokenEUR: StableTokenEURInstance = await getDeployedProxiedContract<StableTokenEURInstance>(
+    'StableTokenEUR',
+    artifacts
+  )
   return [
     config.registry.predeployedProxyAddress,
     stableTokenEUR.address,

--- a/packages/protocol/migrations/24_governance.ts
+++ b/packages/protocol/migrations/24_governance.ts
@@ -13,9 +13,10 @@ import { toFixed } from '@celo/utils/lib/fixidity'
 import { GovernanceApproverMultiSigInstance, GovernanceInstance } from 'types'
 
 const initializeArgs = async (networkName: string): Promise<any[]> => {
-  const governanceApproverMultiSig: GovernanceApproverMultiSigInstance = await getDeployedProxiedContract<
-    GovernanceApproverMultiSigInstance
-  >(CeloContractName.GovernanceApproverMultiSig, artifacts)
+  const governanceApproverMultiSig: GovernanceApproverMultiSigInstance = await getDeployedProxiedContract<GovernanceApproverMultiSigInstance>(
+    CeloContractName.GovernanceApproverMultiSig,
+    artifacts
+  )
   const networkFrom: string = require('@celo/protocol/truffle-config.js').networks[networkName].from
   const approver: string = config.governanceApproverMultiSig.useMultiSig
     ? governanceApproverMultiSig.address

--- a/packages/protocol/migrations/25_elect_validators.ts
+++ b/packages/protocol/migrations/25_elect_validators.ts
@@ -22,10 +22,7 @@ function ganachePrivateKey(num) {
   const seed = bip39.mnemonicToSeedSync(truffle.networks.development.mnemonic)
   const hdk = hdkey.fromMasterSeed(seed)
   const addrNode = hdk.derivePath("m/44'/60'/0'/0/" + num) // m/44'/60'/0'/0/0 is derivation path for the first account. m/44'/60'/0'/0/1 is the derivation path for the second account and so on
-  return addrNode
-    .getWallet()
-    .getPrivateKey()
-    .toString('hex')
+  return addrNode.getWallet().getPrivateKey().toString('hex')
 }
 
 function serializeKeystore(keystore: any) {

--- a/packages/protocol/scripts/truffle/deploy_release_contracts.ts
+++ b/packages/protocol/scripts/truffle/deploy_release_contracts.ts
@@ -64,10 +64,7 @@ async function handleGrant(config: ReleaseGoldConfig, currGrant: number) {
     return
   }
 
-  const adjustedAmountPerPeriod = totalValue
-    .minus(startGold)
-    .div(config.numReleasePeriods)
-    .dp(0)
+  const adjustedAmountPerPeriod = totalValue.minus(startGold).div(config.numReleasePeriods).dp(0)
 
   // Reflect any rounding changes from the division above
   totalValue = adjustedAmountPerPeriod.multipliedBy(config.numReleasePeriods)

--- a/packages/protocol/scripts/truffle/govern.ts
+++ b/packages/protocol/scripts/truffle/govern.ts
@@ -38,10 +38,7 @@ module.exports = async (callback: (error?: any) => number) => {
     }
 
     const functionName = functionCall.split('(')[0]
-    const functionArgs = functionCall
-      .split('(')[1]
-      .split(')')[0]
-      .split(', ')
+    const functionArgs = functionCall.split('(')[1].split(')')[0].split(', ')
 
     console.log(contractName, contract.address, functionName, functionArgs)
     console.log('Calling', '"' + argv.command + '"', 'via MultiSig')

--- a/packages/protocol/scripts/truffle/revoke.ts
+++ b/packages/protocol/scripts/truffle/revoke.ts
@@ -22,9 +22,10 @@ module.exports = async (callback: (error?: any) => number) => {
     const phoneNumber: string = argv.phone
     // @ts-ignore soliditySha3 can take an object
     const phoneHash: string = web3.utils.soliditySha3({ type: 'string', value: phoneNumber })
-    const attestations: AttestationsInstance = await getDeployedProxiedContract<
-      AttestationsInstance
-    >('Attestations', artifacts)
+    const attestations: AttestationsInstance = await getDeployedProxiedContract<AttestationsInstance>(
+      'Attestations',
+      artifacts
+    )
 
     const currentAccounts = await attestations.lookupAccountsForIdentifier(phoneHash)
     const account = (await web3.eth.getAccounts())[0]

--- a/packages/protocol/test/common/addresssortedlinkedlistwithmedian.ts
+++ b/packages/protocol/test/common/addresssortedlinkedlistwithmedian.ts
@@ -198,13 +198,7 @@ contract('AddressSortedLinkedListWithMedianTest', (accounts: string[]) => {
     }
 
     const randomElement = <A>(list: A[]): A => {
-      return list[
-        Math.floor(
-          BigNumber.random()
-            .times(list.length)
-            .toNumber()
-        )
-      ]
+      return list[Math.floor(BigNumber.random().times(list.length).toNumber())]
     }
 
     const randomElementOrNullAddress = (list: string[]): string => {

--- a/packages/protocol/test/common/gaspriceminimum.ts
+++ b/packages/protocol/test/common/gaspriceminimum.ts
@@ -179,10 +179,7 @@ contract('GasPriceMinimum', (accounts: string[]) => {
         const currentGasPriceMinimum = await gasPriceMinimum.gasPriceMinimum()
         await gasPriceMinimum.setGasPriceMinimumFloor(currentGasPriceMinimum)
         const actualUpdatedGasPriceMinimum = await gasPriceMinimum.getUpdatedGasPriceMinimum(1, 1)
-        const expectedUpdatedGasPriceMinimum = currentGasPriceMinimum
-          .times(5)
-          .div(4)
-          .plus(1)
+        const expectedUpdatedGasPriceMinimum = currentGasPriceMinimum.times(5).div(4).plus(1)
         assertEqualBN(actualUpdatedGasPriceMinimum, expectedUpdatedGasPriceMinimum)
       })
     })
@@ -200,10 +197,7 @@ contract('GasPriceMinimum', (accounts: string[]) => {
         const currentGasPriceMinimum = await gasPriceMinimum.gasPriceMinimum()
         await gasPriceMinimum.setGasPriceMinimumFloor(1)
         const actualUpdatedGasPriceMinimum = await gasPriceMinimum.getUpdatedGasPriceMinimum(0, 1)
-        const expectedUpdatedGasPriceMinimum = currentGasPriceMinimum
-          .times(3)
-          .div(4)
-          .plus(1)
+        const expectedUpdatedGasPriceMinimum = currentGasPriceMinimum.times(3).div(4).plus(1)
         assertEqualBN(actualUpdatedGasPriceMinimum, expectedUpdatedGasPriceMinimum)
       })
     })
@@ -239,9 +233,7 @@ contract('GasPriceMinimum', (accounts: string[]) => {
           const curGas = await gasPriceMinimum.gasPriceMinimum()
 
           const blockGasLimit = new BigNumber(web3.utils.randomHex(4))
-          const gasUsed = BigNumber.random()
-            .times(blockGasLimit)
-            .integerValue()
+          const gasUsed = BigNumber.random().times(blockGasLimit).integerValue()
           const actualUpdatedGasPriceMinimum = await gasPriceMinimum.getUpdatedGasPriceMinimum(
             gasUsed,
             blockGasLimit

--- a/packages/protocol/test/governance/network/epochrewards.ts
+++ b/packages/protocol/test/governance/network/epochrewards.ts
@@ -780,14 +780,8 @@ contract('EpochRewards', (accounts: string[]) => {
         web3.utils.padRight(web3.utils.utf8ToHex('empty'), 64),
       ]
       const assetAllocationWeights = [
-        new BigNumber(10)
-          .pow(24)
-          .dividedBy(new BigNumber(2))
-          .integerValue(),
-        new BigNumber(10)
-          .pow(24)
-          .dividedBy(new BigNumber(2))
-          .integerValue(),
+        new BigNumber(10).pow(24).dividedBy(new BigNumber(2)).integerValue(),
+        new BigNumber(10).pow(24).dividedBy(new BigNumber(2)).integerValue(),
       ]
       await reserve.setAssetAllocations(assetAllocationSymbols, assetAllocationWeights)
     })
@@ -795,11 +789,7 @@ contract('EpochRewards', (accounts: string[]) => {
     describe('reserve ratio of 0.5', () => {
       beforeEach(async () => {
         const stableBalance = new BigNumber(2397846127684712867321)
-        const goldBalance = stableBalance
-          .div(exchangeRate)
-          .div(2)
-          .times(0.5)
-          .integerValue()
+        const goldBalance = stableBalance.div(exchangeRate).div(2).times(0.5).integerValue()
         await mockStableToken.setTotalSupply(stableBalance)
         await web3.eth.sendTransaction({
           from: accounts[9],
@@ -833,11 +823,7 @@ contract('EpochRewards', (accounts: string[]) => {
     describe('reserve ratio of 1.5', () => {
       beforeEach(async () => {
         const stableBalance = new BigNumber(2397846127684712867321)
-        const goldBalance = stableBalance
-          .div(exchangeRate)
-          .div(2)
-          .times(1.5)
-          .integerValue()
+        const goldBalance = stableBalance.div(exchangeRate).div(2).times(1.5).integerValue()
         await mockStableToken.setTotalSupply(stableBalance)
         await web3.eth.sendTransaction({
           from: accounts[9],
@@ -878,11 +864,7 @@ contract('EpochRewards', (accounts: string[]) => {
     describe('reserve ratio of 2.5', () => {
       beforeEach(async () => {
         const stableBalance = new BigNumber(2397846127684712867321)
-        const goldBalance = stableBalance
-          .div(exchangeRate)
-          .div(2)
-          .times(2.5)
-          .integerValue()
+        const goldBalance = stableBalance.div(exchangeRate).div(2).times(2.5).integerValue()
         await mockStableToken.setTotalSupply(stableBalance)
         await web3.eth.sendTransaction({
           from: accounts[9],

--- a/packages/protocol/test/governance/validators/sortedlinkedlist.ts
+++ b/packages/protocol/test/governance/validators/sortedlinkedlist.ts
@@ -208,13 +208,7 @@ contract('IntegerSortedLinkedListTest', () => {
     }
 
     const randomElement = (list: any[]) => {
-      return list[
-        Math.floor(
-          BigNumber.random()
-            .times(list.length)
-            .toNumber()
-        )
-      ]
+      return list[Math.floor(BigNumber.random().times(list.length).toNumber())]
     }
 
     const makeActionSequence = (length: number, numKeys: number): SortedLinkedListAction[] => {

--- a/packages/protocol/test/governance/validators/validators.ts
+++ b/packages/protocol/test/governance/validators/validators.ts
@@ -2192,13 +2192,7 @@ contract('Validators', (accounts: string[]) => {
             const removalTimestamp = removalTimestamps[i]
             const requirementExpiry = groupLockedGoldRequirements.duration.plus(removalTimestamp)
             const currentTimestamp = (await web3.eth.getBlock('latest')).timestamp
-            await timeTravel(
-              requirementExpiry
-                .minus(currentTimestamp)
-                .plus(1)
-                .toNumber(),
-              web3
-            )
+            await timeTravel(requirementExpiry.minus(currentTimestamp).plus(1).toNumber(), web3)
           }
         })
       })

--- a/packages/protocol/test/governance/voting/election.ts
+++ b/packages/protocol/test/governance/voting/election.ts
@@ -1810,20 +1810,11 @@ contract('Election', (accounts: string[]) => {
     }
 
     const randomElement = <A>(list: A[]): A => {
-      return list[
-        Math.floor(
-          BigNumber.random()
-            .times(list.length)
-            .toNumber()
-        )
-      ]
+      return list[Math.floor(BigNumber.random().times(list.length).toNumber())]
     }
 
     const randomInteger = (max: BigNumber, min: BigNumber = new BigNumber(1)): BigNumber => {
-      return BigNumber.random()
-        .times(max.minus(min))
-        .plus(min)
-        .dp(0)
+      return BigNumber.random().times(max.minus(min)).plus(min).dp(0)
     }
 
     const makeRandomAction = async (account: Account) => {
@@ -1985,7 +1976,7 @@ contract('Election', (accounts: string[]) => {
       })
     })
 
-    describe('when placing, activating, and revoking votes randomly', function(this: any) {
+    describe('when placing, activating, and revoking votes randomly', function (this: any) {
       this.timeout(0)
       describe('when no epoch rewards are distributed', () => {
         it('actual and expected should always match exactly', async () => {

--- a/packages/protocol/test/governance/voting/release_gold.ts
+++ b/packages/protocol/test/governance/voting/release_gold.ts
@@ -1700,9 +1700,7 @@ contract('ReleaseGold', (accounts: string[]) => {
             })
 
             it('should not allow withdrawal of more than 50% gold', async () => {
-              const unexpectedWithdrawalAmount = TOTAL_AMOUNT.plus(ONE_GOLDTOKEN)
-                .div(2)
-                .plus(1)
+              const unexpectedWithdrawalAmount = TOTAL_AMOUNT.plus(ONE_GOLDTOKEN).div(2).plus(1)
               await assertRevert(
                 releaseGoldInstance.withdraw(unexpectedWithdrawalAmount, { from: beneficiary })
               )

--- a/packages/protocol/test/stability/reserve.ts
+++ b/packages/protocol/test/stability/reserve.ts
@@ -465,14 +465,8 @@ contract('Reserve', (accounts: string[]) => {
       web3.utils.padRight(web3.utils.utf8ToHex('empty'), 64),
     ]
     const newAssetAllocationWeights = [
-      new BigNumber(10)
-        .pow(24)
-        .dividedBy(new BigNumber(2))
-        .integerValue(),
-      new BigNumber(10)
-        .pow(24)
-        .dividedBy(new BigNumber(2))
-        .integerValue(),
+      new BigNumber(10).pow(24).dividedBy(new BigNumber(2)).integerValue(),
+      new BigNumber(10).pow(24).dividedBy(new BigNumber(2)).integerValue(),
     ]
     let mockStableToken: MockStableTokenInstance
 
@@ -557,10 +551,7 @@ contract('Reserve', (accounts: string[]) => {
       })
 
       it('should set tobin tax to 0.5% when reserve gold balance < gold value of floating stable tokens', async () => {
-        const stableTokenSupply = new BN(10)
-          .pow(new BN(20))
-          .mul(new BN(6))
-          .toString()
+        const stableTokenSupply = new BN(10).pow(new BN(20)).mul(new BN(6)).toString()
         await mockStableToken.setTotalSupply(stableTokenSupply)
         await anotherMockStableToken.setTotalSupply(stableTokenSupply)
         const actual = await getOrComputeTobinTax()
@@ -719,19 +710,9 @@ contract('Reserve', (accounts: string[]) => {
       web3.utils.padRight(web3.utils.utf8ToHex('ETH'), 64),
     ]
     const newAssetAllocationWeights = [
-      new BigNumber(10)
-        .pow(24)
-        .dividedBy(new BigNumber(3))
-        .integerValue()
-        .plus(new BigNumber(1)),
-      new BigNumber(10)
-        .pow(24)
-        .dividedBy(new BigNumber(3))
-        .integerValue(),
-      new BigNumber(10)
-        .pow(24)
-        .dividedBy(new BigNumber(3))
-        .integerValue(),
+      new BigNumber(10).pow(24).dividedBy(new BigNumber(3)).integerValue().plus(new BigNumber(1)),
+      new BigNumber(10).pow(24).dividedBy(new BigNumber(3)).integerValue(),
+      new BigNumber(10).pow(24).dividedBy(new BigNumber(3)).integerValue(),
     ]
 
     it('should allow owner to set asset allocations', async () => {

--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -93,7 +93,7 @@ const networks = {
     gasPrice: 0,
     gas: gasLimit,
     from: DEVELOPMENT_FROM,
-    provider: function() {
+    provider: function () {
       if (coverageProvider == null) {
         console.log('building provider!')
         coverageProvider = new ProviderEngine()
@@ -208,7 +208,7 @@ if (process.argv.includes('--forno')) {
 
   networks[argv.network].host = undefined
   networks[argv.network].port = undefined
-  networks[argv.network].provider = function() {
+  networks[argv.network].provider = function () {
     return new Web3.providers.HttpProvider(fornoUrls[argv.network])
   }
 }

--- a/packages/sdk/base/src/task.test.ts
+++ b/packages/sdk/base/src/task.test.ts
@@ -122,10 +122,7 @@ describe('repeatTask()', () => {
 
 describe('conditionWatcher()', () => {
   test('will execute onSuccess when condition triggers', async () => {
-    const pollCondition = jest
-      .fn()
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true)
+    const pollCondition = jest.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
     const onSuccess = jest.fn()
 
     const task = conditionWatcher({
@@ -183,10 +180,7 @@ describe('tryObtainValueWithRetries()', () => {
     const task = tryObtainValueWithRetries({
       name: 'testGet',
       maxAttemps: 2,
-      tryGetValue: jest
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce('HELLO'),
+      tryGetValue: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce('HELLO'),
       timeInBetweenMS: 7,
     })
 

--- a/packages/sdk/connect/src/utils/formatter.ts
+++ b/packages/sdk/connect/src/utils/formatter.ts
@@ -221,15 +221,9 @@ function utf8ToHex(str: string): string {
 
   // remove \u0000 padding from either side
   str = str.replace(/^(?:\u0000)*/, '')
-  str = str
-    .split('')
-    .reverse()
-    .join('')
+  str = str.split('').reverse().join('')
   str = str.replace(/^(?:\u0000)*/, '')
-  str = str
-    .split('')
-    .reverse()
-    .join('')
+  str = str.split('').reverse().join('')
 
   for (let i = 0; i < str.length; i++) {
     const code = str.charCodeAt(i)

--- a/packages/sdk/contractkit/src/wrappers/BaseWrapper.ts
+++ b/packages/sdk/contractkit/src/wrappers/BaseWrapper.ts
@@ -68,9 +68,7 @@ export const valueToFixidityString = (input: BigNumber.Value) =>
   toFixed(valueToBigNumber(input)).toFixed()
 
 export const valueToInt = (input: BigNumber.Value) =>
-  valueToBigNumber(input)
-    .integerValue()
-    .toNumber()
+  valueToBigNumber(input).integerValue().toNumber()
 
 export const valueToFrac = (numerator: BigNumber.Value, denominator: BigNumber.Value) =>
   valueToBigNumber(numerator).div(valueToBigNumber(denominator))
@@ -126,10 +124,7 @@ export const blocksToDurationString = (input: BigNumber.Value) =>
   secondsToDurationString(valueToBigNumber(input).times(5)) // TODO: fetch blocktime
 
 export const unixSecondsTimestampToDateString = (input: BigNumber.Value) =>
-  moment
-    .unix(valueToInt(input))
-    .local()
-    .format('llll [UTC]Z')
+  moment.unix(valueToInt(input)).local().format('llll [UTC]Z')
 
 // Type of bytes in solidity gets repesented as a string of number array by typechain and web3
 // Hopefull this will improve in the future, at which point we can make improvements here

--- a/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.ts
+++ b/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.ts
@@ -1,8 +1,6 @@
 import { MetaTransactionWalletDeployer } from '../generated/MetaTransactionWalletDeployer'
 import { BaseWrapper, proxySend } from './BaseWrapper'
 
-export class MetaTransactionWalletDeployerWrapper extends BaseWrapper<
-  MetaTransactionWalletDeployer
-> {
+export class MetaTransactionWalletDeployerWrapper extends BaseWrapper<MetaTransactionWalletDeployer> {
   deploy = proxySend(this.kit, this.contract.methods.deploy)
 }

--- a/packages/sdk/identity/src/odis/phone-number-identifier.ts
+++ b/packages/sdk/identity/src/odis/phone-number-identifier.ts
@@ -140,10 +140,7 @@ export async function getPhoneNumberIdentifierFromSignature(
 // It simply hashes it with sha256 and encodes it to hex
 export function getPepperFromThresholdSignature(sigBuf: Buffer) {
   // Currently uses 13 chars for a 78 bit pepper
-  return createHash('sha256')
-    .update(sigBuf)
-    .digest('base64')
-    .slice(0, PEPPER_CHAR_LENGTH)
+  return createHash('sha256').update(sigBuf).digest('base64').slice(0, PEPPER_CHAR_LENGTH)
 }
 
 /**

--- a/packages/sdk/identity/src/offchain-data-wrapper.ts
+++ b/packages/sdk/identity/src/offchain-data-wrapper.ts
@@ -35,9 +35,7 @@ export class InvalidSignature extends RootError<OffchainErrorTypes.InvalidSignat
   }
 }
 
-export class NoStorageRootProvidedData extends RootError<
-  OffchainErrorTypes.NoStorageRootProvidedData
-> {
+export class NoStorageRootProvidedData extends RootError<OffchainErrorTypes.NoStorageRootProvidedData> {
   constructor() {
     super(OffchainErrorTypes.NoStorageRootProvidedData)
   }

--- a/packages/sdk/utils/src/account.ts
+++ b/packages/sdk/utils/src/account.ts
@@ -68,10 +68,7 @@ export function validateMnemonic(mnemonic: string, bip39ToUse: Bip39 = bip39Wrap
 
 export function formatNonAccentedCharacters(mnemonic: string) {
   const languages = getAllLanguages()
-  const normMnemonicArr = normalizeAccents(mnemonic)
-    .toLowerCase()
-    .trim()
-    .split(' ')
+  const normMnemonicArr = normalizeAccents(mnemonic).toLowerCase().trim().split(' ')
 
   for (const language of languages) {
     if (isLatinBasedLanguage(language)) {

--- a/packages/sdk/utils/src/ecies.ts
+++ b/packages/sdk/utils/src/ecies.ts
@@ -83,9 +83,7 @@ export function AES128EncryptAndHMAC(
 ): Buffer {
   const iv = randomBytes(IV_LENGTH)
   const dataToMac = AES128Encrypt(encryptionKey, iv, plaintext)
-  const mac = createHmac('sha256', macKey)
-    .update(dataToMac)
-    .digest()
+  const mac = createHmac('sha256', macKey).update(dataToMac).digest()
 
   return Buffer.concat([dataToMac, mac])
 }
@@ -121,9 +119,7 @@ export function AES128DecryptAndHMAC(
   const message = ciphertext.slice(IV_LENGTH, ciphertext.length - 32)
   const mac = ciphertext.slice(ciphertext.length - 32, ciphertext.length)
   const dataToMac = Buffer.concat([iv, message])
-  const computedMac = createHmac('sha256', macKey)
-    .update(dataToMac)
-    .digest()
+  const computedMac = createHmac('sha256', macKey).update(dataToMac).digest()
   if (!mac.equals(computedMac)) {
     throw new Error('MAC mismatch')
   }
@@ -146,9 +142,7 @@ export function Encrypt(pubKeyTo: Buffer, plaintext: Buffer) {
   )
   const hash = ConcatKDF(px.toArrayLike(Buffer), 32)
   const encryptionKey = hash.slice(0, 16)
-  const macKey = createHash('sha256')
-    .update(hash.slice(16))
-    .digest()
+  const macKey = createHash('sha256').update(hash.slice(16)).digest()
   const message = AES128EncryptAndHMAC(encryptionKey, macKey, plaintext)
   const serializedCiphertext = Buffer.concat([
     ephemPubKeyEncoded, // 65 bytes
@@ -173,9 +167,7 @@ export function Decrypt(privKey: Buffer, encrypted: Buffer) {
   const hash = ConcatKDF(px.toBuffer(), 32)
   // km, ke
   const encryptionKey = hash.slice(0, 16)
-  const macKey = createHash('sha256')
-    .update(hash.slice(16))
-    .digest()
+  const macKey = createHash('sha256').update(hash.slice(16)).digest()
 
   return AES128DecryptAndHMAC(encryptionKey, macKey, symmetricEncrypted)
 }

--- a/packages/sdk/utils/src/task.test.ts
+++ b/packages/sdk/utils/src/task.test.ts
@@ -122,10 +122,7 @@ describe('repeatTask()', () => {
 
 describe('conditionWatcher()', () => {
   test('will execute onSuccess when condition triggers', async () => {
-    const pollCondition = jest
-      .fn()
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true)
+    const pollCondition = jest.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
     const onSuccess = jest.fn()
 
     const task = conditionWatcher({
@@ -183,10 +180,7 @@ describe('tryObtainValueWithRetries()', () => {
     const task = tryObtainValueWithRetries({
       name: 'testGet',
       maxAttemps: 2,
-      tryGetValue: jest
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce('HELLO'),
+      tryGetValue: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce('HELLO'),
       timeInBetweenMS: 7,
     })
 

--- a/packages/sdk/wallets/wallet-base/src/signing-utils.ts
+++ b/packages/sdk/wallets/wallet-base/src/signing-utils.ts
@@ -126,9 +126,7 @@ export async function encodeTransaction(
   const v = sanitizedSignature.v
   const r = sanitizedSignature.r
   const s = sanitizedSignature.s
-  const rawTx = RLP.decode(rlpEncoded.rlpEncode)
-    .slice(0, 9)
-    .concat([v, r, s])
+  const rawTx = RLP.decode(rlpEncoded.rlpEncode).slice(0, 9).concat([v, r, s])
 
   const rawTransaction = RLP.encode(rawTx)
   const hash = getHashFromEncoded(rawTransaction)

--- a/packages/sdk/wallets/wallet-remote/src/remote-wallet.ts
+++ b/packages/sdk/wallets/wallet-remote/src/remote-wallet.ts
@@ -6,7 +6,8 @@ import { WalletBase } from '@celo/wallet-base'
 /**
  * Abstract class representing a remote wallet that requires async initialization
  */
-export abstract class RemoteWallet<TSigner extends Signer> extends WalletBase<TSigner>
+export abstract class RemoteWallet<TSigner extends Signer>
+  extends WalletBase<TSigner>
   implements ReadOnlyWallet {
   private setupFinished = false
   private setupLocked = false

--- a/packages/typescript/custom-rules/noGlobalArrowFunctionsRule.js
+++ b/packages/typescript/custom-rules/noGlobalArrowFunctionsRule.js
@@ -3,12 +3,12 @@ exports.__esModule = true
 var tslib_1 = require('tslib')
 var Lint = require('tslint')
 var ts = require('typescript')
-var Rule = /** @class */ (function(_super) {
+var Rule = /** @class */ (function (_super) {
   tslib_1.__extends(Rule, _super)
   function Rule() {
     return (_super !== null && _super.apply(this, arguments)) || this
   }
-  Rule.prototype.apply = function(sourceFile) {
+  Rule.prototype.apply = function (sourceFile) {
     return this.applyWithFunction(sourceFile, walk)
   }
   Rule.FAILURE_STRING = 'arrow functions forbidden in global scope, use named function'

--- a/scripts/dependency-graph-utils.ts
+++ b/scripts/dependency-graph-utils.ts
@@ -50,10 +50,7 @@ const buildGraph = async (): Promise<string> => {
   return JSON.stringify(dependencyGraph, null, 2)
 }
 
-const hash = (input: string): string =>
-  createHash('SHA256')
-    .update(input)
-    .digest('base64')
+const hash = (input: string): string => createHash('SHA256').update(input).digest('base64')
 
 export const graphHasChanged = async (): Promise<boolean> => {
   const oldGraph = readFileSync(DEP_GRAPH_FILENAME).toString()

--- a/scripts/hooks/pre-push.js
+++ b/scripts/hooks/pre-push.js
@@ -1,10 +1,7 @@
 const { execSync } = require('child_process')
 const chalk = require('chalk')
 const path = require('path')
-const exec = (args) =>
-  execSync(args)
-    .toString()
-    .trim()
+const exec = (args) => execSync(args).toString().trim()
 
 ////////////////////////////////////////////////////////////////
 /// CONFIG

--- a/yarn.lock
+++ b/yarn.lock
@@ -5129,10 +5129,10 @@
     "@types/node" "*"
     "@types/pg-types" "*"
 
-"@types/prettier@^1.13.2", "@types/prettier@^1.19.0", "@types/prettier@^2.0.0":
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
-  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+"@types/prettier@^1.13.2", "@types/prettier@^2.0.0", "@types/prettier@^2.2.1":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
+  integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
 "@types/promise.allsettled@^1.0.3":
   version "1.0.3"
@@ -20907,10 +20907,10 @@ prettier-plugin-solidity@1.0.0-alpha.35:
     solidity-parser-antlr "^0.4.11"
     string-width "^4.1.0"
 
-prettier@1.18.2, prettier@1.19.1, prettier@^1.14.2, prettier@^1.14.3, prettier@^1.15.3, prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@1.18.2, prettier@1.19.1, prettier@^1.14.2, prettier@^1.14.3, prettier@^1.15.3, prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
Changes/motivation:
- Prettier versions >=2.0.0 support full Typescript 3.8 functionality including type-only imports/exports; full docs [here](https://prettier.io/blog/2020/03/21/2.0.0.html#typescript-1)
- ran `yarn prettify` to reformat files according to new styles/defaults -- there are some (limited) defaults which we could override, but choosing to embrace Prettier 2.0 means that we will accept the new settings -- (docs on [their "option-philosophy"](https://prettier.io/docs/en/option-philosophy.html))
- does **not** update `prettier-plugin-java` or `prettier-plugin-solidity`, which should both continue to work as expected

Downsides:
- folks with PRs out will have to update + run `yarn prettify` which could cause irritating conflicts
- some new styles included may be less aesthetically pleasing to some as compared with the old styles, and there are intentionally few options that can be overridden through Prettier configuration; deciding we want to stick to the older version of prettier means that we forego future updates + won't access full typescript 3.8 support

Testing:
- waiting for automated tests (Edit: tests were passing)