### PR TITLE
[DO NOT MERGE] Modify helm chart for AS local signing deployment

### DIFF
--- a/packages/helm-charts/attestation-service/templates/attestation.statefulset.yaml
+++ b/packages/helm-charts/attestation-service/templates/attestation.statefulset.yaml
@@ -93,8 +93,6 @@ spec:
           set -euo pipefail
           ATTESTATION_SIGNER_ADDRESS=`cat /root/.celo/attestationSignerAddress`
           exec geth \
-            --password=/root/.celo/password \
-            --unlock=${ATTESTATION_SIGNER_ADDRESS} \
             --ws \
             --wsaddr 0.0.0.0 \
             --wsorigins=* \
@@ -104,8 +102,7 @@ spec:
             --consoleformat=json \
             --consoleoutput=stdout \
             --verbosity={{ .Values.geth.verbosity }} \
-            --metrics \
-            --allow-insecure-unlock
+            --metrics
         env:
         - name: NETWORK_ID
           valueFrom:
@@ -134,7 +131,7 @@ spec:
           sleep 5
           RID=`cat /root/.celo/replica_id`
           NEXMO_APPLICATIONS={{- range $index, $application := .Values.attestation_service.nexmo.applications -}}{{ $application }},{{- end }}
-          NEXMO_APPLICATION=`echo -n $NEXMO_APPLICATIONS | cut -d ',' -f $((RID + 1))` ATTESTATION_SIGNER_ADDRESS=`cat /root/.celo/attestationSignerAddress` CELO_VALIDATOR_ADDRESS=`cat /root/.celo/address` exec yarn start
+          NEXMO_APPLICATION=`echo -n $NEXMO_APPLICATIONS | cut -d ',' -f $((RID + 1))` ATTESTATION_SIGNER_ADDRESS=`cat /root/.celo/attestationSignerAddress` CELO_VALIDATOR_ADDRESS=`cat /root/.celo/address` ATTESTATION_SIGNER_KEYSTORE_PASSPHRASE=`cat /root/.celo/password` exec yarn start
         ports:
         - name: http
           containerPort: 3000
@@ -149,6 +146,8 @@ spec:
           value: production
         - name: CELO_PROVIDER
           value: ws://localhost:8546
+        - name: ATTESTATION_SIGNER_KEYSTORE_DIRPATH
+          value: /root/.celo
         - name: LOG_FORMAT
           value: stackdriver
         - name: NEXMO_KEY


### PR DESCRIPTION
### Description

Minimal modifications to deployment to cause Attestation Service to use new signing + keystore changes. Initially, this will be part of the second deployment (after checking that backwards compatibility is maintained with the original deployment parameters), for both alfajores + baklava. Once AS version 1.3.0 has landed on mainnet, (and these deployment changes have been confirmed to work on both alfajores + baklava) this should be merged and used as the official deployment going forwards.

### Notes on changes
- account creation is maintained as before (i.e. no new process required for creating keystore file), we just need to set the appropriate keystore directory env var
- for now, this will deploy an ultralight geth node (`light-client`) alongside the attestation service, to serve as the `CELO_PROVIDER`. It does change the geth node's args to not unlock the attestation signer (as this will be done directly by the attestation service now). Note: we could also change this to remove the `light-client` container entirely + to use alfajores forno as the provider, but since we will recommend validators use a light node as a  Celo provider, this will mimic those test conditions most closely.)

### Tested
- confirmed via `kubectl exec alfajores-attestation-service-0 --namespace=alfajores -c attestation-service -- ls /root/.celo` that the path to the keystore directory is correct
- TODO: check that this works in `--dry-run` mode