### PR TITLE
Changed CELO display decimals from 3 to 4

### DIFF
--- a/packages/sdk/base/src/currencies.ts
+++ b/packages/sdk/base/src/currencies.ts
@@ -15,7 +15,7 @@ export const CURRENCIES: CurrencyObject = {
   [CURRENCY_ENUM.GOLD]: {
     symbol: '',
     code: 'cGLD',
-    displayDecimals: 3,
+    displayDecimals: 4,
   },
   [CURRENCY_ENUM.DOLLAR]: {
     symbol: '$',


### PR DESCRIPTION
### Description

As part of an update to Valora design, this PR aims to change the default display behavior of values on CELO-denominated screens to four decimal places.

### Other changes

N/A

### Tested

This should be tested in the wallet app/simulation: however the current state of the wallet works around usage of the `displayDecimals` prop anyway and the present PR's change would not be apparent without also creating a PR in the wallet repo to surface it.

### Related issues

- Related to #4713 

### Backwards compatibility

N/A

### Documentation

N/A