### PR TITLE
Fix service account utils.

### DIFF
--- a/packages/celotool/src/lib/service-account-utils.ts
+++ b/packages/celotool/src/lib/service-account-utils.ts
@@ -27,7 +27,7 @@ export async function createServiceAccountIfNotExists(name: string, gcloudProjec
 // given name
 export async function getServiceAccountEmail(serviceAccountName: string) {
   const [output] = await execCmdWithExitOnFailure(
-    `gcloud iam service-accounts list --filter="displayName:${serviceAccountName}" --format='value[terminator=""](email)'`
+    `gcloud iam service-accounts list --filter="displayName<=${serviceAccountName} AND displayName>=${serviceAccountName}" --format='value[terminator=""](email)'`
   )
   return output
 }

--- a/packages/celotool/src/lib/service-account-utils.ts
+++ b/packages/celotool/src/lib/service-account-utils.ts
@@ -1,5 +1,5 @@
-import { execCmdWithExitOnFailure } from './cmd-utils'
-import { outputIncludes, switchToGCPProject, switchToProjectFromEnv } from './utils'
+import { execCmdAndParseJson, execCmdWithExitOnFailure } from './cmd-utils'
+import { switchToGCPProject, switchToProjectFromEnv } from './utils'
 
 // createServiceAccountIfNotExists creates a service account with the given name
 // if it does not exist. Returns if the account was created.
@@ -10,11 +10,10 @@ export async function createServiceAccountIfNotExists(name: string, gcloudProjec
     await switchToProjectFromEnv()
   }
   // TODO: add permissions for cloudsql editor to service account
-  const serviceAccountExists = await outputIncludes(
-    `gcloud iam service-accounts list`,
-    name,
-    `GCP Service account ${name} exists, skipping creation`
+  const serviceAccounts = await execCmdAndParseJson(
+    `gcloud iam service-accounts list --quiet --format json`
   )
+  const serviceAccountExists = serviceAccounts.some((account: any) => account.displayName === name)
   if (!serviceAccountExists) {
     await execCmdWithExitOnFailure(
       `gcloud iam service-accounts create ${name} --display-name="${name}"`


### PR DESCRIPTION
### Description

As it is, when trying to fetch the e-mail associated with a service account, more than one account might match given a name. Change the filtering from "displayName:$QUERY" to "displayName<=$QUERY AND displayName>=$QUERY", as suggested by gcloud's documentation (https://cloud.google.com/sdk/gcloud/reference/topic/filters).

Additionally, there was an existence check that would return false positives due to prefix matches. 

### Tested

Tested locally with helm dry-run.

### Related issues

- https://github.com/celo-org/eksportisto/issues/81

### Backwards compatibility

Backwards compatible.