### PR TITLE
Add utility for generating zenhub release reports

### DIFF
--- a/dependency-graph.json
+++ b/dependency-graph.json
@@ -48,7 +48,9 @@
   },
   "@celo/dev-utils": {
     "location": "packages/dev-utils",
-    "dependencies": []
+    "dependencies": [
+      "@celo/base"
+    ]
   },
   "docs": {
     "location": "packages/docs",

--- a/dependency-graph.json
+++ b/dependency-graph.json
@@ -89,6 +89,7 @@
     "dependencies": [
       "@celo/base",
       "@celo/connect",
+      "@celo/dev-utils",
       "@celo/flake-tracker",
       "@celo/typescript",
       "@celo/utils"

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -21,7 +21,8 @@
     "web3-core-helpers": "1.3.6",
     "tmp": "^0.1.0",
     "targz": "^1.0.1",
-    "fs-extra": "^8.1.0"
+    "fs-extra": "^8.1.0",
+    "@celo/base": "^1.2.3-dev"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",

--- a/packages/dev-utils/src/release-report.ts
+++ b/packages/dev-utils/src/release-report.ts
@@ -1,78 +1,80 @@
 import { concurrentMap } from '@celo/base'
 import fetch from 'node-fetch'
 
-type Issue = {
+interface Issue {
   title: string
   description?: string
   estimate?: number
 }
 
-type Epic = Issue & {
+interface Epic extends Issue {
   issues: Issue[]
 }
 
-export type ReleaseReport = Issue & {
+export interface ReleaseReport extends Issue {
   start: string
   end: string
   epics: Epic[]
   issues: Issue[]
 }
 
-export type GithubConfig = {
+export interface GithubConfig {
   labels: string[]
   org: string
   repo: string
+  apiToken: string
 }
 
-export type ZenhubConfig = {
-  repo_id: string
-  workspace_id: string
+export interface ZenhubConfig {
+  repoId: string
+  workspaceId: string
+  apiKey: string
 }
 
-const req = (
-  url_prefix: string,
+const fetchWrapper = (
+  urlPrefix: string,
   headers: Record<string, string>,
-  base_query?: URLSearchParams
+  baseQuery?: URLSearchParams
 ) => async (method: 'GET' | 'POST' | 'PUT' | 'PATCH', url: string, params: Record<string, any>) => {
   const options = { method, headers, body: '' }
-  let full_url = `${url_prefix}/${url}?${(base_query ?? '').toString()}`
+  let fullUrl = `${urlPrefix}/${url}?${(baseQuery ?? '').toString()}`
 
   if (method === 'GET') {
-    full_url += new URLSearchParams(params).toString()
+    fullUrl += new URLSearchParams(params).toString()
   } else {
     options.body = JSON.stringify(params)
   }
 
-  const resp = await fetch(full_url, options)
+  const resp = await fetch(fullUrl, options)
   if (!resp.ok) {
     throw new Error(
-      `Request failed: ${method} ${full_url} with ${resp.status} (${resp.statusText})`
+      `fetchWrapperuest failed: ${method} ${fullUrl} with ${resp.status} (${resp.statusText})`
     )
   }
   return JSON.parse(await resp.text())
 }
 
-const github_req = (gc: GithubConfig) =>
-  req(`https://api.github.com/repos/${gc.org}/${gc.repo}`, {
-    Authorization: `token ${process.env.GITHUB_PAT ?? ''}`,
+const githubFetch = (gc: GithubConfig) =>
+  fetchWrapper(`https://api.github.com/repos/${gc.org}/${gc.repo}`, {
+    Authorization: `token ${gc.apiToken}`,
     Accept: 'application/vnd.github.v3+json',
     'Content-Type': 'application/json',
   })
 
-const zenhub_req = (zc: ZenhubConfig) =>
-  req(
+const zenhubFetch = (zc: ZenhubConfig) =>
+  fetchWrapper(
     'https://api.zenhub.com/p1',
     {
-      'X-Authentication-Token': process.env.ZENHUB_API_KEY ?? '',
+      'X-Authentication-Token': zc.apiKey,
       'Content-Type': 'application/json',
     },
-    new URLSearchParams(zc)
+    new URLSearchParams({ repo_id: zc.repoId, workspace_id: zc.workspaceId })
   )
 
-const convertGithubToZenhubIssues = (zc: ZenhubConfig) => (githubIssues: Array<any>) =>
-  githubIssues.map((gh_issue) => ({
-    repo_id: parseInt(zc.repo_id),
-    issue_number: parseInt(gh_issue.number),
+const convertGithubToZenhubIssues = (zc: ZenhubConfig) => (githubIssues: any[]) =>
+  githubIssues.map((ghIssue) => ({
+    repo_id: parseInt(zc.repoId, 10),
+    issue_number: parseInt(ghIssue.number, 10),
   }))
 
 export const generateReleaseReport = async (
@@ -80,38 +82,42 @@ export const generateReleaseReport = async (
   zenhubConfig: ZenhubConfig,
   releaseReport: ReleaseReport
 ): Promise<void> => {
-  const zh_req = zenhub_req(zenhubConfig)
-  const gh_req = github_req(githubConfig)
+  const zhFetchWrapper = zenhubFetch(zenhubConfig)
+  const ghFetchWrapper = githubFetch(githubConfig)
 
   // create release
-  const newReport = await zh_req('POST', `repositories/${zenhubConfig.repo_id}/reports/release`, {
-    title: releaseReport.title,
-    description: releaseReport.description,
-    start_date: new Date(releaseReport.start).toISOString(),
-    desired_end_date: new Date(releaseReport.end).toISOString(),
-    repositories: [parseInt(zenhubConfig.repo_id)],
-  })
+  const newReport = await zhFetchWrapper(
+    'POST',
+    `repositories/${zenhubConfig.repoId}/reports/release`,
+    {
+      title: releaseReport.title,
+      description: releaseReport.description,
+      start_date: new Date(releaseReport.start).toISOString(),
+      desired_end_date: new Date(releaseReport.end).toISOString(),
+      repositories: [parseInt(zenhubConfig.repoId, 10)],
+    }
+  )
 
   // create epics
-  const gh_epics = await concurrentMap(1, releaseReport.epics, async (epic) => {
+  const ghEpics = await concurrentMap(1, releaseReport.epics, async (epic) => {
     // create github issue representing epic
-    const gh_epic = await gh_req('POST', 'issues', {
+    const ghEpic = await ghFetchWrapper('POST', 'issues', {
       title: epic.title,
       body: epic.description,
       labels: githubConfig.labels,
     })
 
     // create github issues representing epic contents
-    const gh_issues = await concurrentMap(1, epic.issues, (issue) =>
-      gh_req('POST', 'issues', { title: issue.title, labels: githubConfig.labels })
+    const ghIssues = await concurrentMap(1, epic.issues, (issue) =>
+      ghFetchWrapper('POST', 'issues', { title: issue.title, labels: githubConfig.labels })
     )
-    const zh_issues = convertGithubToZenhubIssues(zenhubConfig)(gh_issues)
+    const zhIssues = convertGithubToZenhubIssues(zenhubConfig)(ghIssues)
 
     // assign estimates to github issues
-    await concurrentMap(1, zh_issues, (zh_issue, i) =>
-      zh_req(
+    await concurrentMap(1, zhIssues, (zhIssue, i) =>
+      zhFetchWrapper(
         'PUT',
-        `repositories/${zenhubConfig.repo_id}/issues/${zh_issue.issue_number}/estimate`,
+        `repositories/${zenhubConfig.repoId}/issues/${zhIssue.issue_number}/estimate`,
         {
           estimate: epic.issues[i].estimate,
         }
@@ -119,27 +125,27 @@ export const generateReleaseReport = async (
     )
 
     // convert github issue to epic and add contents
-    await zh_req(
+    await zhFetchWrapper(
       'POST',
-      `repositories/${zenhubConfig.repo_id}/issues/${gh_epic.number}/convert_to_epic`,
+      `repositories/${zenhubConfig.repoId}/issues/${ghEpic.number}/convert_to_epic`,
       {
-        issues: zh_issues,
+        issues: zhIssues,
       }
     )
 
     // add issues to release report
-    await zh_req('PATCH', `reports/release/${newReport.release_id}/issues`, {
-      add_issues: zh_issues,
+    await zhFetchWrapper('PATCH', `reports/release/${newReport.release_id}/issues`, {
+      add_issues: zhIssues,
       remove_issues: [],
     })
 
-    return gh_epic
+    return ghEpic
   })
 
-  const zh_epics = convertGithubToZenhubIssues(zenhubConfig)(gh_epics)
+  const zhEpics = convertGithubToZenhubIssues(zenhubConfig)(ghEpics)
   // add epics to release report
-  await zh_req('PATCH', `reports/release/${newReport.release_id}/issues`, {
-    add_issues: zh_epics,
+  await zhFetchWrapper('PATCH', `reports/release/${newReport.release_id}/issues`, {
+    add_issues: zhEpics,
     remove_issues: [],
   })
 }

--- a/packages/dev-utils/src/release-report.ts
+++ b/packages/dev-utils/src/release-report.ts
@@ -1,0 +1,145 @@
+import { concurrentMap } from '@celo/base'
+import fetch from 'node-fetch'
+
+type Issue = {
+  title: string
+  description?: string
+  estimate?: number
+}
+
+type Epic = Issue & {
+  issues: Issue[]
+}
+
+export type ReleaseReport = Issue & {
+  start: string
+  end: string
+  epics: Epic[]
+  issues: Issue[]
+}
+
+export type GithubConfig = {
+  labels: string[]
+  org: string
+  repo: string
+}
+
+export type ZenhubConfig = {
+  repo_id: string
+  workspace_id: string
+}
+
+const req = (
+  url_prefix: string,
+  headers: Record<string, string>,
+  base_query?: URLSearchParams
+) => async (method: 'GET' | 'POST' | 'PUT' | 'PATCH', url: string, params: Record<string, any>) => {
+  const options = { method, headers, body: '' }
+  let full_url = `${url_prefix}/${url}?${(base_query ?? '').toString()}`
+
+  if (method === 'GET') {
+    full_url += new URLSearchParams(params).toString()
+  } else {
+    options.body = JSON.stringify(params)
+  }
+
+  const resp = await fetch(full_url, options)
+  if (!resp.ok) {
+    throw new Error(
+      `Request failed: ${method} ${full_url} with ${resp.status} (${resp.statusText})`
+    )
+  }
+  return JSON.parse(await resp.text())
+}
+
+const github_req = (gc: GithubConfig) =>
+  req(`https://api.github.com/repos/${gc.org}/${gc.repo}`, {
+    Authorization: `token ${process.env.GITHUB_PAT ?? ''}`,
+    Accept: 'application/vnd.github.v3+json',
+    'Content-Type': 'application/json',
+  })
+
+const zenhub_req = (zc: ZenhubConfig) =>
+  req(
+    'https://api.zenhub.com/p1',
+    {
+      'X-Authentication-Token': process.env.ZENHUB_API_KEY ?? '',
+      'Content-Type': 'application/json',
+    },
+    new URLSearchParams(zc)
+  )
+
+const convertGithubToZenhubIssues = (zc: ZenhubConfig) => (githubIssues: Array<any>) =>
+  githubIssues.map((gh_issue) => ({
+    repo_id: parseInt(zc.repo_id),
+    issue_number: parseInt(gh_issue.number),
+  }))
+
+export const generateReleaseReport = async (
+  githubConfig: GithubConfig,
+  zenhubConfig: ZenhubConfig,
+  releaseReport: ReleaseReport
+): Promise<void> => {
+  const zh_req = zenhub_req(zenhubConfig)
+  const gh_req = github_req(githubConfig)
+
+  // create release
+  const newReport = await zh_req('POST', `repositories/${zenhubConfig.repo_id}/reports/release`, {
+    title: releaseReport.title,
+    description: releaseReport.description,
+    start_date: new Date(releaseReport.start).toISOString(),
+    desired_end_date: new Date(releaseReport.end).toISOString(),
+    repositories: [parseInt(zenhubConfig.repo_id)],
+  })
+
+  // create epics
+  const gh_epics = await concurrentMap(1, releaseReport.epics, async (epic) => {
+    // create github issue representing epic
+    const gh_epic = await gh_req('POST', 'issues', {
+      title: epic.title,
+      body: epic.description,
+      labels: githubConfig.labels,
+    })
+
+    // create github issues representing epic contents
+    const gh_issues = await concurrentMap(1, epic.issues, (issue) =>
+      gh_req('POST', 'issues', { title: issue.title, labels: githubConfig.labels })
+    )
+    const zh_issues = convertGithubToZenhubIssues(zenhubConfig)(gh_issues)
+
+    // assign estimates to github issues
+    await concurrentMap(1, zh_issues, (zh_issue, i) =>
+      zh_req(
+        'PUT',
+        `repositories/${zenhubConfig.repo_id}/issues/${zh_issue.issue_number}/estimate`,
+        {
+          estimate: epic.issues[i].estimate,
+        }
+      )
+    )
+
+    // convert github issue to epic and add contents
+    await zh_req(
+      'POST',
+      `repositories/${zenhubConfig.repo_id}/issues/${gh_epic.number}/convert_to_epic`,
+      {
+        issues: zh_issues,
+      }
+    )
+
+    // add issues to release report
+    await zh_req('PATCH', `reports/release/${newReport.release_id}/issues`, {
+      add_issues: zh_issues,
+      remove_issues: [],
+    })
+
+    return gh_epic
+  })
+
+  const zh_epics = convertGithubToZenhubIssues(zenhubConfig)(gh_epics)
+  // add epics to release report
+  await zh_req('PATCH', `reports/release/${newReport.release_id}/issues`, {
+    add_issues: zh_epics,
+    remove_issues: [],
+  })
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -91,6 +91,7 @@
     "web3-provider-engine": "^15.0.0"
   },
   "devDependencies": {
+    "@celo/dev-utils": "0.0.1-dev",
     "@celo/flake-tracker": "0.0.1-dev",
     "@celo/typechain-target-web3-v1-celo": "0.2.0",
     "@celo/typescript": "0.0.1",

--- a/packages/protocol/scripts/release-report.ts
+++ b/packages/protocol/scripts/release-report.ts
@@ -1,0 +1,159 @@
+import { concurrentMap } from '@celo/base'
+import fetch from 'node-fetch'
+
+type Issue = {
+  title: string
+  description?: string
+  estimate?: number
+}
+
+type Epic = Issue & {
+  issues: Issue[]
+}
+
+type ReleaseReport = Issue & {
+  start: string
+  end: string
+  epics: Epic[]
+  issues: Issue[]
+}
+
+const n = '5'
+const networks = ['staging', 'alfajores', 'baklava', 'mainnet']
+
+const release_report: ReleaseReport = {
+  title: `Celo Core Contracts Release ${n}`,
+  description: `Manage rollout of core contracts release ${n}`,
+  start: 'July 12, 2021',
+  end: 'August 23, 2021',
+  epics: [
+    {
+      title: `Scope and Audit release ${n}`,
+      description: '',
+      issues: [
+        { title: `Deliver frozen audit ${n + 1} scope to OpenZeppelin`, estimate: 1 },
+        { title: `Facilitate audit ${n + 1} and answer questions`, estimate: 1 },
+        { title: `Triage audit ${n + 1} issues`, estimate: 1 },
+        {
+          title: `Resolve audit ${n + 1} issues and tag release 'core-contracts.v${n}'`,
+          estimate: 5,
+        },
+        { title: `Merge release ${n} to master`, estimate: 1 },
+      ],
+    },
+    {
+      title: `Communicate and Document release ${n}`,
+      description: '',
+      issues: [
+        { title: `Draft and publish release notes for release ${n}`, estimate: 1 },
+        { title: `Draft and publish CGP for release ${n}`, estimate: 1 },
+        { title: `Draft and publish forum post for release ${n}`, estimate: 1 },
+        { title: `Discuss release ${n} on governance community call`, estimate: 1 },
+      ],
+    },
+    {
+      title: `Test and Deploy release ${n}`,
+      description: '',
+      issues: networks.map((network) => ({
+        title: `Deploy release ${n} on ${network}, shepherd through governance, and run env-tests`,
+        estimate: 1,
+      })),
+    },
+  ],
+  issues: [],
+}
+
+const req = (
+  url_prefix: string,
+  headers: Record<string, string>,
+  base_query: URLSearchParams
+) => async (
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH',
+  url: string,
+  params?: Record<string, any>
+) => {
+  const resp = await fetch(`${url_prefix}/${url}?${base_query}`, {
+    method,
+    headers,
+    body: params ? new URLSearchParams(params) : undefined,
+  })
+  return JSON.parse(await resp.text())
+}
+
+const issue_labels = ['Component: Contracts', 'audit', 'CAP']
+const gh_org = 'celo-org'
+const gh_repo = 'celo-monorepo'
+
+const github_req = req(
+  `https://api.github.com/repos/${gh_org}/${gh_repo}/`,
+  {
+    Authorization: process.env.GITHUB_PAT ?? '',
+    'Content-Type': 'application/json',
+  },
+  new URLSearchParams()
+)
+
+const repo_id = '197642503'
+const workspace_id = '600598462807be0011921c65'
+
+const zenhub_req = req(
+  'https://api.zenhub.com/p1',
+  {
+    'X-Authentication-Token': process.env.ZENHUB_API_KEY ?? '',
+    'Content-Type': 'application/json',
+  },
+  new URLSearchParams({ repo_id, workspace_id })
+)
+
+const convertGithubToZenhubIssues = (githubIssues: Array<any>) =>
+  githubIssues.map((gh_issue) => ({ repo_id, issue_number: gh_issue.number }))
+
+const main = async (releaseReport: ReleaseReport): Promise<void> => {
+  // create release
+  const newReport = await zenhub_req('POST', `repositories/${repo_id}/reports/release`, {
+    title: releaseReport.title,
+    description: releaseReport.description,
+    start_date: new Date(releaseReport.start).toISOString(),
+    desired_end_date: new Date(releaseReport.end).toISOString(),
+    repositories: [repo_id],
+  })
+
+  // create epics
+  const gh_epics = await concurrentMap(3, releaseReport.epics, async (epic) => {
+    // create github issue representing epic
+    const gh_epic = await github_req('POST', 'issues', {
+      title: epic.title,
+      body: epic.description,
+      labels: issue_labels,
+    })
+
+    // create github issues representing epic contents
+    const gh_issues = await concurrentMap(4, epic.issues, (title) =>
+      github_req('POST', 'issues', { title })
+    )
+    const zh_issues = convertGithubToZenhubIssues(gh_issues)
+
+    // assign estimates to github issues
+    await concurrentMap(4, zh_issues, (zh_issue, i) =>
+      zenhub_req('PUT', `repositories/${repo_id}/issues/${zh_issue.issue_number}/estimate`, {
+        estimate: epic.issues[i].estimate,
+      })
+    )
+
+    // convert github issue to epic and add contents
+    await zenhub_req('POST', `repositories/${repo_id}/issues/${gh_epic.number}/convert_to_epic`, {
+      issues: zh_issues,
+    })
+
+    return gh_epic
+  })
+
+  const zh_epics = convertGithubToZenhubIssues(gh_epics)
+  // add epics to release report
+  await zenhub_req('PATCH', `reports/release/${newReport.release_id}/issues`, {
+    add_issues: zh_epics,
+    remove_issues: [],
+  })
+}
+
+main(release_report).catch((error) => console.error('error', error))

--- a/packages/protocol/scripts/release-report.ts
+++ b/packages/protocol/scripts/release-report.ts
@@ -77,6 +77,9 @@ const req = (
     headers,
     body: params ? new URLSearchParams(params) : undefined,
   })
+  if (!resp.ok) {
+    throw new Error(`Request failed: ${JSON.stringify(resp, null, 2)}`)
+  }
   return JSON.parse(await resp.text())
 }
 
@@ -156,4 +159,4 @@ const main = async (releaseReport: ReleaseReport): Promise<void> => {
   })
 }
 
-main(release_report).catch((error) => console.error('error', error))
+main(release_report).catch((error) => console.error(error))

--- a/packages/protocol/scripts/release-report.ts
+++ b/packages/protocol/scripts/release-report.ts
@@ -1,6 +1,6 @@
 import { generateReleaseReport, ReleaseReport } from '@celo/dev-utils/lib/release-report'
 
-const n = '5'
+const n = 5
 const networks = ['staging', 'alfajores', 'baklava', 'mainnet']
 
 const releaseReport: ReleaseReport = {
@@ -46,7 +46,12 @@ const releaseReport: ReleaseReport = {
 }
 
 generateReleaseReport(
-  { labels: ['Component: Contracts', 'audit', 'CAP'], org: 'celo-org', repo: 'celo-monorepo' },
-  { repo_id: '197642503', workspace_id: '600598462807be0011921c65' },
+  {
+    labels: ['Component: Contracts', 'audit', 'CAP'],
+    org: 'celo-org',
+    repo: 'celo-monorepo',
+    apiToken: process.env.GITHUB_KEY,
+  },
+  { repoId: '197642503', workspaceId: '600598462807be0011921c65', apiKey: process.env.ZENHUB_KEY },
   releaseReport
 ).catch((error) => console.error(error))

--- a/packages/protocol/scripts/release-report.ts
+++ b/packages/protocol/scripts/release-report.ts
@@ -1,22 +1,4 @@
-import { concurrentMap } from '@celo/base'
-import fetch from 'node-fetch'
-
-type Issue = {
-  title: string
-  description?: string
-  estimate?: number
-}
-
-type Epic = Issue & {
-  issues: Issue[]
-}
-
-type ReleaseReport = Issue & {
-  start: string
-  end: string
-  epics: Epic[]
-  issues: Issue[]
-}
+import { generateReleaseReport, ReleaseReport } from '@celo/dev-utils/lib/release-report'
 
 const n = '5'
 const networks = ['staging', 'alfajores', 'baklava', 'mainnet']
@@ -63,109 +45,8 @@ const release_report: ReleaseReport = {
   issues: [],
 }
 
-const req = (
-  url_prefix: string,
-  headers: Record<string, string>,
-  base_query?: URLSearchParams
-) => async (method: 'GET' | 'POST' | 'PUT' | 'PATCH', url: string, params: Record<string, any>) => {
-  const options = { method, headers, body: undefined }
-  let full_url = `${url_prefix}/${url}?${(base_query ?? '').toString()}`
-
-  if (method === 'GET') {
-    full_url += new URLSearchParams(params).toString()
-  } else {
-    options.body = JSON.stringify(params)
-  }
-
-  const resp = await fetch(full_url, options)
-  if (!resp.ok) {
-    throw new Error(
-      `Request failed: ${method} ${full_url} with ${resp.status} (${resp.statusText})`
-    )
-  }
-  return JSON.parse(await resp.text())
-}
-
-const issue_labels = ['Component: Contracts', 'audit', 'CAP']
-const gh_org = 'celo-org'
-const gh_repo = 'celo-monorepo'
-
-const github_req = req(`https://api.github.com/repos/${gh_org}/${gh_repo}`, {
-  Authorization: `token ${process.env.GITHUB_PAT ?? ''}`,
-  Accept: 'application/vnd.github.v3+json',
-  'Content-Type': 'application/json',
-})
-
-const repo_id = '197642503'
-const workspace_id = '600598462807be0011921c65'
-
-const zenhub_req = req(
-  'https://api.zenhub.com/p1',
-  {
-    'X-Authentication-Token': process.env.ZENHUB_API_KEY ?? '',
-    'Content-Type': 'application/json',
-  },
-  new URLSearchParams({ repo_id, workspace_id })
-)
-
-const convertGithubToZenhubIssues = (githubIssues: Array<any>) =>
-  githubIssues.map((gh_issue) => ({
-    repo_id: parseInt(repo_id),
-    issue_number: parseInt(gh_issue.number),
-  }))
-
-const main = async (releaseReport: ReleaseReport): Promise<void> => {
-  // create release
-  const newReport = await zenhub_req('POST', `repositories/${repo_id}/reports/release`, {
-    title: releaseReport.title,
-    description: releaseReport.description,
-    start_date: new Date(releaseReport.start).toISOString(),
-    desired_end_date: new Date(releaseReport.end).toISOString(),
-    repositories: [parseInt(repo_id)],
-  })
-
-  // create epics
-  const gh_epics = await concurrentMap(1, releaseReport.epics, async (epic) => {
-    // create github issue representing epic
-    const gh_epic = await github_req('POST', 'issues', {
-      title: epic.title,
-      body: epic.description,
-      labels: issue_labels,
-    })
-
-    // create github issues representing epic contents
-    const gh_issues = await concurrentMap(1, epic.issues, (issue) =>
-      github_req('POST', 'issues', { title: issue.title, labels: issue_labels })
-    )
-    const zh_issues = convertGithubToZenhubIssues(gh_issues)
-
-    // assign estimates to github issues
-    await concurrentMap(1, zh_issues, (zh_issue, i) =>
-      zenhub_req('PUT', `repositories/${repo_id}/issues/${zh_issue.issue_number}/estimate`, {
-        estimate: epic.issues[i].estimate,
-      })
-    )
-
-    // convert github issue to epic and add contents
-    await zenhub_req('POST', `repositories/${repo_id}/issues/${gh_epic.number}/convert_to_epic`, {
-      issues: zh_issues,
-    })
-
-    // add issues to release report
-    await zenhub_req('PATCH', `reports/release/${newReport.release_id}/issues`, {
-      add_issues: zh_issues,
-      remove_issues: [],
-    })
-
-    return gh_epic
-  })
-
-  const zh_epics = convertGithubToZenhubIssues(gh_epics)
-  // add epics to release report
-  await zenhub_req('PATCH', `reports/release/${newReport.release_id}/issues`, {
-    add_issues: zh_epics,
-    remove_issues: [],
-  })
-}
-
-main(release_report).catch((error) => console.error(error))
+generateReleaseReport(
+  { labels: ['Component: Contracts', 'audit', 'CAP'], org: 'celo-org', repo: 'celo-monorepo' },
+  { repo_id: '197642503', workspace_id: '600598462807be0011921c65' },
+  release_report
+).catch((error) => console.error(error))

--- a/packages/protocol/scripts/release-report.ts
+++ b/packages/protocol/scripts/release-report.ts
@@ -3,7 +3,7 @@ import { generateReleaseReport, ReleaseReport } from '@celo/dev-utils/lib/releas
 const n = '5'
 const networks = ['staging', 'alfajores', 'baklava', 'mainnet']
 
-const release_report: ReleaseReport = {
+const releaseReport: ReleaseReport = {
   title: `Celo Core Contracts Release ${n}`,
   description: `Manage rollout of core contracts release ${n}`,
   start: 'July 12, 2021',
@@ -48,5 +48,5 @@ const release_report: ReleaseReport = {
 generateReleaseReport(
   { labels: ['Component: Contracts', 'audit', 'CAP'], org: 'celo-org', repo: 'celo-monorepo' },
   { repo_id: '197642503', workspace_id: '600598462807be0011921c65' },
-  release_report
+  releaseReport
 ).catch((error) => console.error(error))

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "baseUrl": ".",
     "jsx": "preserve",
-    "lib": ["dom", "es2015", "es2016"],
+    "lib": ["dom","dom.iterable","es2015", "es2016"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
### Description

- Adds `generateReleaseReport` utility to `@celo/dev-utils` to enable celo teams to easily generate zenhub release reports providing a standard schema and API authentication

### Other changes

- Adds `protocol/scripts/release-report.ts` for generating core contracts zenhub release reports

### Tested

Used to generated https://app.zenhub.com/workspaces/cap-backlog-board-600598462807be0011921c65/reports/release?release=Z2lkOi8vcmFwdG9yL1JlbGVhc2UvNjM2ODg
