### PR TITLE
Fix sourcify verification full_match path

### DIFF
--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -150,7 +150,7 @@ blockscout:
     sourcify:
       enabled: true
       serverUrl: https://sourcify.dev/server
-      repoUrl: https://repo.sourcify.dev/contracts/full_match/
+      repoUrl: https://repo.sourcify.dev/contracts
     resources:
       requests:
         memory: 250M


### PR DESCRIPTION
### Description

The link has an extra '/full_match' in it that breaks it.

### Tested

In alfajores

### Related issues

- Close https://github.com/celo-org/blockscout/issues/427
