### PR TITLE
Prevent dangling async calls

### DIFF
--- a/packages/phone-number-privacy/combiner/src/signing/get-threshold-signature.ts
+++ b/packages/phone-number-privacy/combiner/src/signing/get-threshold-signature.ts
@@ -102,7 +102,6 @@ async function requestSignatures(request: Request, response: Response) {
             data,
             res.status,
             response,
-            sentResult,
             responses,
             service.url,
             blsCryptoClient,
@@ -116,7 +115,6 @@ async function requestSignatures(request: Request, response: Response) {
             signers.length,
             failedRequests,
             response,
-            sentResult,
             controller,
             errorCodes
           )
@@ -143,7 +141,6 @@ async function requestSignatures(request: Request, response: Response) {
           signers.length,
           failedRequests,
           response,
-          sentResult,
           controller,
           errorCodes
         )
@@ -163,6 +160,9 @@ async function requestSignatures(request: Request, response: Response) {
   const majorityErrorCode = getMajorityErrorCode(errorCodes, logger)
   if (!blsCryptoClient.hasSufficientVerifiedSignatures()) {
     handleMissingSignatures(majorityErrorCode, response, logger, sentResult)
+  } else {
+    const combinedSignature = await blsCryptoClient.combinePartialBlindedSignatures()
+    response.json({ success: true, combinedSignature, version: VERSION })
   }
 }
 
@@ -170,7 +170,6 @@ async function handleSuccessResponse(
   data: string,
   status: number,
   response: Response,
-  sentResult: { sent: boolean },
   responses: SignMsgRespWithStatus[],
   serviceUrl: string,
   blsCryptoClient: BLSCryptographyClient,
@@ -199,23 +198,14 @@ async function handleSuccessResponse(
   logger.info(
     {
       signer: serviceUrl,
-      sent: sentResult.sent,
       hasSufficientSignatures: blsCryptoClient.hasSufficientVerifiedSignatures(),
     },
     'Added signature'
   )
   // Send response immediately once we cross threshold
-  if (!sentResult.sent && blsCryptoClient.hasSufficientVerifiedSignatures()) {
+  if (blsCryptoClient.hasSufficientVerifiedSignatures()) {
     // Close outstanding requests
     controller.abort()
-    logger.info({ signer: serviceUrl }, 'Combine signatures')
-    const combinedSignature = await blsCryptoClient.combinePartialBlindedSignatures()
-    if (!sentResult.sent) {
-      response.json({ success: true, combinedSignature, version: VERSION })
-      sentResult.sent = true
-    } else {
-      logger.info({ signer: serviceUrl }, 'Already sent response')
-    }
   }
 }
 
@@ -226,7 +216,6 @@ function handleFailedResponse(
   signerCount: number,
   failedRequests: Set<string>,
   response: Response,
-  sentResult: { sent: boolean },
   controller: AbortController,
   errorCodes: Map<number, number>
 ) {
@@ -239,12 +228,9 @@ function handleFailedResponse(
   failedRequests.add(service.url)
   const shouldFailFast = signerCount - failedRequests.size < config.thresholdSignature.threshold
   logger.info(`Recieved failure from ${failedRequests.size}/${signerCount} signers.`)
-  if (!sentResult.sent && shouldFailFast) {
+  if (shouldFailFast) {
     logger.info('Not possible to reach a sufficient number of signatures. Failing fast.')
-    const majorityErrorCode = getMajorityErrorCode(errorCodes, logger)
-    handleMissingSignatures(majorityErrorCode, response, logger, sentResult)
     controller.abort()
-    sentResult.sent = true
   }
 }
 

--- a/packages/phone-number-privacy/signer/test/signing/query-quota.test.ts
+++ b/packages/phone-number-privacy/signer/test/signing/query-quota.test.ts
@@ -1,5 +1,6 @@
 import { isVerified, rootLogger } from '@celo/phone-number-privacy-common'
 import BigNumber from 'bignumber.js'
+import allSettled from 'promise.allsettled'
 import {
   ContractRetrieval,
   createMockAccounts,
@@ -12,7 +13,6 @@ import { mockAccount, mockPhoneNumber } from '../../../common/src/test/values'
 import { getPerformedQueryCount } from '../../src/database/wrappers/account'
 import { getRemainingQueryCount } from '../../src/signing/query-quota'
 import { getContractKit } from '../../src/web3/contracts'
-import allSettled from 'promise.allsettled'
 
 allSettled.shim()
 
@@ -43,7 +43,7 @@ describe(getRemainingQueryCount, () => {
     mockGetContractKit.mockImplementation(() => contractKitVerifiedNoTx)
     expect(await getRemainingQueryCount(rootLogger, mockAccount, mockPhoneNumber)).toEqual({
       performedQueryCount: 2,
-      totalQuota: 52,
+      totalQuota: 60,
     })
   })
   it('Calculates remaining query count for unverified account', async () => {
@@ -61,7 +61,7 @@ describe(getRemainingQueryCount, () => {
     mockIsVerified.mockReturnValue(false)
     expect(await getRemainingQueryCount(rootLogger, mockAccount, mockPhoneNumber)).toEqual({
       performedQueryCount: 1,
-      totalQuota: 2,
+      totalQuota: 10,
     })
   })
   it('Calculates remaining query count for verified account with many txs', async () => {
@@ -79,7 +79,7 @@ describe(getRemainingQueryCount, () => {
     mockGetContractKit.mockImplementation(() => contractKitVerifiedNoTx)
     expect(await getRemainingQueryCount(rootLogger, mockAccount, mockPhoneNumber)).toEqual({
       performedQueryCount: 10,
-      totalQuota: 432,
+      totalQuota: 440,
     })
   })
   it('Calculates remaining query count for unverified account with many txs', async () => {
@@ -97,7 +97,7 @@ describe(getRemainingQueryCount, () => {
     mockGetContractKit.mockImplementation(() => contractKitVerifiedNoTx)
     expect(await getRemainingQueryCount(rootLogger, mockAccount, mockPhoneNumber)).toEqual({
       performedQueryCount: 0,
-      totalQuota: 402,
+      totalQuota: 410,
     })
   })
   it('Calculates remaining query count for unverified account without any balance', async () => {
@@ -133,7 +133,7 @@ describe(getRemainingQueryCount, () => {
     mockGetContractKit.mockImplementation(() => contractKitVerifiedNoTx)
     expect(await getRemainingQueryCount(rootLogger, mockAccount, mockPhoneNumber)).toEqual({
       performedQueryCount: 1,
-      totalQuota: 2,
+      totalQuota: 10,
     })
   })
   it('Calculates remaining query count for unverified account with only CELO balance', async () => {
@@ -151,7 +151,7 @@ describe(getRemainingQueryCount, () => {
     mockGetContractKit.mockImplementation(() => contractKitVerifiedNoTx)
     expect(await getRemainingQueryCount(rootLogger, mockAccount, mockPhoneNumber)).toEqual({
       performedQueryCount: 1,
-      totalQuota: 2,
+      totalQuota: 10,
     })
   })
   it('No phone number hash when request own phone number', async () => {
@@ -168,7 +168,7 @@ describe(getRemainingQueryCount, () => {
     mockGetContractKit.mockImplementation(() => contractKitVerifiedNoTx)
     expect(await getRemainingQueryCount(rootLogger, mockAccount, undefined)).toEqual({
       performedQueryCount: 0,
-      totalQuota: 2,
+      totalQuota: 10,
     })
   })
 })


### PR DESCRIPTION
### Description

Dangling async calls can interfere with Google Function execution since [GCP starves the process of resources after it believes it should be terminated](https://cloud.google.com/functions/docs/bestpractices/tips#do_not_start_background_activities).

Instead of responding in nested calls, the calls only signal controller.abort(). The end of the main method is the only one responsible for responding to the user. This might take a little longer to return the response to the user, but ensures all async processes are wrapped up before the function ends.

### Tested

TODO: Test in alfajores.