### PR TITLE
Check the vote value is > Abstain in Governance vote function.

### DIFF
--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -629,7 +629,7 @@ contract Governance is
     uint256 weight = getLockedGold().getAccountTotalLockedGold(account);
     require(proposal.isApproved(), "Proposal not approved");
     require(stage == Proposals.Stage.Referendum, "Incorrect proposal state");
-    require(value != Proposals.VoteValue.None, "Vote value unset");
+    require(value > Proposals.VoteValue.Abstain, "Vote value unset");
     require(weight > 0, "Voter weight zero");
     VoteRecord storage voteRecord = voter.referendumVotes[index];
     proposal.updateVote(

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -629,7 +629,7 @@ contract Governance is
     uint256 weight = getLockedGold().getAccountTotalLockedGold(account);
     require(proposal.isApproved(), "Proposal not approved");
     require(stage == Proposals.Stage.Referendum, "Incorrect proposal state");
-    require(value > Proposals.VoteValue.Abstain, "Vote value unset");
+    require(value <= Proposals.VoteValue.Abstain, "Vote value unset");
     require(weight > 0, "Voter weight zero");
     VoteRecord storage voteRecord = voter.referendumVotes[index];
     proposal.updateVote(

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -629,7 +629,10 @@ contract Governance is
     uint256 weight = getLockedGold().getAccountTotalLockedGold(account);
     require(proposal.isApproved(), "Proposal not approved");
     require(stage == Proposals.Stage.Referendum, "Incorrect proposal state");
-    require(value <= Proposals.VoteValue.Abstain, "Vote value unset");
+    require(
+      value >= Proposals.VoteValue.Abstain && value <= Proposals.VoteValue.Yes,
+      "Vote value unset"
+    );
     require(weight > 0, "Voter weight zero");
     VoteRecord storage voteRecord = voter.referendumVotes[index];
     proposal.updateVote(

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -1566,8 +1566,8 @@ contract('Governance', (accounts: string[]) => {
       })
     })
 
-    it('should revert for abstain vote', async () => {
-      await assertRevert(governance.vote(proposalId, index, VoteValue.Abstain))
+    it('should revert for abstain plus 1 vote', async () => {
+      await assertRevert(governance.vote(proposalId, index, VoteValue.Abstain + 1))
     })
 
     it('should revert when the account weight is 0', async () => {

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -1566,10 +1566,6 @@ contract('Governance', (accounts: string[]) => {
       })
     })
 
-    it('should revert for abstain plus 1 vote', async () => {
-      await assertRevert(governance.vote(proposalId, index, VoteValue.Abstain + 1))
-    })
-
     it('should revert when the account weight is 0', async () => {
       await mockLockedGold.setAccountTotalLockedGold(account, 0)
       await assertRevert(governance.vote(proposalId, index, value))

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -62,9 +62,9 @@ const parseTransactionParams = (transactionParams: any) => {
 
 enum VoteValue {
   None = 0,
-  Abstain = 1,
-  No = 2,
-  Yes = 3,
+  Abstain,
+  No,
+  Yes,
 }
 
 interface Transaction {
@@ -1500,7 +1500,7 @@ contract('Governance', (accounts: string[]) => {
     })
   })
 
-  describe.only('#vote()', () => {
+  describe('#vote()', () => {
     const proposalId = 1
     const index = 0
     const value = VoteValue.Yes

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -62,9 +62,9 @@ const parseTransactionParams = (transactionParams: any) => {
 
 enum VoteValue {
   None = 0,
-  Abstain,
-  No,
-  Yes,
+  Abstain = 1,
+  No = 2,
+  Yes = 3,
 }
 
 interface Transaction {
@@ -1500,7 +1500,7 @@ contract('Governance', (accounts: string[]) => {
     })
   })
 
-  describe('#vote()', () => {
+  describe.only('#vote()', () => {
     const proposalId = 1
     const index = 0
     const value = VoteValue.Yes
@@ -1564,6 +1564,10 @@ contract('Governance', (accounts: string[]) => {
           weight: new BigNumber(weight),
         },
       })
+    })
+
+    it('should revert for abstain vote', async () => {
+      await assertRevert(governance.vote(proposalId, index, VoteValue.Abstain))
     })
 
     it('should revert when the account weight is 0', async () => {


### PR DESCRIPTION
### Description
Expected Behavior
Governance vote value > Yes and value <= None should be reverted

Current Behavior
Governance vote reverts on uint8 value=None but not uint8 value>Yes

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

Can't be unit tested as we can't pass negative values or positive values greater than Yes vote is not allowed. 

### Related issues

- Fixes #6948

### Backwards compatibility

It doesn't change any existing feature except handling the boundary condition.

### Documentation

N/A