### PR TITLE
Whitelist Should Not Accept New Fee Currencies Without An Oracle Price

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "install-pkg": "yarn install --link-duplicates",
     "lint": "yarn lerna run lint && yarn run --silent lint:do-not-merge",
     "lint:do-not-merge": "! git grep -E 'DO[ _]*NOT[ _]*MERGE'",
-    "prettify": "yarn run prettier --config .prettierrc.js --write '**/*.+(ts|tsx|js|jsx|sol|java)'",
-    "prettify:diff": "yarn run prettier --config .prettierrc.js --list-different '**/*.+(ts|tsx|js|jsx|sol|java)'",
+    "prettify": "yarn run prettier --config .prettierrc.js --write '**/*.+{ts,tsx,js,jsx,sol,java}'",
+    "prettify:diff": "yarn run prettier --config .prettierrc.js --list-different '**/*.+{ts,tsx,js,jsx,sol,java}'",
     "reset": "yarn reset-modules && yarn reset-cache",
     "reset-cache": "yarn reset-yarn && yarn reset-rn",
     "reset-modules": "rm -rf node_modules/ packages/*/node_modules",
@@ -31,7 +31,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern '**/*.+(ts|tsx|js|jsx|sol|java)'",
+      "pre-commit": "pretty-quick --staged --pattern '**/*.+{ts,tsx,js,jsx,sol,java}'",
       "pre-push": "node ./scripts/hooks/pre-push.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "install-pkg": "yarn install --link-duplicates",
     "lint": "yarn lerna run lint && yarn run --silent lint:do-not-merge",
     "lint:do-not-merge": "! git grep -E 'DO[ _]*NOT[ _]*MERGE'",
-    "prettify": "yarn run prettier --config .prettierrc.js --write '**/*.+{ts,tsx,js,jsx,sol,java}'",
-    "prettify:diff": "yarn run prettier --config .prettierrc.js --list-different '**/*.+{ts,tsx,js,jsx,sol,java}'",
+    "prettify": "yarn run prettier --config .prettierrc.js --write '**/*.+(ts|tsx|js|jsx|sol|java)'",
+    "prettify:diff": "yarn run prettier --config .prettierrc.js --list-different '**/*.+(ts|tsx|js|jsx|sol|java)'",
     "reset": "yarn reset-modules && yarn reset-cache",
     "reset-cache": "yarn reset-yarn && yarn reset-rn",
     "reset-modules": "rm -rf node_modules/ packages/*/node_modules",
@@ -31,7 +31,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern '**/*.+{ts,tsx,js,jsx,sol,java}'",
+      "pre-commit": "pretty-quick --staged --pattern '**/*.+(ts|tsx|js|jsx|sol|java)'",
       "pre-push": "node ./scripts/hooks/pre-push.js"
     }
   },

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -32,7 +32,7 @@ contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, Initializable, 
     (rateNumerator, rateDenominator) = ISortedOracles(
       registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID)
     )
-      .medianRate(stable);
+      .medianRate(tokenAddress);
     require(rateDenominator > 0, "FeeCurrencyWhitelist: Invalid Oracle Price (Denominator)");
     require(rateNumerator > 0, "FeeCurrencyWhitelist: Invalid Oracle Price (Numerator)");
     whitelist.push(tokenAddress);

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -4,22 +4,25 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 import "./interfaces/IFeeCurrencyWhitelist.sol";
 
-import "../common/Initializable.sol";
+import "../common/InitializableV2.sol";
 
 import "../common/UsingRegistry.sol";
 import "../stability/interfaces/ISortedOracles.sol";
 /**
  * @title Holds a whitelist of the ERC20+ tokens that can be used to pay for gas
  */
-contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, Initializable, UsingRegistry {
+contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, InitializableV2, UsingRegistry {
   address[] public whitelist;
+
+  constructor(bool test) public InitializableV2(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.
+   * @param registryAddress Address of the Registry contract.
    */
   function initialize(address registryAddress) external initializer {
-    setRegistry(registryAddress);
     _transferOwnership(msg.sender);
+    setRegistry(registryAddress);
   }
 
   /**

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -6,16 +6,19 @@ import "./interfaces/IFeeCurrencyWhitelist.sol";
 
 import "../common/Initializable.sol";
 
+import "../common/UsingRegistry.sol";
+import "../stability/interfaces/ISortedOracles.sol";
 /**
  * @title Holds a whitelist of the ERC20+ tokens that can be used to pay for gas
  */
-contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, Initializable {
+contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, Initializable, UsingRegistry {
   address[] public whitelist;
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.
    */
-  function initialize() external initializer {
+  function initialize(address registryAddress) external initializer {
+     setRegistry(registryAddress);
     _transferOwnership(msg.sender);
   }
 
@@ -24,6 +27,14 @@ contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, Initializable {
    * @param tokenAddress The address of the token to add.
    */
   function addToken(address tokenAddress) external onlyOwner {
+    uint256 rateNumerator;
+    uint256 rateDenominator;
+    (rateNumerator, rateDenominator) = ISortedOracles(
+      registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID)
+    )
+      .medianRate(stable);
+    require(rateDenominator > 0, "FeeCurrencyWhitelist: Invalid Oracle Price (Denominator)");
+    require(rateNumerator > 0, "FeeCurrencyWhitelist: Invalid Oracle Price (Numerator)");
     whitelist.push(tokenAddress);
   }
 

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -18,7 +18,7 @@ contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, Initializable, 
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.
    */
   function initialize(address registryAddress) external initializer {
-     setRegistry(registryAddress);
+    setRegistry(registryAddress);
     _transferOwnership(msg.sender);
   }
 

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -4,22 +4,22 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 import "./interfaces/IFeeCurrencyWhitelist.sol";
 
-import "../common/Initializable.sol";
+import "../common/InitializableV2.sol";
 
 import "../common/UsingRegistry.sol";
 import "../stability/interfaces/ISortedOracles.sol";
 /**
  * @title Holds a whitelist of the ERC20+ tokens that can be used to pay for gas
  */
-contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, Initializable, UsingRegistry {
+contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, InitializableV2, UsingRegistry {
   address[] public whitelist;
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.
    */
   function initialize(address registryAddress) external initializer {
-    setRegistry(registryAddress);
     _transferOwnership(msg.sender);
+    setRegistry(registryAddress);
   }
 
   /**

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -32,10 +32,7 @@ contract FeeCurrencyWhitelist is IFeeCurrencyWhitelist, Ownable, InitializableV2
   function addToken(address tokenAddress) external onlyOwner {
     uint256 rateNumerator;
     uint256 rateDenominator;
-    (rateNumerator, rateDenominator) = ISortedOracles(
-      registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID)
-    )
-      .medianRate(tokenAddress);
+    (rateNumerator, rateDenominator) = getSortedOracles().medianRate(tokenAddress);
     require(rateDenominator > 0, "FeeCurrencyWhitelist: Invalid Oracle Price (Denominator)");
     require(rateNumerator > 0, "FeeCurrencyWhitelist: Invalid Oracle Price (Numerator)");
     whitelist.push(tokenAddress);

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -6,7 +6,7 @@ import "./interfaces/IFeeCurrencyWhitelist.sol";
 
 import "../common/InitializableV2.sol";
 
-import "../common/UsingRegistry.sol";
+import "./UsingRegistry.sol";
 import "../stability/interfaces/ISortedOracles.sol";
 /**
  * @title Holds a whitelist of the ERC20+ tokens that can be used to pay for gas

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -4,7 +4,7 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 import "./interfaces/IFeeCurrencyWhitelist.sol";
 
-import "../common/InitializableV2.sol";
+import "./InitializableV2.sol";
 
 import "./UsingRegistry.sol";
 import "../stability/interfaces/ISortedOracles.sol";

--- a/packages/protocol/migrations/03_whitelist.ts
+++ b/packages/protocol/migrations/03_whitelist.ts
@@ -1,9 +1,15 @@
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { deploymentForCoreContract } from '@celo/protocol/lib/web3-utils'
 import { FeeCurrencyWhitelistInstance } from 'types'
+import { config } from '@celo/protocol/migrationsConfig'
+
+const initializeArgs = async (): Promise<any[]> => {
+  return [config.registry.predeployedProxyAddress]
+}
 
 module.exports = deploymentForCoreContract<FeeCurrencyWhitelistInstance>(
   web3,
   artifacts,
-  CeloContractName.FeeCurrencyWhitelist
+  CeloContractName.FeeCurrencyWhitelist,
+  initializeArgs
 )

--- a/packages/protocol/migrations/03_whitelist.ts
+++ b/packages/protocol/migrations/03_whitelist.ts
@@ -1,7 +1,7 @@
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { deploymentForCoreContract } from '@celo/protocol/lib/web3-utils'
-import { FeeCurrencyWhitelistInstance } from 'types'
 import { config } from '@celo/protocol/migrationsConfig'
+import { FeeCurrencyWhitelistInstance } from 'types'
 
 const initializeArgs = async (): Promise<any[]> => {
   return [config.registry.predeployedProxyAddress]

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -1,5 +1,7 @@
 import { assertRevert } from '@celo/protocol/lib/test-utils'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
+import { fixed1 } from '@celo/utils/lib/fixidity'
+import BigNumber from 'bignumber.js'
 import {
     FeeCurrencyWhitelistContract,
     FeeCurrencyWhitelistInstance,
@@ -7,22 +9,45 @@ import {
     RegistryInstance,
     MockSortedOraclesContract,
     MockSortedOraclesInstance,
+    StableTokenContract,
+    StableTokenInstance,
 } from 'types'
 
 const FeeCurrencyWhitelist: FeeCurrencyWhitelistContract = artifacts.require('FeeCurrencyWhitelist')
 const Registry: RegistryContract = artifacts.require('Registry')
 const MockSortedOracles: MockSortedOraclesContract = artifacts.require('MockSortedOracles')
+const StableToken: StableTokenContract = artifacts.require('StableToken')
+
+StableToken.numberFormat = 'BigNumber'
 
 contract('FeeCurrencyWhitelist', (accounts: string[]) => {
     let feeCurrencyWhitelist: FeeCurrencyWhitelistInstance
     let registry: RegistryInstance
+    let stableToken: StableTokenInstance
     let mockSortedOracles: MockSortedOraclesInstance
-    const aTokenAddress = '0x000000000000000000000000000000000000ce10'
 
     const nonOwner = accounts[1]
 
+    const decimals = 18
+    const SECONDS_IN_A_WEEK = 604800
+    const goldAmountForRate = new BigNumber('0x10000000000000000')
+    const stableAmountForRate = new BigNumber(2).times(goldAmountForRate)
     beforeEach(async () => {
+        stableToken = await StableToken.new()
         registry = await Registry.new()
+
+        await stableToken.initialize(
+            'Celo Dollar',
+            'cUSD',
+            decimals,
+            registry.address,
+            fixed1,
+            SECONDS_IN_A_WEEK,
+            [],
+            [],
+            'Exchange'
+        )
+
         mockSortedOracles = await MockSortedOracles.new()
         await registry.setAddressFor(CeloContractName.SortedOracles, mockSortedOracles.address)
         feeCurrencyWhitelist = await FeeCurrencyWhitelist.new()
@@ -41,18 +66,22 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
     })
 
     describe('#addToken()', () => {
+        it('should not allow to add a token with an invalid oracle price', async () => {
+            await assertRevert(feeCurrencyWhitelist.addToken(stableToken.address))
+        })
+
         it('should allow the owner to add a token', async () => {
-            await feeCurrencyWhitelist.addToken(aTokenAddress)
+            await mockSortedOracles.setMedianRate(stableToken.address, stableAmountForRate)
+            await mockSortedOracles.setMedianTimestampToNow(stableToken.address)
+            await mockSortedOracles.setNumRates(stableToken.address, 2)
+            await feeCurrencyWhitelist.addToken(stableToken.address)
             const tokens = await feeCurrencyWhitelist.getWhitelist()
-            assert.sameMembers(tokens, [aTokenAddress])
+            assert.sameMembers(tokens, [stableToken.address])
         })
 
         it('should not allow a non-owner to add a token', async () => {
-            await assertRevert(feeCurrencyWhitelist.addToken(aTokenAddress, { from: nonOwner }))
+            await assertRevert(feeCurrencyWhitelist.addToken(stableToken.address, { from: nonOwner }))
         })
 
-        it('should not allow to add a token with an invalid oracle price', async () => {
-            await assertRevert(feeCurrencyWhitelist.addToken(aTokenAddress))
-        })
     })
 })

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -1,15 +1,15 @@
-import { assertRevert } from '@celo/protocol/lib/test-utils'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
+import { assertRevert } from '@celo/protocol/lib/test-utils'
 import BigNumber from 'bignumber.js'
 import {
   FeeCurrencyWhitelistContract,
   FeeCurrencyWhitelistInstance,
-  RegistryContract,
-  RegistryInstance,
   MockSortedOraclesContract,
   MockSortedOraclesInstance,
   MockStableTokenContract,
   MockStableTokenInstance,
+  RegistryContract,
+  RegistryInstance,
 } from 'types'
 
 const FeeCurrencyWhitelist: FeeCurrencyWhitelistContract = artifacts.require('FeeCurrencyWhitelist')

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -48,28 +48,29 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
       await assertRevert(feeCurrencyWhitelist.initialize(registry.address))
     })
   })
-
-  describe('#addToken() with an invalid oracle price', () => {
+  describe('#addToken()', () => {
     it('should not allow to add a token with an invalid oracle price', async () => {
       await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address))
     })
-  })
 
-  describe('#addToken() with a valid oracle price', () => {
-    beforeEach(async () => {
-      await mockSortedOracles.setMedianRate(mockStableToken.address, stableAmountForRate)
-      await mockSortedOracles.setMedianTimestampToNow(mockStableToken.address)
-      await mockSortedOracles.setNumRates(mockStableToken.address, 2)
-    })
+    describe('when token has a valid oracle price', () => {
+      beforeEach(async () => {
+        await mockSortedOracles.setMedianRate(mockStableToken.address, stableAmountForRate)
+        await mockSortedOracles.setMedianTimestampToNow(mockStableToken.address)
+        await mockSortedOracles.setNumRates(mockStableToken.address, 2)
+      })
 
-    it('should allow the owner to add a token', async () => {
-      await feeCurrencyWhitelist.addToken(mockStableToken.address)
-      const tokens = await feeCurrencyWhitelist.getWhitelist()
-      assert.sameMembers(tokens, [mockStableToken.address])
-    })
+      it('should allow the owner to add a token', async () => {
+        await feeCurrencyWhitelist.addToken(mockStableToken.address)
+        const tokens = await feeCurrencyWhitelist.getWhitelist()
+        assert.sameMembers(tokens, [mockStableToken.address])
+      })
 
-    it('should not allow a non-owner to add a token', async () => {
-      await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address, { from: nonOwner }))
+      it('should not allow a non-owner to add a token', async () => {
+        await assertRevert(
+          feeCurrencyWhitelist.addToken(mockStableToken.address, { from: nonOwner })
+        )
+      })
     })
   })
 })

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -49,7 +49,7 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
   })
   describe('#addToken()', () => {
     describe('when token has an invalid oracle price', () => {
-      it('should not allow to add a token with an invalid oracle price', async () => {
+      it('should not allow to add a token without a valid oracle price', async () => {
         await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address))
       })
     })

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -18,6 +18,7 @@ const Registry: RegistryContract = artifacts.require('Registry')
 const MockSortedOracles: MockSortedOraclesContract = artifacts.require('MockSortedOracles')
 const StableToken: StableTokenContract = artifacts.require('StableToken')
 
+// @ts-ignore
 StableToken.numberFormat = 'BigNumber'
 
 contract('FeeCurrencyWhitelist', (accounts: string[]) => {

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -9,45 +9,31 @@ import {
     RegistryInstance,
     MockSortedOraclesContract,
     MockSortedOraclesInstance,
-    StableTokenContract,
-    StableTokenInstance,
+    MockStableTokenContract,
+    MockStableTokenInstance,
 } from 'types'
 
 const FeeCurrencyWhitelist: FeeCurrencyWhitelistContract = artifacts.require('FeeCurrencyWhitelist')
 const Registry: RegistryContract = artifacts.require('Registry')
 const MockSortedOracles: MockSortedOraclesContract = artifacts.require('MockSortedOracles')
-const StableToken: StableTokenContract = artifacts.require('StableToken')
+const MockStableToken: MockStableTokenContract = artifacts.require('MockStableToken')
 
-// @ts-ignore
-StableToken.numberFormat = 'BigNumber'
+
 
 contract('FeeCurrencyWhitelist', (accounts: string[]) => {
     let feeCurrencyWhitelist: FeeCurrencyWhitelistInstance
     let registry: RegistryInstance
-    let stableToken: StableTokenInstance
+    let mockStableToken: MockStableTokenInstance
     let mockSortedOracles: MockSortedOraclesInstance
 
     const nonOwner = accounts[1]
 
-    const decimals = 18
-    const SECONDS_IN_A_WEEK = 604800
     const goldAmountForRate = new BigNumber('0x10000000000000000')
     const stableAmountForRate = new BigNumber(2).times(goldAmountForRate)
     beforeEach(async () => {
-        stableToken = await StableToken.new()
+        mockStableToken = await MockStableToken.new()
         registry = await Registry.new()
-
-        await stableToken.initialize(
-            'Celo Dollar',
-            'cUSD',
-            decimals,
-            registry.address,
-            fixed1,
-            SECONDS_IN_A_WEEK,
-            [],
-            [],
-            'Exchange'
-        )
+        // await registry.setAddressFor(CeloContractName.StableToken, mockStableToken.address)
 
         mockSortedOracles = await MockSortedOracles.new()
         await registry.setAddressFor(CeloContractName.SortedOracles, mockSortedOracles.address)
@@ -66,23 +52,27 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
         })
     })
 
-    describe('#addToken()', () => {
-        it('should not allow to add a token without an oracle price', async () => {
-            await assertRevert(feeCurrencyWhitelist.addToken(stableToken.address))
+    describe('#addToken() with an invalid oracle price', () => {
+        it('should not allow to add a token with an invalid oracle price', async () => {
+            await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address))
+        })
+    })
+
+    describe('#addToken() with a valid oracle price', () => {
+        beforeEach(async () => {
+            await mockSortedOracles.setMedianRate(mockStableToken.address, stableAmountForRate)
+            await mockSortedOracles.setMedianTimestampToNow(mockStableToken.address)
+            await mockSortedOracles.setNumRates(mockStableToken.address, 2)
         })
 
         it('should allow the owner to add a token', async () => {
-            await mockSortedOracles.setMedianRate(stableToken.address, stableAmountForRate)
-            await mockSortedOracles.setMedianTimestampToNow(stableToken.address)
-            await mockSortedOracles.setNumRates(stableToken.address, 2)
-            await feeCurrencyWhitelist.addToken(stableToken.address)
+            await feeCurrencyWhitelist.addToken(mockStableToken.address)
             const tokens = await feeCurrencyWhitelist.getWhitelist()
-            assert.sameMembers(tokens, [stableToken.address])
+            assert.sameMembers(tokens, [mockStableToken.address])
         })
 
         it('should not allow a non-owner to add a token', async () => {
-            await assertRevert(feeCurrencyWhitelist.addToken(stableToken.address, { from: nonOwner }))
+            await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address, { from: nonOwner }))
         })
-
     })
 })

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -1,40 +1,58 @@
 import { assertRevert } from '@celo/protocol/lib/test-utils'
-import { FeeCurrencyWhitelistContract, FeeCurrencyWhitelistInstance } from 'types'
+import { CeloContractName } from '@celo/protocol/lib/registry-utils'
+import {
+    FeeCurrencyWhitelistContract,
+    FeeCurrencyWhitelistInstance,
+    RegistryContract,
+    RegistryInstance,
+    MockSortedOraclesContract,
+    MockSortedOraclesInstance,
+} from 'types'
 
 const FeeCurrencyWhitelist: FeeCurrencyWhitelistContract = artifacts.require('FeeCurrencyWhitelist')
+const Registry: RegistryContract = artifacts.require('Registry')
+const MockSortedOracles: MockSortedOraclesContract = artifacts.require('MockSortedOracles')
 
 contract('FeeCurrencyWhitelist', (accounts: string[]) => {
-  let feeCurrencyWhitelist: FeeCurrencyWhitelistInstance
+    let feeCurrencyWhitelist: FeeCurrencyWhitelistInstance
+    let registry: RegistryInstance
+    let mockSortedOracles: MockSortedOraclesInstance
+    const aTokenAddress = '0x000000000000000000000000000000000000ce10'
 
-  const aTokenAddress = '0x000000000000000000000000000000000000ce10'
+    const nonOwner = accounts[1]
 
-  const nonOwner = accounts[1]
-
-  beforeEach(async () => {
-    feeCurrencyWhitelist = await FeeCurrencyWhitelist.new()
-    await feeCurrencyWhitelist.initialize()
-  })
-
-  describe('#initialize()', () => {
-    it('should have set the owner', async () => {
-      const owner: string = await feeCurrencyWhitelist.owner()
-      assert.equal(owner, accounts[0])
+    beforeEach(async () => {
+        registry = await Registry.new()
+        mockSortedOracles = await MockSortedOracles.new()
+        await registry.setAddressFor(CeloContractName.SortedOracles, mockSortedOracles.address)
+        feeCurrencyWhitelist = await FeeCurrencyWhitelist.new()
+        await feeCurrencyWhitelist.initialize(registry.address)
     })
 
-    it('should not be callable again', async () => {
-      await assertRevert(feeCurrencyWhitelist.initialize())
-    })
-  })
+    describe('#initialize()', () => {
+        it('should have set the owner', async () => {
+            const owner: string = await feeCurrencyWhitelist.owner()
+            assert.equal(owner, accounts[0])
+        })
 
-  describe('#addToken()', () => {
-    it('should allow the owner to add a token', async () => {
-      await feeCurrencyWhitelist.addToken(aTokenAddress)
-      const tokens = await feeCurrencyWhitelist.getWhitelist()
-      assert.sameMembers(tokens, [aTokenAddress])
+        it('should not be callable again', async () => {
+            await assertRevert(feeCurrencyWhitelist.initialize(registry.address))
+        })
     })
 
-    it('should not allow a non-owner to add a token', async () => {
-      await assertRevert(feeCurrencyWhitelist.addToken(aTokenAddress, { from: nonOwner }))
+    describe('#addToken()', () => {
+        it('should allow the owner to add a token', async () => {
+            await feeCurrencyWhitelist.addToken(aTokenAddress)
+            const tokens = await feeCurrencyWhitelist.getWhitelist()
+            assert.sameMembers(tokens, [aTokenAddress])
+        })
+
+        it('should not allow a non-owner to add a token', async () => {
+            await assertRevert(feeCurrencyWhitelist.addToken(aTokenAddress, { from: nonOwner }))
+        })
+
+        it('should not allow to add a token with an invalid oracle price', async () => {
+            await assertRevert(feeCurrencyWhitelist.addToken(aTokenAddress))
+        })
     })
-  })
 })

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -1,6 +1,5 @@
 import { assertRevert } from '@celo/protocol/lib/test-utils'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
-import { fixed1 } from '@celo/utils/lib/fixidity'
 import BigNumber from 'bignumber.js'
 import {
     FeeCurrencyWhitelistContract,

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -67,7 +67,7 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
     })
 
     describe('#addToken()', () => {
-        it('should not allow to add a token with an invalid oracle price', async () => {
+        it('should not allow to add a token without an oracle price', async () => {
             await assertRevert(feeCurrencyWhitelist.addToken(stableToken.address))
         })
 

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -34,7 +34,7 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
 
     mockSortedOracles = await MockSortedOracles.new()
     await registry.setAddressFor(CeloContractName.SortedOracles, mockSortedOracles.address)
-    feeCurrencyWhitelist = await FeeCurrencyWhitelist.new()
+    feeCurrencyWhitelist = await FeeCurrencyWhitelist.new(true)
     await feeCurrencyWhitelist.initialize(registry.address)
   })
 

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -2,14 +2,14 @@ import { assertRevert } from '@celo/protocol/lib/test-utils'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import BigNumber from 'bignumber.js'
 import {
-    FeeCurrencyWhitelistContract,
-    FeeCurrencyWhitelistInstance,
-    RegistryContract,
-    RegistryInstance,
-    MockSortedOraclesContract,
-    MockSortedOraclesInstance,
-    MockStableTokenContract,
-    MockStableTokenInstance,
+  FeeCurrencyWhitelistContract,
+  FeeCurrencyWhitelistInstance,
+  RegistryContract,
+  RegistryInstance,
+  MockSortedOraclesContract,
+  MockSortedOraclesInstance,
+  MockStableTokenContract,
+  MockStableTokenInstance,
 } from 'types'
 
 const FeeCurrencyWhitelist: FeeCurrencyWhitelistContract = artifacts.require('FeeCurrencyWhitelist')
@@ -17,61 +17,59 @@ const Registry: RegistryContract = artifacts.require('Registry')
 const MockSortedOracles: MockSortedOraclesContract = artifacts.require('MockSortedOracles')
 const MockStableToken: MockStableTokenContract = artifacts.require('MockStableToken')
 
-
-
 contract('FeeCurrencyWhitelist', (accounts: string[]) => {
-    let feeCurrencyWhitelist: FeeCurrencyWhitelistInstance
-    let registry: RegistryInstance
-    let mockStableToken: MockStableTokenInstance
-    let mockSortedOracles: MockSortedOraclesInstance
+  let feeCurrencyWhitelist: FeeCurrencyWhitelistInstance
+  let registry: RegistryInstance
+  let mockStableToken: MockStableTokenInstance
+  let mockSortedOracles: MockSortedOraclesInstance
 
-    const nonOwner = accounts[1]
+  const nonOwner = accounts[1]
 
-    const goldAmountForRate = new BigNumber('0x10000000000000000')
-    const stableAmountForRate = new BigNumber(2).times(goldAmountForRate)
+  const goldAmountForRate = new BigNumber('0x10000000000000000')
+  const stableAmountForRate = new BigNumber(2).times(goldAmountForRate)
+  beforeEach(async () => {
+    mockStableToken = await MockStableToken.new()
+    registry = await Registry.new()
+    // await registry.setAddressFor(CeloContractName.StableToken, mockStableToken.address)
+
+    mockSortedOracles = await MockSortedOracles.new()
+    await registry.setAddressFor(CeloContractName.SortedOracles, mockSortedOracles.address)
+    feeCurrencyWhitelist = await FeeCurrencyWhitelist.new()
+    await feeCurrencyWhitelist.initialize(registry.address)
+  })
+
+  describe('#initialize()', () => {
+    it('should have set the owner', async () => {
+      const owner: string = await feeCurrencyWhitelist.owner()
+      assert.equal(owner, accounts[0])
+    })
+
+    it('should not be callable again', async () => {
+      await assertRevert(feeCurrencyWhitelist.initialize(registry.address))
+    })
+  })
+
+  describe('#addToken() with an invalid oracle price', () => {
+    it('should not allow to add a token with an invalid oracle price', async () => {
+      await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address))
+    })
+  })
+
+  describe('#addToken() with a valid oracle price', () => {
     beforeEach(async () => {
-        mockStableToken = await MockStableToken.new()
-        registry = await Registry.new()
-        // await registry.setAddressFor(CeloContractName.StableToken, mockStableToken.address)
-
-        mockSortedOracles = await MockSortedOracles.new()
-        await registry.setAddressFor(CeloContractName.SortedOracles, mockSortedOracles.address)
-        feeCurrencyWhitelist = await FeeCurrencyWhitelist.new()
-        await feeCurrencyWhitelist.initialize(registry.address)
+      await mockSortedOracles.setMedianRate(mockStableToken.address, stableAmountForRate)
+      await mockSortedOracles.setMedianTimestampToNow(mockStableToken.address)
+      await mockSortedOracles.setNumRates(mockStableToken.address, 2)
     })
 
-    describe('#initialize()', () => {
-        it('should have set the owner', async () => {
-            const owner: string = await feeCurrencyWhitelist.owner()
-            assert.equal(owner, accounts[0])
-        })
-
-        it('should not be callable again', async () => {
-            await assertRevert(feeCurrencyWhitelist.initialize(registry.address))
-        })
+    it('should allow the owner to add a token', async () => {
+      await feeCurrencyWhitelist.addToken(mockStableToken.address)
+      const tokens = await feeCurrencyWhitelist.getWhitelist()
+      assert.sameMembers(tokens, [mockStableToken.address])
     })
 
-    describe('#addToken() with an invalid oracle price', () => {
-        it('should not allow to add a token with an invalid oracle price', async () => {
-            await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address))
-        })
+    it('should not allow a non-owner to add a token', async () => {
+      await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address, { from: nonOwner }))
     })
-
-    describe('#addToken() with a valid oracle price', () => {
-        beforeEach(async () => {
-            await mockSortedOracles.setMedianRate(mockStableToken.address, stableAmountForRate)
-            await mockSortedOracles.setMedianTimestampToNow(mockStableToken.address)
-            await mockSortedOracles.setNumRates(mockStableToken.address, 2)
-        })
-
-        it('should allow the owner to add a token', async () => {
-            await feeCurrencyWhitelist.addToken(mockStableToken.address)
-            const tokens = await feeCurrencyWhitelist.getWhitelist()
-            assert.sameMembers(tokens, [mockStableToken.address])
-        })
-
-        it('should not allow a non-owner to add a token', async () => {
-            await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address, { from: nonOwner }))
-        })
-    })
+  })
 })

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -30,7 +30,6 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
   beforeEach(async () => {
     mockStableToken = await MockStableToken.new()
     registry = await Registry.new()
-    // await registry.setAddressFor(CeloContractName.StableToken, mockStableToken.address)
 
     mockSortedOracles = await MockSortedOracles.new()
     await registry.setAddressFor(CeloContractName.SortedOracles, mockSortedOracles.address)

--- a/packages/protocol/test/common/gascurrencywhitelist.ts
+++ b/packages/protocol/test/common/gascurrencywhitelist.ts
@@ -49,8 +49,10 @@ contract('FeeCurrencyWhitelist', (accounts: string[]) => {
     })
   })
   describe('#addToken()', () => {
-    it('should not allow to add a token with an invalid oracle price', async () => {
-      await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address))
+    describe('when token has an invalid oracle price', () => {
+      it('should not allow to add a token with an invalid oracle price', async () => {
+        await assertRevert(feeCurrencyWhitelist.addToken(mockStableToken.address))
+      })
     })
 
     describe('when token has a valid oracle price', () => {


### PR DESCRIPTION
### Description

Updated addToken function to reject tokens without a valid oracle price

### Other changes


### Tested

unit tests added

### Related issues

- Fixes #7315

### Backwards compatibility

initialize method needs a register address. addToken change doesnt effect other features