### PR TITLE
Support proxy transfer ownership to arbitrary deployment address

### DIFF
--- a/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
@@ -12,7 +12,7 @@ contract MetaTransactionWalletDeployer is IMetaTransactionWalletDeployer, ICeloV
      * @return The storage, major, minor, and patch version of the contract.
      */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 0, 1);
+    return (1, 1, 0, 2);
   }
 
   /**
@@ -23,7 +23,7 @@ contract MetaTransactionWalletDeployer is IMetaTransactionWalletDeployer, ICeloV
      * @param initCallData calldata pointing to a method on implementation used to initialize
      */
   function deploy(address owner, address implementation, bytes calldata initCallData) external {
-    MetaTransactionWalletProxy proxy = new MetaTransactionWalletProxy();
+    MetaTransactionWalletProxy proxy = new MetaTransactionWalletProxy(msg.sender);
     proxy._setAndInitializeImplementation(implementation, initCallData);
     proxy._transferOwnership(owner);
 

--- a/packages/protocol/contracts/common/Proxy.sol
+++ b/packages/protocol/contracts/common/Proxy.sol
@@ -17,8 +17,8 @@ contract Proxy {
   event OwnerSet(address indexed owner);
   event ImplementationSet(address indexed implementation);
 
-  constructor() public {
-    _setOwner(msg.sender);
+  constructor(address owner) public {
+    _setOwner(owner);
   }
 
   /**

--- a/packages/protocol/scripts/truffle/deploy_multisig.ts
+++ b/packages/protocol/scripts/truffle/deploy_multisig.ts
@@ -24,7 +24,7 @@ module.exports = async (callback: (error?: any) => number) => {
     const Proxy: ProxyContract = artifacts.require('Proxy')
 
     console.info('  Deploying MultiSigProxy...')
-    const proxy = await retryTx(Proxy.new, [{ from: argv.from }])
+    const proxy = await retryTx(Proxy.new, [argv.from, { from: argv.from }])
     console.info('  Deploying MultiSig...')
     const multiSig = await retryTx(multSig.new, [{ from: argv.from }])
     await _setInitialProxyImplementation(

--- a/packages/protocol/scripts/truffle/deploy_release_contracts.ts
+++ b/packages/protocol/scripts/truffle/deploy_release_contracts.ts
@@ -134,6 +134,7 @@ async function handleGrant(config: ReleaseGoldConfig, currGrant: number) {
   }
   console.info('  Deploying ReleaseGoldMultiSigProxy...')
   const releaseGoldMultiSigProxy = await retryTx(ReleaseGoldMultiSigProxy.new, [
+    fromAddress,
     { from: fromAddress },
   ])
   console.info('  Deploying ReleaseGoldMultiSig...')
@@ -161,7 +162,7 @@ async function handleGrant(config: ReleaseGoldConfig, currGrant: number) {
     },
   ])
   console.info('  Deploying ReleaseGoldProxy...')
-  const releaseGoldProxy = await retryTx(ReleaseGoldProxy.new, [{ from: fromAddress }])
+  const releaseGoldProxy = await retryTx(ReleaseGoldProxy.new, [fromAddress, { from: fromAddress }])
   console.info('  Deploying ReleaseGold...')
   const releaseGoldInstance = await retryTx(ReleaseGold.new, [false, { from: fromAddress }])
 

--- a/packages/protocol/test/common/onboarding.ts
+++ b/packages/protocol/test/common/onboarding.ts
@@ -282,7 +282,7 @@ contract('Komenci Onboarding', (_accounts: string[]) => {
     describe('With EIP-1167', () => {
       let proxyCloneFactory: ProxyCloneFactoryInstance
       before(async () => {
-        const proxy: ProxyInstance = await Proxy.new()
+        const proxy: ProxyInstance = await Proxy.new(accounts[0])
         proxyCloneFactory = await ProxyCloneFactory.new()
         await proxyCloneFactory.setImplementationAddress(proxy.address)
         mtw = await MTW.new(false)

--- a/packages/protocol/test/common/proxy.ts
+++ b/packages/protocol/test/common/proxy.ts
@@ -29,7 +29,7 @@ contract('Proxy', (accounts: string[]) => {
   const owner = accounts[0]
 
   beforeEach(async () => {
-    proxy = await Proxy.new({ from: owner })
+    proxy = await Proxy.new(owner)
     getSet = await GetSetV0.new({ from: owner })
     proxiedGetSet = await GetSetV0.at(proxy.address)
   })

--- a/packages/protocol/test/compatibility/verify-bytecode.ts
+++ b/packages/protocol/test/compatibility/verify-bytecode.ts
@@ -29,7 +29,7 @@ const makeTruffleContract = (artifact: Artifact) => {
 }
 
 const deployProxiedContract = async (Contract: any, from: string) => {
-  const proxy = await Proxy.new()
+  const proxy = await Proxy.new(from)
   const contract = await Contract.new({ from })
   await proxy._setImplementation(contract.address)
   return Contract.at(proxy.address)

--- a/packages/protocol/test/identity/identityproxy.ts
+++ b/packages/protocol/test/identity/identityproxy.ts
@@ -14,7 +14,7 @@ contract('IdentityProxyHub', (accounts: string[]) => {
   let identityProxyTest: IdentityProxyTestInstance
 
   beforeEach(async () => {
-    identityProxy = await IdentityProxy.new()
+    identityProxy = await IdentityProxy.new(accounts[0])
     identityProxyTest = await IdentityProxyTest.new()
   })
 


### PR DESCRIPTION
### Description

Take in an `address owner` in the constructor of `Proxy.sol` to allow the deployer to transfer ownership atomically to an address other than `msg.sender`

### Other changes

Update scripts and tests to accommodate new proxy deployment params

### Tested

CI tests

### Related issues

- Mitigates transfer ownership front running surfaced by https://github.com/celo-org/celo-monorepo/issues/8326

### Backwards compatibility

Only the constructor of `Proxy.sol` is changed which does not affect any already deployed contracts.

### Documentation

None