### PR TITLE
Add a Binance CELO/EUR implicit pair.

### DIFF
--- a/packages/helm-charts/oracle/CELOEUR.yaml
+++ b/packages/helm-charts/oracle/CELOEUR.yaml
@@ -11,7 +11,7 @@ oracle:
     prometheusPort: 9090
   apiRequestTimeoutMs: 5000
   circuitBreakerPriceChangeThreshold: 0.25
-  priceSources: "[[{exchange: 'BITTREX', symbol: 'CELOEUR', toInvert: false}],[{exchange: 'COINBASE', symbol: 'CELOEUR', toInvert: false}]]"
+  priceSources: "[[{exchange: 'BITTREX', symbol: 'CELOEUR', toInvert: false}],[{exchange: 'COINBASE', symbol: 'CELOEUR', toInvert: false}],[{exchange: 'BINANCE', symbol: 'CELOUSDT', toInvert: false}, {exchange: 'BINANCE', symbol: 'EURUSDT', toInvert: true}]]"
   reportStrategy: BLOCK_BASED
   reporter:
     blockBased:


### PR DESCRIPTION
### Description

Add a Binance implicit CELO/EUR pair via USDT.

### Tested

Tested on Baklava and Alfajores.

### Related issues

- Fixes #8013