### PR TITLE
Make bash script variables local

### DIFF
--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# USAGE: build_tag <branch> <log file>
+# This function:
+# 1. checks out the given branch
+# 2. builds contracts
+# 3. returns to original branch
+# piping output of any commands to the specified log file.
+# Sets $BUILD_DIR to the directory where resulting build artifacts may be found.
 function build_tag() {
   local BRANCH="$1"
   local LOG_FILE="$2"

--- a/packages/protocol/scripts/bash/release-lib.sh
+++ b/packages/protocol/scripts/bash/release-lib.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 function build_tag() {
-  BRANCH="$1"
-  LOG_FILE="$2"
+  local BRANCH="$1"
+  local LOG_FILE="$2"
 
   echo " - Checkout contracts source code at $BRANCH"
   BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'))


### PR DESCRIPTION
### Description

A utility function in `protocol/` bash scripts used variables without declaring them local to the function.

### Other changes

Added a documenting comment to the function.

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/852

### Backwards compatibility

Just fixing code quality of a script.