### PR TITLE
Allow core services to review blockscout helm chart changes.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,5 +38,5 @@
 
 # helm-charts rules.
 /packages/helm-charts/ @nambrot @timmoreton
-/packages/helm-charts/blockscout @celo-org/core-services
+/packages/helm-charts/blockscout/ @celo-org/core-services
 /packages/helm-charts/oracle/ @celo-org/platform-economics

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,4 +38,5 @@
 
 # helm-charts rules.
 /packages/helm-charts/ @nambrot @timmoreton
+/packages/helm-charts/blockscout @celo-org/core-services
 /packages/helm-charts/oracle/ @celo-org/platform-economics


### PR DESCRIPTION
Add `@celo-org/core-services` to `packages/helm-charts/blockscout` codeowners