### PR TITLE
Check if executing a proposal would overflow

### DIFF
--- a/packages/protocol/contracts/liquidity/GrandaMento.sol
+++ b/packages/protocol/contracts/liquidity/GrandaMento.sol
@@ -265,7 +265,7 @@ contract GrandaMento is
     // overflow for very large StableToken amounts. Call it here as a sanity
     // check, so that the overflow happens here, blocking proposal creation
     // rather than when attempting to execute the proposal, which would lock
-    // funds in this contrac.
+    // funds in this contract.
     getSellTokenAndSellAmount(exchangeProposals[exchangeProposalCount]);
     // Push it into the array of active proposals.
     activeProposalIdsSuperset.push(exchangeProposalCount);

--- a/packages/protocol/contracts/liquidity/GrandaMento.sol
+++ b/packages/protocol/contracts/liquidity/GrandaMento.sol
@@ -261,6 +261,12 @@ contract GrandaMento is
       vetoPeriodSeconds: vetoPeriodSeconds,
       approvalTimestamp: 0 // initial value when not approved yet
     });
+    // StableToken.unitsToValue (called within getSellTokenAndSellAmount) can
+    // overflow for very large StableToken amounts. Call it here as a sanity
+    // check, so that the overflow happens here, blocking proposal creation
+    // rather than when attempting to execute the proposal, which would lock
+    // funds in this contrac.
+    getSellTokenAndSellAmount(exchangeProposals[exchangeProposalCount]);
     // Push it into the array of active proposals.
     activeProposalIdsSuperset.push(exchangeProposalCount);
     // Even if stable tokens are being sold, the sellAmount emitted is the "value."

--- a/packages/protocol/test/liquidity/grandamento.ts
+++ b/packages/protocol/test/liquidity/grandamento.ts
@@ -275,12 +275,12 @@ contract('GrandaMento', (accounts: string[]) => {
       // We need to deploy the real StableToken contract because MockStableToken
       // calls balanceOf during transfers which can overflow before the overflow
       // we actually want to detect.
-      const stableToken: StableTokenInstance = await StableToken.new(true)
-      await registry.setAddressFor(stableTokenRegistryId, stableToken.address)
+      const realStableToken: StableTokenInstance = await StableToken.new(true)
+      await registry.setAddressFor(realStableTokenRegistryId, realStableToken.address)
 
-      await sortedOracles.setMedianRate(stableToken.address, defaultCeloStableTokenRate)
-      await sortedOracles.setMedianTimestampToNow(stableToken.address)
-      await sortedOracles.setNumRates(stableToken.address, 2)
+      await sortedOracles.setMedianRate(realStableToken.address, defaultCeloStableTokenRate)
+      await sortedOracles.setMedianTimestampToNow(realStableToken.address)
+      await sortedOracles.setNumRates(realStableToken.address, 2)
 
       // StableToken.transferFrom is freezable so it looks up Freezer in the
       // Registry
@@ -290,7 +290,7 @@ contract('GrandaMento', (accounts: string[]) => {
 
       // We set ourselves as the Exchange to be able to mint
       await registry.setAddressFor('Exchange', owner)
-      await stableToken.initialize(
+      await realStableToken.initialize(
         'Celo Dollar',
         'cUSD',
         18,
@@ -303,16 +303,16 @@ contract('GrandaMento', (accounts: string[]) => {
       )
 
       await grandaMento.setStableTokenExchangeLimits(
-        stableTokenRegistryId,
+        realStableTokenRegistryId,
         minExchangeAmount,
         unit.times(2e12)
       )
       const sellAmount = unit.times(2e11)
-      await stableToken.mint(owner, sellAmount)
-      await stableToken.approve(grandaMento.address, sellAmount)
+      await realStableToken.mint(owner, sellAmount)
+      await realStableToken.approve(grandaMento.address, sellAmount)
 
       await assertRevertWithReason(
-        createExchangeProposal(false, owner, stableTokenRegistryId, sellAmount),
+        createExchangeProposal(false, owner, realStableTokenRegistryId, sellAmount),
         'overflow at divide'
       )
     })

--- a/packages/protocol/test/liquidity/grandamento.ts
+++ b/packages/protocol/test/liquidity/grandamento.ts
@@ -9,6 +9,8 @@ import {
 import { fromFixed, reciprocal, toFixed } from '@celo/utils/lib/fixidity'
 import BigNumber from 'bignumber.js'
 import {
+  FreezerContract,
+  FreezerInstance,
   GoldTokenContract,
   GoldTokenInstance,
   GrandaMentoContract,
@@ -23,8 +25,12 @@ import {
   MockStableTokenInstance,
   RegistryContract,
   RegistryInstance,
+  StableTokenContract,
+  StableTokenInstance,
 } from 'types'
+import { SECONDS_IN_A_WEEK } from '../constants'
 
+const Freezer: FreezerContract = artifacts.require('Freezer')
 const GoldToken: GoldTokenContract = artifacts.require('GoldToken')
 const GrandaMento: GrandaMentoContract = artifacts.require('GrandaMento')
 const MockGoldToken: MockGoldTokenContract = artifacts.require('MockGoldToken')
@@ -32,6 +38,7 @@ const MockSortedOracles: MockSortedOraclesContract = artifacts.require('MockSort
 const MockStableToken: MockStableTokenContract = artifacts.require('MockStableToken')
 const Registry: RegistryContract = artifacts.require('Registry')
 const MockReserve: MockReserveContract = artifacts.require('MockReserve')
+const StableToken: StableTokenContract = artifacts.require('StableToken')
 
 // @ts-ignore
 GoldToken.numberFormat = 'BigNumber'
@@ -127,18 +134,22 @@ contract('GrandaMento', (accounts: string[]) => {
   const createExchangeProposal = async (
     sellCelo: boolean,
     from: string = owner,
-    _stableTokenRegistryId?: CeloContractName
+    _stableTokenRegistryId?: CeloContractName,
+    sellAmount?: BigNumber
   ) => {
+    if (!sellAmount) {
+      sellAmount = sellCelo ? celoSellAmount : stableTokenSellAmount
+    }
     // When a test sets sellCelo to true, the sender in the test must approve
     // the CELO to grandaMento.
     // The MockStableToken does not enforce allowances so there is no need
     // to approve the stable token to grandaMento when sellCelo is false.
     if (sellCelo) {
-      await goldToken.approve(grandaMento.address, celoSellAmount, { from })
+      await goldToken.approve(grandaMento.address, sellAmount, { from })
     }
     return grandaMento.createExchangeProposal(
       _stableTokenRegistryId || stableTokenRegistryId,
-      sellCelo ? celoSellAmount : stableTokenSellAmount,
+      sellAmount,
       sellCelo,
       { from }
     )
@@ -258,6 +269,52 @@ contract('GrandaMento', (accounts: string[]) => {
       await createExchangeProposal(false)
       assertEqualBN(await grandaMento.activeProposalIdsSuperset(0), new BigNumber(1))
       assertEqualBN(await grandaMento.activeProposalIdsSuperset(1), new BigNumber(2))
+    })
+
+    it('fails if the stable token amount would overflow in a unitsToValue call', async () => {
+      // We need to deploy the real StableToken contract because MockStableToken
+      // calls balanceOf during transfers which can overflow before the overflow
+      // we actually want to detect.
+      const stableToken: StableTokenInstance = await StableToken.new(true)
+      await registry.setAddressFor(stableTokenRegistryId, stableToken.address)
+
+      await sortedOracles.setMedianRate(stableToken.address, defaultCeloStableTokenRate)
+      await sortedOracles.setMedianTimestampToNow(stableToken.address)
+      await sortedOracles.setNumRates(stableToken.address, 2)
+
+      // StableToken.transferFrom is freezable so it looks up Freezer in the
+      // Registry
+      const freezer: FreezerInstance = await Freezer.new(true)
+      await freezer.initialize()
+      await registry.setAddressFor(CeloContractName.Freezer, freezer.address)
+
+      // We set ourselves as the Exchange to be able to mint
+      await registry.setAddressFor('Exchange', owner)
+      await stableToken.initialize(
+        'Celo Dollar',
+        'cUSD',
+        18,
+        registry.address,
+        unit,
+        SECONDS_IN_A_WEEK,
+        [],
+        [],
+        'Exchange' // USD
+      )
+
+      await grandaMento.setStableTokenExchangeLimits(
+        stableTokenRegistryId,
+        minExchangeAmount,
+        unit.times(2e12)
+      )
+      const sellAmount = unit.times(2e11)
+      await stableToken.mint(owner, sellAmount)
+      await stableToken.approve(grandaMento.address, sellAmount)
+
+      await assertRevertWithReason(
+        createExchangeProposal(false, owner, stableTokenRegistryId, sellAmount),
+        'overflow at divide'
+      )
     })
 
     for (const sellCelo of [true, false]) {

--- a/packages/protocol/test/liquidity/grandamento.ts
+++ b/packages/protocol/test/liquidity/grandamento.ts
@@ -276,7 +276,7 @@ contract('GrandaMento', (accounts: string[]) => {
       // calls balanceOf during transfers which can overflow before the overflow
       // we actually want to detect.
       const realStableToken: StableTokenInstance = await StableToken.new(true)
-      await registry.setAddressFor(realStableTokenRegistryId, realStableToken.address)
+      await registry.setAddressFor(stableTokenRegistryId, realStableToken.address)
 
       await sortedOracles.setMedianRate(realStableToken.address, defaultCeloStableTokenRate)
       await sortedOracles.setMedianTimestampToNow(realStableToken.address)
@@ -303,7 +303,7 @@ contract('GrandaMento', (accounts: string[]) => {
       )
 
       await grandaMento.setStableTokenExchangeLimits(
-        realStableTokenRegistryId,
+        stableTokenRegistryId,
         minExchangeAmount,
         unit.times(2e12)
       )
@@ -312,7 +312,7 @@ contract('GrandaMento', (accounts: string[]) => {
       await realStableToken.approve(grandaMento.address, sellAmount)
 
       await assertRevertWithReason(
-        createExchangeProposal(false, owner, realStableTokenRegistryId, sellAmount),
+        createExchangeProposal(false, owner, stableTokenRegistryId, sellAmount),
         'overflow at divide'
       )
     })


### PR DESCRIPTION
### Description

For very large `stableToken` amounts, GrandaMento's `executeExchangeProposal` could overflow during a `unitsToValue` computation. This PR adds a call to the same arithmetic logic at proposal creation time, so that a proposal that would overflow cannot be created.

### Tested
 
Unit test to ensure this reverts when proposal is too big.

### Related issues

- Fixes #8323 

### Backwards compatibility

Adds features to a new contract.