### PR TITLE
Ensure deleted proposals indicate expired stage

### DIFF
--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -502,6 +502,7 @@ contract Governance is
     Proposals.Stage stage = proposal.getDequeuedStage(stageDurations);
     if (_isDequeuedProposalExpired(proposal, stage)) {
       deleteDequeuedProposal(proposal, proposalId, index);
+      return (proposal, Proposals.Stage.Expiration);
     }
     return (proposal, stage);
   }


### PR DESCRIPTION
### Description

`requireDequeuedAndDeleteExpired` retrieves the proposal's stage based purely on timing. If the proposal is expired even though all the phases haven't been executed (eg. if it was not approved in the `Approval` stage), then that proposal is deleted. However, `revokeVotes` doesn't account for the possibility of deletion, which means it might be updating an obsolete record. In practice, nobody can vote on a non-approved proposal but this is fragile.

### Tested

`requireDequeuedAndDeleteExpired` is used across `Governance` endpoints and is thoroughly tested for regressions

### Backwards compatibility

Yes