### PR TITLE
Use non-headless private nodes service

### DIFF
--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -131,8 +131,8 @@ async function helmParameters(
     params.push(`--set blockscout.jsonrpc_http_url=http://${txNodeLbIp}:8545`)
     params.push(`--set blockscout.jsonrpc_ws_url=ws://${txNodeLbIp}:8546`)
   } else if (privateNodes > 0) {
-    params.push(`--set blockscout.jsonrpc_http_url=http://tx-nodes-private-headless:8545`)
-    params.push(`--set blockscout.jsonrpc_ws_url=ws://tx-nodes-private-headless:8546`)
+    params.push(`--set blockscout.jsonrpc_http_url=http://tx-nodes-private:8545`)
+    params.push(`--set blockscout.jsonrpc_ws_url=ws://tx-nodes-private:8546`)
   } else {
     params.push(`--set blockscout.jsonrpc_http_url=http://tx-nodes-headless:8545`)
     params.push(`--set blockscout.jsonrpc_ws_url=ws://tx-nodes-headless:8546`)


### PR DESCRIPTION
### Description

Headless service doesn't use session affinity which causes race conditions on the indexer.

### Tested

Tested on Alfajores.

### Backwards compatibility

Yes.