### PR TITLE
Exclude phoenix metrics in grafana cloud

### DIFF
--- a/packages/celotool/src/lib/prometheus.ts
+++ b/packages/celotool/src/lib/prometheus.ts
@@ -213,6 +213,7 @@ async function helmParameters(context?: string, clusterConfig?: BaseClusterConfi
       'kube_pod_[^cs].+',
       'workqueue_.+',
       'kube_secret_.+',
+      'phoenix_.+',
     ]
     params.push(
       `--set remote_write.url='${fetchEnv(envVar.PROMETHEUS_REMOTE_WRITE_URL)}'`,


### PR DESCRIPTION
Exclude the `phoenix_.+` metrics from grafana cloud because their size and we are not using those metrics.
