### PR TITLE
Build whole phone-number-privacy in docker image

### DIFF
--- a/dockerfiles/phone-number-privacy/Dockerfile
+++ b/dockerfiles/phone-number-privacy/Dockerfile
@@ -2,10 +2,13 @@ FROM node:12
 
 WORKDIR /celo-phone-number-privacy/
 
-COPY packages/phone-number-privacy/signer signer
+#Copy monorepo settings
+COPY lerna.json package.json yarn.lock ./
+COPY scripts/ scripts/
+COPY patches/ patches/
 
-WORKDIR /celo-phone-number-privacy/signer
-COPY yarn.lock ./
+#Copy identity code
+COPY packages/phone-number-privacy packages/phone-number-privacy
 
 RUN yarn install --network-timeout 100000 && yarn cache clean
 
@@ -13,5 +16,6 @@ ENV NODE_ENV production
 
 RUN yarn build
 
+WORKDIR /celo-phone-number-privacy/packages/phone-number-privacy/signer
 EXPOSE 8080
 ENTRYPOINT ["yarn", "start:docker"]


### PR DESCRIPTION
### Description

Build signer with common package alongside.

### Tested

I changed version in common/package.json to "1.0.36-dev", a dependency in signer/package.json to
`"@celo/phone-number-privacy-common": "1.0.36-dev"` and then build a docker image locally and run it.
