### PR TITLE
Add --txpool.nolocals to forno full nodes

### DIFF
--- a/packages/celotool/src/lib/k8s-fullnode/gcp.ts
+++ b/packages/celotool/src/lib/k8s-fullnode/gcp.ts
@@ -17,6 +17,7 @@ export class GCPFullNodeDeployer extends BaseFullNodeDeployer {
       `--set storage.storageClass=ssd`,
       `--set geth.public_ip_per_node='{${staticIps}}'`,
       `--set geth.create_network_endpoint_group=${this.deploymentConfig.createNEG}`,
+      `--set geth.flags='--txpool.nolocals'`,
     ]
   }
 

--- a/packages/helm-charts/common/templates/_helpers.tpl
+++ b/packages/helm-charts/common/templates/_helpers.tpl
@@ -494,7 +494,7 @@ prometheus.io/port: "{{ $pprof.port | default 6060 }}"
   - "-c"
   - |
     if [ -d /root/.celo/celo/chaindata ]; then
-      lastBlockTimestamp=$(timeout 120 geth console --maxpeers 0 --light.maxpeers 0 --syncmode full --exec "eth.getBlock(\"latest\").timestamp")
+      lastBlockTimestamp=$(timeout 600 geth console --maxpeers 0 --light.maxpeers 0 --syncmode full --txpool.nolocals --exec "eth.getBlock(\"latest\").timestamp")
       day=$(date +%s)
       diff=$(($day - $lastBlockTimestamp))
       # If lastBlockTimestamp is older than 1 day old, pull the chaindata rather than using the current PVC.


### PR DESCRIPTION
### Description

A small change made along with @piersy when forno was having some issues. `--txpool.nolocals` is recommended when exposing nodes publicly: https://github.com/ethereum/go-ethereum/issues/18242#issuecomment-444073885.

We noticed it took a really long time for the command to find the most recent block timestamp, which was due to the `transactions.rlp` file being loaded. Adding `--txpool.nolocals` causes that to not be loaded or written to.

I added the `--txpool.nolocals` only for GCP-based full nodes, which I believe are only used for forno (@jcortejoso correct me if I'm wrong or if this will mess other infrastructure up that I'm not familiar with).

### Other changes

n/a

### Tested

Deployed forno full nodes

### Related issues

n/a

### Backwards compatibility

backward compatible

### Documentation

n/a