### PR TITLE
Attestation Service: Fix application_id filter

### DIFF
--- a/packages/attestation-service/package.json
+++ b/packages/attestation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/attestation-service",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Issues attestation messages for Celo's identity protocol",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/attestation-service/src/sms/nexmo.ts
+++ b/packages/attestation-service/src/sms/nexmo.ts
@@ -142,7 +142,7 @@ export class NexmoSmsProvider extends SmsProvider {
   private getAvailableNumbers = async (): Promise<any> => {
     return new Promise((resolve, reject) => {
       const options = this.applicationId
-        ? { applicationId: this.applicationId, has_application: true }
+        ? { application_id: this.applicationId, has_application: true }
         : null
       this.client.number.get(options, (err: Error, responseData: any) => {
         if (err) {


### PR DESCRIPTION
### Description

While testing 1.2.1 I noticed that the application id filter wasn't being applied (all numbers are returned). 

### Tested

Deployed to Alfajores. Pointed all to a single application_id and verified the sending phone number matched what was expected.

### Backwards compatibility

Yes

### Documentation

N/A