### PR TITLE
CLI governance:propose support for dependencies on existing proposals

### DIFF
--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -255,23 +255,32 @@ USAGE
   $ celocli governance:show
 
 OPTIONS
-  --account=account                    Address of account or voter
-  --globalHelp                         View all available global flags
-  --hotfix=hotfix                      Hash of hotfix proposal
-  --jsonTransactions=jsonTransactions  Output proposal JSON to provided file
+  --account=account                                Address of account or voter
 
-  --nonwhitelisters                    If set, displays validators that have not
-                                       whitelisted the hotfix.
+  --afterExecutingID=afterExecutingID              Governance proposal identifier which
+                                                   will be executed prior to proposal
 
-  --notwhitelisted                     List validators who have not whitelisted the
-                                       specified hotfix
+  --afterExecutingProposal=afterExecutingProposal  Path to proposal which will be
+                                                   executed prior to proposal
 
-  --proposalID=proposalID              UUID of proposal to view
+  --globalHelp                                     View all available global flags
 
-  --raw                                Display proposal in raw bytes format
+  --hotfix=hotfix                                  Hash of hotfix proposal
 
-  --whitelisters                       If set, displays validators that have whitelisted
-                                       the hotfix.
+  --jsonTransactions=jsonTransactions              Output proposal JSON to provided file
+
+  --nonwhitelisters                                If set, displays validators that have
+                                                   not whitelisted the hotfix.
+
+  --notwhitelisted                                 List validators who have not
+                                                   whitelisted the specified hotfix
+
+  --proposalID=proposalID                          UUID of proposal to view
+
+  --raw                                            Display proposal in raw bytes format
+
+  --whitelisters                                   If set, displays validators that have
+                                                   whitelisted the hotfix.
 
 ALIASES
   $ celocli governance:show

--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -193,6 +193,13 @@ USAGE
   $ celocli governance:propose
 
 OPTIONS
+  --afterExecutingID=afterExecutingID                Governance proposal identifier
+                                                     which will be executed prior to
+                                                     proposal
+
+  --afterExecutingProposal=afterExecutingProposal    Path to proposal which will be
+                                                     executed prior to proposal
+
   --deposit=deposit                                  (required) Amount of Gold to attach
                                                      to proposal
 

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -132,13 +132,15 @@ export const proposalToJSON = async (
     await blockExplorer.updateContractDetailsMapping(stripProxy(name), address)
   }
 
-  // Update the registry mapping with registry additions prior to processing the proposal.
-  for (const nameStr in registryAdditions) {
-    const name = nameStr as CeloContract
-    if (!CeloContract[name]) {
-      throw new Error(`Name ${nameStr} in registry additions not a CeloContract`)
+  if (registryAdditions) {
+    // Update the registry mapping with registry additions prior to processing the proposal.
+    for (const nameStr of Object.keys(registryAdditions)) {
+      const name = nameStr as CeloContract
+      if (!CeloContract[name]) {
+        throw new Error(`Name ${nameStr} in registry additions not a CeloContract`)
+      }
+      await updateRegistryMapping(name, registryAdditions[name])
     }
-    await updateRegistryMapping(name, registryAdditions[name])
   }
 
   const abiCoder = kit.connection.getAbiCoder()


### PR DESCRIPTION
### Description

This was needed to create the GrandaMento "activation" governance proposal on staging while CR5 (the proposal that would set GrandaMento in the registry & initialize the contract) was not executed yet.

* Brings out the `--afterExecutingProposal` and `--afterExecutingID` logic from `governance:build-proposal` and reuses it in `governance:propose`
* Allows registry additions to be passed into `proposalToJSON`

### Other changes

n/a

### Tested

Was able to propose the GrandaMento activation governance proposal with the use of `--afterExecutingID`

### Related issues

n/a

### Backwards compatibility

Fully backward compatible

### Documentation

Doc changes autogenerated