### PR TITLE
Identity proxy hub return

### DIFF
--- a/packages/protocol/contracts/identity/IdentityProxyHub.sol
+++ b/packages/protocol/contracts/identity/IdentityProxyHub.sol
@@ -92,10 +92,15 @@ contract IdentityProxyHub is UsingRegistry {
    * @param identifier The identifier whose IdentityProxy to call through.
    * @param destination The address the IdentityProxy should call.
    * @param data The calldata the IdentityProxy should send with the call.
+   * @return The return value of the external call.
    */
-  function makeCall(bytes32 identifier, address destination, bytes calldata data) external payable {
+  function makeCall(bytes32 identifier, address destination, bytes calldata data)
+    external
+    payable
+    returns (bytes memory)
+  {
     require(passesIdentityHeuristic(msg.sender, identifier));
-    getOrDeployIdentityProxy(identifier).makeCall.value(msg.value)(destination, data);
+    return getOrDeployIdentityProxy(identifier).makeCall.value(msg.value)(destination, data);
   }
 
   function deployIdentityProxy(bytes32 identifier) internal returns (IdentityProxy) {


### PR DESCRIPTION
### Description

- Makes https://github.com/celo-org/celo-monorepo/pull/8032 useful for `IdentityProxyHub` consumers