### PR TITLE
fixed typo in word "governance"

### DIFF
--- a/packages/docs/developer-resources/contractkit/contracts-wrappers-registry.md
+++ b/packages/docs/developer-resources/contractkit/contracts-wrappers-registry.md
@@ -45,7 +45,7 @@ For the moment, we have contract wrappers for:
 - Exchange (Uniswap kind exchange between Gold and Stable tokens)
 - GasPriceMinimum
 - GoldToken
-- Gobernance
+- Governance
 - LockedGold
 - Reserve
 - SortedOracles


### PR DESCRIPTION
### Description

"gobernance" -> "governance"

### Other changes

n/a
### Tested

just docs

### Related issues

n/a
### Backwards compatibility

Fully backwards compatible

### Documentation

modifies `packages/docs/developer-resources/contractkit/contracts-wrappers-registry.md`