### PR TITLE
Slightly refactor and pre-approve when possible

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -81,6 +81,15 @@ contract MetaTransactionWallet is
    * @param _signer The address authorized to execute transactions via this wallet.
    */
   function initialize(address _signer) external {
+    _initialize(_signer);
+  }
+
+  function initializeAndCall(address _signer, bytes calldata initCallback) external {
+    _initialize(_signer);
+    ExternalCall.execute(address(this), 0, initCallback);
+  }
+
+  function _initialize(address _signer) internal {
     require(signer == address(0));
     _setSigner(_signer);
     setEip712DomainSeparator();

--- a/packages/protocol/contracts/common/ProxyCloneFactory.sol
+++ b/packages/protocol/contracts/common/ProxyCloneFactory.sol
@@ -45,7 +45,7 @@ contract ProxyCloneFactory is CloneFactory, Ownable {
     proxy._initialize(address(this));
     proxy._setAndInitializeImplementation(implementation, initCallData);
     proxy._transferOwnership(owner);
-    IERC20(token).transfer(address(proxy), value);
+    IERC20(token).transferFrom(msg.sender, address(proxy), value);
     emit ProxyCreated(proxy);
   }
 
@@ -60,14 +60,13 @@ contract ProxyCloneFactory is CloneFactory, Ownable {
     proxy._setAndInitializeImplementation(implementation, initCallData);
     // TODO(asa): This is different, I believe in current komenci we transfer ownership to the user?
     proxy._transferOwnership(address(proxy));
-    IERC20(token).transfer(address(proxy), value);
+    IERC20(token).transferFrom(msg.sender, address(proxy), value);
     emit ProxyCreated(proxy);
   }
 
   function deployAndFundV3(
     address implementation,
     bytes calldata initCallData,
-    bytes calldata approvalCallData,
     address token,
     uint256 value
   ) external {
@@ -78,7 +77,7 @@ contract ProxyCloneFactory is CloneFactory, Ownable {
     // Call MetaTransactionWallet(proxy).executeTransactions([approve cUSD, set signer])
     // TODO(asa): This is different, I believe in current komenci we transfer ownership to the user?
     proxy._transferOwnership(address(proxy));
-    IERC20(token).transfer(address(proxy), value);
+    IERC20(token).transferFrom(msg.sender, address(proxy), value);
     emit ProxyCreated(proxy);
   }
 }

--- a/packages/protocol/contracts/identity/AttestationsV2.sol
+++ b/packages/protocol/contracts/identity/AttestationsV2.sol
@@ -73,6 +73,9 @@ contract AttestationsV2 is
   uint256 public attestationRequestFee;
   address public attestationRequestFeeToken;
 
+  // Make it compile
+  mapping(address => uint256) public attestationRequestFees;
+
   // Maps an attestation issuer to the amount that they're owed.
   mapping(address => uint256) public pendingWithdrawals;
 

--- a/packages/protocol/scripts/truffle/proxy-gas-costs.ts
+++ b/packages/protocol/scripts/truffle/proxy-gas-costs.ts
@@ -1,4 +1,4 @@
-import { ProxyContract, ProxyCloneFactoryContract, ProxyFactoryContract } from 'types'
+import { ProxyCloneFactoryContract, ProxyContract, ProxyFactoryContract } from 'types'
 
 /*
  * A script for testing gas optimizations for proxy deployments.


### PR DESCRIPTION
### Description

Major change is the addition of a `initializeAndCall` method to the MetaTransactionWallet which makes it easy to pre-approve the attestation fee on the proxy. Based on that I moved the approve in the deploy step for all pooled flows and removed it from the request attestation batch.

Other side changes:
- Fixed some variable scoping thing that caused subsequent contexts to fail when not running a single one via `describe.only`
- Removed the need for the various `ts-ignores` by extending some types.

### Latest run timings:
```
  Contract: Komenci Onboarding
    With AttestationsV1
      Current flow
Deploying and initializing a proxy takes 694696 gas
Setting the account takes 189076 gas
Requesting attestations takes 219973 gas
Selecting issuers takes 249327 gas
Completing an attestation takes 144819 gas
Completing an attestation takes 104207 gas
Completing an attestation takes 104215 gas
Onboarding a user takes 1706313 gas
        ✓ should onboard a new user (720ms)
      With EIP-1167
        Current flow
Deploying a proxy takes 187539 gas
Setting the account takes 189971 gas
Requesting attestations takes 206676 gas
Selecting issuers takes 250204 gas
Completing an attestation takes 115670 gas
Completing an attestation takes 90078 gas
Completing an attestation takes 90110 gas
Onboarding a user takes 1130248 gas
          ✓ should onboard a new user (707ms)
        Pooled proxy flow
Deploying a proxy takes 229035 gas
Transferring ownership to the user takes 52583 gas
Setting the account takes 189943 gas
Requesting attestations takes 151993 gas
Selecting issuers takes 250204 gas
Completing an attestation takes 115682 gas
Completing an attestation takes 90090 gas
Completing an attestation takes 90070 gas
Onboarding a user takes 1169600 gas: 940565 + 229035 prepaid
          ✓ should onboard a new user (808ms)
        Pooled proxy optimized flow
Deploying, funding and pre-approve a proxy takes 264141 gas
Requesting attestations takes 102858 gas
Selecting issuers takes 419173 gas
Completing an attestation takes 130690 gas
Completing an attestation takes 90110 gas
Completing an attestation takes 90070 gas
Onboarding a user takes 1097042 gas: 832901 + 264141 prepaid
          ✓ should onboard a new user (737ms)
    With AttestationsV2
      Pooled proxy optimized flow
Deploying and funding a proxy takes 208238 gas
Requesting attestations takes 318035 gas
Completing an attestation takes 175447 gas
Completing an attestation takes 126119 gas
Completing an attestation takes 132450 gas
Onboarding a user takes 939289 gas: 752051 + 187238 prepaid
        ✓ should onboard a new user (729ms)
```