### PR TITLE
(docs): Update Go version to 1.16 in SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -35,7 +35,7 @@ Follow these steps to get everything that you need installed to build the celo-m
 
 We need Go for [celo-blockchain], the Go Celo implementation, and `gobind` to build Java language bindings to Go code for the Android Geth client).
 
-Note: We currently use Go 1.13. [Install Go 1.13 manually](https://golang.org/dl/), then run
+Note: We currently use Go 1.16. [Install Go 1.16 manually](https://golang.org/dl/), then run
 
 ```
 go get golang.org/x/mobile/cmd/gobind


### PR DESCRIPTION
It appears that celo-blockchain now uses Go 1.16 since this PR https://github.com/celo-org/celo-blockchain/pull/1454

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_