### PR TITLE
Bump reference RELEASE_TAG in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
       - image: celohq/node10-gcloud:v3
     resource_class: large
     environment:
-      RELEASE_TAG: celo-core-contracts-v3.rc0
+      RELEASE_TAG: celo-core-contracts-v5.mainnet # release 4
     steps:
       - attach_workspace:
           at: ~/app
@@ -268,7 +268,7 @@ jobs:
     <<: *defaults
     resource_class: large
     environment:
-      RELEASE_TAG: celo-core-contracts-v3.rc0
+      RELEASE_TAG: celo-core-contracts-v5.mainnet # release 4
     steps:
       - attach_workspace:
           at: ~/app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
       - image: celohq/node10-gcloud:v3
     resource_class: large
     environment:
-      RELEASE_TAG: celo-core-contracts-v5.mainnet # release 4
+      RELEASE_TAG: core-contracts-v4
     steps:
       - attach_workspace:
           at: ~/app
@@ -268,7 +268,7 @@ jobs:
     <<: *defaults
     resource_class: large
     environment:
-      RELEASE_TAG: celo-core-contracts-v5.mainnet # release 4
+      RELEASE_TAG: core-contracts-v4
     steps:
       - attach_workspace:
           at: ~/app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ defaults: &defaults
     # To avoid ENOMEM problem when running node
     NODE_OPTIONS: '--max-old-space-size=4096'
 
+contract-defaults: &contract-defaults
+  <<: *defaults
+  environment:
+    LATEST_RELEASE: git tag -l "core-contracts.v*" --format "%(refname)" | tail -n 1
+
 e2e-defaults: &e2e-defaults
   <<: *defaults
   docker:
@@ -233,15 +238,13 @@ jobs:
   # This pre script, generates the build and devchain, and adds it to the workspace to be used for the
   # other script
   pre-protocol-test-release:
-    <<: *defaults
+    <<: *contract-defaults
     docker:
       # We override the default docker image here because this job builds the
       # previous release and requires node 10 rather than node 12 to build
       # properly.
       - image: celohq/node10-gcloud:v3
     resource_class: large
-    environment:
-      RELEASE_TAG: core-contracts-v4
     steps:
       - attach_workspace:
           at: ~/app
@@ -257,18 +260,16 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            echo "Comparing against $RELEASE_TAG"
-            yarn --cwd packages/protocol test:generate-old-devchain-and-build -b $RELEASE_TAG -d .tmp/released_chain -l /dev/stdout -g scripts/truffle/releaseGoldExampleConfigs.json
+            echo "Comparing against $LATEST_RELEASE"
+            yarn --cwd packages/protocol test:generate-old-devchain-and-build -b $LATEST_RELEASE -d .tmp/released_chain -l /dev/stdout -g scripts/truffle/releaseGoldExampleConfigs.json
       - persist_to_workspace:
           root: .
           paths:
             - 'packages/protocol/.tmp/released_chain/*'
 
   protocol-test-release:
-    <<: *defaults
+    <<: *contract-defaults
     resource_class: large
-    environment:
-      RELEASE_TAG: core-contracts-v4
     steps:
       - attach_workspace:
           at: ~/app
@@ -279,16 +280,16 @@ jobs:
       - run:
           name: Copy DevChain and Build generated from released tag
           command: |
-            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $RELEASE_TAG | sed -e 's/\//_/g'))
+            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $LATEST_RELEASE | sed -e 's/\//_/g'))
             (cp -r packages/protocol/.tmp/released_chain packages/protocol/$BUILD_AND_DEVCHAIN_DIR)
       - run:
           name: Test against current release
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            echo "Comparing against $RELEASE_TAG"
-            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $RELEASE_TAG | sed -e 's/\//_/g'))
-            yarn --cwd packages/protocol test:devchain-release -b $RELEASE_TAG -d $BUILD_AND_DEVCHAIN_DIR -l /dev/stdout
+            echo "Comparing against $LATEST_RELEASE"
+            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $LATEST_RELEASE | sed -e 's/\//_/g'))
+            yarn --cwd packages/protocol test:devchain-release -b $LATEST_RELEASE -d $BUILD_AND_DEVCHAIN_DIR -l /dev/stdout
 
   protocol-test-release-snapshots:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ defaults: &defaults
 contract-defaults: &contract-defaults
   <<: *defaults
   environment:
-    LATEST_RELEASE: git tag -l "core-contracts.v*" --format "%(refname)" | tail -n 1
+    RELEASE_TAG: core-contracts.v4
 
 e2e-defaults: &e2e-defaults
   <<: *defaults
@@ -260,8 +260,8 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            echo "Comparing against $LATEST_RELEASE"
-            yarn --cwd packages/protocol test:generate-old-devchain-and-build -b $LATEST_RELEASE -d .tmp/released_chain -l /dev/stdout -g scripts/truffle/releaseGoldExampleConfigs.json
+            echo "Comparing against $RELEASE_TAG"
+            yarn --cwd packages/protocol test:generate-old-devchain-and-build -b $RELEASE_TAG -d .tmp/released_chain -l /dev/stdout -g scripts/truffle/releaseGoldExampleConfigs.json
       - persist_to_workspace:
           root: .
           paths:
@@ -280,19 +280,19 @@ jobs:
       - run:
           name: Copy DevChain and Build generated from released tag
           command: |
-            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $LATEST_RELEASE | sed -e 's/\//_/g'))
+            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $RELEASE_TAG | sed -e 's/\//_/g'))
             (cp -r packages/protocol/.tmp/released_chain packages/protocol/$BUILD_AND_DEVCHAIN_DIR)
       - run:
           name: Test against current release
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            echo "Comparing against $LATEST_RELEASE"
-            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $LATEST_RELEASE | sed -e 's/\//_/g'))
-            yarn --cwd packages/protocol test:devchain-release -b $LATEST_RELEASE -d $BUILD_AND_DEVCHAIN_DIR -l /dev/stdout
+            echo "Comparing against $RELEASE_TAG"
+            BUILD_AND_DEVCHAIN_DIR=$(echo build/$(echo $RELEASE_TAG | sed -e 's/\//_/g'))
+            yarn --cwd packages/protocol test:devchain-release -b $RELEASE_TAG -d $BUILD_AND_DEVCHAIN_DIR -l /dev/stdout
 
   protocol-test-release-snapshots:
-    <<: *defaults
+    <<: *contract-defaults
     resource_class: large
     steps:
       - attach_workspace:

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -44,7 +44,7 @@
     "truffle:migrate": "truffle migrate",
     "devchain": "ts-node scripts/devchain.ts",
     "set-exchange-rate": "./scripts/bash/set_exchange_rate.sh",
-    "view-tags": "git for-each-ref 'refs/tags/celo-core-contracts-*' --sort=-committerdate --format='%(color:magenta)%(committerdate:short) %(color:blue)%(tree) %(color:green)github.com/celo-org/celo-monorepo/releases/tag/%(color:yellow)%(refname:short)'"
+    "view-tags": "git for-each-ref 'refs/tags/core-contracts.*' --sort=-committerdate --format='%(color:magenta)%(committerdate:short) %(color:blue)%(tree) %(color:green)github.com/celo-org/celo-monorepo/releases/tag/%(color:yellow)%(refname:short)'"
   },
   "dependencies": {
     "@0x/sol-compiler": "^3.1.11",

--- a/packages/protocol/releaseData/versionReports/release1-report.json
+++ b/packages/protocol/releaseData/versionReports/release1-report.json
@@ -1,6 +1,6 @@
 {
-  "oldArtifactsFolder": "/home/circleci/app/packages/protocol/build/celo-core-contracts-v0.mainnet/contracts",
-  "newArtifactsFolder": "/home/circleci/app/packages/protocol/build/celo-core-contracts-v1.mainnet/contracts",
+  "oldArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v0/contracts",
+  "newArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v1/contracts",
   "exclude": "/.*Test|Mock.*|I[A-Z].*|.*Proxy|MultiSig.*|ReleaseGold|SlasherUtil|UsingPrecompiles/",
   "report": {
     "contracts": {

--- a/packages/protocol/releaseData/versionReports/release2-report.json
+++ b/packages/protocol/releaseData/versionReports/release2-report.json
@@ -1,6 +1,6 @@
 {
-  "oldArtifactsFolder": "/home/circleci/app/packages/protocol/build/celo-core-contracts-v1.mainnet/contracts",
-  "newArtifactsFolder": "/home/circleci/app/packages/protocol/build/celo-core-contracts-v2.mainnet/contracts",
+  "oldArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v1/contracts",
+  "newArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v2/contracts",
   "exclude": "/.*Test|Mock.*|I[A-Z].*|.*Proxy|MultiSig.*|ReleaseGold|SlasherUtil|UsingPrecompiles/",
   "report": {
     "contracts": {

--- a/packages/protocol/releaseData/versionReports/release3-report.json
+++ b/packages/protocol/releaseData/versionReports/release3-report.json
@@ -1,6 +1,6 @@
 {
-  "oldArtifactsFolder": "/home/circleci/app/packages/protocol/build/celo-core-contracts-v2.mainnet/contracts",
-  "newArtifactsFolder": "/home/circleci/app/packages/protocol/build/celo-core-contracts-v3.mainnet/contracts",
+  "oldArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v2/contracts",
+  "newArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v3/contracts",
   "exclude": "/.*Test|Mock.*|I[A-Z].*|.*Proxy|MultiSig.*|ReleaseGold|SlasherUtil|UsingPrecompiles/",
   "report": {
     "contracts": {

--- a/packages/protocol/releaseData/versionReports/release4-report.json
+++ b/packages/protocol/releaseData/versionReports/release4-report.json
@@ -1,0 +1,279 @@
+{
+  "oldArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v3/contracts",
+  "newArtifactsFolder": "/home/circleci/app/packages/protocol/build/core-contracts.v4/contracts",
+  "exclude": "/.*Test|Mock.*|I[A-Z].*|.*Proxy|MultiSig.*|ReleaseGold|SlasherUtil|UsingPrecompiles/",
+  "report": {
+    "contracts": {
+      "Accounts": {
+        "changes": {
+          "storage": [],
+          "major": [],
+          "minor": [
+            {
+              "contract": "Accounts",
+              "signature": "setEip712DomainSeparator()",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "setIndexedSigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "authorizeSignerWithSignature(address,bytes32,uint8,bytes32,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "authorizeSigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "completeSignerAuthorization(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "isLegacySigner(address,address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "isDefaultSigner(address,address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "isIndexedSigner(address,address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "isSigner(address,address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "removeDefaultSigner(bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "removeIndexedSigner(bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "removeSigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "isLegacyRole(bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "getLegacySigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "getDefaultSigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "getIndexedSigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "hasLegacySigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "hasDefaultSigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "hasIndexedSigner(address,bytes32)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "hasAuthorizedSigner(address,string)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "Accounts",
+              "signature": "getRoleAuthorizationSigner(address,address,bytes32,uint8,bytes32,bytes32)",
+              "type": "MethodAdded"
+            }
+          ],
+          "patch": [
+            {
+              "contract": "Accounts",
+              "type": "DeployedBytecode"
+            }
+          ]
+        },
+        "versionDelta": {
+          "storage": "=",
+          "major": "=",
+          "minor": "+1",
+          "patch": "0"
+        }
+      },
+      "Election": {
+        "changes": {
+          "storage": [],
+          "major": [],
+          "minor": [
+            {
+              "contract": "Election",
+              "signature": "activateForAccount(address,address)",
+              "type": "MethodAdded"
+            }
+          ],
+          "patch": [
+            {
+              "contract": "Election",
+              "type": "DeployedBytecode"
+            }
+          ]
+        },
+        "versionDelta": {
+          "storage": "=",
+          "major": "=",
+          "minor": "+1",
+          "patch": "0"
+        }
+      },
+      "Governance": {
+        "changes": {
+          "storage": [],
+          "major": [],
+          "minor": [
+            {
+              "contract": "Governance",
+              "signature": "revokeVotes()",
+              "type": "MethodAdded"
+            }
+          ],
+          "patch": [
+            {
+              "contract": "Governance",
+              "type": "DeployedBytecode"
+            }
+          ]
+        },
+        "versionDelta": {
+          "storage": "=",
+          "major": "=",
+          "minor": "+1",
+          "patch": "0"
+        }
+      },
+      "MetaTransactionWallet": {
+        "changes": {
+          "storage": [],
+          "major": [],
+          "minor": [
+            {
+              "contract": "MetaTransactionWallet",
+              "signature": "setGuardian(address)",
+              "type": "MethodAdded"
+            },
+            {
+              "contract": "MetaTransactionWallet",
+              "signature": "recoverWallet(address)",
+              "type": "MethodAdded"
+            }
+          ],
+          "patch": [
+            {
+              "contract": "MetaTransactionWallet",
+              "type": "DeployedBytecode"
+            }
+          ]
+        },
+        "versionDelta": {
+          "storage": "=",
+          "major": "=",
+          "minor": "+1",
+          "patch": "0"
+        }
+      },
+      "GoldToken": {
+        "changes": {
+          "storage": [],
+          "major": [],
+          "minor": [],
+          "patch": [
+            {
+              "contract": "GoldToken",
+              "type": "DeployedBytecode"
+            }
+          ]
+        },
+        "versionDelta": {
+          "storage": "=",
+          "major": "=",
+          "minor": "=",
+          "patch": "+1"
+        }
+      },
+      "MetaTransactionWalletDeployer": {
+        "changes": {
+          "storage": [],
+          "major": [],
+          "minor": [],
+          "patch": [
+            {
+              "contract": "MetaTransactionWalletDeployer",
+              "type": "DeployedBytecode"
+            }
+          ]
+        },
+        "versionDelta": {
+          "storage": "=",
+          "major": "=",
+          "minor": "=",
+          "patch": "+1"
+        }
+      },
+      "Reserve": {
+        "changes": {
+          "storage": [],
+          "major": [],
+          "minor": [],
+          "patch": [
+            {
+              "contract": "Reserve",
+              "signature": "getExchangeSpenders()",
+              "oldValue": "public",
+              "newValue": "external",
+              "type": "MethodVisibility"
+            },
+            {
+              "contract": "Reserve",
+              "type": "DeployedBytecode"
+            }
+          ]
+        },
+        "versionDelta": {
+          "storage": "=",
+          "major": "=",
+          "minor": "=",
+          "patch": "+1"
+        }
+      }
+    },
+    "libraries": {}
+  }
+}

--- a/packages/protocol/scripts/bash/release-snapshots.sh
+++ b/packages/protocol/scripts/bash/release-snapshots.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-NETWORK="mainnet"
+LATEST_TAG=`git tag -l "core-contracts.v*" --format "%(refname)" | tail -n 1`
+LATEST_N=`echo -n $LATEST_TAG | tail -c -1`
 
-for i in 1 2 3
+for i in {1..$LATEST_N}
 do
     yarn check-versions \
-        -a "celo-core-contracts-v$(($i - 1)).$NETWORK" \
-        -b "celo-core-contracts-v$i.$NETWORK" \
+        -a "core-contracts.v$(($i - 1))" \
+        -b "core-contracts.v$i" \
         -r "releaseData/versionReports/release$i-report.json"
 done

--- a/packages/protocol/scripts/bash/release-snapshots.sh
+++ b/packages/protocol/scripts/bash/release-snapshots.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-LATEST_TAG=`git tag -l "core-contracts.v*" --format "%(refname)" | tail -n 1`
-LATEST_N=`echo -n $LATEST_TAG | tail -c -1`
+N=`echo -n $RELEASE_TAG | tail -c -1`
 
-for i in {1..$LATEST_N}
+for i in `eval echo {1..$N}`
 do
     yarn check-versions \
         -a "core-contracts.v$(($i - 1))" \


### PR DESCRIPTION
### Description

- Bumps the reference release used in CI to compare contract versions to

### Other changes

- Use new simplified tagging scheme which is environment agnostic

### Tested

`protocol-test-release` CI job

<img width="828" alt="Screen Shot 2021-07-07 at 6 24 31 PM" src="https://user-images.githubusercontent.com/3020995/124836274-b7dca300-df50-11eb-8124-bc879c69f109.png">

### Backwards compatibility

No contract changes

Release notes on github updated to point to new tags

Forum posts also updated