### PR TITLE
Skip unvoted proposals in revokeVotes

### DIFF
--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -687,7 +687,7 @@ contract Governance is
       ) {
         (Proposals.Proposal storage proposal, Proposals.Stage stage) =
           requireDequeuedAndDeleteExpired(voteRecord.proposalId, dequeueIndex); // prettier-ignore
-        
+
         // only revoke from proposals which are still in referendum
         if (stage == Proposals.Stage.Referendum) {
           proposal.updateVote(voteRecord.weight, 0, voteRecord.value, Proposals.VoteValue.None);

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -1510,10 +1510,28 @@ contract('Governance', (accounts: string[]) => {
   })
 
   describe('#revokeVotes()', () => {
-    const proposalId = 1
-    const index = 0
-    const value = VoteValue.Yes
     beforeEach(async () => {
+      await governance.setConcurrentProposals(3)
+      await governance.propose(
+        [transactionSuccess1.value],
+        [transactionSuccess1.destination],
+        // @ts-ignore bytes type
+        transactionSuccess1.data,
+        [transactionSuccess1.data.length],
+        descriptionUrl,
+        // @ts-ignore: TODO(mcortesi) fix typings for TransactionDetails
+        { value: minDeposit }
+      )
+      await governance.propose(
+        [transactionSuccess2.value],
+        [transactionSuccess2.destination],
+        // @ts-ignore bytes type
+        transactionSuccess2.data,
+        [transactionSuccess2.data.length],
+        descriptionUrl,
+        // @ts-ignore: TODO(mcortesi) fix typings for TransactionDetails
+        { value: minDeposit }
+      )
       await governance.propose(
         [transactionSuccess1.value],
         [transactionSuccess1.destination],
@@ -1525,93 +1543,56 @@ contract('Governance', (accounts: string[]) => {
         { value: minDeposit }
       )
       await timeTravel(dequeueFrequency, web3)
-      await governance.approve(proposalId, index)
+      await governance.approve(1, 0)
+      await governance.approve(2, 1)
+      await governance.approve(3, 2)
       await timeTravel(approvalStageDuration, web3)
       await mockLockedGold.setAccountTotalLockedGold(account, weight)
-      await governance.vote(proposalId, index, value)
     })
 
-    it('should unset the most recent referendum proposal voted on', async () => {
-      await governance.revokeVotes()
-      assert.equal((await governance.getMostRecentReferendumProposal(account)).toNumber(), 0)
-    })
+    for (let numVoted = 0; numVoted < 3; numVoted++) {
+      describe(`when account has voted on ${numVoted} proposals`, () => {
+        const value = VoteValue.Yes
+        beforeEach(async () => {
+          for (let i = 0; i < numVoted; i++) {
+            await governance.vote(i + 1, i, value)
+          }
+        })
 
-    it('should return false on `isVoting`', async () => {
-      await governance.revokeVotes()
-      const voting = await governance.isVoting(accounts[0])
-      assert.isFalse(voting)
-    })
+        it('should unset the most recent referendum proposal voted on', async () => {
+          await governance.revokeVotes()
+          const mostRecentReferendum = await governance.getMostRecentReferendumProposal(account)
+          assert.equal(mostRecentReferendum.toNumber(), 0)
+        })
 
-    it('should emit the ProposalVoteRevoked event', async () => {
-      const resp = await governance.revokeVotes()
-      assert.equal(resp.logs.length, 1)
-      const log = resp.logs[0]
-      assertLogMatches2(log, {
-        event: 'ProposalVoteRevoked',
-        args: {
-          proposalId,
-          account,
-          value,
-          weight,
-        },
+        it('should return false on `isVoting`', async () => {
+          await governance.revokeVotes()
+          const voting = await governance.isVoting(accounts[0])
+          assert.isFalse(voting)
+        })
+
+        it(`should emit the ProposalVoteRevoked event ${numVoted} times`, async () => {
+          const resp = await governance.revokeVotes()
+          assert.equal(resp.logs.length, numVoted)
+          resp.logs.map((log, i) =>
+            assertLogMatches2(log, {
+              event: 'ProposalVoteRevoked',
+              args: {
+                proposalId: i + 1,
+                account,
+                value,
+                weight,
+              },
+            })
+          )
+        })
+
+        it('should not revert when proposals are not in the Referendum stage', async () => {
+          await timeTravel(referendumStageDuration, web3)
+          await governance.revokeVotes()
+        })
       })
-    })
-
-    it('should not revert when proposals are not in the Referendum stage', async () => {
-      await governance.vote(proposalId, index, VoteValue.Yes)
-      await timeTravel(referendumStageDuration, web3)
-      await governance.revokeVotes()
-    })
-
-    describe('when voting on two proposals', () => {
-      const proposalId1 = 2
-      const proposalId2 = 3
-      const index1 = 1
-      const index2 = 2
-      beforeEach(async () => {
-        const newDequeueFrequency = 60
-        await governance.setDequeueFrequency(newDequeueFrequency)
-        await governance.propose(
-          [transactionSuccess1.value],
-          [transactionSuccess1.destination],
-          // @ts-ignore bytes type
-          transactionSuccess1.data,
-          [transactionSuccess1.data.length],
-          descriptionUrl,
-          // @ts-ignore: TODO(mcortesi) fix typings for TransactionDetails
-          { value: minDeposit }
-        )
-        await timeTravel(newDequeueFrequency, web3)
-        await governance.approve(proposalId1, index1)
-        await governance.propose(
-          [transactionSuccess2.value],
-          [transactionSuccess2.destination],
-          // @ts-ignore bytes type
-          transactionSuccess2.data,
-          [transactionSuccess2.data.length],
-          descriptionUrl,
-          // @ts-ignore: TODO(mcortesi) fix typings for TransactionDetails
-          { value: minDeposit }
-        )
-        await timeTravel(newDequeueFrequency, web3)
-        await governance.approve(proposalId2, index2)
-        await timeTravel(approvalStageDuration, web3)
-        await mockLockedGold.setAccountTotalLockedGold(account, weight)
-        await governance.vote(proposalId2, index2, value)
-        await governance.vote(proposalId1, index1, value)
-      })
-
-      it('should return false on `isVoting`', async () => {
-        await governance.revokeVotes()
-        const voting = await governance.isVoting(accounts[0])
-        assert.isFalse(voting)
-      })
-
-      it('should emit the ProposalVoteRevoked event 3 times', async () => {
-        const resp = await governance.revokeVotes()
-        assert.equal(resp.logs.length, 3)
-      })
-    })
+    }
   })
 
   describe('#vote()', () => {


### PR DESCRIPTION
### Description

- Only perform revoke operations on votes which have been previously cast for a specific proposal

### Related issues

- Fixes #7994

### Backwards compatibility

Yes
