### PR TITLE
Updated the max body size limit for Blockscout ingress

### DIFF
--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -156,6 +156,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
     nginx.ingress.kubernetes.io/configuration-snippet: |
     location ~ /admin/.* {
       deny all;

--- a/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ /admin/.* {
         deny all;


### PR DESCRIPTION
### Description

Smart contract verification requires uploading source code files that might reach the size of megabytes. Currently, the ingress throws 413 Payload Too Large.

### Tested

Tested on Alfajores.