### PR TITLE
Fix bug in signature parsing for EIP712TypedData

### DIFF
--- a/packages/sdk/identity/src/offchain-data-wrapper.ts
+++ b/packages/sdk/identity/src/offchain-data-wrapper.ts
@@ -1,11 +1,15 @@
-import { Address, ensureLeading0x, eqAddress } from '@celo/base/lib/address'
+import { Address, ensureLeading0x } from '@celo/base/lib/address'
 import { Err, makeAsyncThrowable, Ok, Result, RootError } from '@celo/base/lib/result'
 import { ContractKit } from '@celo/contractkit'
 import { ClaimTypes } from '@celo/contractkit/lib/identity/claims/types'
 import { IdentityMetadataWrapper } from '@celo/contractkit/lib/identity/metadata'
 import { publicKeyToAddress } from '@celo/utils/lib/address'
 import { ensureUncompressed } from '@celo/utils/lib/ecdh'
-import { recoverEIP712TypedDataSigner } from '@celo/utils/lib/signatureUtils'
+import {
+  recoverEIP712TypedDataSignerRsv,
+  recoverEIP712TypedDataSignerVrs,
+  verifyEIP712TypedDataSigner,
+} from '@celo/utils/lib/signatureUtils'
 import fetch from 'cross-fetch'
 import debugFactory from 'debug'
 import * as t from 'io-ts'
@@ -166,8 +170,8 @@ class StorageRoot {
 
     const toParse = type ? JSON.parse(body.toString()) : body
     const typedData = await buildEIP712TypedData(this.wrapper, dataPath, toParse, type)
-    const guessedSigner = recoverEIP712TypedDataSigner(typedData, signature)
-    if (eqAddress(guessedSigner, this.account)) {
+
+    if (verifyEIP712TypedDataSigner(typedData, signature, this.account)) {
       return Ok(body)
     }
 
@@ -183,11 +187,17 @@ class StorageRoot {
       const dekAddress = keys[3] ? publicKeyToAddress(ensureUncompressed(keys[3])) : '0x0'
       const signers = [keys[0], keys[1], keys[2], dekAddress]
 
-      if (signers.some((signer) => eqAddress(signer, guessedSigner))) {
+      if (signers.some((signer) => verifyEIP712TypedDataSigner(typedData, signature, signer))) {
         return Ok(body)
       }
 
       if (checkOffchainSigners) {
+        let guessedSigner: string
+        try {
+          guessedSigner = recoverEIP712TypedDataSignerRsv(typedData, signature)
+        } catch (error) {
+          guessedSigner = recoverEIP712TypedDataSignerVrs(typedData, signature)
+        }
         const authorizedSignerAccessor = new AuthorizedSignerAccessor(this.wrapper)
         const authorizedSigner = await authorizedSignerAccessor.readAsResult(
           this.account,

--- a/packages/sdk/utils/src/signatureUtils.test.ts
+++ b/packages/sdk/utils/src/signatureUtils.test.ts
@@ -70,5 +70,21 @@ describe('signatures', () => {
       )
       expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
     })
+    it('should verify signer from sig of EIP712 typed data', () => {
+      // generated via contractKit's signTypedData
+      const vrsSignature =
+        '0x1c106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
+      expect(
+        SignatureUtils.verifyEIP712TypedDataSigner(typedData, vrsSignature, signer)
+      ).toBeTruthy()
+    })
+    it('should not verify signer from invalid sig of EIP712 typed data', () => {
+      // Modified 'v' from 1c -> 1b (28 -> 27)
+      const invalidSignature =
+        '0x1b106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
+      expect(
+        SignatureUtils.verifyEIP712TypedDataSigner(typedData, invalidSignature, signer)
+      ).toBeFalsy()
+    })
   })
 })

--- a/packages/sdk/utils/src/signatureUtils.test.ts
+++ b/packages/sdk/utils/src/signatureUtils.test.ts
@@ -33,57 +33,54 @@ describe('signatures', () => {
     const pKey = '0xac8ca7aeb0f57f1ed1ce98a695dabcb0278faf03d68e1bae08c9095355a28b06'
     const signer = privateKeyToAddress(pKey)
     const typedData = attestationSecurityCode('1000023')
+    // generated via LocalWallet's signTypedData
+    const rsvSignature =
+      '0x106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a10001'
+    // generated via contractKit's signTypedData
+    const vrsSignature =
+      '0x1c106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
+    const signature = {
+      v: 28,
+      r: '0x106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b',
+      s: '0x39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100',
+    }
+    // Modified 'v' from 1c -> 1b (28 -> 27)
+    const invalidVrsSignature =
+      '0x1b106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
 
     it('should recover signer from RSV-serialized sig of EIP712 typed data ', () => {
-      // generated via LocalWallet's signTypedData
-      const rsvSignature =
-        '0x106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a10001'
-      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
+      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSignerRsv(
         typedData,
-        rsvSignature,
-        signer
+        rsvSignature
       )
       expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
     })
     it('should recover signer from VSR-serialized sig of EIP712 typed data', () => {
-      // generated via contractKit's signTypedData
-      const vrsSignature =
-        '0x1c106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
-      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
+      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSignerVrs(
         typedData,
-        vrsSignature,
-        signer
+        vrsSignature
       )
       expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
     })
-    it('should recover signer from serializeSignature output', () => {
-      const signature = {
-        v: 28,
-        r: '0x106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b',
-        s: '0x39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100',
-      }
-      const serializedSig = SignatureUtils.serializeSignature(signature)
-      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
-        typedData,
-        serializedSig,
-        signer
-      )
-      expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
+    it('should verify signer from RSV-serialized sig of EIP712 typed data', () => {
+      expect(
+        SignatureUtils.verifyEIP712TypedDataSigner(typedData, rsvSignature, signer)
+      ).toBeTruthy()
     })
-    it('should verify signer from sig of EIP712 typed data', () => {
-      // generated via contractKit's signTypedData
-      const vrsSignature =
-        '0x1c106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
+    it('should verify signer from VSR-serialized sig of EIP712 typed data', () => {
       expect(
         SignatureUtils.verifyEIP712TypedDataSigner(typedData, vrsSignature, signer)
       ).toBeTruthy()
     })
-    it('should not verify signer from invalid sig of EIP712 typed data', () => {
-      // Modified 'v' from 1c -> 1b (28 -> 27)
-      const invalidSignature =
-        '0x1b106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
+    it('should verify signer from serializeSignature output', () => {
+      const serializedSig = SignatureUtils.serializeSignature(signature)
       expect(
-        SignatureUtils.verifyEIP712TypedDataSigner(typedData, invalidSignature, signer)
+        SignatureUtils.verifyEIP712TypedDataSigner(typedData, serializedSig, signer)
+      ).toBeTruthy()
+    })
+    it('should not verify signer from invalid sig of EIP712 typed data', () => {
+      expect(
+        SignatureUtils.verifyEIP712TypedDataSigner(typedData, invalidVrsSignature, signer)
       ).toBeFalsy()
     })
   })

--- a/packages/sdk/utils/src/signatureUtils.test.ts
+++ b/packages/sdk/utils/src/signatureUtils.test.ts
@@ -1,9 +1,13 @@
+import { newKit } from '@celo/contractkit'
+import { attestationSecurityCode } from '@celo/utils/lib/typed-data-constructors'
+import { LocalWallet } from '@celo/wallet-local'
 import * as Web3Utils from 'web3-utils'
 import { privateKeyToAddress } from './address'
 import {
   parseSignature,
   parseSignatureWithoutPrefix,
   serializeSignature,
+  SignatureUtils,
   signMessage,
   signMessageWithoutPrefix,
 } from './signatureUtils'
@@ -25,5 +29,40 @@ describe('signatures', () => {
     const signature = signMessage(message, pKey, address)
     const serializedSig = serializeSignature(signature)
     parseSignature(message, serializedSig, address)
+  })
+
+  it('should recover signer from RSV-serialized sig of EIP712 typed data ', async () => {
+    const pKey = '0xac8ca7aeb0f57f1ed1ce98a695dabcb0278faf03d68e1bae08c9095355a28b06'
+    const wallet = new LocalWallet()
+    wallet.addAccount(pKey)
+    const typedData = attestationSecurityCode('1000023')
+    const signer = wallet.getAccounts()[0]
+    // returns RSV-serialized signature
+    const signature = await wallet.signTypedData(signer, typedData)
+    const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
+      typedData,
+      signature,
+      signer
+    )
+    expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
+  })
+
+  it('should recover signer from VSR-serialized sig of EIP712 typed data', async () => {
+    const pKey = '0xac8ca7aeb0f57f1ed1ce98a695dabcb0278faf03d68e1bae08c9095355a28b06'
+    const wallet = new LocalWallet()
+    wallet.addAccount(pKey)
+    const kit = newKit('https://alfajores-forno.celo-testnet.org', wallet)
+    const typedData = attestationSecurityCode('1000023')
+    const signer = wallet.getAccounts()[0]
+    // returns raw signature
+    const signature = await kit.signTypedData(signer, typedData)
+    // serializes to VRS-serialized signature
+    const serializedSig = SignatureUtils.serializeSignature(signature)
+    const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
+      typedData,
+      serializedSig,
+      signer
+    )
+    expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
   })
 })

--- a/packages/sdk/utils/src/signatureUtils.test.ts
+++ b/packages/sdk/utils/src/signatureUtils.test.ts
@@ -1,6 +1,3 @@
-import { newKit } from '@celo/contractkit'
-import { attestationSecurityCode } from '@celo/utils/lib/typed-data-constructors'
-import { LocalWallet } from '@celo/wallet-local'
 import * as Web3Utils from 'web3-utils'
 import { privateKeyToAddress } from './address'
 import {
@@ -11,6 +8,7 @@ import {
   signMessage,
   signMessageWithoutPrefix,
 } from './signatureUtils'
+import { attestationSecurityCode } from './typed-data-constructors'
 
 describe('signatures', () => {
   it('should sign appropriately with a hash of a message', () => {
@@ -31,38 +29,46 @@ describe('signatures', () => {
     parseSignature(message, serializedSig, address)
   })
 
-  it('should recover signer from RSV-serialized sig of EIP712 typed data ', async () => {
+  describe('EIP712 signatures', () => {
     const pKey = '0xac8ca7aeb0f57f1ed1ce98a695dabcb0278faf03d68e1bae08c9095355a28b06'
-    const wallet = new LocalWallet()
-    wallet.addAccount(pKey)
+    const signer = privateKeyToAddress(pKey)
     const typedData = attestationSecurityCode('1000023')
-    const signer = wallet.getAccounts()[0]
-    // returns RSV-serialized signature
-    const signature = await wallet.signTypedData(signer, typedData)
-    const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
-      typedData,
-      signature,
-      signer
-    )
-    expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
-  })
 
-  it('should recover signer from VSR-serialized sig of EIP712 typed data', async () => {
-    const pKey = '0xac8ca7aeb0f57f1ed1ce98a695dabcb0278faf03d68e1bae08c9095355a28b06'
-    const wallet = new LocalWallet()
-    wallet.addAccount(pKey)
-    const kit = newKit('https://alfajores-forno.celo-testnet.org', wallet)
-    const typedData = attestationSecurityCode('1000023')
-    const signer = wallet.getAccounts()[0]
-    // returns raw signature
-    const signature = await kit.signTypedData(signer, typedData)
-    // serializes to VRS-serialized signature
-    const serializedSig = SignatureUtils.serializeSignature(signature)
-    const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
-      typedData,
-      serializedSig,
-      signer
-    )
-    expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
+    it('should recover signer from RSV-serialized sig of EIP712 typed data ', () => {
+      // generated via LocalWallet's signTypedData
+      const rsvSignature =
+        '0x106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a10001'
+      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
+        typedData,
+        rsvSignature,
+        signer
+      )
+      expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
+    })
+    it('should recover signer from VSR-serialized sig of EIP712 typed data', () => {
+      // generated via contractKit's signTypedData
+      const vrsSignature =
+        '0x1c106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100'
+      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
+        typedData,
+        vrsSignature,
+        signer
+      )
+      expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
+    })
+    it('should recover signer from serializeSignature output', () => {
+      const signature = {
+        v: 28,
+        r: '0x106c6f892c5667c298dddc023161b58657c47fb03348fa0ec9b3b515841df47b',
+        s: '0x39985d448104683fcef8d81f2cdcf8bce83c97f8dfb130438f7d26c6e3b2a100',
+      }
+      const serializedSig = SignatureUtils.serializeSignature(signature)
+      const recoveredSigner = SignatureUtils.recoverEIP712TypedDataSigner(
+        typedData,
+        serializedSig,
+        signer
+      )
+      expect(signer.toLowerCase()).toEqual(recoveredSigner.toLowerCase())
+    })
   })
 })

--- a/packages/sdk/utils/src/signatureUtils.ts
+++ b/packages/sdk/utils/src/signatureUtils.ts
@@ -1,6 +1,6 @@
 import { NativeSigner, serializeSignature, Signature, Signer } from '@celo/base/lib/signatureUtils'
 import * as Web3Utils from 'web3-utils'
-import { ensureLeading0x, eqAddress, privateKeyToAddress } from './address'
+import { ensureLeading0x, eqAddress, privateKeyToAddress, trimLeading0x } from './address'
 import { EIP712TypedData, generateTypedDataHash } from './sign-typed-data-utils'
 
 // Exports moved to @celo/base, forwarding them
@@ -140,7 +140,7 @@ function recoverEIP712TypedDataSigner(
   parseFunction: (signature: string) => Signature
 ): string {
   const dataBuff = generateTypedDataHash(typedData)
-  const { r, s, v } = parseFunction(signature.slice(2))
+  const { r, s, v } = parseFunction(trimLeading0x(signature))
   const publicKey = ethjsutil.ecrecover(
     ethjsutil.toBuffer(dataBuff),
     v,


### PR DESCRIPTION
## Description

When parsing EIP712 signed typed data in `SignatureUtils.recoverEIP712TypedDataSigner`, we break and return a value as soon as a signature can be parsed. The issue is that 1) we do not serialize signatures consistently (examples from the monorepo: `SignatureUtils.serializeSignature` serializes as VRS, but `LocalSigner.signTypedData` returns an RSV-serialized sig) 2) some small percentage of signatures can be parsed as both RSV & VRS signatures, in which case the order of the parsing matters as long as we do not check against the expected signer.

Given that the usage in `offchain-data-wrapper` is relatively new (and breaking changes shouldn't be too disruptive), the proposed fix splits up `recoverEIP712TypedDataSigner` into two (VRS & RSV-specific, so the caller can choose to explicitly call these if it's necessary to "guess" an address), while modifying the `verify` function to be in line with how the existing message parsing `verifySignature` function works -- i.e. boolean that suppresses errors but works regardless of RSV/VRS serialization.

This is a breaking change in that `recoverEIP712TypedDataSigner` has been deprecated in favor of two functions.

### Other changes
- wraps `SignatureUtils.verifyEIP712TypedDataSigner` in a try/catch to ensure that it always returns a boolean (and no longer propagates the error from the recovery step). This is in line with the other signature parsing/verification functions.
- adds unit tests for `recover & verify`: these are pretty dumb and based on hardcoded examples in order to not add the CK/LocalWallet dependencies to the utils package -- open to thoughts on this though, if you think it's worthwhile to randomize PKs but incorporate these dependencies)

### Testing
- [x] unit tests for `recover & verify` against a hard-coded edge case that was failing
- [x] existing unit tests for `offchain-data-wrapper` pass
- [x] programmatically tested that previous issue with certain AS codes causing this is resolved for large ranges of codes
- [x] TODO deploy to alfajores AS + make sure no changes to existing flow (also tried with contrived code examples that would have thrown the `Invalid signature` error, but now throw "Invalid code" as we want)

Closes #8812


_Edit: further notes for future documentation:_
### Notes on implementation choices in `offchain-data-wrapper` and future TODOs here:

Initially @nambrot and I thought it would make sense to double down on the usage of just VRS-serialization. This PR diverges from that initial thought due to the following:
- in `PublicSimpleAccessor.sign` we are actually using the `wallet.signTypedData` method which returns an RSV-signature (we can switch this to using the `CK.signTypedData` + `SignatureUtils.serializeSignature`, but this increases the scope of this PR)
- we could just use the RSV recover function, but this moves away from compatibility with serializeSignature (VRS)
- (even within the wrapper code, we use both `wallet.signTypedData` and `serializeSignature` (in the tests), so standardizing should take a more rigorous comb through of everything here IMO)

The current implementation is slightly less efficient than before, but should not suffer from the same edge case that this PR fixes (except in the case that the `guessedSignature` must still be used, which seems unavoidable). Notes on this:
- we repeat signature recoveries here (i.e. use the `verifyEIP712TypedDataSigner`) which is less efficient (on the order of a few milliseconds in total)
- if we don’t have a single standard signature, then moving the signature-guessing logic up will either 1) reintroduce the parsing edge case or 2) make it less readable & duplicates logic IMO (try to parse both, check equality against up to 2 parsed sigs)

I ultimately opted for minimizing the amount of signature standardization across the module for now and eliminating the possible edge case, and would be slightly in favor of splitting out signature standardization across the offchain-data-wrapper into a separate ticket for the future.

TODOs
- [x] [immediate] create a ticket for the below and link here -> created issue #8862 (assigned to Applications initially)
