### PR TITLE
Remove eksportisto 8 deployment config.

### DIFF
--- a/.env.rc1
+++ b/.env.rc1
@@ -242,13 +242,6 @@ TRANSACTION_METRICS_EXPORTER_DOCKER_IMAGE_REPOSITORY="gcr.io/celo-testnet/celo-m
 TRANSACTION_METRICS_EXPORTER_DOCKER_IMAGE_TAG="transaction-metrics-exporter-f4a55e143932ea559cf4bcbd9bcccc14da43d6ed"
 
 # This is still being used-- we have multiple eksportisto deployments at the moment.
-# Uncomment if an upgrade for suffix 8 is needed:
-# EKSPORTISTO_DOCKER_IMAGE_REPOSITORY="us.gcr.io/celo-testnet/eksportisto"
-# EKSPORTISTO_DOCKER_IMAGE_TAG="5bdf79c3b079c4ca15da37142056520f25101880"
-# EKSPORTISTO_SUFFIX='8'
-# EKSPORTISTO_CHART_VERSION=1
-
-# This is still being used-- we have multiple eksportisto deployments at the moment.
 # Uncomment if an upgrade for suffix 11 is needed:
 # EKSPORTISTO_DOCKER_IMAGE_REPOSITORY="us.gcr.io/celo-testnet/eksportisto"
 # EKSPORTISTO_DOCKER_IMAGE_TAG="23e89b23f6b6ac76f9d22107b34f88f5f3d57e52"


### PR DESCRIPTION
### Description

As eksportisto 8 is no longer running, remove it from the deployment configuration.

### Tested

Not tested, as we're removing commented out lines from a configuration file.

### Related issues

- https://github.com/celo-org/eksportisto/issues/81

### Backwards compatibility

We'll no longer be able to deploy eksportisto 8.