### PR TITLE
Fixed nginx ip address for contexted and regional clusters

### DIFF
--- a/packages/celotool/src/lib/helm_deploy.ts
+++ b/packages/celotool/src/lib/helm_deploy.ts
@@ -5,6 +5,7 @@ import { entries, range } from 'lodash'
 import os from 'os'
 import path from 'path'
 import sleep from 'sleep-promise'
+import { GCPClusterConfig } from 'src/lib/k8s-cluster/gcp'
 import { getKubernetesClusterRegion, switchToClusterFromEnv } from './cluster'
 import {
   execCmd,
@@ -260,16 +261,20 @@ async function nginxHelmParameters(
   "$request_length", "responseSize": "$upstream_response_length", "userAgent":
   "$http_user_agent", "remoteIp": "$remote_addr", "referer": "$http_referer",
   "latency": "$upstream_response_time s", "protocol":"$server_protocol"}}`
+
   let loadBalancerIP = ''
-  if (clusterConfig?.cloudProvider === CloudProvider.GCP) {
-    loadBalancerIP = await getOrCreateNginxStaticIp(celoEnv)
+  if (clusterConfig == null || clusterConfig?.cloudProvider === CloudProvider.GCP) {
+    loadBalancerIP = await getOrCreateNginxStaticIp(celoEnv, clusterConfig)
   }
 
   const valueFileContent = `
 controller:
   autoscaling:
     enabled: "true"
-    targetMemoryUtilizationPercentage: 85
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
   config:
     log-format-escape-json: "true"
     log-format-upstream: '${logFormat}'
@@ -283,17 +288,26 @@ controller:
     loadBalancerIP: ${loadBalancerIP}
   resources:
     requests:
-      cpu: 200m
-      memory: 400Mi
+      cpu: 300m
+      memory: 600Mi
 `
   fs.writeFileSync(valueFilePath, valueFileContent)
 }
 
-async function getOrCreateNginxStaticIp(celoEnv: string) {
-  const staticIpName = `${celoEnv}-nginx`
-  await registerIPAddress(staticIpName)
-  const staticIpAddress = await retrieveIPAddress(staticIpName)
-  console.info(staticIpAddress)
+async function getOrCreateNginxStaticIp(celoEnv: string, clusterConfig?: BaseClusterConfig) {
+  const staticIpName = clusterConfig?.clusterName
+    ? `${clusterConfig?.clusterName}-nginx`
+    : `${celoEnv}-nginx`
+  let staticIpAddress
+  if (clusterConfig !== undefined && clusterConfig.hasOwnProperty('zone')) {
+    const zone = (clusterConfig as GCPClusterConfig).zone
+    await registerIPAddress(staticIpName, zone)
+    staticIpAddress = await retrieveIPAddress(staticIpName, zone)
+  } else {
+    await registerIPAddress(staticIpName)
+    staticIpAddress = await retrieveIPAddress(staticIpName)
+  }
+  console.info(`nginx-ingress static ip --> ${staticIpName}: ${staticIpAddress}`)
   return staticIpAddress
 }
 


### PR DESCRIPTION
### Description

Fix the ingress-nginx external address registration for contexted clusters when region is not the default gcp region.
Also modified the nginx autoscaling parameters to be closer to current usage in mainnet cluster (current setup has always max replicas because the default memory usage for nginx controller pods is over 50% of requested.