### PR TITLE
Granda Mento env test small fixes

### DIFF
--- a/packages/env-tests/src/tests/granda-mento.ts
+++ b/packages/env-tests/src/tests/granda-mento.ts
@@ -47,7 +47,6 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
 
           let buyToken: GoldTokenWrapper | StableTokenWrapper
           let sellToken: GoldTokenWrapper | StableTokenWrapper
-          let stableTokenAddress: string
           let sellAmount: BigNumber
 
           beforeEach(async () => {
@@ -55,7 +54,7 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
             const stableTokenWrapper = await context.kit.celoTokens.getWrapper(
               stableToken as StableToken
             )
-            stableTokenAddress = stableTokenWrapper.address
+            // stableTokenAddress = stableTokenWrapper.address
             if (sellCelo) {
               buyToken = stableTokenWrapper
               sellToken = goldTokenWrapper
@@ -234,13 +233,7 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
             }
             expect(sellTokenBalanceAfter.toString()).toBe(expectedSellTokenBalanceAfter.toString())
 
-            const sortedOracles = await context.kit.contracts.getSortedOracles()
-            const celoStableTokenRate = (await sortedOracles.medianRate(stableTokenAddress)).rate
-
-            const exchangeRate = sellCelo
-              ? celoStableTokenRate
-              : new BigNumber(1).div(celoStableTokenRate)
-            const buyAmount = getBuyAmount(exchangeRate, sellAmount, await grandaMento.spread())
+            const { buyAmount } = await grandaMento.getExchangeProposal(creationInfo.proposalId)
 
             const buyTokenBalanceAfter = await buyToken.balanceOf(from.address)
             let expectedBuyTokenBalanceAfter = buyTokenBalanceBefore.plus(buyAmount)
@@ -249,9 +242,7 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
                 creationInfo.celoFees
               )
             }
-            expect(
-              almostEqual(buyTokenBalanceAfter, expectedBuyTokenBalanceAfter, new BigNumber(50000))
-            ).toEqual(true)
+            expect(buyTokenBalanceAfter.toString()).toEqual(expectedBuyTokenBalanceAfter.toString)
           })
         })
       }
@@ -259,10 +250,10 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
   })
 }
 
-// exchangeRate is the price of the sell token quoted in buy token
-function getBuyAmount(exchangeRate: BigNumber, sellAmount: BigNumber, spread: BigNumber.Value) {
-  return sellAmount.times(new BigNumber(1).minus(spread)).times(exchangeRate)
-}
+// // exchangeRate is the price of the sell token quoted in buy token
+// function getBuyAmount(exchangeRate: BigNumber, sellAmount: BigNumber, spread: BigNumber.Value) {
+//   return sellAmount.times(new BigNumber(1).minus(spread)).times(exchangeRate)
+// }
 
 function almostEqual(a: BigNumber, b: BigNumber, tolerance: BigNumber) {
   const minValue = b.minus(tolerance)

--- a/packages/env-tests/src/tests/granda-mento.ts
+++ b/packages/env-tests/src/tests/granda-mento.ts
@@ -249,14 +249,3 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
     }
   })
 }
-
-// // exchangeRate is the price of the sell token quoted in buy token
-// function getBuyAmount(exchangeRate: BigNumber, sellAmount: BigNumber, spread: BigNumber.Value) {
-//   return sellAmount.times(new BigNumber(1).minus(spread)).times(exchangeRate)
-// }
-
-function almostEqual(a: BigNumber, b: BigNumber, tolerance: BigNumber) {
-  const minValue = b.minus(tolerance)
-  const maxValue = b.plus(tolerance)
-  return a.gte(minValue) && a.lte(maxValue)
-}

--- a/packages/env-tests/src/tests/granda-mento.ts
+++ b/packages/env-tests/src/tests/granda-mento.ts
@@ -54,7 +54,6 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
             const stableTokenWrapper = await context.kit.celoTokens.getWrapper(
               stableToken as StableToken
             )
-            // stableTokenAddress = stableTokenWrapper.address
             if (sellCelo) {
               buyToken = stableTokenWrapper
               sellToken = goldTokenWrapper

--- a/packages/env-tests/src/tests/granda-mento.ts
+++ b/packages/env-tests/src/tests/granda-mento.ts
@@ -16,11 +16,11 @@ import {
 } from '../scaffold'
 
 export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: StableToken[]) {
-  const celoAmountToFund = ONE.times(61000)
-  const stableTokenAmountToFund = ONE.times(61000)
+  const celoAmountToFund = ONE.times(610000)
+  const stableTokenAmountToFund = ONE.times(610000)
 
-  const celoAmountToSell = ONE.times(60000)
-  const stableTokenAmountToSell = ONE.times(60000)
+  const celoAmountToSell = ONE.times(600000)
+  const stableTokenAmountToSell = ONE.times(600000)
 
   describe('Granda Mento Test', () => {
     beforeAll(async () => {
@@ -249,7 +249,9 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
                 creationInfo.celoFees
               )
             }
-            expect(buyTokenBalanceAfter.toString()).toBe(expectedBuyTokenBalanceAfter.toString())
+            expect(
+              almostEqual(buyTokenBalanceAfter, expectedBuyTokenBalanceAfter, new BigNumber(50000))
+            ).toEqual(true)
           })
         })
       }
@@ -260,4 +262,10 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
 // exchangeRate is the price of the sell token quoted in buy token
 function getBuyAmount(exchangeRate: BigNumber, sellAmount: BigNumber, spread: BigNumber.Value) {
   return sellAmount.times(new BigNumber(1).minus(spread)).times(exchangeRate)
+}
+
+function almostEqual(a: BigNumber, b: BigNumber, tolerance: BigNumber) {
+  const minValue = b.minus(tolerance)
+  const maxValue = b.plus(tolerance)
+  return a.gte(minValue) && a.lte(maxValue)
 }

--- a/packages/env-tests/src/tests/granda-mento.ts
+++ b/packages/env-tests/src/tests/granda-mento.ts
@@ -242,7 +242,7 @@ export function runGrandaMentoTest(context: EnvTestContext, stableTokensToTest: 
                 creationInfo.celoFees
               )
             }
-            expect(buyTokenBalanceAfter.toString()).toEqual(expectedBuyTokenBalanceAfter.toString)
+            expect(buyTokenBalanceAfter.toString()).toBe(expectedBuyTokenBalanceAfter.toString)
           })
         })
       }


### PR DESCRIPTION
### Description

* Changed the trade size to be within the proposed limits of [500k, 50m] (cUSD) and [400k, 40m] (cEUR)
* Rather than relying upon the oracle price (which can change) for calculating the buy amount, just uses the buyAmount from the proposal itself

### Other changes

n/a

### Tested

Ran Granda Mento env test on staging

### Related issues

n/a

### Backwards compatibility

Fully

### Documentation

n/a