### PR TITLE
Set name and symbol of the native ERC-20 currency to CELO

### DIFF
--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -156,9 +156,9 @@ contract GoldToken is
   }
 
   /**
-   * @notice Mints new cGLD and gives it to 'to'.
+   * @notice Mints new CELO and gives it to 'to'.
    * @param to The account for which to mint tokens.
-   * @param value The amount of cGLD to mint.
+   * @param value The amount of CELO to mint.
    */
   function mint(address to, uint256 value) external onlyVm returns (bool) {
     if (value == 0) {

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -24,7 +24,7 @@ contract GoldToken is
   // Address of the TRANSFER precompiled contract.
   // solhint-disable state-visibility
   address constant TRANSFER = address(0xff - 2);
-  string constant NAME = "CELO";
+  string constant NAME = "Celo native asset";
   string constant SYMBOL = "CELO";
   uint8 constant DECIMALS = 18;
   uint256 internal totalSupply_;

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -24,7 +24,7 @@ contract GoldToken is
   // Address of the TRANSFER precompiled contract.
   // solhint-disable state-visibility
   address constant TRANSFER = address(0xff - 2);
-  string constant NAME = "Celo Gold";
+  string constant NAME = "CELO";
   string constant SYMBOL = "CELO";
   uint8 constant DECIMALS = 18;
   uint256 internal totalSupply_;

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -25,7 +25,7 @@ contract GoldToken is
   // solhint-disable state-visibility
   address constant TRANSFER = address(0xff - 2);
   string constant NAME = "Celo Gold";
-  string constant SYMBOL = "cGLD";
+  string constant SYMBOL = "CELO";
   uint8 constant DECIMALS = 18;
   uint256 internal totalSupply_;
   // solhint-enable state-visibility

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -63,9 +63,9 @@ contract GoldToken is
   }
 
   /**
-   * @notice Transfers Celo Gold from one address to another.
-   * @param to The address to transfer Celo Gold to.
-   * @param value The amount of Celo Gold to transfer.
+   * @notice Transfers CELO from one address to another.
+   * @param to The address to transfer CELO to.
+   * @param value The amount of CELO to transfer.
    * @return True if the transaction succeeds.
    */
   // solhint-disable-next-line no-simple-event-func-name
@@ -74,9 +74,9 @@ contract GoldToken is
   }
 
   /**
-   * @notice Transfers Celo Gold from one address to another with a comment.
-   * @param to The address to transfer Celo Gold to.
-   * @param value The amount of Celo Gold to transfer.
+   * @notice Transfers CELO from one address to another with a comment.
+   * @param to The address to transfer CELO to.
+   * @param value The amount of CELO to transfer.
    * @param comment The transfer comment
    * @return True if the transaction succeeds.
    */
@@ -90,9 +90,9 @@ contract GoldToken is
   }
 
   /**
-   * @notice Approve a user to transfer Celo Gold on behalf of another user.
-   * @param spender The address which is being approved to spend Celo Gold.
-   * @param value The amount of Celo Gold approved to the spender.
+   * @notice Approve a user to transfer CELO on behalf of another user.
+   * @param spender The address which is being approved to spend CELO.
+   * @param value The amount of CELO approved to the spender.
    * @return True if the transaction succeeds.
    */
   function approve(address spender, uint256 value) external returns (bool) {
@@ -104,8 +104,8 @@ contract GoldToken is
 
   /**
    * @notice Increases the allowance of another user.
-   * @param spender The address which is being approved to spend Celo Gold.
-   * @param value The increment of the amount of Celo Gold approved to the spender.
+   * @param spender The address which is being approved to spend CELO.
+   * @param value The increment of the amount of CELO approved to the spender.
    * @return True if the transaction succeeds.
    */
   function increaseAllowance(address spender, uint256 value) external returns (bool) {
@@ -119,8 +119,8 @@ contract GoldToken is
 
   /**
    * @notice Decreases the allowance of another user.
-   * @param spender The address which is being approved to spend Celo Gold.
-   * @param value The decrement of the amount of Celo Gold approved to the spender.
+   * @param spender The address which is being approved to spend CELO.
+   * @param value The decrement of the amount of CELO approved to the spender.
    * @return True if the transaction succeeds.
    */
   function decreaseAllowance(address spender, uint256 value) external returns (bool) {
@@ -132,10 +132,10 @@ contract GoldToken is
   }
 
   /**
-   * @notice Transfers Celo Gold from one address to another on behalf of a user.
-   * @param from The address to transfer Celo Gold from.
-   * @param to The address to transfer Celo Gold to.
-   * @param value The amount of Celo Gold to transfer.
+   * @notice Transfers CELO from one address to another on behalf of a user.
+   * @param from The address to transfer CELO from.
+   * @param to The address to transfer CELO to.
+   * @param value The amount of CELO to transfer.
    * @return True if the transaction succeeds.
    */
   function transferFrom(address from, address to, uint256 value) external returns (bool) {
@@ -148,7 +148,7 @@ contract GoldToken is
 
     bool success;
     (success, ) = TRANSFER.call.value(0).gas(gasleft())(abi.encode(from, to, value));
-    require(success, "Celo Gold transfer failed");
+    require(success, "CELO transfer failed");
 
     allowed[from][msg.sender] = allowed[from][msg.sender].sub(value);
     emit Transfer(from, to, value);
@@ -170,52 +170,52 @@ contract GoldToken is
 
     bool success;
     (success, ) = TRANSFER.call.value(0).gas(gasleft())(abi.encode(address(0), to, value));
-    require(success, "Celo Gold transfer failed");
+    require(success, "CELO transfer failed");
 
     emit Transfer(address(0), to, value);
     return true;
   }
 
   /**
-   * @return The name of the Celo Gold token.
+   * @return The name of the CELO token.
    */
   function name() external view returns (string memory) {
     return NAME;
   }
 
   /**
-   * @return The symbol of the Celo Gold token.
+   * @return The symbol of the CELO token.
    */
   function symbol() external view returns (string memory) {
     return SYMBOL;
   }
 
   /**
-   * @return The number of decimal places to which Celo Gold is divisible.
+   * @return The number of decimal places to which CELO is divisible.
    */
   function decimals() external view returns (uint8) {
     return DECIMALS;
   }
 
   /**
-   * @return The total amount of Celo Gold in existence.
+   * @return The total amount of CELO in existence.
    */
   function totalSupply() external view returns (uint256) {
     return totalSupply_;
   }
 
   /**
-   * @notice Gets the amount of owner's Celo Gold allowed to be spent by spender.
-   * @param owner The owner of the Celo Gold.
-   * @param spender The spender of the Celo Gold.
-   * @return The amount of Celo Gold owner is allowing spender to spend.
+   * @notice Gets the amount of owner's CELO allowed to be spent by spender.
+   * @param owner The owner of the CELO.
+   * @param spender The spender of the CELO.
+   * @return The amount of CELO owner is allowing spender to spend.
    */
   function allowance(address owner, address spender) external view returns (uint256) {
     return allowed[owner][spender];
   }
 
   /**
-   * @notice Increases the variable for total amount of Celo Gold in existence.
+   * @notice Increases the variable for total amount of CELO in existence.
    * @param amount The amount to increase counter by
    */
   function increaseSupply(uint256 amount) external onlyVm {
@@ -232,9 +232,9 @@ contract GoldToken is
   }
 
   /**
-   * @notice internal Celo Gold transfer from one address to another.
-   * @param to The address to transfer Celo Gold to.
-   * @param value The amount of Celo Gold to transfer.
+   * @notice internal CELO transfer from one address to another.
+   * @param to The address to transfer CELO to.
+   * @param value The amount of CELO to transfer.
    * @return True if the transaction succeeds.
    */
   function _transfer(address to, uint256 value) internal returns (bool) {
@@ -243,7 +243,7 @@ contract GoldToken is
 
     bool success;
     (success, ) = TRANSFER.call.value(0).gas(gasleft())(abi.encode(msg.sender, to, value));
-    require(success, "Celo Gold transfer failed");
+    require(success, "CELO transfer failed");
     emit Transfer(msg.sender, to, value);
     return true;
   }

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -32,7 +32,7 @@ contract Election is
 
   // 1e20 ensures that units can be represented as precisely as possible to avoid rounding errors
   // when translating to votes, without risking integer overflow.
-  // A maximum of 1,000,000,000 cGLD (1e27) yields a maximum of 1e47 units, whose product is at
+  // A maximum of 1,000,000,000 CELO (1e27) yields a maximum of 1e47 units, whose product is at
   // most 1e74, which is less than 2^256.
   uint256 private constant UNIT_PRECISION_FACTOR = 100000000000000000000;
 

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -195,7 +195,7 @@ contract Governance is
    * @param registryAddress The address of the registry contract.
    * @param _approver The address that needs to approve proposals to move to the referendum stage.
    * @param _concurrentProposals The number of proposals to dequeue at once.
-   * @param _minDeposit The minimum Celo Gold deposit needed to make a proposal.
+   * @param _minDeposit The minimum CELO deposit needed to make a proposal.
    * @param _queueExpiry The number of seconds a proposal can stay in the queue before expiring.
    * @param _dequeueFrequency The number of seconds before the next batch of proposals can be
    *   dequeued.
@@ -268,7 +268,7 @@ contract Governance is
 
   /**
    * @notice Updates the minimum deposit needed to make a proposal.
-   * @param _minDeposit The minimum Celo Gold deposit needed to make a proposal.
+   * @param _minDeposit The minimum CELO deposit needed to make a proposal.
    */
   function setMinDeposit(uint256 _minDeposit) public onlyOwner {
     require(_minDeposit > 0, "minDeposit must be larger than 0");
@@ -433,7 +433,7 @@ contract Governance is
 
   /**
    * @notice Creates a new proposal and adds it to end of the queue with no upvotes.
-   * @param values The values of Celo Gold to be sent in the proposed transactions.
+   * @param values The values of CELO to be sent in the proposed transactions.
    * @param destinations The destination addresses of the proposed transactions.
    * @param data The concatenated data to be included in the proposed transactions.
    * @param dataLengths The lengths of each transaction's data.
@@ -715,7 +715,7 @@ contract Governance is
 
   /**
    * @notice Executes a whitelisted proposal.
-   * @param values The values of Celo Gold to be sent in the proposed transactions.
+   * @param values The values of CELO to be sent in the proposed transactions.
    * @param destinations The destination addresses of the proposed transactions.
    * @param data The concatenated data to be included in the proposed transactions.
    * @param dataLengths The lengths of each transaction's data.
@@ -743,7 +743,7 @@ contract Governance is
   }
 
   /**
-   * @notice Withdraws refunded Celo Gold deposits.
+   * @notice Withdraws refunded CELO deposits.
    * @return Whether or not the withdraw was successful.
    */
   function withdraw() external nonReentrant returns (bool) {

--- a/packages/protocol/contracts/governance/Proposals.sol
+++ b/packages/protocol/contracts/governance/Proposals.sol
@@ -58,7 +58,7 @@ library Proposals {
   /**
    * @notice Constructs a proposal.
    * @param proposal The proposal struct to be constructed.
-   * @param values The values of Celo Gold to be sent in the proposed transactions.
+   * @param values The values of CELO to be sent in the proposed transactions.
    * @param destinations The destination addresses of the proposed transactions.
    * @param data The concatenated data to be included in the proposed transactions.
    * @param dataLengths The lengths of each transaction's data.
@@ -102,7 +102,7 @@ library Proposals {
 
   /**
    * @notice Constructs a proposal for use in memory.
-   * @param values The values of Celo Gold to be sent in the proposed transactions.
+   * @param values The values of CELO to be sent in the proposed transactions.
    * @param destinations The destination addresses of the proposed transactions.
    * @param data The concatenated data to be included in the proposed transactions.
    * @param dataLengths The lengths of each transaction's data.
@@ -355,7 +355,7 @@ library Proposals {
   // of the Solidity's code generator to produce a loop that copies tx.data into memory.
   /**
    * @notice Executes a function call.
-   * @param value The value of Celo Gold to be sent with the function call.
+   * @param value The value of CELO to be sent with the function call.
    * @param destination The destination address of the function call.
    * @param dataLength The length of the data to be included in the function call.
    * @param data The data to be included in the function call.

--- a/packages/protocol/contracts/governance/ReleaseGold.sol
+++ b/packages/protocol/contracts/governance/ReleaseGold.sol
@@ -216,7 +216,7 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
     releaseSchedule.releaseStartTime = releaseStartTime;
     // Expiry is opt-in for folks who can validate, opt-out for folks who cannot.
     // This is because folks who are running Validators or Groups are likely to want to keep
-    // cGLD in the ReleaseGold contract even after it becomes withdrawable.
+    // CELO in the ReleaseGold contract even after it becomes withdrawable.
     revocationInfo.canExpire = !canValidate;
     require(releaseSchedule.numReleasePeriods >= 1, "There must be at least one releasing period");
     require(
@@ -512,12 +512,12 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
   /**
    * @notice Funds a signer address so that transaction fees can be paid.
    * @param signer The signer address to fund.
-   * @dev Note that this effectively decreases the total balance by 1 cGLD.
+   * @dev Note that this effectively decreases the total balance by 1 CELO.
    */
   function fundSigner(address payable signer) private {
-    // Fund signer account with 1 cGLD.
+    // Fund signer account with 1 CELO.
     uint256 value = 1 ether;
-    require(address(this).balance >= value, "no available cGLD to fund signer");
+    require(address(this).balance >= value, "no available CELO to fund signer");
     signer.sendValue(value);
     require(getRemainingTotalBalance() > 0, "no remaining balance");
   }

--- a/packages/protocol/contracts/governance/ReleaseGold.sol
+++ b/packages/protocol/contracts/governance/ReleaseGold.sol
@@ -48,7 +48,7 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
   // 2 years
   uint256 public constant EXPIRATION_TIME = 63072000;
 
-  // Beneficiary of the Celo Gold released in this contract.
+  // Beneficiary of the CELO released in this contract.
   address payable public beneficiary;
 
   // Address capable of (where applicable) revoking, setting the liquidity provision, and

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -181,7 +181,7 @@ contract Reserve is
   }
 
   /**
-   * @notice Sets target allocations for Celo Gold and a diversified basket of non-Celo assets.
+   * @notice Sets target allocations for CELO and a diversified basket of non-Celo assets.
    * @param symbols The symbol of each asset in the Reserve portfolio.
    * @param weights The weight for the corresponding asset as unwrapped Fixidity.Fraction.
    */
@@ -462,8 +462,8 @@ contract Reserve is
   }
 
   /**
-   * @notice Returns the amount of unfrozen Celo Gold in the reserve.
-   * @return The total unfrozen Celo Gold in the reserve.
+   * @notice Returns the amount of unfrozen CELO in the reserve.
+   * @return The total unfrozen CELO in the reserve.
    */
   function getUnfrozenBalance() public view returns (uint256) {
     uint256 balance = address(this).balance;
@@ -472,16 +472,16 @@ contract Reserve is
   }
 
   /**
-   * @notice Returns the amount of Celo Gold included in the reserve.
-   * @return The Celo Gold amount included in the reserve.
+   * @notice Returns the amount of CELO included in the reserve.
+   * @return The CELO amount included in the reserve.
    */
   function getReserveGoldBalance() public view returns (uint256) {
     return address(this).balance.add(getOtherReserveAddressesGoldBalance());
   }
 
   /**
-   * @notice Returns the amount of Celo Gold included in other reserve addresses.
-   * @return The Celo Gold amount included in other reserve addresses.
+   * @notice Returns the amount of CELO included in other reserve addresses.
+   * @return The CELO amount included in other reserve addresses.
    */
   function getOtherReserveAddressesGoldBalance() public view returns (uint256) {
     uint256 reserveGoldBalance = 0;
@@ -492,16 +492,16 @@ contract Reserve is
   }
 
   /**
-   * @notice Returns the amount of unfrozen Celo Gold included in the reserve.
-   * @return The unfrozen Celo Gold amount included in the reserve.
+   * @notice Returns the amount of unfrozen CELO included in the reserve.
+   * @return The unfrozen CELO amount included in the reserve.
    */
   function getUnfrozenReserveGoldBalance() public view returns (uint256) {
     return getUnfrozenBalance().add(getOtherReserveAddressesGoldBalance());
   }
 
   /**
-   * @notice Returns the amount of frozen Celo Gold in the reserve.
-   * @return The total frozen Celo Gold in the reserve.
+   * @notice Returns the amount of frozen CELO in the reserve.
+   * @return The total frozen CELO in the reserve.
    */
   function getFrozenReserveGoldBalance() public view returns (uint256) {
     uint256 currentDay = now / 1 days;

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -170,8 +170,8 @@ contract Reserve is
 
   /**
    * @notice Sets the balance of reserve gold frozen from transfer.
-   * @param frozenGold The amount of cGLD frozen.
-   * @param frozenDays The number of days the frozen cGLD thaws over.
+   * @param frozenGold The amount of CELO frozen.
+   * @param frozenDays The number of days the frozen CELO thaws over.
    */
   function setFrozenGold(uint256 frozenGold, uint256 frozenDays) public onlyOwner {
     require(frozenGold <= address(this).balance, "Cannot freeze more than balance");
@@ -203,6 +203,11 @@ contract Reserve is
       require(assetAllocationWeights[symbols[i]] == 0, "Cannot set weight twice");
       assetAllocationWeights[symbols[i]] = weights[i];
     }
+    // NOTE: The CELO asset launched as "Celo Gold" (cGLD), but was renamed to
+    // just CELO by the community.
+    // TODO: Change "cGLD" to "CELO" in this file, after ensuring that any
+    // off chain tools working with asset allocation weights are aware of this
+    // change.
     require(assetAllocationWeights["cGLD"] != 0, "Must set cGLD asset weight");
     emit AssetAllocationSet(symbols, weights);
   }

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -12,7 +12,7 @@ import "../common/linkedlists/AddressSortedLinkedListWithMedian.sol";
 import "../common/linkedlists/SortedLinkedListWithMedian.sol";
 
 /**
- * @title Maintains a sorted list of oracle exchange rates between Celo Gold and other currencies.
+ * @title Maintains a sorted list of oracle exchange rates between CELO and other currencies.
  */
 contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initializable {
   using SafeMath for uint256;
@@ -137,7 +137,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Removes a report that is expired.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @param n The number of expired reports to remove, at most (deterministic upper gas bound).
    */
   function removeExpiredReports(address token, uint256 n) external {
@@ -157,7 +157,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Check if last report is expired.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return bool isExpired and the address of the last report
    */
   function isOldestReportExpired(address token) public view returns (bool, address) {
@@ -173,8 +173,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Updates an oracle value and the median.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
-   * @param value The amount of `token` equal to one Celo Gold, expressed as a fixidity value.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
+   * @param value The amount of `token` equal to one CELO, expressed as a fixidity value.
    * @param lesserKey The element which should be just left of the new oracle value.
    * @param greaterKey The element which should be just right of the new oracle value.
    * @dev Note that only one of `lesserKey` or `greaterKey` needs to be correct to reduce friction.
@@ -217,7 +217,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the number of rates.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return The number of reported oracle rates for `token`.
    */
   function numRates(address token) public view returns (uint256) {
@@ -226,7 +226,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the median rate.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return The median exchange rate for `token`.
    */
   function medianRate(address token) external view returns (uint256, uint256) {
@@ -235,7 +235,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return An unpacked list of elements from largest to smallest.
    */
   function getRates(address token)
@@ -248,7 +248,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the number of timestamps.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return The number of oracle report timestamps for `token`.
    */
   function numTimestamps(address token) public view returns (uint256) {
@@ -257,7 +257,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the median timestamp.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return The median report timestamp for `token`.
    */
   function medianTimestamp(address token) external view returns (uint256) {
@@ -266,7 +266,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return An unpacked list of elements from largest to smallest.
    */
   function getTimestamps(address token)
@@ -279,7 +279,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns whether a report exists on token from oracle.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @param oracle The oracle whose report should be checked.
    */
   function reportExists(address token, address oracle) internal view returns (bool) {
@@ -310,7 +310,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Removes an oracle value and updates the median.
-   * @param token The address of the token for which the Celo Gold exchange rate is being reported.
+   * @param token The address of the token for which the CELO exchange rate is being reported.
    * @param oracle The oracle whose value should be removed.
    * @dev This can be used to delete elements for oracles that have been removed.
    * However, a > 1 elements reports list should always be maintained

--- a/packages/protocol/scripts/truffle/deploy_release_contracts.ts
+++ b/packages/protocol/scripts/truffle/deploy_release_contracts.ts
@@ -22,8 +22,8 @@ let ReleaseGoldMultiSig: ReleaseGoldMultiSigContract
 let ReleaseGoldMultiSigProxy: ReleaseGoldMultiSigProxyContract
 let ReleaseGold: ReleaseGoldContract
 let ReleaseGoldProxy: ReleaseGoldProxyContract
-const ONE_CGLD = web3.utils.toWei('1', 'ether')
-const TWO_CGLD = web3.utils.toWei('2', 'ether')
+const ONE_CELO = web3.utils.toWei('1', 'ether')
+const TWO_CELO = web3.utils.toWei('2', 'ether')
 const MAINNET_START_TIME = new Date('22 April 2020 16:00:00 UTC').getTime() / 1000
 const ZERO_ADDRESS: Address = '0x0000000000000000000000000000000000000000'
 
@@ -60,7 +60,7 @@ async function handleGrant(config: ReleaseGoldConfig, currGrant: number) {
 
   let totalValue = weiAmountReleasedPerPeriod.multipliedBy(config.numReleasePeriods)
   if (totalValue.lt(startGold)) {
-    console.info('Total value of grant less than cGLD for beneficiary addreess')
+    console.info('Total value of grant less than CELO for beneficiary addreess')
     return
   }
 
@@ -234,7 +234,7 @@ async function checkBalance(config: ReleaseGoldConfig) {
   )
   const grantDeploymentCost = weiAmountReleasedPerPeriod
     .multipliedBy(config.numReleasePeriods)
-    .plus(ONE_CGLD) // Tx Fees
+    .plus(ONE_CELO) // Tx Fees
     .toFixed()
   while (true) {
     const fromBalance = new BigNumber(await web3.eth.getBalance(fromAddress))
@@ -268,10 +268,10 @@ async function checkBalance(config: ReleaseGoldConfig) {
       )
       continue
     }
-    // Must be enough to handle 1cGLD test transfer and 1cGLD for transaction fees
-    if (fromBalance.gt(TWO_CGLD)) {
+    // Must be enough to handle 1CELO test transfer and 1CELO for transaction fees
+    if (fromBalance.gt(TWO_CELO)) {
       console.info(
-        '\nSending 1 cGLD as a test from ' +
+        '\nSending 1 CELO as a test from ' +
           fromAddress +
           ' to ' +
           addressResponse.newFromAddress +
@@ -281,14 +281,14 @@ async function checkBalance(config: ReleaseGoldConfig) {
         {
           from: fromAddress,
           to: addressResponse.newFromAddress,
-          value: ONE_CGLD,
+          value: ONE_CELO,
         },
       ])
       const confirmResponse = await prompts({
         type: 'confirm',
         name: 'confirmation',
         message:
-          'Please check the balance of your provided address. You should see the 1cGLD transfer and an initial genesis balance if this is a shard from the genesis block.\nCan you confirm this (y/n)?',
+          'Please check the balance of your provided address. You should see the 1CELO transfer and an initial genesis balance if this is a shard from the genesis block.\nCan you confirm this (y/n)?',
       })
       if (!confirmResponse.confirmation) {
         console.info(chalk.red('Setting new address failed.\nRetrying.'))
@@ -300,7 +300,7 @@ async function checkBalance(config: ReleaseGoldConfig) {
         {
           from: fromAddress,
           to: addressResponse.newFromAddress,
-          value: fromBalancePostTransfer.minus(ONE_CGLD).toFixed(), // minus Tx Fees
+          value: fromBalancePostTransfer.minus(ONE_CELO).toFixed(), // minus Tx Fees
         },
       ])
     }
@@ -548,7 +548,7 @@ async function handleJSONFile(data) {
       type: 'confirm',
       name: 'confirmation',
       message:
-        'Grants in provided json would send ' + totalValue.toString() + 'cGld.\nIs this OK (y/n)?',
+        'Grants in provided json would send ' + totalValue.toString() + 'CELO.\nIs this OK (y/n)?',
     })
 
     if (!response.confirmation) {

--- a/packages/protocol/test/common/goldtoken.ts
+++ b/packages/protocol/test/common/goldtoken.ts
@@ -47,7 +47,7 @@ contract('GoldToken', (accounts: string[]) => {
   describe('#symbol()', () => {
     it('should have a symbol', async () => {
       const name: string = await goldToken.symbol()
-      assert.equal(name, 'cGLD')
+      assert.equal(name, 'CELO')
     })
   })
 

--- a/packages/protocol/test/common/goldtoken.ts
+++ b/packages/protocol/test/common/goldtoken.ts
@@ -40,7 +40,7 @@ contract('GoldToken', (accounts: string[]) => {
   describe('#name()', () => {
     it('should have a name', async () => {
       const name: string = await goldToken.name()
-      assert.equal(name, 'CELO')
+      assert.equal(name, 'Celo native asset')
     })
   })
 

--- a/packages/protocol/test/common/goldtoken.ts
+++ b/packages/protocol/test/common/goldtoken.ts
@@ -40,7 +40,7 @@ contract('GoldToken', (accounts: string[]) => {
   describe('#name()', () => {
     it('should have a name', async () => {
       const name: string = await goldToken.name()
-      assert.equal(name, 'Celo Gold')
+      assert.equal(name, 'CELO')
     })
   })
 

--- a/packages/protocol/test/governance/voting/release_gold.ts
+++ b/packages/protocol/test/governance/voting/release_gold.ts
@@ -861,14 +861,14 @@ contract('ReleaseGold', (accounts: string[]) => {
 
         // The attestations signer does not send txs.
         if (authorizationTestDescriptions[key].subject !== 'attestationSigner') {
-          it(`should transfer 1 cGLD to the ${authorizationTestDescriptions[key].me}`, async () => {
+          it(`should transfer 1 CELO to the ${authorizationTestDescriptions[key].me}`, async () => {
             const balance1 = await web3.eth.getBalance(authorized)
             await authorizationTest.fn(authorized, sig.v, sig.r, sig.s, { from: beneficiary })
             const balance2 = await web3.eth.getBalance(authorized)
             assertEqualBN(new BigNumber(balance2).minus(balance1), web3.utils.toWei('1'))
           })
         } else {
-          it(`should not transfer 1 cGLD to the ${authorizationTestDescriptions[key].me}`, async () => {
+          it(`should not transfer 1 CELO to the ${authorizationTestDescriptions[key].me}`, async () => {
             const balance1 = await web3.eth.getBalance(authorized)
             await authorizationTest.fn(authorized, sig.v, sig.r, sig.s, { from: beneficiary })
             const balance2 = await web3.eth.getBalance(authorized)
@@ -944,7 +944,7 @@ contract('ReleaseGold', (accounts: string[]) => {
             )
           })
 
-          it(`should not transfer 1 cGLD to the ${authorizationTestDescriptions[key].me}`, async () => {
+          it(`should not transfer 1 CELO to the ${authorizationTestDescriptions[key].me}`, async () => {
             const balance2 = await web3.eth.getBalance(newAuthorized)
             assertEqualBN(new BigNumber(balance2).minus(balance1), 0)
           })

--- a/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
@@ -18,8 +18,8 @@ testWithGanache('GoldToken Wrapper', (web3) => {
   test('SBAT check balance', () =>
     expect(goldToken.balanceOf(accounts[0])).resolves.toBeBigNumber())
   test('SBAT check decimals', () => expect(goldToken.decimals()).resolves.toBe(18))
-  test('SBAT check name', () => expect(goldToken.name()).resolves.toBe('Celo Gold'))
-  test('SBAT check symbol', () => expect(goldToken.symbol()).resolves.toBe('cGLD'))
+  test('SBAT check name', () => expect(goldToken.name()).resolves.toBe('CELO'))
+  test('SBAT check symbol', () => expect(goldToken.symbol()).resolves.toBe('CELO'))
   test('SBAT check totalSupply', () => expect(goldToken.totalSupply()).resolves.toBeBigNumber())
 
   test('SBAT transfer', async () => {

--- a/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
@@ -18,7 +18,7 @@ testWithGanache('GoldToken Wrapper', (web3) => {
   test('SBAT check balance', () =>
     expect(goldToken.balanceOf(accounts[0])).resolves.toBeBigNumber())
   test('SBAT check decimals', () => expect(goldToken.decimals()).resolves.toBe(18))
-  test('SBAT check name', () => expect(goldToken.name()).resolves.toBe('CELO'))
+  test('SBAT check name', () => expect(goldToken.name()).resolves.toBe('Celo native asset'))
   test('SBAT check symbol', () => expect(goldToken.symbol()).resolves.toBe('CELO'))
   test('SBAT check totalSupply', () => expect(goldToken.totalSupply()).resolves.toBeBigNumber())
 


### PR DESCRIPTION
### Description

The Celo blockchain launched with the native token called "Celo Gold" (symbol "cGLD"), but to avoid confusion (since the token has nothing to do with physical gold), after a community proposal and vote ([CGP 4](https://github.com/celo-org/celo-proposals/blob/master/CGPs/0004.md)), it was renamed to "Celo native asset" (ticker symbol CELO). This PR updates the ERC-20 contract's `name` and `symbol` constants to the correct values.

### Other changes

Fixed many references in comments and variable names from Celo Gold/cGLD to CELO.

### Tested

Adjusted appropriate unit tests.

### Related issues

- Fixes #7471

### Backwards compatibility

Changes the strings output by `name` and `symbol` on GoldToken.