### PR TITLE
Make updateMembershipHistory in Validators.sol correct if epoch number is 0

### DIFF
--- a/packages/protocol/contracts/governance/Validators.sol
+++ b/packages/protocol/contracts/governance/Validators.sol
@@ -1167,7 +1167,7 @@ contract Validators is
       history.lastRemovedFromGroupTimestamp = now;
     }
 
-    if (history.entries[head].epochNumber == epochNumber) {
+    if (history.numEntries > 0 && history.entries[head].epochNumber == epochNumber) {
       // There have been no elections since the validator last changed membership, overwrite the
       // previous entry.
       history.entries[head] = MembershipHistoryEntry(epochNumber, group);

--- a/packages/protocol/contracts/governance/Validators.sol
+++ b/packages/protocol/contracts/governance/Validators.sol
@@ -163,7 +163,7 @@ contract Validators is
    * @return The storage, major, minor, and patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 2, 0, 0);
+    return (1, 2, 0, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/Validators.sol
+++ b/packages/protocol/contracts/governance/Validators.sol
@@ -8,7 +8,7 @@ import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./interfaces/IValidators.sol";
 
 import "../common/CalledByVm.sol";
-import "../common/Initializable.sol";
+import "../common/InitializableV2.sol";
 import "../common/FixidityLib.sol";
 import "../common/linkedlists/AddressLinkedList.sol";
 import "../common/UsingRegistry.sol";
@@ -24,7 +24,7 @@ contract Validators is
   ICeloVersionedContract,
   Ownable,
   ReentrancyGuard,
-  Initializable,
+  InitializableV2,
   UsingRegistry,
   UsingPrecompiles,
   CalledByVm
@@ -206,6 +206,12 @@ contract Validators is
     setSlashingMultiplierResetPeriod(_slashingMultiplierResetPeriod);
     setDowntimeGracePeriod(_downtimeGracePeriod);
   }
+
+  /**
+   * @notice Sets initialized == true on implementation contracts
+   * @param test Set to true to skip implementation initialization
+   */
+  constructor(bool test) public InitializableV2(test) {}
 
   /**
    * @notice Updates the block delay for a ValidatorGroup's commission udpdate

--- a/packages/protocol/contracts/governance/test/ValidatorsTest.sol
+++ b/packages/protocol/contracts/governance/test/ValidatorsTest.sol
@@ -6,7 +6,7 @@ import "../../common/FixidityLib.sol";
 /**
  * @title A wrapper around Validators that exposes onlyVm functions for testing.
  */
-contract ValidatorsTest is Validators {
+contract ValidatorsTest is Validators(true) {
   function updateValidatorScoreFromSigner(address signer, uint256 uptime) external {
     return _updateValidatorScoreFromSigner(signer, uptime);
   }


### PR DESCRIPTION
### Description

Celo-blockchain has a tool called mycelo which applies the core contract migrations as part of genesis generation. This means that the epoch number when they are run is zero. However, the updateMembershipHistory() method in Validators.sol did not expect that to be possible. As a result, when mycelo adds a validator to a validator group, the method does not add a new entry to the member's history (specifically, it does not increase numEntries from 0 to 1 as it should). This commit fixes that by adding a condition to the check for whether to replace an existing entry, namely that the number of entries isn't zero.

This will allow the e2e slashing tests to use mycelo instead of running the migrations against the live network.

### Other changes

* Updated the contract to use `InitializableV2` as required by CI.

### Tested

* Verified that, before this fix, validators' membership history is empty when they are added to the group using mycelo
* Verified that, after this fix, validators' membership history is correct when they are added to the group using mycelo
* Protocol package's automated tests pass
* Logically speaking, the change makes sense

### Backwards compatibility

Backwards compatible, as this only fixes a bug in an edge case the contract wasn't originally designed to handle.