### PR TITLE
add tests for nixSecondsTimestampToDateString (moment removal prework)

### DIFF
--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -48,6 +48,7 @@
     "@celo/protocol": "1.0.0",
     "@types/debug": "^4.1.5",
     "fetch-mock": "9.10.4",
+    "timezone-mock": "1.1.4",
     "jest": "^26.6.3",
     "ts-node": "8.3.0",
     "typedoc": "^0.19.2",
@@ -61,5 +62,5 @@
   },
   "browser":{
     "child_process": false
-  }  
+  }
 }

--- a/packages/sdk/contractkit/src/wrappers/BaseWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/BaseWrapper.test.ts
@@ -1,5 +1,6 @@
 import { NULL_ADDRESS } from '@celo/base'
 import { CeloTxObject } from '@celo/connect'
+import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import {
   ICeloVersionedContract,
@@ -7,7 +8,7 @@ import {
 } from '../generated/ICeloVersionedContract'
 import { newKitFromWeb3 } from '../kit'
 import { ContractVersion, newContractVersion } from '../versions'
-import { BaseWrapper } from './BaseWrapper'
+import { BaseWrapper, unixSecondsTimestampToDateString } from './BaseWrapper'
 
 const web3 = new Web3('http://localhost:8545')
 const mockContract = newICeloVersionedContract(web3, NULL_ADDRESS)
@@ -52,4 +53,29 @@ describe('TestWrapper', () => {
       })
     })
   })
+})
+
+describe('unixSecondsTimestampToDateString()', () => {
+  const date = new BigNumber(1627489780)
+
+  // describe("when Brazil/East", () => {
+  //   it("returns local time", () => {
+  //     expect(unixSecondsTimestampToDateString(date)).toEqual("")
+  //   })
+  // })
+  describe('when UTC', () => {
+    it('returns utc time', () => {
+      expect(unixSecondsTimestampToDateString(date)).toEqual('Wed, Jul 28, 2021 9:29 AM UTC-07:00')
+    })
+  })
+  // describe("when Australia/Adelaide", () => {
+  //   it("returns local time", () => {
+  //     expect(unixSecondsTimestampToDateString(date)).toEqual("")
+  //   })
+  // })
+  // describe("when Europe/London", () => {
+  //   it("returns local time", () => {
+  //     expect(unixSecondsTimestampToDateString(date)).toEqual("")
+  //   })
+  // })
 })

--- a/packages/sdk/contractkit/src/wrappers/BaseWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/BaseWrapper.test.ts
@@ -1,6 +1,7 @@
 import { NULL_ADDRESS } from '@celo/base'
 import { CeloTxObject } from '@celo/connect'
 import BigNumber from 'bignumber.js'
+import timezoneMock from 'timezone-mock'
 import Web3 from 'web3'
 import {
   ICeloVersionedContract,
@@ -58,24 +59,31 @@ describe('TestWrapper', () => {
 describe('unixSecondsTimestampToDateString()', () => {
   const date = new BigNumber(1627489780)
 
-  // describe("when Brazil/East", () => {
-  //   it("returns local time", () => {
-  //     expect(unixSecondsTimestampToDateString(date)).toEqual("")
-  //   })
-  // })
-  describe('when UTC', () => {
-    it('returns utc time', () => {
-      expect(unixSecondsTimestampToDateString(date)).toEqual('Wed, Jul 28, 2021 9:29 AM UTC-07:00')
+  describe('when Brazil/East', () => {
+    it('returns local time', () => {
+      timezoneMock.register('Brazil/East')
+      expect(unixSecondsTimestampToDateString(date)).toEqual('Wed, Jul 28, 2021 1:29 PM UTC-03:00')
     })
   })
-  // describe("when Australia/Adelaide", () => {
-  //   it("returns local time", () => {
-  //     expect(unixSecondsTimestampToDateString(date)).toEqual("")
-  //   })
-  // })
-  // describe("when Europe/London", () => {
-  //   it("returns local time", () => {
-  //     expect(unixSecondsTimestampToDateString(date)).toEqual("")
-  //   })
-  // })
+  describe('when UTC', () => {
+    it('returns utc time', () => {
+      timezoneMock.register('UTC')
+      expect(unixSecondsTimestampToDateString(date)).toEqual('Wed, Jul 28, 2021 4:29 PM UTC+00:00')
+    })
+  })
+  describe('when Australia/Adelaide', () => {
+    it('returns local time', () => {
+      timezoneMock.register('Australia/Adelaide')
+      expect(unixSecondsTimestampToDateString(date)).toEqual('Thu, Jul 29, 2021 1:59 AM UTC+09:30')
+    })
+  })
+  describe('when Europe/London', () => {
+    it('returns local time', () => {
+      timezoneMock.register('Europe/London')
+      expect(unixSecondsTimestampToDateString(date)).toEqual('Wed, Jul 28, 2021 5:29 PM UTC+01:00')
+    })
+  })
+  afterEach(() => {
+    timezoneMock.unregister()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -24788,6 +24788,11 @@ timers-ext@^0.1.5:
     es5-ext "~0.10.46"
     next-tick "1"
 
+timezone-mock@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.1.4.tgz#3dfc0c8a864132873e1de8459c4bb7757dd8a96e"
+  integrity sha512-TeDA/tpbgJPC6dFkFpz3+sZmjtma8n+ECQbf7FQK9+TqIa38PUzIx8LBJGv0v3994Z9FFwLU0zJT/ABeb3bZWQ==
+
 tiny-async-pool@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tiny-async-pool/-/tiny-async-pool-1.0.4.tgz#bbac28a39a754576d8d0615d4e2ad35c87da6169"


### PR DESCRIPTION
### Description

We want to remove moment.js so i added tests around the one function that uses it so we can be more confident about changing the implementation

### Other changes

because this tests dates, which are localized I also added timezone-mock for deterministic testing

### Tested

new tests tested

### Related issues

- relates to #7357 

### Backwards compatibility

yes

### Documentation

Just adding tests for now