### PR TITLE
Exclude phoenix metric until is being need it

### DIFF
--- a/packages/celotool/src/lib/prometheus.ts
+++ b/packages/celotool/src/lib/prometheus.ts
@@ -180,6 +180,7 @@ async function helmParameters(context?: string, clusterConfig?: BaseClusterConfi
       'apiserver_.+',
       'etcd_.+',
       'nginx_.+',
+      'phoenix_.+',
       'erlang_.+',
       'kubelet_[^v].+',
       'container_tasks_state',


### PR DESCRIPTION
### Description

Exclude phoenix metric until we need it for some alerting or dashboarding.
