### PR TITLE
ODIS: Reduce error noise by not calling combine when insufficient sigs

### DIFF
--- a/packages/phone-number-privacy/combiner/package.json
+++ b/packages/phone-number-privacy/combiner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/phone-number-privacy-combiner",
-  "version": "1.1.4-dev",
+  "version": "1.1.5-dev",
   "description": "Orchestrates and combines threshold signatures for use in ODIS",
   "author": "Celo",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description

Small change to only call `combinePartialBlindedSignatures` when we have sufficient sigs. Without this check, `combinePartialBlindedSignatures` is called, even when user has no quota. Since `combinePartialBlindedSignatures` logs an error when there are not sufficient sigs, our logs are becoming noisy with unactionable errors.

### Other changes

Combiner version bump

### Tested

Unit tests


### Backwards compatibility

Yes

### Documentation

N/A