### PR TITLE
Add token address support to oracle commands.

### DIFF
--- a/packages/cli/src/commands/oracle/list.ts
+++ b/packages/cli/src/commands/oracle/list.ts
@@ -1,5 +1,4 @@
 import { CeloContract } from '@celo/contractkit'
-import { stableTokenContractArray } from '@celo/contractkit/lib/base'
 import { BaseCommand } from '../../base'
 import { failWith } from '../../utils/cli'
 
@@ -15,7 +14,6 @@ export default class List extends BaseCommand {
       name: 'token',
       required: true,
       description: 'Token to list the oracles for',
-      options: stableTokenContractArray,
       default: CeloContract.StableToken,
     },
   ]
@@ -26,13 +24,7 @@ export default class List extends BaseCommand {
     const res = this.parse(List)
     const sortedOracles = await this.kit.contracts.getSortedOracles()
 
-    try {
-      await this.kit.registry.addressFor(res.args.token)
-    } catch {
-      failWith(`The ${res.args.token} contract was not deployed yet`)
-    }
-
-    const oracles = await sortedOracles.getOracles(res.args.token)
+    const oracles = await sortedOracles.getOracles(res.args.token).catch((e) => failWith(e))
     console.log(oracles)
   }
 }

--- a/packages/cli/src/commands/oracle/remove-expired-reports.ts
+++ b/packages/cli/src/commands/oracle/remove-expired-reports.ts
@@ -1,12 +1,10 @@
 import { CeloContract } from '@celo/contractkit'
-import { stableTokenContractArray } from '@celo/contractkit/lib/base'
 import { BaseCommand } from '../../base'
 import { displaySendTx, failWith } from '../../utils/cli'
 import { Flags } from '../../utils/command'
 
 export default class RemoveExpiredReports extends BaseCommand {
-  static description =
-    'Remove expired oracle reports for a specified token (currently just Celo Dollar, aka "StableToken")'
+  static description = 'Remove expired oracle reports for a specified token'
 
   static args = [
     {
@@ -14,7 +12,6 @@ export default class RemoveExpiredReports extends BaseCommand {
       required: true,
       default: CeloContract.StableToken,
       description: 'Token to remove expired reports for',
-      options: stableTokenContractArray,
     },
   ]
   static flags = {
@@ -34,13 +31,7 @@ export default class RemoveExpiredReports extends BaseCommand {
   async run() {
     const res = this.parse(RemoveExpiredReports)
 
-    try {
-      await this.kit.registry.addressFor(res.args.token)
-    } catch {
-      failWith(`The ${res.args.token} contract was not deployed yet`)
-    }
-
-    const sortedOracles = await this.kit.contracts.getSortedOracles()
+    const sortedOracles = await this.kit.contracts.getSortedOracles().catch((e) => failWith(e))
     const txo = await sortedOracles.removeExpiredReports(res.args.token)
     await displaySendTx('removeExpiredReports', txo)
   }

--- a/packages/cli/src/commands/oracle/report.ts
+++ b/packages/cli/src/commands/oracle/report.ts
@@ -1,5 +1,4 @@
 import { CeloContract } from '@celo/contractkit'
-import { stableTokenContractArray } from '@celo/contractkit/lib/base'
 import { flags } from '@oclif/command'
 import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
@@ -7,8 +6,7 @@ import { displaySendTx, failWith } from '../../utils/cli'
 import { Flags } from '../../utils/command'
 
 export default class ReportPrice extends BaseCommand {
-  static description =
-    'Report the price of CELO in a specified token (currently just Celo Dollar, aka "StableToken")'
+  static description = 'Report the price of CELO in a specified token'
 
   static args = [
     {
@@ -16,7 +14,6 @@ export default class ReportPrice extends BaseCommand {
       required: true,
       default: CeloContract.StableToken,
       description: 'Token to report on',
-      options: stableTokenContractArray,
     },
   ]
   static flags = {
@@ -39,15 +36,9 @@ export default class ReportPrice extends BaseCommand {
     const sortedOracles = await this.kit.contracts.getSortedOracles()
     const value = new BigNumber(res.flags.value)
 
-    try {
-      await this.kit.registry.addressFor(res.args.token)
-    } catch {
-      failWith(`The ${res.args.token} contract was not deployed yet`)
-    }
-
     await displaySendTx(
       'sortedOracles.report',
-      await sortedOracles.report(res.args.token, value, res.flags.from)
+      await sortedOracles.report(res.args.token, value, res.flags.from).catch((e) => failWith(e))
     )
     this.log(`Reported oracle value: ${value.toString()} ${res.args.token} == 1 CELO`)
   }

--- a/packages/cli/src/commands/oracle/reports.ts
+++ b/packages/cli/src/commands/oracle/reports.ts
@@ -1,5 +1,4 @@
 import { CeloContract } from '@celo/contractkit'
-import { stableTokenContractArray } from '@celo/contractkit/lib/base'
 import { cli } from 'cli-ux'
 import { BaseCommand } from '../../base'
 import { failWith } from '../../utils/cli'
@@ -17,7 +16,6 @@ export default class Reports extends BaseCommand {
       name: 'token',
       required: true,
       description: 'Token to list the reports for',
-      options: stableTokenContractArray,
       default: CeloContract.StableToken,
     },
   ]
@@ -28,13 +26,7 @@ export default class Reports extends BaseCommand {
     const res = this.parse(Reports)
     const sortedOracles = await this.kit.contracts.getSortedOracles()
 
-    try {
-      await this.kit.registry.addressFor(res.args.token)
-    } catch {
-      failWith(`The ${res.args.token} contract was not deployed yet`)
-    }
-
-    const reports = await sortedOracles.getReports(res.args.token)
+    const reports = await sortedOracles.getReports(res.args.token).catch((e) => failWith(e))
     cli.table(
       reports,
       {

--- a/packages/docs/command-line-interface/oracle.md
+++ b/packages/docs/command-line-interface/oracle.md
@@ -31,10 +31,10 @@ _See code: [src/commands/oracle/list.ts](https://github.com/celo-org/celo-monore
 
 ## `celocli oracle:remove-expired-reports TOKEN`
 
-Remove expired oracle reports for a specified token (currently just Celo Dollar, aka "StableToken")
+Remove expired oracle reports for a specified token
 
 ```
-Remove expired oracle reports for a specified token (currently just Celo Dollar, aka "StableToken")
+Remove expired oracle reports for a specified token
 
 USAGE
   $ celocli oracle:remove-expired-reports TOKEN
@@ -61,10 +61,10 @@ _See code: [src/commands/oracle/remove-expired-reports.ts](https://github.com/ce
 
 ## `celocli oracle:report TOKEN`
 
-Report the price of CELO in a specified token (currently just Celo Dollar, aka "StableToken")
+Report the price of CELO in a specified token
 
 ```
-Report the price of CELO in a specified token (currently just Celo Dollar, aka "StableToken")
+Report the price of CELO in a specified token
 
 USAGE
   $ celocli oracle:report TOKEN

--- a/packages/sdk/contractkit/src/base.ts
+++ b/packages/sdk/contractkit/src/base.ts
@@ -30,7 +30,6 @@ export enum CeloContract {
 }
 
 export type StableTokenContract = CeloContract.StableToken | CeloContract.StableTokenEUR
-export const stableTokenContractArray = [CeloContract.StableToken, CeloContract.StableTokenEUR]
 
 export type ExchangeContract = CeloContract.Exchange | CeloContract.ExchangeEUR
 


### PR DESCRIPTION
### Description

Allows a celocli user to interact with the SortedOracles contract by passing an address (in addition to passing the token contract name). Currently, celocli only support two options: "StableToken" and "StableTokenEUR". This PR makes it so that it also accepts a report target address (e.g. 0x018CAad1ED69eeDD40ed8309A81Eb78c937563a6 for CELOBTC).

### Other changes

Update commands help string to remove mention of supporting only cUSD (StableToken), when it already supports cEUR.

### Tested

Manually tested the commands on baklava.

### Backwards compatibility

This PR adds new functionality to the changed commands, but doesn't change the way it worked previously. The CLI remains compatible with all previous commands.

### Documentation

Oclif docs updated.