### PR TITLE
Do not include ws port in service if is 8545

### DIFF
--- a/packages/helm-charts/testnet/templates/_helpers.tpl
+++ b/packages/helm-charts/testnet/templates/_helpers.tpl
@@ -57,8 +57,11 @@ spec:
   ports:
   - port: 8545
     name: rpc
-  - port: {{ .ws_port | default .Values.geth.ws_port }}
+{{- $wsPort := ((.ws_port | default .Values.geth.ws_port) | int) -}}
+{{- if ne $wsPort 8545 }}
+  - port: {{ $wsPort }}
     name: ws
+{{- end }}
   selector:
 {{- if .proxy | default false }}
 {{- $validatorProxied := printf "%s-validators-%d" .Release.Namespace .validator_index }}
@@ -82,8 +85,10 @@ spec:
   ports:
   - port: 8545
     name: rpc
+{{- if ne $wsPort 8545 }}
   - port: {{ .ws_port | default .Values.geth.ws_port }}
     name: ws
+{{- end }}
   selector:
 {{- if .proxy | default false }}
 {{- $validatorProxied := printf "%s-validators-%d" .Release.Namespace .validator_index }}


### PR DESCRIPTION
### Description

Fix testnet package if wsPort is 8545 (services cannot have same port defined multiple times)