### PR TITLE
Remove timer and trades based parameters from oracle deployment.

### DIFF
--- a/packages/helm-charts/oracle/CELOBTC.yaml
+++ b/packages/helm-charts/oracle/CELOBTC.yaml
@@ -22,5 +22,3 @@ oracle:
   reporter:
     blockBased:
       minReportPriceChangeThreshold: 0.005 # 0.5%
-    timer:
-      removeExpiredFrequencyMs: 60000

--- a/packages/helm-charts/oracle/CELOBTC.yaml
+++ b/packages/helm-charts/oracle/CELOBTC.yaml
@@ -7,11 +7,6 @@ oracle:
       bidMaxPercentageDeviation: 0.05
       maxPercentageBidAskSpread: 0.025
       # minReportPriceChangeThreshold
-    trades:
-      periodMs: 300000
-      # dataFetchFrequency
-      # minimumTrades
-      # scalingRate
   metrics:
     enabled: true
     prometheusPort: 9090

--- a/packages/helm-charts/oracle/CELOEUR.yaml
+++ b/packages/helm-charts/oracle/CELOEUR.yaml
@@ -22,5 +22,3 @@ oracle:
   reporter:
     blockBased:
       minReportPriceChangeThreshold: 0.005 # 0.5%
-    timer:
-      removeExpiredFrequencyMs: 60000

--- a/packages/helm-charts/oracle/CELOEUR.yaml
+++ b/packages/helm-charts/oracle/CELOEUR.yaml
@@ -7,11 +7,6 @@ oracle:
       bidMaxPercentageDeviation: 0.05
       maxPercentageBidAskSpread: 0.025
       # minReportPriceChangeThreshold
-    trades:
-      periodMs: 300000
-      # dataFetchFrequency
-      # minimumTrades
-      # scalingRate
   metrics:
     enabled: true
     prometheusPort: 9090

--- a/packages/helm-charts/oracle/CELOUSD.yaml
+++ b/packages/helm-charts/oracle/CELOUSD.yaml
@@ -22,5 +22,3 @@ oracle:
   reporter:
     blockBased:
       minReportPriceChangeThreshold: 0.005 # 0.5%
-    timer:
-      removeExpiredFrequencyMs: 60000

--- a/packages/helm-charts/oracle/CELOUSD.yaml
+++ b/packages/helm-charts/oracle/CELOUSD.yaml
@@ -7,11 +7,6 @@ oracle:
       bidMaxPercentageDeviation: 0.05
       maxPercentageBidAskSpread: 0.025
       # minReportPriceChangeThreshold
-    trades:
-      periodMs: 300000
-      # dataFetchFrequency
-      # minimumTrades
-      # scalingRate
   metrics:
     enabled: true
     prometheusPort: 9090

--- a/packages/helm-charts/oracle/templates/statefulset.yaml
+++ b/packages/helm-charts/oracle/templates/statefulset.yaml
@@ -115,14 +115,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-{{ include "common.env-var" (dict "name" "AGGREGATION_PERIOD" "dict" .Values.oracle.aggregation.trades "value_name" "periodMs" "optional" true) | indent 8 }}
-{{ include "common.env-var" (dict "name" "AGGREGATION_SCALING_RATE" "dict" .Values.oracle.aggregation.trades "value_name" "scalingRate" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "API_REQUEST_TIMEOUT" "dict" .Values.oracle "value_name" "apiRequestTimeoutMs" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "AZURE_HSM_INIT_TRY_COUNT" "dict" .Values.oracle.azureHsm "value_name" "initTryCount") | indent 8 }}
 {{ include "common.env-var" (dict "name" "AZURE_HSM_INIT_MAX_RETRY_BACKOFF_MS" "dict" .Values.oracle.azureHsm "value_name" "initMaxRetryBackoffMs") | indent 8 }}
 {{ include "common.env-var" (dict "name" "CIRCUIT_BREAKER_PRICE_CHANGE_THRESHOLD" "dict" .Values.oracle "value_name" "circuitBreakerPriceChangeThreshold") | indent 8 }}
 {{ include "common.env-var" (dict "name" "CURRENCY_PAIR" "dict" .Values.oracle "value_name" "currencyPair") | indent 8 }}
-{{ include "common.env-var" (dict "name" "DATA_FETCH_FREQUENCY" "dict" .Values.oracle.aggregation.trades "value_name" "dataFetchFrequency" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "EXCHANGES" "dict" .Values.oracle "value_name" "exchanges") | indent 8 }}
 {{ include "common.env-var" (dict "name" "HTTP_RPC_PROVIDER_URL" "dict" .Values.oracle.rpcProviderUrls "value_name" "http") | indent 8 }}
 {{ include "common.env-var" (dict "name" "MAX_BLOCK_TIMESTAMP_AGE_MS" "dict" .Values.oracle "value_name" "maxBlockTimestampAgeMs" "optional" true) | indent 8 }}
@@ -132,7 +129,6 @@ spec:
 {{ include "common.env-var" (dict "name" "MID_AGGREGATION_MAX_EXCHANGE_VOLUME_SHARE" "dict" .Values.oracle.aggregation.mid "value_name" "maxExchangeVolumeShare" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "MID_AGGREGATION_MAX_PERCENTAGE_BID_ASK_SPREAD" "dict" .Values.oracle.aggregation.mid "value_name" "maxPercentageBidAskSpread" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "MIN_REPORT_PRICE_CHANGE_THRESHOLD" "dict" .Values.oracle.reporter.blockBased "value_name" "minReportPriceChangeThreshold" "optional" true) | indent 8 }}
-{{ include "common.env-var" (dict "name" "MINIMUM_DATA" "dict" .Values.oracle.aggregation.trades "value_name" "minimumTrades" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "OVERRIDE_INDEX" "dict" .Values.oracle "value_name" "overrideIndex" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "OVERRIDE_ORACLE_COUNT" "dict" .Values.oracle "value_name" "overrideOracleCount" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "PRIVATE_KEY_PATH" "dict" .Values.oracle "value_name" "privateKeyPath" "optional" true) | indent 8 }}

--- a/packages/helm-charts/oracle/templates/statefulset.yaml
+++ b/packages/helm-charts/oracle/templates/statefulset.yaml
@@ -137,10 +137,6 @@ spec:
 {{ include "common.env-var" (dict "name" "OVERRIDE_ORACLE_COUNT" "dict" .Values.oracle "value_name" "overrideOracleCount" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "PRIVATE_KEY_PATH" "dict" .Values.oracle "value_name" "privateKeyPath" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "PROMETHEUS_PORT" "dict" .Values.oracle.metrics "value_name" "prometheusPort") | indent 8 }}
-{{ include "common.env-var" (dict "name" "REMOVE_EXPIRED_FREQUENCY" "dict" .Values.oracle.reporter.timer "value_name" "removeExpiredFrequencyMs" "optional" true) | indent 8 }}
-{{ include "common.env-var" (dict "name" "REMOVE_EXPIRED_OFFSET_OVERRIDE" "dict" .Values.oracle.reporter.timer "value_name" "removeExpiredOffsetOverride" "optional" true) | indent 8 }}
-{{ include "common.env-var" (dict "name" "REPORT_FREQUENCY_OVERRIDE" "dict" .Values.oracle.reporter.timer "value_name" "removeFrequencyOverride" "optional" true) | indent 8 }}
-{{ include "common.env-var" (dict "name" "REPORT_OFFSET_OVERRIDE" "dict" .Values.oracle.reporter.timer "value_name" "reportOffsetOverride" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "REPORT_STRATEGY" "dict" .Values.oracle "value_name" "reportStrategy") | indent 8 }}
 {{ include "common.env-var" (dict "name" "REPORT_TARGET_OVERRIDE" "dict" .Values.oracle "value_name" "reportTargetOverride" "optional" true) | indent 8 }}
 {{ include "common.env-var" (dict "name" "TARGET_MAX_HEARTBEAT_PERIOD_MS" "dict" .Values.oracle.reporter.blockBased "value_name" "targetMaxHeartbeatPeriodMs" "optional" true) | indent 8 }}

--- a/packages/helm-charts/oracle/values.yaml
+++ b/packages/helm-charts/oracle/values.yaml
@@ -60,11 +60,6 @@ oracle:
     blockBased:
       minReportPriceChangeThreshold: 0.005 # 0.5%
       # targetMaxHeartbeatPeriodMs
-    timer:
-      removeExpiredFrequencyMs: 60000
-      # removeExpiredOffsetOverride
-      # removeFrequencyOverride
-      # reportOffsetOverride
   # privateKeyPath
   # unusedOracleAddresses
   # overrideIndex

--- a/packages/helm-charts/oracle/values.yaml
+++ b/packages/helm-charts/oracle/values.yaml
@@ -44,11 +44,6 @@ oracle:
       bidMaxPercentageDeviation: 0.05
       maxPercentageBidAskSpread: 0.025
       # minReportPriceChangeThreshold
-    trades:
-      periodMs: 300000
-      # dataFetchFrequency
-      # minimumTrades
-      # scalingRate
   metrics:
     enabled: true
     prometheusPort: 9090


### PR DESCRIPTION
### Description

These parameters are not currently used, haven't been used in a while, and will soon be removed from the Oracle code.

Timer based reporting is being removed from the oracle on
https://github.com/celo-org/celo-oracle/pull/16.
Trade based aggregation is being removed from the oracle on
celo-org/celo-oracle#36.

### Tested

Re-deployed alfajores CELOEUR oracles using the new configuration.

### Related issues

- https://github.com/celo-org/celo-oracle/issues/15