### PR TITLE
Fix truffle console script and add notes to readme

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -67,6 +67,39 @@ yarn run upload-artifacts -n NAME
 
 By default, `NAME` will be set as `RELEASE_NAME`, `NAMESPACE_NAME`, `TESTNET_NAME` which you should have used with the same name in prior instructions. If you used separate names for the above, you can customize the run with the `-r -n -t` flags respectively.
 
+### Console
+
+To start a truffle console run:
+```
+yarn console -f -n rc1
+```
+
+Options:
+- "-f" for Forno mode, otherwise there needs to be a node running at localhost:8585
+- "-n <network>" possible values are: "rc1", "alfajores", "baklava"
+
+All compiled assets from `build/contracts` are injected in scope so for example you can do:
+
+```
+truffle(rc1)> let exchange = await ExchangeEUR.at("0xE383394B913d7302c49F794C7d3243c429d53D1d")
+```
+To instantiate a contract at a known address, and then interact with it:
+
+```
+truffle(rc1)> exchange.getBuyAndSellBuckets(true)
+Result {
+  '0': <BN: 744b931719b5411d57c3>,
+  '1': <BN: 17105bfef1e6943fd144> }
+
+```
+
+Or you can use ContractKit:
+
+```
+truffle(rc1)> let kit = require('@celo/contractkit').newKitFromWeb3(web3)
+truffle(rc1)> let exchange = await kit.contracts.getExchange()
+```
+
 ### Testing
 
 To test the smart contracts, run:

--- a/packages/protocol/scripts/bash/console.sh
+++ b/packages/protocol/scripts/bash/console.sh
@@ -26,4 +26,4 @@ if ! nc -z 127.0.0.1 8545 && [ -z $FORNO ] ; then
   exit 1
 fi
 
-yarn run truffle console --network $NETWORK --build_directory $PWD/build/$NETWORK $FORNO
+yarn run truffle console --network $NETWORK --contracts_build_directory $PWD/build/contracts $FORNO


### PR DESCRIPTION
### Description

Fix the console script so that it can pick-up the contract artefacts and add a readme section on usage

### Tested

Ran the commands

### Backwards compatibility

No issues

### Documentation

Updated readme