### PR TITLE
Fix ongoingDeliveryId bug (duplicates with Verify API) in attestation service

### DIFF
--- a/packages/attestation-service/migrations/20211109200901-attestation-v8.js
+++ b/packages/attestation-service/migrations/20211109200901-attestation-v8.js
@@ -1,0 +1,68 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+
+    try {
+      await queryInterface.removeIndex(
+        'Attestations',
+        ['ongoingDeliveryId'],
+        { fields: ['ongoingDeliveryId'], unique: true },
+        { transaction }
+      )
+      await queryInterface.addIndex(
+        'Attestations',
+        ['ongoingDeliveryId'],
+        { fields: ['ongoingDeliveryId'], unique: false },
+        { transaction }
+      )
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  },
+  down: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.removeIndex(
+        'Attestations',
+        ['ongoingDeliveryId'],
+        { fields: ['ongoingDeliveryId'], unique: false },
+        { transaction }
+      )
+      await queryInterface.addIndex(
+        'Attestations',
+        ['ongoingDeliveryId'],
+        { fields: ['ongoingDeliveryId'], unique: true },
+        { transaction }
+      )
+    } catch (error) {
+      await transaction.rollback()
+      if (
+        error.errors.length == 1 &&
+        error.errors[0].path == 'ongoingDeliveryId' &&
+        error.errors[0].type == 'unique violation'
+      ) {
+        try {
+          console.warn('Duplicates in ongoingDeliveryId; nulling out column and retrying.')
+          await queryInterface.removeColumn('Attestations', 'ongoingDeliveryId')
+          await queryInterface.addColumn('Attestations', 'ongoingDeliveryId', {
+            type: Sequelize.STRING,
+            allowNull: true,
+          })
+          await queryInterface.addIndex(
+            'Attestations',
+            ['ongoingDeliveryId'],
+            { fields: ['ongoingDeliveryId'], unique: true },
+            { transaction }
+          )
+        } catch (error) {
+          await transaction.rollback()
+          throw error
+        }
+      }
+    }
+  },
+}

--- a/packages/attestation-service/src/db.ts
+++ b/packages/attestation-service/src/db.ts
@@ -320,10 +320,15 @@ export async function findAttestationByDeliveryId(
   ongoingDeliveryId: string,
   options: FindOptions = {}
 ): Promise<AttestationModel | null> {
-  return (await getAttestationTable()).findOne({
+  // For testing only, delete
+  const val = (await getAttestationTable()).findOne({
     where: { ongoingDeliveryId },
+    // Ensure deterministic result, since deliveryId uniqueness is not enforced
+    order: ['createdAt', 'desc'],
     ...options,
   })
+  rootLogger.warn(`In findAttestationByDeliveryId, deliveryId: ${ongoingDeliveryId}, val: ${val} `)
+  return val
 }
 
 export async function findOrCreateAttestation(

--- a/packages/attestation-service/src/db.ts
+++ b/packages/attestation-service/src/db.ts
@@ -320,15 +320,12 @@ export async function findAttestationByDeliveryId(
   ongoingDeliveryId: string,
   options: FindOptions = {}
 ): Promise<AttestationModel | null> {
-  // For testing only, delete
-  const val = (await getAttestationTable()).findOne({
+  return (await getAttestationTable()).findOne({
     where: { ongoingDeliveryId },
     // Ensure deterministic result, since deliveryId uniqueness is not enforced
     order: [['createdAt', 'DESC']],
     ...options,
   })
-  rootLogger.warn(`In findAttestationByDeliveryId, deliveryId: ${ongoingDeliveryId}, val: ${val} `)
-  return val
 }
 
 export async function findOrCreateAttestation(

--- a/packages/attestation-service/src/db.ts
+++ b/packages/attestation-service/src/db.ts
@@ -324,7 +324,7 @@ export async function findAttestationByDeliveryId(
   const val = (await getAttestationTable()).findOne({
     where: { ongoingDeliveryId },
     // Ensure deterministic result, since deliveryId uniqueness is not enforced
-    order: ['createdAt', 'desc'],
+    order: [['createdAt', 'DESC']],
     ...options,
   })
   rootLogger.warn(`In findAttestationByDeliveryId, deliveryId: ${ongoingDeliveryId}, val: ${val} `)

--- a/packages/attestation-service/src/models/attestation.ts
+++ b/packages/attestation-service/src/models/attestation.ts
@@ -15,6 +15,7 @@ export interface SmsFields {
   attestationCode: string | null
   appSignature: string | undefined
   language: string | undefined
+  attempt: number
 }
 
 export interface AttestationModel extends Model, SmsFields {
@@ -22,7 +23,6 @@ export interface AttestationModel extends Model, SmsFields {
   securityCodeAttempt: number
   ongoingDeliveryId: string | null
   providers: string
-  attempt: number
   status: AttestationStatus
   errors: string | null
   createdAt: Date

--- a/packages/attestation-service/src/models/attestation.ts
+++ b/packages/attestation-service/src/models/attestation.ts
@@ -15,7 +15,6 @@ export interface SmsFields {
   attestationCode: string | null
   appSignature: string | undefined
   language: string | undefined
-  attempt: number
 }
 
 export interface AttestationModel extends Model, SmsFields {
@@ -23,6 +22,7 @@ export interface AttestationModel extends Model, SmsFields {
   securityCodeAttempt: number
   ongoingDeliveryId: string | null
   providers: string
+  attempt: number
   status: AttestationStatus
   errors: string | null
   createdAt: Date

--- a/packages/attestation-service/src/sms/twilioVerify.ts
+++ b/packages/attestation-service/src/sms/twilioVerify.ts
@@ -109,30 +109,6 @@ export class TwilioVerifyProvider extends TwilioSmsProvider {
       }
     }
 
-    // If there's a previous verification
-    // if (attestation.attempt) {
-    // console.log('hellooooo')
-    // const y = new Date()
-    // try {
-    //   // const x = await this.client.verify
-    //   await this.client.verify
-    //     .services(this.verifyServiceSid)
-    //     .verifications(attestation.phoneNumber)
-    //     .update({ status: 'canceled' })
-    //   // console.log(x)
-    // } catch (e) {
-    //   // let errorMsg = 'no error message'
-    //   // if (e instanceof Error) {
-    //   //   errorMsg = e.message
-    //   // }
-    //   // throw new Error(`Unable to cancel previous verification: ${errorMsg}`)
-    // }
-    // const z = new Date()
-    // console.log('total time: ', z.getTime() - y.getTime())
-    // // }
-
-    let deliveryId: string
-
     // Note: SID returned by Verify API is not unique for a phone number (within a 10 min interval)
     // i.e. re-requests to the same phone number in <10 min will return an exisiting SID
 
@@ -140,7 +116,7 @@ export class TwilioVerifyProvider extends TwilioSmsProvider {
       const m = await this.client.verify
         .services(this.verifyServiceSid)
         .verifications.create(requestParams)
-      deliveryId = m.sid
+      return m.sid
     } catch (e) {
       // Verify landlines using voice
       if (
@@ -152,23 +128,10 @@ export class TwilioVerifyProvider extends TwilioSmsProvider {
         const m = await this.client.verify
           .services(this.verifyServiceSid)
           .verifications.create(requestParams)
-        deliveryId = m.sid
+        return m.sid
       } else {
         throw e
       }
-    }
-    try {
-      // Change status of verification to ensure unique delivery IDs are created
-      await this.client.verify
-        .services(this.verifyServiceSid)
-        .verifications(deliveryId)
-        .update({ status: 'canceled' })
-    } catch {
-      // This shouldn't throw a hard error though as this is to prevent a tiny edge case:
-      // 2 Verify requests for the same issuer + phone number in <10 min.
-      // At this point, the text has already been sent.
-    } finally {
-      return deliveryId
     }
   }
 }

--- a/packages/attestation-service/src/sms/twilioVerify.ts
+++ b/packages/attestation-service/src/sms/twilioVerify.ts
@@ -108,7 +108,34 @@ export class TwilioVerifyProvider extends TwilioSmsProvider {
         requestParams.locale = locale
       }
     }
+
+    // If there's a previous verification
+    // if (attestation.attempt) {
+    // console.log('hellooooo')
+    // const y = new Date()
+    // try {
+    //   // const x = await this.client.verify
+    //   await this.client.verify
+    //     .services(this.verifyServiceSid)
+    //     .verifications(attestation.phoneNumber)
+    //     .update({ status: 'canceled' })
+    //   // console.log(x)
+    // } catch (e) {
+    //   // let errorMsg = 'no error message'
+    //   // if (e instanceof Error) {
+    //   //   errorMsg = e.message
+    //   // }
+    //   // throw new Error(`Unable to cancel previous verification: ${errorMsg}`)
+    // }
+    // const z = new Date()
+    // console.log('total time: ', z.getTime() - y.getTime())
+    // // }
+
     let deliveryId: string
+
+    // Note: SID returned by Verify API is not unique for a phone number (within a 10 min interval)
+    // i.e. re-requests to the same phone number in <10 min will return an exisiting SID
+
     try {
       const m = await this.client.verify
         .services(this.verifyServiceSid)
@@ -138,9 +165,8 @@ export class TwilioVerifyProvider extends TwilioSmsProvider {
         .update({ status: 'canceled' })
     } catch {
       // This shouldn't throw a hard error though as this is to prevent a tiny edge case:
-      // >5 Verify requests to the same phone number in <10 min.
-      // At this point, the text has been sent; .
-      // throw new Error(`Canceling Verify SID ${deliveryId} failed with message ${e}`)
+      // 2 Verify requests for the same issuer + phone number in <10 min.
+      // At this point, the text has already been sent.
     } finally {
       return deliveryId
     }

--- a/packages/attestation-service/test/__mocks__/twilio.ts
+++ b/packages/attestation-service/test/__mocks__/twilio.ts
@@ -6,6 +6,7 @@ export const mockVerifyCreate = jest.fn((_obj: Object) => {
     sid: undefined,
   }
 })
+export const mockVerifyUpdate = jest.fn()
 export const mockMessagesCreate = jest.fn((_obj: Object) => {
   return {
     sid: undefined,
@@ -28,9 +29,16 @@ const twilio = jest.fn().mockImplementation((_twilioSid, _twilioAuthToken) => {
       services: Object.assign(
         (_sid: string) => {
           return {
-            verifications: {
-              create: mockVerifyCreate,
-            },
+            verifications: Object.assign(
+              (_sid: string) => {
+                return {
+                  update: mockVerifyUpdate,
+                }
+              },
+              {
+                create: mockVerifyCreate,
+              }
+            ),
           }
         },
         {

--- a/packages/attestation-service/test/sms/twilio.test.ts
+++ b/packages/attestation-service/test/sms/twilio.test.ts
@@ -1,6 +1,6 @@
 import { SmsFields } from '../../src/models/attestation'
 import { TwilioMessagingProvider, TwilioVerifyProvider } from '../../src/sms/twilio'
-import { mockMessagesCreate, mockVerifyCreate, mockVerifyUpdate } from '../__mocks__/twilio'
+import { mockMessagesCreate, mockVerifyCreate } from '../__mocks__/twilio'
 
 jest.mock('../__mocks__/twilio')
 
@@ -25,48 +25,30 @@ describe('TwilioSmsProvider tests', () => {
       attestationCode: '56789',
       appSignature: undefined,
       language: 'en',
-      attempt: 0,
     }
   })
-  describe('TwilioVerifyProvider tests', () => {
-    it('should initialize and send SMS', async () => {
-      const twilioVerifyProvider = new TwilioVerifyProvider(
-        twilioSid,
-        twilioAuthToken,
-        unsupportedRegionCodes,
-        verifyServiceSid
-      )
-      await twilioVerifyProvider.initialize('fake-delivery-status-url')
-      await twilioVerifyProvider.sendSms(attestation)
-      expect(mockVerifyCreate).toBeCalledTimes(1)
-      expect(mockMessagesCreate).not.toBeCalled()
-    })
-    it('should create new SID on second attempt', async () => {
-      const twilioVerifyProvider = new TwilioVerifyProvider(
-        twilioSid,
-        twilioAuthToken,
-        unsupportedRegionCodes,
-        verifyServiceSid
-      )
-      await twilioVerifyProvider.initialize('fake-delivery-status-url')
-      await twilioVerifyProvider.sendSms(attestation)
-      expect(mockVerifyCreate).toBeCalledTimes(1)
-      expect(mockVerifyUpdate).toBeCalledTimes(1)
-      expect(mockMessagesCreate).not.toBeCalled()
-    })
+  it('should initialize and send SMS via TwilioVerifyProvider', async () => {
+    const twilioVerifyProvider = new TwilioVerifyProvider(
+      twilioSid,
+      twilioAuthToken,
+      unsupportedRegionCodes,
+      verifyServiceSid
+    )
+    await twilioVerifyProvider.initialize('fake-delivery-status-url')
+    await twilioVerifyProvider.sendSms(attestation)
+    expect(mockVerifyCreate).toBeCalledTimes(1)
+    expect(mockMessagesCreate).not.toBeCalled()
   })
-  describe('TwilioMessagingProvider tests', () => {
-    it('should initialize and send SMS', async () => {
-      const twilioMessagingProvider = new TwilioMessagingProvider(
-        twilioSid,
-        twilioAuthToken,
-        unsupportedRegionCodes,
-        messagingServiceSid
-      )
-      await twilioMessagingProvider.initialize('fake-delivery-status-url')
-      await twilioMessagingProvider.sendSms(attestation)
-      expect(mockMessagesCreate).toBeCalledTimes(1)
-      expect(mockVerifyCreate).not.toBeCalled()
-    })
+  it('should initialize and send SMS via TwilioMessagingProvider', async () => {
+    const twilioMessagingProvider = new TwilioMessagingProvider(
+      twilioSid,
+      twilioAuthToken,
+      unsupportedRegionCodes,
+      messagingServiceSid
+    )
+    await twilioMessagingProvider.initialize('fake-delivery-status-url')
+    await twilioMessagingProvider.sendSms(attestation)
+    expect(mockMessagesCreate).toBeCalledTimes(1)
+    expect(mockVerifyCreate).not.toBeCalled()
   })
 })

--- a/packages/attestation-service/test/sms/twilio.test.ts
+++ b/packages/attestation-service/test/sms/twilio.test.ts
@@ -1,16 +1,20 @@
+import { SmsFields } from '../../src/models/attestation'
 import { TwilioMessagingProvider, TwilioVerifyProvider } from '../../src/sms/twilio'
-import { mockMessagesCreate, mockVerifyCreate } from '../__mocks__/twilio'
+import { mockMessagesCreate, mockVerifyCreate, mockVerifyUpdate } from '../__mocks__/twilio'
 
 jest.mock('../__mocks__/twilio')
 
 describe('TwilioSmsProvider tests', () => {
-  describe('sendSms', () => {
-    const twilioSid = 'twilioSid-123!'
-    const verifyServiceSid = 'verify-sid-123!'
-    const twilioAuthToken = 'fakeAuth-123!'
-    const unsupportedRegionCodes = ['GH', 'IJ', 'KL']
-    const messagingServiceSid = 'messagingId-123!'
-    const attestation = {
+  const twilioSid = 'twilioSid-123!'
+  const verifyServiceSid = 'verify-sid-123!'
+  const twilioAuthToken = 'fakeAuth-123!'
+  const unsupportedRegionCodes = ['GH', 'IJ', 'KL']
+  const messagingServiceSid = 'messagingId-123!'
+  let attestation: SmsFields
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    attestation = {
       account: '0x123',
       identifier: '0x456',
       issuer: '0x789',
@@ -21,13 +25,11 @@ describe('TwilioSmsProvider tests', () => {
       attestationCode: '56789',
       appSignature: undefined,
       language: 'en',
+      attempt: 0,
     }
-
-    beforeEach(() => {
-      jest.clearAllMocks()
-    })
-
-    it('should initialize and send SMS via TwilioVerifyProvider', async () => {
+  })
+  describe('TwilioVerifyProvider tests', () => {
+    it('should initialize and send SMS', async () => {
       const twilioVerifyProvider = new TwilioVerifyProvider(
         twilioSid,
         twilioAuthToken,
@@ -39,7 +41,22 @@ describe('TwilioSmsProvider tests', () => {
       expect(mockVerifyCreate).toBeCalledTimes(1)
       expect(mockMessagesCreate).not.toBeCalled()
     })
-    it('should initialize and send SMS via TwilioMessagingProvider', async () => {
+    it('should create new SID on second attempt', async () => {
+      const twilioVerifyProvider = new TwilioVerifyProvider(
+        twilioSid,
+        twilioAuthToken,
+        unsupportedRegionCodes,
+        verifyServiceSid
+      )
+      await twilioVerifyProvider.initialize('fake-delivery-status-url')
+      await twilioVerifyProvider.sendSms(attestation)
+      expect(mockVerifyCreate).toBeCalledTimes(1)
+      expect(mockVerifyUpdate).toBeCalledTimes(1)
+      expect(mockMessagesCreate).not.toBeCalled()
+    })
+  })
+  describe('TwilioMessagingProvider tests', () => {
+    it('should initialize and send SMS', async () => {
       const twilioMessagingProvider = new TwilioMessagingProvider(
         twilioSid,
         twilioAuthToken,


### PR DESCRIPTION
## Description 

Closes #8808 

The fix/code changes here is fairly simple, but the decision behind it is a bit more involved, so I've included details on the options considered below:

### Options considered (implemented (3))

1. when sending SMS via verify, check if there is an existing verification for that phone number and if so cancel it
    (--) slow (adds (from rough benchmarking) 0.7 ms before attempting to send the SMS, really not ideal since we are trying as hard as possible to cut time pre-send)
   (-?) possible that this (and (2) below) would mess with Twilio Verify's smart routing and make performance worse
2. cancel the verify flow immediately after sending it via Verify. 
    (+) adds no time to receiving SMS, verify flow from perspective of client; 
    (--?) Seems like it should only create the Verification Resource once the message has been sent, but I can't find confirmation that canceling immediately wouldn't in some cases cause the message to not send at all, and there's not great visibility into delivery status here, so bugs here would likely be really insidious/hard to detect going forwards
3. **make the DB index on ongoingDeliveryId non-unique. Only keep these records for DB_RECORD_EXPIRY_MINS anyways and old records are purged.**
    (+) just updating the index to be non-null (but keeping the index) should maintain DB performance
    (+) minimal change that should not affect any other areas of the code; highly unlikely to degrade the performance of Verify/other providers sends
    () would need to add a time-ordering constraint to the one area that accesses status by delivery ID (delivery report stuff); though even this is a formality given that the Verify delivery IDs are not used and all the others are already unique
    (-) if more than 5 codes are sent to the same number in 10 min with the Verify API, the sendSMS would fail for Verify API anyways (as it maxes out at 5) -- however, this situation should (if at all) only happen exceedingly rarely (for real use cases; more often on alfajores due to there being only one shared AS under the hood) due to attempt limits, and this should at least result in retrying the send. A possible situation could look like some combination of: in a country where only `twilioverify` is configured; a bunch of issuers use the same attestation service + twilio config and at least 2 of the selected issuers use the same AS; both messages fail + are resent 3 times (should max out attempts and switch issuer at this point); or perhaps something similar to before + user tries to connect PN to another address within 10 min and is randomly assigned to the same issuers as before.
    (-) if we re-add the uniqueness constraint in the future, the DB migration as is would cause a one-time dip as the delivery report retry logic to not work for stored attestation sends (this should not impact too many attestations; only those sent recently enough to receive a delivery report, and even so would be only for the built-in resend logic)

## Drive by changes
- Improved test mocks (to include update functionality) + restructured unit tests just slightly (when experimenting with + testing out solutions 1/2)

## Testing
- tested database migration (up/down) locally
- deployed and tested on alfajores; will continue to leave it up for continued testing + examination of logs
