### PR TITLE
Use tx.value when getting revert reason in estimateGas

### DIFF
--- a/packages/sdk/connect/src/connection.ts
+++ b/packages/sdk/connect/src/connection.ts
@@ -333,7 +333,7 @@ export class Connection {
       debugGasEstimation('estimatedGas: %s', gas.toString())
       return gas
     } catch (e) {
-      const called = await caller({ data: tx.data, to: tx.to, from: tx.from })
+      const called = await caller({ data: tx.data, to: tx.to, from: tx.from, value: tx.value })
       let revertReason = 'Could not decode transaction failure reason'
       if (called.startsWith('0x08c379a')) {
         revertReason = decodeStringParameter(this.getAbiCoder(), called.substring(10))


### PR DESCRIPTION
### Description

Ran into an issue with @yorhodes where if an `eth_estimateGas` call fails, the subsequent `eth_call` to get the revert reason does not use the tx's value.

### Other changes

n/a

### Tested

Ran code path via CLI

### Related issues

n/a

### Backwards compatibility

Fully backward compatible

### Documentation

n/a