### PR TITLE
Blockscout nginx redirects

### DIFF
--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -179,6 +179,12 @@ metadata:
       location ~ /wobserver/.* {
         deny all;
       }
+      location ~ /address/(.*)/token_transfers {
+        return 301 /address/$1/token-transfers;
+      }
+      location ~ /address/(.*)/coin_balances {
+        return 301 /address/$1/coin-balances;
+      }
   labels:
     app: blockscout
     chart: blockscout


### PR DESCRIPTION
### Description

This adds redirects to the default Blockscout ingress as well.

### Other changes

-

### Tested

Tested on all envs.

### Related issues

- A follow-up for https://github.com/celo-org/data-services/issues/55

### Backwards compatibility

Yes.