### PR TITLE
Ensure all node modules cached by CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,8 @@ commands:
           name: Create cached node_modules (if necessary)
           command: |
             if [ ! -e ~/.tmp/node_modules.tgz ]; then
-              tar -c node_modules/ packages/*/node_modules/ packages/phone-number-privacy/*/node_modules/ | gzip --fast > ~/.tmp/node_modules.tgz
+              # This find command finds all top level node_modules directories, I.E all node modules that are not contained in a node_modules directory.
+              tar -c `find -type d -name node_modules | grep -v "node_modules.*node_modules"` | gzip --fast > ~/.tmp/node_modules.tgz
             fi
       - save_cache:
           name: Save cached node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
           keys:
             # Using a single cache key here as we don't want to fallback on restoring node_modules produced
             # by a different yarn.lock and patches
-            - node_modules-v4-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/patches" }}
+            - node_modules-v5-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/patches" }}
       - run:
           name: Extract cached node_modules (if present)
           command: |
@@ -106,7 +106,7 @@ commands:
             fi
       - save_cache:
           name: Save cached node_modules
-          key: node_modules-v4-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/patches" }}
+          key: node_modules-v5-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/patches" }}
           paths:
             - ~/.tmp/node_modules.tgz
 


### PR DESCRIPTION
### Description

As per the title. I believe this PR fixes #7638.

We were not caching all the `node_modules` in CI, in particular we were not caching `node_modules` under `packages/sdk/wallets`. The result of this was that CI would work if there was no cache since all `node_modules` would be installed, but when using the cache, in the case of the wallets test, CI would not be able to find `"secp256k1": "^4.0.0"` imported in the `node_modules` of `packages/sdk/wallets` and instead would fall back to `"secp256k1": "^3.0.1"` imported by modules inside the main `node_modules` folder. This would cause the wallets test to fail because the old version `3.0.8` in this case did not contain the function `secp256k1_1.ecdsaRecover`.


### Tested

We can re-run this in CI to ensure cache use and see that it works.

### Related issues

- Fixes #7638

### Backwards compatibility

This is backwards compatible, no APIs were changed.