### PR TITLE
Add signature verification code for CIP-40 requests

### DIFF
--- a/dependency-graph.json
+++ b/dependency-graph.json
@@ -111,7 +111,8 @@
       "@celo/base",
       "@celo/contractkit",
       "@celo/identity",
-      "@celo/utils"
+      "@celo/utils",
+      "@celo/wallet-local"
     ]
   },
   "@celo/phone-number-privacy-monitor": {

--- a/packages/phone-number-privacy/common/package.json
+++ b/packages/phone-number-privacy/common/package.json
@@ -34,6 +34,7 @@
     "libphonenumber-js": "^1.9.11"
   },
   "devDependencies": {
+    "@celo/wallet-local": "1.3.1-dev",
     "@types/btoa": "^1.2.3",
     "@types/bunyan": "1.8.4",
     "@types/elliptic": "^6.4.12",

--- a/packages/phone-number-privacy/common/src/interfaces/requests.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/requests.ts
@@ -131,6 +131,7 @@ export type DomainRequest<
   | DomainQuotaStatusRequest<D, O>
   | DisableDomainRequest<D, O>
 
+/** Wraps the signature request as an EIP-712 typed data structure for hashing and signing */
 export function domainRestrictedSignatureRequestEIP712<D extends KnownDomain>(
   request: DomainRestrictedSignatureRequest<D>
 ): EIP712TypedData {
@@ -162,6 +163,7 @@ export function domainRestrictedSignatureRequestEIP712<D extends KnownDomain>(
   }
 }
 
+/** Wraps the domain quota request as an EIP-712 typed data structure for hashing and signing */
 export function domainQuotaStatusRequestEIP712<D extends KnownDomain>(
   request: DomainQuotaStatusRequest<D>
 ): EIP712TypedData {
@@ -192,6 +194,7 @@ export function domainQuotaStatusRequestEIP712<D extends KnownDomain>(
   }
 }
 
+/** Wraps the disable domain request as an EIP-712 typed data structure for hashing and signing */
 export function disableDomainRequestEIP712<D extends KnownDomain>(
   request: DisableDomainRequest<D>
 ): EIP712TypedData {
@@ -265,18 +268,42 @@ function verifyRequestSignature<R extends DomainRequest<SequentialDelayDomain>>(
   return verifyEIP712TypedDataSigner(typedData, signature, signer)
 }
 
+/**
+ * Verifies the signature over a signature request for authenticated domains.
+ * If the domain is unauthenticated, this function returns true.
+ *
+ * @remarks As specified in CIP-40, the signed message is the full request interpretted as EIP-712
+ * typed data with the signature field in the domain options set to its zero value (i.e. It is set
+ * to the undefined value for type EIP712Optional<string>).
+ */
 export function verifyDomainRestrictedSignatureRequestSignature(
   request: DomainRestrictedSignatureRequest<SequentialDelayDomain>
 ): boolean {
   return verifyRequestSignature(domainRestrictedSignatureRequestEIP712, request)
 }
 
+/**
+ * Verifies the signature over a domain quota status request for authenticated domains.
+ * If the domain is unauthenticated, this function returns true.
+ *
+ * @remarks As specified in CIP-40, the signed message is the full request interpretted as EIP-712
+ * typed data with the signature field in the domain options set to its zero value (i.e. It is set
+ * to the undefined value for type EIP712Optional<string>).
+ */
 export function verifyDomainQuotaStatusRequestSignature(
   request: DomainQuotaStatusRequest<SequentialDelayDomain>
 ): boolean {
   return verifyRequestSignature(domainQuotaStatusRequestEIP712, request)
 }
 
+/**
+ * Verifies the signature over a disable domain request for authenticated domains.
+ * If the domain is unauthenticated, this function returns true.
+ *
+ * @remarks As specified in CIP-40, the signed message is the full request interpretted as EIP-712
+ * typed data with the signature field in the domain options set to its zero value (i.e. It is set
+ * to the undefined value for type EIP712Optional<string>).
+ */
 export function verifyDisableDomainRequestSignature(
   request: DisableDomainRequest<SequentialDelayDomain>
 ): boolean {

--- a/packages/sdk/identity/src/odis/domains.ts
+++ b/packages/sdk/identity/src/odis/domains.ts
@@ -34,17 +34,25 @@ export interface Domain {
 export type DomainOptions = EIP712Object
 
 export type SequentialDelayStage = {
-  // How many seconds each batch of attempts in this stage is delayed with
-  // respect to the timer.
+  /**
+   * How many seconds each batch of attempts in this stage is delayed with
+   * respect to the timer.
+   */
   delay: number
-  // Whether the timer should be reset between attempts during this stage.
-  // Defaults to true.
+  /**
+   * Whether the timer should be reset between attempts during this stage.
+   * Defaults to true.
+   */
   resetTimer: EIP712Optional<boolean>
-  // The number of continuous attempts a user gets before the next delay
-  // in each repetition of this stage. Defaults to 1.
+  /**
+   * The number of continuous attempts a user gets before the next delay
+   * in each repetition of this stage. Defaults to 1.
+   */
   batchSize: EIP712Optional<number>
-  // The number of times this stage repeats before continuing to the next stage
-  // in the RateLimit array. Defaults to 1.
+  /**
+   * The number of times this stage repeats before continuing to the next stage
+   * in the RateLimit array. Defaults to 1.
+   */
   repetitions: EIP712Optional<number>
 }
 
@@ -52,20 +60,32 @@ export type SequentialDelayDomain = {
   name: 'ODIS Sequential Delay Domain'
   version: '1'
   stages: SequentialDelayStage[]
-  // Optional Celo address against which signed requests must be authenticated.
-  // In the case of Cloud Backup, this will be derived from a one-time key stored with the ciphertext.
+  /**
+   * Optional Celo address against which signed requests must be authenticated.
+   * In the case of Cloud Backup, this will be derived from a one-time key stored with the ciphertext.
+   * Encoded as a checksummed address with leading "0x".
+   */
   address: EIP712Optional<string>
-  // Optional string to distinguish the output of this domain instance from
-  // other SequentialDelayDomain instances
+  /**
+   * Optional string to distinguish the output of this domain instance from
+   * other SequentialDelayDomain instances
+   */
   salt: EIP712Optional<string>
 }
 
 export type SequentialDelayDomainOptions = {
-  // EIP-712 signature over the entire request by the address specified in the domain.
-  // Required if `address` is defined in the domain instance. If `address` is
-  // not defined in the domain instance, then a signature must not be provided.
+  /**
+   * EIP-712 signature over the entire request by the address specified in the domain.
+   * Required if `address` is defined in the domain instance. If `address` is
+   * not defined in the domain instance, then a signature must not be provided.
+   * Encoded as a hex string with leading 0x.
+   */
   signature: EIP712Optional<string>
-  // Used to prevent replay attacks. Required if a signature is provided.
+  /**
+   * Used to prevent replay attacks. Required if a signature is provided.
+   * Code verifying the signature for rate limiting should check this nonce against a counter of
+   * applied requests. E.g. Ensure the nonce is 0 on the first request and 2 on the third.
+   */
   nonce: EIP712Optional<number>
 }
 


### PR DESCRIPTION
### Description

Adds signature verification functions for the three new requests in the ODIS Domains API.

Signature creation and verification follows the specification of CIP-30. Verification is now implemented for use in other places. Signature creation is not implemented in a client library as part of this PR, but an example is given through the test code of how to create a valid signature.

### Other changes

* Add comments to domain structures and functions that did not already have comments.

### Tested

* Added a number of new unit tests to ensure the correctness of the verification code.