### PR TITLE
Redirect token_transfers to token-transfer new endpoint

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
@@ -21,6 +21,9 @@ metadata:
       location ~ /wobserver/.* {
         deny all;
       }
+      location ~ /address/(.*)/token_transfers {
+        return 301 /address/$1/token-transfers;
+      }
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
### Description

 In the new version of blockscout, a new URL schema is used /token-transfers vs /token_transfers in the old version.
This change redirect to the new endpoint

### Tested

In alfafajores environment.

### Related issues

- Fixes https://github.com/celo-org/blockscout/issues/288

### Backwards compatibility

Yes
