### PR TITLE
Remove validator group confirmation for revoking votes

### DIFF
--- a/packages/cli/src/commands/election/revoke.ts
+++ b/packages/cli/src/commands/election/revoke.ts
@@ -24,10 +24,7 @@ export default class ElectionRevoke extends BaseCommand {
   async run() {
     const res = this.parse(ElectionRevoke)
 
-    await newCheckBuilder(this, res.flags.from)
-      .isSignerOrAccount()
-      .isValidatorGroup(res.flags.for)
-      .runChecks()
+    await newCheckBuilder(this, res.flags.from).isSignerOrAccount().runChecks()
 
     const election = await this.kit.contracts.getElection()
     const accounts = await this.kit.contracts.getAccounts()

--- a/packages/cli/src/commands/releasegold/revoke-votes.ts
+++ b/packages/cli/src/commands/releasegold/revoke-votes.ts
@@ -30,10 +30,7 @@ export default class RevokeVotes extends ReleaseGoldBaseCommand {
     const beneficiary = await this.releaseGoldWrapper.getBeneficiary()
     const releaseOwner = await this.releaseGoldWrapper.getReleaseOwner()
     const votes = new BigNumber(flags.votes)
-    await newCheckBuilder(this)
-      .isAccount(this.releaseGoldWrapper.address)
-      .isValidatorGroup(flags.group)
-      .runChecks()
+    await newCheckBuilder(this).isAccount(this.releaseGoldWrapper.address).runChecks()
 
     this.kit.defaultAccount = isRevoked ? releaseOwner : beneficiary
     const txos = await this.releaseGoldWrapper.revoke(


### PR DESCRIPTION
### Description

Currently if you have votes for a validator group and that group is deregistered you are unable to revoke your votes for that group.

### Tested

Was still able to revoke for an existing validator group.

### Backwards compatibility

Yes backwards compatible.

### Documentation

No changes.