### PR TITLE
Add Bittrex to the CELOEUR oracles exchanges.

### DIFF
--- a/packages/helm-charts/oracle/CELOEUR.yaml
+++ b/packages/helm-charts/oracle/CELOEUR.yaml
@@ -17,7 +17,7 @@ oracle:
     prometheusPort: 9090
   apiRequestTimeoutMs: 5000
   circuitBreakerPriceChangeThreshold: 0.25
-  exchanges: COINBASE
+  exchanges: COINBASE,BITTREX
   reportStrategy: BLOCK_BASED
   reporter:
     blockBased:


### PR DESCRIPTION
### Description

Currently the CELOEUR oracles are fetching prices from Coinbase only. This PR adds Bittrex as another exchange where the oracles can fetch prices from.

### Tested

Deployed to Baklava and Mainnet.

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/858 
- Fixes https://github.com/celo-org/celo-labs/issues/859

### Backwards compatibility

Backwards compatible. Bittrex as an exchange option has been supported for a while.