### PR TITLE
Prune Ownable from GoldToken inheritance graph

### DIFF
--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -13,7 +13,6 @@ import "../common/interfaces/ICeloVersionedContract.sol";
 contract GoldToken is
   Initializable,
   CalledByVm,
-  Ownable,
   UsingRegistry,
   IERC20,
   ICeloToken,


### PR DESCRIPTION
### Description

Remove `Ownable` from `GoldToken`

### Other changes

None

### Tested

NA

### Related issues

- Fixes #7997

### Backwards compatibility

Yes

### Documentation

NA