### PR TITLE
Fix eksportisto helm release existence test.

### DIFF
--- a/packages/celotool/src/lib/eksportisto.ts
+++ b/packages/celotool/src/lib/eksportisto.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { execCmd, execCmdAndParseJson, outputIncludes } from 'src/lib/cmd-utils'
+import { execCmd, execCmdAndParseJson } from 'src/lib/cmd-utils'
 import { envVar, fetchEnv, fetchEnvOrFallback, isVmBased } from 'src/lib/env-utils'
 import {
   getConfigMapHashes,
@@ -82,7 +82,8 @@ export async function removeHelmRelease(celoEnv: string) {
 async function getServiceAccountKeyBase64FromHelm(celoEnv: string) {
   const suffix = fetchEnvOrFallback(envVar.EKSPORTISTO_SUFFIX, '1')
   const relName = releaseName(celoEnv, suffix)
-  const chartInstalled = await outputIncludes(`helm list -n ${celoEnv}`, `${relName}`)
+  const installedCharts = await execCmdAndParseJson(`helm list --short -o json -n ${celoEnv}`)
+  const chartInstalled = installedCharts.includes(relName)
   if (chartInstalled) {
     const [output] = await execCmd(`helm get values -n ${celoEnv} ${relName}`)
     const values: any = yaml.safeLoad(output)


### PR DESCRIPTION
### Description

Fix eksportisto helm release existence test -- the previous implementation would incorrectly match for
`rc1-eksportisto-1` on `rc1-eksportisto-11`.

### Tested

Tested with helmdryrun.

### Related issues

- https://github.com/celo-org/eksportisto/issues/81

### Backwards compatibility

Backwards compatible.