### PR TITLE
Clarify requirement to use Node.js v12.x

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -50,6 +50,8 @@ export PATH=$PATH:$GOPATH/bin
 
 #### Install Node
 
+Currently Node.js v12.x is required in order to work with this repo.
+
 Install `nvm` (allows you to manage multiple versions of Node) by following the instructions here: [https://github.com/nvm-sh/nvm].
 
 Once `nvm` is successfully installed, restart the terminal and run the following commands to install the `npm` versions that [celo-monorepo] will need:


### PR DESCRIPTION
### Description

This PR aims to make it clearer from the setup instructions that Node.js v12.x must be
used when working with the monorepo.