### PR TITLE
add accessors for Reserve Target Allocations

### DIFF
--- a/packages/sdk/contractkit/src/wrappers/Reserve.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Reserve.test.ts
@@ -1,4 +1,5 @@
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import BigNumber from 'bignumber.js'
 import { newKitFromWeb3 } from '../kit'
 import { MultiSigWrapper } from './MultiSig'
 import { ReserveWrapper } from './Reserve'
@@ -20,6 +21,23 @@ testWithGanache('Reserve Wrapper', (web3) => {
     // assumes that the multisig is the most recent spender in the spenders array
     const multiSigAddress = spenders.length > 0 ? spenders[spenders.length - 1] : ''
     reserveSpenderMultiSig = await kit.contracts.getMultiSig(multiSigAddress)
+  })
+
+  test('can get asset target weights which sum to 100%', async () => {
+    const targets = await reserve.getAssetAllocationWeights()
+    expect(targets.reduce((total, current) => total.plus(current), new BigNumber(0))).toEqual(
+      new BigNumber(100 * 10_000_000_000_000_000_000_000)
+    )
+  })
+
+  test('can get asset target symbols ', async () => {
+    const targets = await reserve.getAssetAllocationSymbols()
+
+    const expectation = ['cGLD', 'BTC', 'ETH', 'DAI']
+
+    targets.forEach((sym, i) => {
+      expect(sym).toEqual(expect.stringMatching(expectation[i]))
+    })
   })
 
   test('can get reserve unfrozen balance ', async () => {

--- a/packages/sdk/contractkit/src/wrappers/Reserve.ts
+++ b/packages/sdk/contractkit/src/wrappers/Reserve.ts
@@ -55,6 +55,26 @@ export class ReserveWrapper extends BaseWrapper<Reserve> {
   )
 
   /**
+   * @notice Returns a list of weights used for the allocation of reserve assets.
+   * @return An array of a list of weights used for the allocation of reserve assets.
+   */
+  getAssetAllocationWeights = proxyCall(
+    this.contract.methods.getAssetAllocationWeights,
+    undefined,
+    (weights) => weights.map(valueToBigNumber)
+  )
+
+  /**
+   * @notice Returns a list of token symbols that have been allocated.
+   * @return An array of token symbols that have been allocated.
+   */
+  getAssetAllocationSymbols = proxyCall(
+    this.contract.methods.getAssetAllocationSymbols,
+    undefined,
+    (symbols) => symbols.map(this.kit.web3.utils.hexToAscii)
+  )
+
+  /**
    * @alias {getReserveCeloBalance}
    */
   getReserveGoldBalance = proxyCall(


### PR DESCRIPTION
### Description

This exposes functions for getting reserve target asset allocations in contract kit. 

### Other changes

n/a

### Tested

wrote a test for each function.

tested symbols are there and that the weights add up to 100

### Related issues

- Fixes #8461 

### Backwards compatibility

yes. just new functions

### Documentation

✅