### PR TITLE
Add indices for queried cols for signer/combiner DBs

### DIFF
--- a/packages/phone-number-privacy/combiner/migrations/20210421212301_create-indices.ts
+++ b/packages/phone-number-privacy/combiner/migrations/20210421212301_create-indices.ts
@@ -1,0 +1,27 @@
+import * as Knex from 'knex'
+import { ACCOUNTS_COLUMNS, ACCOUNTS_TABLE } from '../src/database/models/account'
+import { NUMBER_PAIRS_COLUMN, NUMBER_PAIRS_TABLE } from '../src/database/models/numberPair'
+
+export async function up(knex: Knex): Promise<any> {
+  if (!(await knex.schema.hasTable(NUMBER_PAIRS_TABLE))) {
+    throw new Error('Unexpected error: Could not find NUMBER_PAIRS_TABLE')
+  }
+  if (!(await knex.schema.hasTable(ACCOUNTS_TABLE))) {
+    throw new Error('Unexpected error: Could not find ACCOUNTS_TABLE')
+  }
+  await knex.schema.alterTable(NUMBER_PAIRS_TABLE, (t) => {
+    t.index(NUMBER_PAIRS_COLUMN.contactPhoneHash)
+  })
+  return knex.schema.alterTable(ACCOUNTS_TABLE, (t) => {
+    t.index(ACCOUNTS_COLUMNS.address)
+  })
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.alterTable(NUMBER_PAIRS_TABLE, (t) => {
+    t.dropIndex(NUMBER_PAIRS_COLUMN.contactPhoneHash)
+  })
+  return knex.schema.alterTable(ACCOUNTS_TABLE, (t) => {
+    t.dropIndex(ACCOUNTS_COLUMNS.address)
+  })
+}

--- a/packages/phone-number-privacy/combiner/src/database/database.ts
+++ b/packages/phone-number-privacy/combiner/src/database/database.ts
@@ -1,5 +1,8 @@
+import { rootLogger as logger } from '@celo/phone-number-privacy-common'
 import knex from 'knex'
+import Knex from 'knex/types'
 import config, { DEV_MODE } from '../config'
+import { NUMBER_PAIRS_COLUMN, NUMBER_PAIRS_TABLE } from './models/numberPair'
 
 const db = knex({
   client: 'pg',
@@ -7,10 +10,41 @@ const db = knex({
   debug: DEV_MODE,
 })
 
+export async function initDatabase(doTestQuery = true) {
+  logger.info('Running Migrations')
+
+  await db.migrate.latest({
+    directory: './dist/migrations',
+    loadExtensions: ['.js'],
+  })
+
+  if (doTestQuery) {
+    await executeTestQuery(db)
+  }
+
+  logger.info('Database initialized successfully')
+}
+
 export function getDatabase() {
   return db
 }
 
 export function getTransaction() {
   return db.transaction()
+}
+
+async function executeTestQuery(_db: Knex) {
+  logger.info('Querying first row')
+  const result = await _db(NUMBER_PAIRS_TABLE).select(NUMBER_PAIRS_COLUMN.userPhoneHash).limit(1)
+
+  if (!result) {
+    throw new Error('No result from count, have migrations been run?')
+  }
+
+  const userPhoneHash = Object.values(result)[0]
+  if (userPhoneHash === undefined || userPhoneHash === null || userPhoneHash === '') {
+    throw new Error('No result from count, have migrations been run?')
+  }
+
+  logger.info(`Found ${userPhoneHash} userPhoneHash`)
 }

--- a/packages/phone-number-privacy/combiner/src/database/database.ts
+++ b/packages/phone-number-privacy/combiner/src/database/database.ts
@@ -1,8 +1,5 @@
-import { rootLogger as logger } from '@celo/phone-number-privacy-common'
 import knex from 'knex'
-import Knex from 'knex/types'
 import config, { DEV_MODE } from '../config'
-import { NUMBER_PAIRS_COLUMN, NUMBER_PAIRS_TABLE } from './models/numberPair'
 
 const db = knex({
   client: 'pg',
@@ -10,41 +7,10 @@ const db = knex({
   debug: DEV_MODE,
 })
 
-export async function initDatabase(doTestQuery = true) {
-  logger.info('Running Migrations')
-
-  await db.migrate.latest({
-    directory: './dist/migrations',
-    loadExtensions: ['.js'],
-  })
-
-  if (doTestQuery) {
-    await executeTestQuery(db)
-  }
-
-  logger.info('Database initialized successfully')
-}
-
 export function getDatabase() {
   return db
 }
 
 export function getTransaction() {
   return db.transaction()
-}
-
-async function executeTestQuery(_db: Knex) {
-  logger.info('Querying first row')
-  const result = await _db(NUMBER_PAIRS_TABLE).select(NUMBER_PAIRS_COLUMN.userPhoneHash).limit(1)
-
-  if (!result) {
-    throw new Error('No result from count, have migrations been run?')
-  }
-
-  const userPhoneHash = Object.values(result)[0]
-  if (userPhoneHash === undefined || userPhoneHash === null || userPhoneHash === '') {
-    throw new Error('No result from count, have migrations been run?')
-  }
-
-  logger.info(`Found ${userPhoneHash} userPhoneHash`)
 }

--- a/packages/phone-number-privacy/signer/src/migrations/20210421212301_create-indices.ts
+++ b/packages/phone-number-privacy/signer/src/migrations/20210421212301_create-indices.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex'
+import { ACCOUNTS_COLUMNS, ACCOUNTS_TABLE } from '../database/models/account'
+
+export async function up(knex: Knex): Promise<any> {
+  if (!(await knex.schema.hasTable(ACCOUNTS_TABLE))) {
+    throw new Error('Unexpected error: Could not find ACCOUNTS_TABLE')
+  }
+  return knex.schema.alterTable(ACCOUNTS_TABLE, (t) => {
+    t.index(ACCOUNTS_COLUMNS.address)
+  })
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.alterTable(ACCOUNTS_TABLE, (t) => {
+    t.dropIndex(ACCOUNTS_COLUMNS.address)
+  })
+}


### PR DESCRIPTION
### Description

We've noticed extremely poor performance on DB lookups with many queries taking more than 1 second and some queries taking 10s of minutes. This change introduces column indexing on the queried columns in the DBs.

### Other changes

None

### Tested

- [x] Manual testing in staging
- [x] Manual testing in alfajores

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Applying indexing on existing columns

### Documentation

N/A