### PR TITLE
Impemented a smoother scale down policy for blockscout api hpa

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-api
@@ -16,4 +16,27 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.blockscout.api.autoscaling.target.cpu }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.blockscout.api.autoscaling.target.cpu }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 60
+      - type: Pods
+        value: 1
+        periodSeconds: 60
+      selectPolicy: Min
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 30
+      - type: Pods
+        value: 2
+        periodSeconds: 30
+      selectPolicy: Max


### PR DESCRIPTION
### Description

Defines scale up and scale down behavior for blockscout API HPA.
Scales up if the average CPU usage is higher than the defined threshold (currently 70%), doubling the number of pods or adding 2 pods every 30 seconds whichever affects the higher number of pods.
Scales down after 10 minutes removing 20% of pods or 1 pod every minute whichever affects the smaller number of pods.

### Tested

Tested on staging.

### Documentation

https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior