### PR TITLE
Add more params to status endpoint

### DIFF
--- a/packages/attestation-service/src/requestHandlers/status.ts
+++ b/packages/attestation-service/src/requestHandlers/status.ts
@@ -2,7 +2,7 @@ import { AttestationServiceStatusResponseType, SignatureType } from '@celo/utils
 import express from 'express'
 import * as t from 'io-ts'
 import { getAgeOfLatestBlock, isNodeSyncing, useKit } from '../db'
-import { fetchEnvOrDefault, getAccountAddress, getAttestationSignerAddress } from '../env'
+import { fetchEnvOrDefault, getAccountAddress, getAttestationSignerAddress, isYes } from '../env'
 import { ErrorMessages, respondWithError } from '../request'
 import { configuredSmsProviders } from '../sms'
 
@@ -44,6 +44,15 @@ export async function handleStatusRequest(
           ageOfLatestBlock,
           isNodeSyncing: await isNodeSyncing(),
           appSignature: fetchEnvOrDefault('APP_SIGNATURE', 'unknown'),
+          smsProvidersRandomized: isYes(fetchEnvOrDefault('SMS_PROVIDERS_RANDOMIZED', '0')),
+          maxDeliveryAttempts: parseInt(
+            fetchEnvOrDefault(
+              'MAX_DELIVERY_ATTEMPTS',
+              fetchEnvOrDefault('MAX_PROVIDER_RETRIES', '3')
+            ),
+            10
+          ),
+          maxRerequestMins: parseInt(fetchEnvOrDefault('MAX_REREQUEST_MINS', '55'), 10),
         })
       )
       .status(200)

--- a/packages/metadata-crawler/src/crawler.ts
+++ b/packages/metadata-crawler/src/crawler.ts
@@ -190,6 +190,9 @@ async function processAttestationServiceStatusForValidator(
     state,
     version,
     ageOfLatestBlock,
+    smsProvidersRandomized,
+    maxDeliveryAttempts,
+    maxRerequestMins,
   } = status
   const isElected = electedValidators.has(validator.address)
   dataLogger.info(
@@ -208,6 +211,9 @@ async function processAttestationServiceStatusForValidator(
       state,
       version,
       ageOfLatestBlock,
+      smsProvidersRandomized,
+      maxDeliveryAttempts,
+      maxRerequestMins,
     },
     'checked_attestation_service_status'
   )

--- a/packages/sdk/contractkit/src/wrappers/Attestations.ts
+++ b/packages/sdk/contractkit/src/wrappers/Attestations.ts
@@ -705,6 +705,9 @@ export class AttestationsWrapper extends BaseWrapper<Attestations> {
       state: AttestationServiceStatusState.NoAttestationSigner,
       version: null,
       ageOfLatestBlock: null,
+      smsProvidersRandomized: null,
+      maxDeliveryAttempts: null,
+      maxRerequestMins: null,
     }
 
     if (!hasAttestationSigner) {
@@ -760,6 +763,10 @@ export class AttestationsWrapper extends BaseWrapper<Attestations> {
       ret.state = ret.rightAccount
         ? AttestationServiceStatusState.Valid
         : AttestationServiceStatusState.WrongAccount
+      ret.ageOfLatestBlock = statusResponseBody.ageOfLatestBlock
+      ret.smsProvidersRandomized = statusResponseBody.smsProvidersRandomized
+      ret.maxDeliveryAttempts = statusResponseBody.maxDeliveryAttempts
+      ret.maxRerequestMins = statusResponseBody.maxRerequestMins
 
       // Healthcheck was added in 1.0.1, same time version started being reported.
       if (statusResponseBody.version) {
@@ -843,4 +850,7 @@ export interface AttestationServiceStatusResponse {
   state: AttestationServiceStatusState
   version: string | null
   ageOfLatestBlock: number | null
+  smsProvidersRandomized: boolean | null
+  maxDeliveryAttempts: number | null
+  maxRerequestMins: number | null
 }

--- a/packages/sdk/utils/src/io.ts
+++ b/packages/sdk/utils/src/io.ts
@@ -87,6 +87,9 @@ export const AttestationServiceStatusResponseType = t.type({
   ageOfLatestBlock: t.number,
   isNodeSyncing: t.boolean,
   appSignature: t.string,
+  smsProvidersRandomized: t.boolean,
+  maxDeliveryAttempts: t.number,
+  maxRerequestMins: t.number,
 })
 
 export const AttestationServiceTestRequestType = t.type({


### PR DESCRIPTION
### Description

Add new params to Attestation Service status endpoint and pick up these new params in the metadata crawler logger. Specifically we'd like to know the value `smsProvidersRandomized` since this lets us remove bias when evaluating the efficacy of SMS Providers.

### Tested

Example endpoint here:
http://51.143.108.134/status

### Related issues

- Fixes #7351 

### Backwards compatibility

Added new params, nothing removed.

### Documentation

N/A