### PR TITLE
Ingest AKS logs in Grafana Cloud

### DIFF
--- a/packages/celotool/src/lib/promtail.ts
+++ b/packages/celotool/src/lib/promtail.ts
@@ -85,9 +85,10 @@ async function helmParameters(clusterConfig?: BaseClusterConfig) {
       break
 
     case CloudProvider.AZURE:
-    // TODO
+      // Nothing special to be done.
+      break
+
     case CloudProvider.AWS:
-    // TODO
     default:
       console.error(`Unrecognised or unsupported cloud provider: ${cloudProvider}`)
       process.exit(1)

--- a/packages/helm-charts/promtail/values.yaml
+++ b/packages/helm-charts/promtail/values.yaml
@@ -14,6 +14,11 @@ config:
       - docker: {}
 
     extraRelabelConfigs:
+    # Do not ingest logs for fluentd.
+    - action: drop
+      source_labels:
+        - app
+      regex: fluentd-log-agent
     # Keep Kubernetes pod labels.
     - action: labelmap
       regex: __meta_kubernetes_pod_label_(.+)
@@ -23,7 +28,7 @@ config:
         - namespace
       # TODO: reconsider what should be kept from the default namespace
       # eg: ingress controller
-      regex: (alfajores|baklava|default|rc1|walletconnect)
+      regex: (alfajores|baklava|default|komenci|rc1|walletconnect)
 
 serviceAccount:
   # add a iam.gke.io/gcp-service-account, see


### PR DESCRIPTION
### Description

Forward AKS application logs to Grafana Cloud's Loki instance through the Promtail client.
Same rationale and implementation as #8827.

### Other changes

N/A

### Tested

```sh
celotooljs.sh deploy initial promtail -e alfajores --verbose --context azure-odis-eastus-1 
```

### Related issues

- Relates to celo-org/data-services#70

### Backwards compatibility

No breaking changes.

### Documentation

N/A

### NB

This is a stacked pull request on top of #8827.