### PR TITLE
Add recaptcha for blockscout.

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -112,6 +112,21 @@ spec:
           value: {{ .Values.blockscout.web.appsMenu.resourcesList | quote }}
         - name: LEARNING_MENU_LIST
           value: {{ .Values.blockscout.web.appsMenu.learningList | quote }}
+        - name: RE_CAPTCHA_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  {{ .Values.blockscout.web.recaptchaSecretName | quote }}
+              key: project_id
+        - name: RE_CAPTCHA_SITE_KEY
+          valueFrom:
+            secretKeyRef:
+              name:  {{ .Values.blockscout.web.recaptchaSecretName | quote }}
+              key: site_key
+        - name: RE_CAPTCHA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name:  {{ .Values.blockscout.web.recaptchaSecretName | quote }}
+              key: api_key
 {{ include "celo.blockscout-env-vars" . | indent 8 }}
 {{- $data := dict "Values" .Values "Database" .Values.blockscout.web.db }}
 {{ include "celo.blockscout-db-sidecar" $data | indent 6 }}

--- a/packages/helm-charts/blockscout/values-alfajores.yaml
+++ b/packages/helm-charts/blockscout/values-alfajores.yaml
@@ -47,5 +47,6 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
+    recaptchaSecretName: alfajores-blockscout-recaptcha
   metrics:
     enabled: true

--- a/packages/helm-charts/blockscout/values-baklava.yaml
+++ b/packages/helm-charts/blockscout/values-baklava.yaml
@@ -49,5 +49,6 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
+    recaptchaSecretName: baklava-blockscout-recaptcha
   metrics:
     enabled: true

--- a/packages/helm-charts/blockscout/values-blockscoutstagingrc1.yaml
+++ b/packages/helm-charts/blockscout/values-blockscoutstagingrc1.yaml
@@ -49,5 +49,6 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
+    recaptchaSecretName: blockscoutstagingrc1-blockscout-recaptcha
   metrics:
     enabled: false

--- a/packages/helm-charts/blockscout/values-rc1.yaml
+++ b/packages/helm-charts/blockscout/values-rc1.yaml
@@ -47,5 +47,6 @@ blockscout:
       requests:
         memory: 500Mi
         cpu: 1500m
+    recaptchaSecretName: rc1-blockscout-recaptcha
   metrics:
     enabled: true


### PR DESCRIPTION
### Description

Adds required credentials to blockscout deployments for recaptcha enterprise api. Secrets have already been created on each cluster.

### Tested

* Test deployed to staging environment
