### PR TITLE
Certora specs: missing constructor in harness

### DIFF
--- a/packages/protocol/specs/harnesses/GoldTokenHarness.sol
+++ b/packages/protocol/specs/harnesses/GoldTokenHarness.sol
@@ -7,6 +7,7 @@ contract GoldTokenHarness is GoldToken {
   using Address for address payable; // prettier-ignore
   /* solhint-disable no-empty-blocks */
   function init_state() public {}
+  constructor(bool test) public GoldToken(test) {}
 
   function _transfer(address to, uint256 value) internal returns (bool) {
     require(to != address(0), "Transfer attempted to reserved address 0x0");


### PR DESCRIPTION
### Description

A constructor was added to `GoldToken`, which means that `GoldTokenHarness` should include a constructor as well.

### Other changes

### Tested
Run CI

### Related issues


### Backwards compatibility

### Documentation
