### PR TITLE
Fix governance encoding and decoding for unregistered contracts

### DIFF
--- a/packages/cli/src/commands/governance/build-proposal.ts
+++ b/packages/cli/src/commands/governance/build-proposal.ts
@@ -1,4 +1,3 @@
-import { Proposal } from '@celo/contractkit/src/wrappers/Governance'
 import {
   InteractiveProposalBuilder,
   ProposalBuilder,

--- a/packages/cli/src/commands/governance/build-proposal.ts
+++ b/packages/cli/src/commands/governance/build-proposal.ts
@@ -1,6 +1,12 @@
-import { InteractiveProposalBuilder, ProposalBuilder } from '@celo/governance/lib/proposals'
+import { Proposal } from '@celo/contractkit/src/wrappers/Governance'
+import {
+  InteractiveProposalBuilder,
+  ProposalBuilder,
+  proposalToJSON,
+  ProposalTransactionJSON,
+} from '@celo/governance/lib/proposals'
 import { flags } from '@oclif/command'
-import { writeFileSync } from 'fs-extra'
+import { readJsonSync, writeFileSync } from 'fs-extra'
 import { BaseCommand } from '../../base'
 import { checkProposal } from '../../utils/governance'
 
@@ -10,8 +16,20 @@ export default class BuildProposal extends BaseCommand {
   static flags = {
     ...BaseCommand.flags,
     output: flags.string({
-      required: true,
+      required: false,
       description: 'Path to output',
+      default: 'proposalTransactions.json',
+    }),
+    afterExecutingProposal: flags.string({
+      required: false,
+      description: 'Path to proposal which will be executed prior to proposal being built',
+      exclusive: ['afterExecutingID'],
+    }),
+    afterExecutingID: flags.string({
+      required: false,
+      description:
+        'Governance proposal identifier which will be executed prior to proposal being built',
+      exclusive: ['afterExecutingProposal'],
     }),
   }
 
@@ -21,6 +39,30 @@ export default class BuildProposal extends BaseCommand {
     const res = this.parse(BuildProposal)
 
     const builder = new ProposalBuilder(this.kit)
+
+    if (res.flags.afterExecutingID || res.flags.afterExecutingProposal) {
+      let preProposal: ProposalTransactionJSON[]
+      if (res.flags.afterExecutingID) {
+        const governance = await this.kit.contracts.getGovernance()
+        const proposalRaw = await governance.getProposal(res.flags.afterExecutingID)
+        preProposal = await proposalToJSON(this.kit, proposalRaw)
+      } else {
+        preProposal = readJsonSync(res.flags.afterExecutingProposal!)
+      }
+
+      // accounts for registry additions and caches in builder
+      for (const tx of preProposal) {
+        await builder.fromJsonTx(tx)
+      }
+
+      console.info(
+        `After executing provided proposal, account for registry remappings: ${JSON.stringify(
+          builder.registryAdditions,
+          null,
+          2
+        )}`
+      )
+    }
 
     // TODO: optimize builder redundancies
 

--- a/packages/cli/src/commands/network/contracts.ts
+++ b/packages/cli/src/commands/network/contracts.ts
@@ -2,7 +2,6 @@ import { concurrentMap } from '@celo/base'
 import { CeloContract } from '@celo/contractkit'
 import { newICeloVersionedContract } from '@celo/contractkit/lib/generated/ICeloVersionedContract'
 import { newProxy } from '@celo/contractkit/lib/generated/Proxy'
-import BigNumber from 'bignumber.js'
 import { cli } from 'cli-ux'
 import { table } from 'cli-ux/lib/styled/table'
 import { BaseCommand } from '../../base'
@@ -26,24 +25,11 @@ export default class Contracts extends BaseCommand {
   async run() {
     const res = this.parse(Contracts)
 
-    const undeployedMessage = 'Not deployed yet'
-    const addressMapping = await this.kit.registry.addressMappingWithNotDeployedContracts(
-      undeployedMessage
-    )
+    const addressMapping = await this.kit.registry.addressMapping()
     const contractInfo = await concurrentMap(
       4,
       Array.from(addressMapping.entries()),
       async ([contract, proxy]) => {
-        if (proxy === undefined || proxy === undeployedMessage) {
-          return {
-            contract,
-            proxy: undeployedMessage,
-            implementation: undeployedMessage,
-            version: 'NONE',
-            balances: await this.kit.celoTokens.forEachCeloToken(() => new BigNumber(0)),
-          }
-        }
-
         // skip implementation check for unproxied contract
         const implementation = UNPROXIED_CONTRACTS.includes(contract)
           ? 'NONE'

--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -14,8 +14,18 @@ USAGE
   $ celocli governance:build-proposal
 
 OPTIONS
-  --globalHelp     View all available global flags
-  --output=output  (required) Path to output
+  --afterExecutingID=afterExecutingID              Governance proposal identifier which
+                                                   will be executed prior to proposal
+                                                   being built
+
+  --afterExecutingProposal=afterExecutingProposal  Path to proposal which will be
+                                                   executed prior to proposal being
+                                                   built
+
+  --globalHelp                                     View all available global flags
+
+  --output=output                                  [default: proposalTransactions.json]
+                                                   Path to output
 
 EXAMPLE
   build-proposal --output ./transactions.json

--- a/packages/sdk/connect/src/utils/abi-utils.ts
+++ b/packages/sdk/connect/src/utils/abi-utils.ts
@@ -1,8 +1,8 @@
 import { ensureLeading0x } from '@celo/base/lib/address'
 import { AbiCoder, AbiItem, DecodedParamsObject } from '../abi-types'
 
-export const getAbiTypes = (abi: AbiItem[], methodName: string) =>
-  abi.find((entry) => entry.name! === methodName)!.inputs!.map((input) => input.type)
+export const getAbiByName = (abi: AbiItem[], methodName: string) =>
+  abi.find((entry) => entry.name! === methodName)!
 
 export const parseDecodedParams = (params: DecodedParamsObject) => {
   const args = new Array(params.__length__)

--- a/packages/sdk/contractkit/src/address-registry.ts
+++ b/packages/sdk/contractkit/src/address-registry.ts
@@ -9,6 +9,12 @@ const debug = debugFactory('kit:registry')
 // Registry contract is always predeployed to this address
 export const REGISTRY_CONTRACT_ADDRESS = '0x000000000000000000000000000000000000ce10'
 
+export class UnregisteredError extends Error {
+  constructor(contract: CeloContract) {
+    super(`${contract} not (yet) registered`)
+  }
+}
+
 /**
  * Celo Core Contract's Address Registry
  */
@@ -31,7 +37,7 @@ export class AddressRegistry {
 
       debug('Fetched address %s', address)
       if (!address || address === NULL_ADDRESS) {
-        throw new Error(`Failed to get address for ${contract} from the Registry`)
+        throw new UnregisteredError(contract)
       }
       this.cache.set(contract, address)
     }
@@ -43,24 +49,15 @@ export class AddressRegistry {
    * Get the address mapping for known registered contracts
    */
   async addressMapping() {
-    const allContracts = await this.addressMappingWithNotDeployedContracts()
-    const contracts: Map<CeloContract, string> = new Map()
-    allContracts.forEach((value, key) => (value ? contracts.set(key, value) : undefined))
-    return contracts
-  }
-
-  async addressMappingWithNotDeployedContracts(notDeployedValue?: string) {
-    const contracts: Map<CeloContract, string | undefined> = new Map()
     await Promise.all(
-      RegisteredContracts.map(async (r) => {
+      RegisteredContracts.map(async (contract) => {
         try {
-          const address = await this.addressFor(r)
-          contracts.set(r, address)
-        } catch {
-          contracts.set(r, notDeployedValue)
+          await this.addressFor(contract)
+        } catch (e) {
+          debug(e)
         }
       })
     )
-    return contracts
+    return this.cache
   }
 }

--- a/packages/sdk/contractkit/src/address-registry.ts
+++ b/packages/sdk/contractkit/src/address-registry.ts
@@ -7,7 +7,7 @@ import { ContractKit } from './kit'
 const debug = debugFactory('kit:registry')
 
 // Registry contract is always predeployed to this address
-const REGISTRY_CONTRACT_ADDRESS = '0x000000000000000000000000000000000000ce10'
+export const REGISTRY_CONTRACT_ADDRESS = '0x000000000000000000000000000000000000ce10'
 
 /**
  * Celo Core Contract's Address Registry

--- a/packages/sdk/contractkit/src/celo-tokens.ts
+++ b/packages/sdk/contractkit/src/celo-tokens.ts
@@ -251,13 +251,8 @@ export class CeloTokens {
    * @param token the token to get the (proxy) contract address for
    * @return A promise resolving to the address of the token's contract
    */
-  getAddress(token: CeloTokenType) {
-    try {
-      return this.kit.registry.addressFor(celoTokenInfos[token].contract)
-    } catch {
-      throw new Error(`${token} token not deployed yet in the chain`)
-    }
-  }
+  getAddress = (token: CeloTokenType) =>
+    this.kit.registry.addressFor(celoTokenInfos[token].contract)
 
   /**
    * Gets the address to use as the feeCurrency when paying for gas with the

--- a/packages/sdk/contractkit/src/index.ts
+++ b/packages/sdk/contractkit/src/index.ts
@@ -1,6 +1,5 @@
 export { Address, NULL_ADDRESS } from '@celo/base/lib/address'
 export { REGISTRY_CONTRACT_ADDRESS } from './address-registry'
-export { ABI as RegistryABI } from './generated/Registry'
 export {
   AllContracts,
   CeloContract,

--- a/packages/sdk/contractkit/src/index.ts
+++ b/packages/sdk/contractkit/src/index.ts
@@ -1,4 +1,6 @@
 export { Address, NULL_ADDRESS } from '@celo/base/lib/address'
+export { REGISTRY_CONTRACT_ADDRESS } from './address-registry'
+export { ABI as RegistryABI } from './generated/Registry'
 export {
   AllContracts,
   CeloContract,

--- a/packages/sdk/contractkit/src/proxy.ts
+++ b/packages/sdk/contractkit/src/proxy.ts
@@ -14,6 +14,7 @@ import { ABI as FreezerABI } from './generated/Freezer'
 import { ABI as GasPriceMinimumABI } from './generated/GasPriceMinimum'
 import { ABI as GoldTokenABI } from './generated/GoldToken'
 import { ABI as GovernanceABI } from './generated/Governance'
+import { ABI as GrandaMentoABI } from './generated/GrandaMento'
 import { ABI as LockedGoldABI } from './generated/LockedGold'
 import { ABI as MetaTransactionWalletABI } from './generated/MetaTransactionWallet'
 import { ABI as MetaTransactionWalletDeployerABI } from './generated/MetaTransactionWalletDeployer'
@@ -107,6 +108,7 @@ const initializeAbiMap = {
   GasPriceMinimumProxy: findInitializeAbi(GasPriceMinimumABI),
   GoldTokenProxy: findInitializeAbi(GoldTokenABI),
   GovernanceProxy: findInitializeAbi(GovernanceABI),
+  GrandaMentoProxy: findInitializeAbi(GrandaMentoABI),
   LockedGoldProxy: findInitializeAbi(LockedGoldABI),
   MetaTransactionWalletProxy: findInitializeAbi(MetaTransactionWalletABI),
   MetaTransactionWalletDeployerProxy: findInitializeAbi(MetaTransactionWalletDeployerABI),

--- a/packages/sdk/contractkit/src/web3-contract-cache.ts
+++ b/packages/sdk/contractkit/src/web3-contract-cache.ts
@@ -170,28 +170,17 @@ export class Web3ContractCache {
     if (this.cacheMap[contract] == null || address !== undefined) {
       // core contract in the registry
       if (!address) {
-        try {
-          address = await this.kit.registry.addressFor(contract)
-        } catch (e) {
-          throw new Error(`${contract} not yet deployed for this chain`)
-        }
+        address = await this.kit.registry.addressFor(contract)
       }
       debug('Initiating contract %s', contract)
-      const createFn = ProxyContracts.includes(contract)
-        ? newProxy
-        : ContractFactories[contract]
-        ? (ContractFactories[contract] as CFType[C])
-        : newProxy
-      // @ts-ignore: Too complex union type
-      this.cacheMap[contract] = createFn(this.kit.connection.web3, address) as NonNullable<
-        ContractCacheMap[C]
-      >
+      const createFn = ProxyContracts.includes(contract) ? newProxy : ContractFactories[contract]
+      this.cacheMap[contract] = createFn(this.kit.connection.web3, address) as ContractCacheMap[C]
     }
     // we know it's defined (thus the !)
     return this.cacheMap[contract]!
   }
 
   public invalidateContract<C extends keyof typeof ContractFactories>(contract: C) {
-    ;(this.cacheMap[contract] as any) = null
+    this.cacheMap[contract] = undefined
   }
 }

--- a/packages/sdk/explorer/src/base.ts
+++ b/packages/sdk/explorer/src/base.ts
@@ -1,6 +1,6 @@
 import { concurrentMap } from '@celo/base/lib/async'
 import { AbiItem, Address } from '@celo/connect'
-import { CeloContract, ContractKit, RegisteredContracts } from '@celo/contractkit'
+import { CeloContract, ContractKit } from '@celo/contractkit'
 
 export interface ContractDetails {
   name: string
@@ -21,13 +21,10 @@ export const getContractDetailsFromContract = async (
   }
 }
 
-export type AddressOverride = { [key in CeloContract]?: string }
-export async function obtainKitContractDetails(
-  kit: ContractKit,
-  addressOverride: AddressOverride = {}
-): Promise<ContractDetails[]> {
-  return concurrentMap(5, RegisteredContracts, (celoContract) =>
-    getContractDetailsFromContract(kit, celoContract, addressOverride[celoContract])
+export async function obtainKitContractDetails(kit: ContractKit): Promise<ContractDetails[]> {
+  const registry = await kit.registry.addressMapping()
+  return concurrentMap(5, Array.from(registry.entries()), ([celoContract, address]) =>
+    getContractDetailsFromContract(kit, celoContract, address)
   )
 }
 

--- a/packages/sdk/explorer/src/base.ts
+++ b/packages/sdk/explorer/src/base.ts
@@ -21,9 +21,13 @@ export const getContractDetailsFromContract = async (
   }
 }
 
-export async function obtainKitContractDetails(kit: ContractKit): Promise<ContractDetails[]> {
+export type AddressOverride = { [key in CeloContract]?: string }
+export async function obtainKitContractDetails(
+  kit: ContractKit,
+  addressOverride: AddressOverride = {}
+): Promise<ContractDetails[]> {
   return concurrentMap(5, RegisteredContracts, (celoContract) =>
-    getContractDetailsFromContract(kit, celoContract)
+    getContractDetailsFromContract(kit, celoContract, addressOverride[celoContract])
   )
 }
 

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -13,11 +13,11 @@ import {
   CeloContract,
   ContractKit,
   RegisteredContracts,
-  RegistryABI,
   REGISTRY_CONTRACT_ADDRESS,
 } from '@celo/contractkit'
 import { stripProxy, suffixProxy } from '@celo/contractkit/lib/base'
 import { ABI as GovernanceABI } from '@celo/contractkit/lib/generated/Governance'
+import { ABI as RegistryABI } from '@celo/contractkit/lib/generated/Registry'
 // tslint:disable: ordered-imports
 import {
   getInitializeAbiOfImplementation,

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -193,7 +193,7 @@ export class ProposalBuilder {
   constructor(
     private readonly kit: ContractKit,
     private readonly builders: Array<() => Promise<ProposalTransaction>> = [],
-    private readonly registryAdditions: RegistryAdditions = {}
+    public readonly registryAdditions: RegistryAdditions = {}
   ) {}
 
   /**

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -77,6 +77,9 @@ export interface ProposalTransactionJSON {
 const isRegistryRepoint = (tx: ProposalTransactionJSON) =>
   tx.contract === 'Registry' && tx.function === 'setAddressFor'
 
+const isGovernanceConstitutionSetter = (tx: ProposalTransactionJSON) =>
+  tx.contract === 'Governance' && tx.function === 'setConstitution'
+
 const registryRepointArgs = (tx: ProposalTransactionJSON) => {
   if (!isRegistryRepoint(tx)) {
     throw new Error(`Proposal transaction not a registry repoint:\n${JSON.stringify(tx, null, 2)}`)
@@ -103,9 +106,6 @@ const registryRepointRawArgs = (abiCoder: AbiCoder, tx: ProposalTransaction) => 
     address: params.addr,
   }
 }
-
-const isGovernanceConstitutionSetter = (tx: ProposalTransactionJSON) =>
-  tx.contract === 'Governance' && tx.function === 'setConstitution'
 
 const isProxySetAndInitFunction = (tx: ProposalTransactionJSON) =>
   tx.function === SET_AND_INITIALIZE_IMPLEMENTATION_ABI.name!


### PR DESCRIPTION
### Description

- Handles unregistered contracts in governance tooling
- Adds `--afterExecuting{ID|Proposal}` to `governance build:proposal` for batching support

### Other changes

- Unify unregistered contracts handling in sdk

### Tested

against staging
`./bin/run governance:show --node http://localhost:8545 --proposalID 19`

```yaml
proposal:
  0:
    contract: Registry
    function: setAddressFor
    args:
      0: GrandaMento
      1: 0xF9F8bfFB41883A0a224400C2CA3Aa629ae8156DC
    params:
      identifier: GrandaMento
      addr: 0xF9F8bfFB41883A0a224400C2CA3Aa629ae8156DC
    value: 0
  1:
    contract: GrandaMentoProxy
    function: _setAndInitializeImplementation
    args:
      0: 0xFA5696a00b612f23386fE0a58AdccB78c76012Fc
      1: 0xd13f90b4000000000000000000000000000000000000000000000000000000000000ce100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003f870857a3e0e380000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000127500
    params:
      implementation: 0xFA5696a00b612f23386fE0a58AdccB78c76012Fc
      callbackData: 0xd13f90b4000000000000000000000000000000000000000000000000000000000000ce100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003f870857a3e0e380000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000127500
      initialize@d13f90b4:
        _registry: 0x000000000000000000000000000000000000ce10
        _approver: 0x0000000000000000000000000000000000000000
        _maxApprovalExchangeRateChange: 300000000000000000000000
        _spread: 0
        _vetoPeriodSeconds: 1209600
    value: 0
```

`./bin/run governance:build-proposal --node http://localhost:8545 --output test.json --afterExecutingID 19`

```
After executing provided proposal, account for registry remappings: {
  "GrandaMento": "0xF9F8bfFB41883A0a224400C2CA3Aa629ae8156DC"
}
Transaction #1:
? Celo Contract: GrandaMento
? GrandaMento Function: setStableTokenExchangeLimits
? stableTokenRegistryId: StableTokenEUR
? minExchangeAmount: 100
? maxExchangeAmount: 10000
Transaction #2:
? Celo Contract: ✔ done
Outputting proposal to test.json
Simulating proposal execution
```