### PR TITLE
Enabled metrics, changed the pool size

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - name: POOL_SIZE
           value: {{ .Values.blockscout.indexer.pool_size | quote }}
         - name: METRICS_ENABLED
-          value: "{{.Values.blockscout.indexer.metrics.enabled}}"
+          value: "{{.Values.blockscout.metrics.enabled}}"
 {{ include "celo.blockscout-env-vars" . | indent 8 }}
 {{- $data := dict "Values" .Values "Database" .Values.blockscout.indexer.db }}
 {{ include "celo.blockscout-db-sidecar" $data | indent 6 }}

--- a/packages/helm-charts/blockscout/values-alfajores.yaml
+++ b/packages/helm-charts/blockscout/values-alfajores.yaml
@@ -48,4 +48,4 @@ blockscout:
         memory: 250M
         cpu: 500m
   metrics:
-    enabled: false
+    enabled: true

--- a/packages/helm-charts/blockscout/values-baklava.yaml
+++ b/packages/helm-charts/blockscout/values-baklava.yaml
@@ -50,4 +50,4 @@ blockscout:
         memory: 250M
         cpu: 500m
   metrics:
-    enabled: false
+    enabled: true

--- a/packages/helm-charts/blockscout/values-rc1.yaml
+++ b/packages/helm-charts/blockscout/values-rc1.yaml
@@ -12,8 +12,6 @@ blockscout:
       requests:
         memory: 12Gi
         cpu: 5
-    metrics:
-      enabled: true
   api:
     autoscaling:
         maxReplicas: 10
@@ -50,4 +48,4 @@ blockscout:
         memory: 250M
         cpu: 500m
   metrics:
-    enabled: false
+    enabled: true

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -80,7 +80,7 @@ blockscout:
           requests:
             memory: 500Mi
             cpu: 700m
-    pool_size: 10
+    pool_size: 30
     readinessProbe:
       enabled: true
       initialDelaySeconds: 10
@@ -132,7 +132,7 @@ blockscout:
           requests:
             memory: 500Mi
             cpu: 700m
-    pool_size: 10
+    pool_size: 30
     readinessProbe:
       enabled: true
       initialDelaySeconds: 10


### PR DESCRIPTION
### Description

Enabled blockscout metrics by default.

### Other changes

Increased the connection pool size.

### Tested

Tested on all envs.

### Backwards compatibility

Yes.