### PR TITLE
CLI Bug Fix: invalid gas option

### DIFF
--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -42,7 +42,7 @@ export function getGasCurrency(configDir: string): string {
 }
 
 export function writeConfig(configDir: string, configObj: CeloConfig) {
-  if (Object.keys(gasOptions).includes(configObj.gasCurrency)) {
+  if (!Object.keys(gasOptions).includes(configObj.gasCurrency)) {
     throw new Error('Invalid gas option')
   }
   fs.outputJSONSync(configPath(configDir), configObj)


### PR DESCRIPTION
### Description

When the `config:set` command was used, the following error would come up: `Error: Invalid gas option`. 
This PR fixes the error brought up in #7524  
cc: @asaj for flagging the issue

### Other changes

n/a

### Tested

tried locally, works

### Related issues

n/a

### Backwards compatibility

n/a