### PR TITLE
Bump MTWD patch due to Proxy change and include in check-versions

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
@@ -12,7 +12,7 @@ contract MetaTransactionWalletDeployer is IMetaTransactionWalletDeployer, ICeloV
      * @return The storage, major, minor, and patch version of the contract.
      */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 0, 0);
+    return (1, 1, 0, 1);
   }
 
   /**

--- a/packages/protocol/scripts/bash/release-on-devchain.sh
+++ b/packages/protocol/scripts/bash/release-on-devchain.sh
@@ -47,7 +47,7 @@ yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network development
 
 echo "- Check versions of current branch"
 # From check-versions.sh
-CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|MetaTransactionWallet|SlasherUtil|FixidityLib|Signatures|Proposals|UsingPrecompiles"
+CONTRACT_EXCLUSION_REGEX=".*Test|Mock.*|I[A-Z].*|.*Proxy|.*LinkedList.*|MultiSig.*|ReleaseGold|SlasherUtil|FixidityLib|Signatures|Proposals|UsingPrecompiles"
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR/contracts --new_contracts build/contracts --exclude $CONTRACT_EXCLUSION_REGEX --output_file report.json
 
 # From make-release.sh


### PR DESCRIPTION
### Description

- local `check-versions` indicates MTWD has unexpected version because it is ignored in CI `check-versions`

### Tested

- Tested in `protocol-test-release check-versions`

### Related issues

- Flagged in https://github.com/celo-org/celo-monorepo/pull/7869/ against master

### Backwards compatibility

Yes