### PR TITLE
Only deploy changed libraries

### DIFF
--- a/packages/protocol/scripts/truffle/make-release.ts
+++ b/packages/protocol/scripts/truffle/make-release.ts
@@ -5,7 +5,6 @@ import { ASTDetailedVersionedReport } from '@celo/protocol/lib/compatibility/rep
 import { getCeloContractDependencies } from '@celo/protocol/lib/contract-dependencies'
 import { CeloContractName, celoRegistryAddress } from '@celo/protocol/lib/registry-utils'
 import { checkImports } from '@celo/protocol/lib/web3-utils'
-import { linkedLibraries } from '@celo/protocol/migrationsConfig'
 import { Address, eqAddress, NULL_ADDRESS } from '@celo/utils/lib/address'
 import { readdirSync, readJsonSync, writeJsonSync } from 'fs-extra'
 import { basename, join } from 'path'
@@ -261,7 +260,9 @@ module.exports = async (callback: (error?: any) => number) => {
       await Promise.all(contractDependencies.map((d) => contractArtifact.link(d, addresses.get(d))))
 
       // 3. Deploy new versions of the contract or library, if indicated by the report.
-      if (Object.keys(report.contracts).includes(contractName)) {
+      const shouldDeployContract = Object.keys(report.contracts).includes(contractName)
+      const shouldDeployLibrary = Object.keys(report.libraries).includes(contractName)
+      if (shouldDeployContract) {
         await deployCoreContract(
           contractName,
           contractArtifact,
@@ -272,7 +273,7 @@ module.exports = async (callback: (error?: any) => number) => {
           argv.dry_run,
           argv.from
         )
-      } else if (Object.keys(report.libraries).includes(contractName)) {
+      } else if (shouldDeployLibrary) {
         await deployLibrary(contractName, contractArtifact, addresses, argv.dry_run, argv.from)
       }
 


### PR DESCRIPTION
### Description

Adapts `make-release` to only release libraries when the compatibility report indicates to

### Tested

tested against `alexbharley/cip10` where [this ci job](https://app.circleci.com/pipelines/github/celo-org/celo-monorepo/35145/workflows/1ad6c9f7-3734-4b99-8307-860c27a18194/jobs/456932) was previously failing it is now passing in [this ci job](https://app.circleci.com/pipelines/github/celo-org/celo-monorepo/35149/workflows/da378db8-796f-47a6-a9d0-1b85c6db2e6c/jobs/456998)

### Related issues

- Fixes #6606
- Resolves failures from https://github.com/celo-org/celo-monorepo/pull/7859

### Backwards compatibility

Yes