### PR TITLE
Allow quick e2e test reruns

### DIFF
--- a/packages/celotool/src/e2e-tests/utils.ts
+++ b/packages/celotool/src/e2e-tests/utils.ts
@@ -388,6 +388,11 @@ export function getContext(gethConfig: GethRunConfig, verbose: boolean = verbose
       if (!instance.privateKey && instance.validating) {
         instance.privateKey = validatorPrivateKeys[validatorIndices[i]]
       }
+
+      if (!instance.minerValidator && (instance.validating || instance.isProxied)) {
+        instance.minerValidator = privateKeyToAddress(instance.privateKey!)
+      }
+
       await startGeth(gethConfig, gethBinaryPath, instance, verbose)
     }
 


### PR DESCRIPTION
### Description

Developers could previously avoid rerunning most of the setup for e2e tests by commenting out the `hooks.before()` call. #6471 broke this by adding a new value on geth instances that was set only at `hooks.before` time, but not at `hooks.restart` time. With this PR, the necessary values are set in `hooks.restart`, allowing for e2e test reruns without having to wait for migrations and other initialization steps after having run them once.

### Tested

Before, after running the governance e2e tests once, commenting out the `hooks.before()` call, and running the e2e tests again, the tests would fail with "Error: miner.validator address from the instance is required". With these changes, e2e tests run as expected.