### PR TITLE
Set vulnerable dependency to fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "set-value": "^3.0.2",
     "sha3": "1.2.3",
     "tar": "4.4.15",
-    "ua-parser-js": "^0.7.24",
+    "ua-parser-js": "0.7.28",
     "underscore": "^1.12.1",
     "url-parse": "^1.5.0",
     "web3-eth-contract": "1.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26225,7 +26225,7 @@ u2f-api@0.2.7:
   resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
   integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
 
-ua-parser-js@^0.7.18, ua-parser-js@^0.7.24:
+ua-parser-js@0.7.28, ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==


### PR DESCRIPTION
### Description

Security vulnerability: https://github.com/advisories/GHSA-pjwm-rvh2-c87w
Setting dependency to fixed version that does not have vulnerability. `0.7.28` is safe according to [this thread](https://github.com/faisalman/ua-parser-js/issues/536).