### PR TITLE
Set minimum number of price sources for the oracles.

### DIFF
--- a/packages/helm-charts/oracle/CELOBTC.yaml
+++ b/packages/helm-charts/oracle/CELOBTC.yaml
@@ -12,6 +12,7 @@ oracle:
   apiRequestTimeoutMs: 5000
   circuitBreakerPriceChangeThreshold: 0.25
   priceSources: "[[{exchange: 'BITTREX', symbol: 'CELOBTC', toInvert: false}],[{exchange: 'COINBASE', symbol: 'CELOBTC', toInvert: false}]]"
+  minPriceSourceCount: 2
   reportStrategy: BLOCK_BASED
   reporter:
     blockBased:

--- a/packages/helm-charts/oracle/CELOEUR.yaml
+++ b/packages/helm-charts/oracle/CELOEUR.yaml
@@ -12,6 +12,7 @@ oracle:
   apiRequestTimeoutMs: 5000
   circuitBreakerPriceChangeThreshold: 0.25
   priceSources: "[[{exchange: 'BITTREX', symbol: 'CELOEUR', toInvert: false}],[{exchange: 'COINBASE', symbol: 'CELOEUR', toInvert: false}],[{exchange: 'BINANCE', symbol: 'CELOUSDT', toInvert: false}, {exchange: 'BINANCE', symbol: 'EURUSDT', toInvert: true}]]"
+  minPriceSourceCount: 2
   reportStrategy: BLOCK_BASED
   reporter:
     blockBased:

--- a/packages/helm-charts/oracle/CELOUSD.yaml
+++ b/packages/helm-charts/oracle/CELOUSD.yaml
@@ -12,6 +12,7 @@ oracle:
   apiRequestTimeoutMs: 5000
   circuitBreakerPriceChangeThreshold: 0.25
   priceSources: "[[{exchange: 'BITTREX', symbol: 'CELOUSD', toInvert: false}],[{exchange: 'COINBASE', symbol: 'CELOUSD', toInvert: false}],[{exchange: 'OKCOIN', symbol: 'CELOUSD', toInvert: false}]]"
+  minPriceSourceCount: 2
   reportStrategy: BLOCK_BASED
   reporter:
     blockBased:

--- a/packages/helm-charts/oracle/templates/statefulset.yaml
+++ b/packages/helm-charts/oracle/templates/statefulset.yaml
@@ -120,6 +120,7 @@ spec:
 {{ include "common.env-var" (dict "name" "AZURE_HSM_INIT_MAX_RETRY_BACKOFF_MS" "dict" .Values.oracle.azureHsm "value_name" "initMaxRetryBackoffMs") | indent 8 }}
 {{ include "common.env-var" (dict "name" "CIRCUIT_BREAKER_PRICE_CHANGE_THRESHOLD" "dict" .Values.oracle "value_name" "circuitBreakerPriceChangeThreshold") | indent 8 }}
 {{ include "common.env-var" (dict "name" "CURRENCY_PAIR" "dict" .Values.oracle "value_name" "currencyPair") | indent 8 }}
+{{ include "common.env-var" (dict "name" "MINIMUM_PRICE_SOURCES" "dict" .Values.oracle "value_name" "minPriceSourceCount") | indent 8 }}
 {{ include "common.env-var" (dict "name" "PRICE_SOURCES" "dict" .Values.oracle "value_name" "priceSources") | indent 8 }}
 {{ include "common.env-var" (dict "name" "GAS_PRICE_MULTIPLIER" "dict" .Values.oracle "value_name" "gasPriceMultiplier") | indent 8 }}
 {{ include "common.env-var" (dict "name" "HTTP_RPC_PROVIDER_URL" "dict" .Values.oracle.rpcProviderUrls "value_name" "http") | indent 8 }}


### PR DESCRIPTION
### Description

Add the MINIMUM_PRICE_SOURCES environment variable to the Oracle's Helm chart, and set it to 2 on the oracle configuration files.

### Tested

Deployed to Baklava and Alfajores.