### PR TITLE
Add comments to clarify identity hueristic on IdentityProxyHub

### DIFF
--- a/packages/protocol/contracts/identity/IdentityProxyHub.sol
+++ b/packages/protocol/contracts/identity/IdentityProxyHub.sol
@@ -49,18 +49,25 @@ contract IdentityProxyHub is UsingRegistry {
    * @param identifier The identifier to check.
    * @return True if the given address is the likely owner of the given
    * identifier, false otherwise.
+   * @dev Heuristic for ownership checks that the given account:
+   *   1. Has at least 3 completed attestations on the given identifier.
+   *   2. Completed strictly more than half of requested attestations.
+   *   3. Has at least as many completed attestations as any other account.
    */
   function passesIdentityHeuristic(address addr, bytes32 identifier) public view returns (bool) {
     IAttestations attestations = getAttestations();
     (uint32 completed, uint32 requested) = attestations.getAttestationStats(identifier, addr);
 
+    // 1. Check that the account has at least 3 completed attestations on the given identifier.
     bool hasEnoughCompletions = completed >= 3;
 
+    // 2. Check that the account Completed strictly more than half of requested attestations.
     bool completedOverHalfRequests = false;
     if (completed > 0) {
       completedOverHalfRequests = requested / completed < 2;
     }
 
+    // 3. Check that the account has at least as many completed attestations as any other account.
     bool hasMostCompletions = true;
     address[] memory addresses = attestations.lookupAccountsForIdentifier(identifier);
     for (uint256 i = 0; i < addresses.length; i++) {
@@ -74,6 +81,8 @@ contract IdentityProxyHub is UsingRegistry {
       }
     }
 
+    // Return true if the account passed all three checks above.
+    // Note: We do not return early on failures as we are optimizing for the passing case.
     return hasEnoughCompletions && completedOverHalfRequests && hasMostCompletions;
   }
 


### PR DESCRIPTION
### Description

This PR adds some comments to the identity hueristic in IdentityProxyHub to clarify what each of the
rules used within the hueristic, and to explain why we do not return early when a rule check fails.

### Related issues

Related: github.com/celo-org/celo-monorepo/issues/7998