### PR TITLE
Process Signer response only if needed

### DIFF
--- a/packages/phone-number-privacy/combiner/src/signing/get-threshold-signature.ts
+++ b/packages/phone-number-privacy/combiner/src/signing/get-threshold-signature.ts
@@ -191,21 +191,21 @@ async function handleSuccessResponse(
   if (!signResponse.signature) {
     throw new Error(`Signature is missing from signer ${serviceUrl}`)
   }
-  responses.push({ url: serviceUrl, signMessageResponse: signResponse, status })
-  const partialSig = { url: serviceUrl, signature: signResponse.signature }
-  logger.info({ signer: serviceUrl }, 'Add signature')
-  const signatureAdditionStart = Date.now()
-  await blsCryptoClient.addSignature(partialSig, blindedQueryPhoneNumber, logger)
-  logger.info(
-    {
-      signer: serviceUrl,
-      hasSufficientSignatures: blsCryptoClient.hasSufficientVerifiedSignatures(),
-      additionLatency: Date.now() - signatureAdditionStart,
-    },
-    'Added signature'
-  )
-  // Send response immediately once we cross threshold
-  if (blsCryptoClient.hasSufficientVerifiedSignatures()) {
+  if (!blsCryptoClient.hasSufficientVerifiedSignatures()) {
+    responses.push({ url: serviceUrl, signMessageResponse: signResponse, status })
+    const partialSig = { url: serviceUrl, signature: signResponse.signature }
+    logger.info({ signer: serviceUrl }, 'Add signature')
+    const signatureAdditionStart = Date.now()
+    await blsCryptoClient.addSignature(partialSig, blindedQueryPhoneNumber, logger)
+    logger.info(
+      {
+        signer: serviceUrl,
+        hasSufficientSignatures: blsCryptoClient.hasSufficientVerifiedSignatures(),
+        additionLatency: Date.now() - signatureAdditionStart,
+      },
+      'Added signature'
+    )
+  } else {
     // Close outstanding requests
     controller.abort()
   }

--- a/packages/phone-number-privacy/combiner/src/signing/get-threshold-signature.ts
+++ b/packages/phone-number-privacy/combiner/src/signing/get-threshold-signature.ts
@@ -191,6 +191,9 @@ async function handleSuccessResponse(
   if (!signResponse.signature) {
     throw new Error(`Signature is missing from signer ${serviceUrl}`)
   }
+
+  // Only process signatures if we still need more
+  // Signature verification takes around 500ms
   if (!blsCryptoClient.hasSufficientVerifiedSignatures()) {
     responses.push({ url: serviceUrl, signMessageResponse: signResponse, status })
     const partialSig = { url: serviceUrl, signature: signResponse.signature }
@@ -205,9 +208,10 @@ async function handleSuccessResponse(
       },
       'Added signature'
     )
-  } else {
-    // Close outstanding requests
-    controller.abort()
+    if (blsCryptoClient.hasSufficientVerifiedSignatures()) {
+      // Close outstanding requests
+      controller.abort()
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Only process signer response if we need more signatures. It may be that we called abort() but the requests still make it in after. This can save us up to 1 second in overall latency.