### PR TITLE
Fix blockscout default ingress yaml and custom env values

### DIFF
--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -28,6 +28,9 @@ export async function installHelmChart(
   blockscoutDBPassword: string,
   blockscoutDBConnectionName: string
 ) {
+  const valuesEnvFile = fs.existsSync(`${helmChartPath}/values-${celoEnv}.yaml`)
+    ? `values-${celoEnv}.yaml`
+    : `values.yaml`
   return installGenericHelmChart(
     celoEnv,
     releaseName,
@@ -40,7 +43,7 @@ export async function installHelmChart(
       blockscoutDBConnectionName
     ),
     true,
-    `values-${celoEnv}.yaml`
+    valuesEnvFile
   )
 }
 
@@ -148,7 +151,7 @@ export async function createDefaultIngressIfNotExists(celoEnv: string, ingressNa
   )
   if (!ingressExists) {
     console.info(`Creating ingress ${celoEnv}-blockscout-web-ingress`)
-    const ingressFilePath = `/tmp/${celoEnv}-blockscout-web-ingress.json`
+    const ingressFilePath = `/tmp/${celoEnv}-blockscout-web-ingress.yaml`
     const ingressResource = `
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -158,12 +161,12 @@ metadata:
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 8m
     nginx.ingress.kubernetes.io/configuration-snippet: |
-    location ~ /admin/.* {
-      deny all;
-    }
-    location ~ /wobserver/.* {
-      deny all;
-    }
+      location ~ /admin/.* {
+        deny all;
+      }
+      location ~ /wobserver/.* {
+        deny all;
+      }
   labels:
     app: blockscout
     chart: blockscout


### PR DESCRIPTION
### Description
Fix blockscout default ingress yaml.
Use a default helm file `values.yaml` when there is not a custom values file for that env.

### Tested

Pending
