### PR TITLE
[L07] Unnecessary Access Control

### DIFF
--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -119,7 +119,7 @@ contract Accounts is
   /**
    * @notice Sets the EIP712 domain separator for the Celo Accounts abstraction.
    */
-  function setEip712DomainSeparator() public onlyOwner {
+  function setEip712DomainSeparator() public {
     uint256 chainId;
     assembly {
       chainId := chainid

--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -114,6 +114,7 @@ contract Accounts is
   function initialize(address registryAddress) external initializer {
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
+    setEip712DomainSeparator();
   }
 
   /**


### PR DESCRIPTION
### Description

Remove `onlyOwner` modifier from the `setEip712DomainSeparator` function.

As a note, OZ requested that this be moved into the `initialize` call, however the Accounts contract cannot be reinitialized without a storage upgrade. 

### Related issues

- Fixes #7993