### PR TITLE
feat: expose blockscout prometheus metrics

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -21,6 +21,12 @@ spec:
       component: blockscout-api
   template:
     metadata:
+      { { - if .Values.blockscout.metrics.enabled } }
+      annotations:
+        prometheus.io/path: /metrics/web
+        prometheus.io/port: "4000"
+        prometheus.io/scrape: "true"
+      { { - end } }
       labels:
         app: blockscout
         release: {{ .Release.Name }}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -21,7 +21,7 @@ spec:
       component: blockscout-indexer
   template:
     metadata:
-      {{- if .Values.blockscout.indexer.metrics.enabled}}
+      {{- if .Values.blockscout.metrics.enabled}}
       annotations:
         prometheus.io/path: /metrics/indexer
         prometheus.io/port: "4001"

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -21,6 +21,12 @@ spec:
       component: blockscout-web
   template:
     metadata:
+      { { - if .Values.blockscout.metrics.enabled } }
+      annotations:
+        prometheus.io/path: /metrics/web
+        prometheus.io/port: "4000"
+        prometheus.io/scrape: "true"
+      { { - end } }
       labels:
         app: blockscout
         release: {{ .Release.Name }}

--- a/packages/helm-charts/blockscout/values-alfajores.yaml
+++ b/packages/helm-charts/blockscout/values-alfajores.yaml
@@ -12,8 +12,6 @@ blockscout:
       requests:
         memory: 700Mi
         cpu: 1500m
-    metrics:
-      enabled: true
   api:
     autoscaling:
         maxReplicas: 3
@@ -49,3 +47,5 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
+  metrics:
+    enabled: false

--- a/packages/helm-charts/blockscout/values-baklava.yaml
+++ b/packages/helm-charts/blockscout/values-baklava.yaml
@@ -49,3 +49,5 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
+  metrics:
+    enabled: false

--- a/packages/helm-charts/blockscout/values-blockscoutstagingrc1.yaml
+++ b/packages/helm-charts/blockscout/values-blockscoutstagingrc1.yaml
@@ -49,3 +49,5 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
+  metrics:
+    enabled: false

--- a/packages/helm-charts/blockscout/values-rc1.yaml
+++ b/packages/helm-charts/blockscout/values-rc1.yaml
@@ -49,3 +49,5 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
+  metrics:
+    enabled: false


### PR DESCRIPTION
### Description

Necessary changes to expose prometheus metrics on web and api.

### Other changes

Pulled the variable for enabling metrics one level higher so we don't have to set it for indexer, web and api separately.
