### PR TITLE
Odis forno rate limiting fix

### DIFF
--- a/packages/phone-number-privacy/combiner/src/match-making/get-contact-matches.ts
+++ b/packages/phone-number-privacy/combiner/src/match-making/get-contact-matches.ts
@@ -47,7 +47,17 @@ export async function handleGetContactMatches(request: Request, response: Respon
       respondWithError(response, 400, WarningMessage.INVALID_INPUT, logger)
       return
     }
-    if (!(await authenticateUser(request, getContractKit(), logger))) {
+
+    // TODO: this error handling shouldn't be necessary here but there is a bug in the common package's
+    // error handling. Remove this or refactor once that bug is resolved.
+    let isAuthenticated = true // We assume user is authenticated on Forno errors
+    try {
+      isAuthenticated = await authenticateUser(request, getContractKit(), logger)
+    } catch {
+      logger.error('Forno error caught in handleGetContactMatches line 57') // Temporary for debugging
+      logger.error(ErrorMessage.CONTRACT_GET_FAILURE)
+    }
+    if (!isAuthenticated) {
       respondWithError(response, 401, WarningMessage.UNAUTHENTICATED_USER, logger)
       return
     }
@@ -61,7 +71,16 @@ export async function handleGetContactMatches(request: Request, response: Respon
     } = request.body
 
     if (!shouldBypassVerificationForE2ETesting(userPhoneNumber, account)) {
-      if (!(await isVerified(account, hashedPhoneNumber, getContractKit(), logger))) {
+      // TODO: this error handling shouldn't be necessary here but there is a bug in the common package's
+      // error handling. Remove this or refactor once that bug is resolved.
+      let _isVerified = true // We assume user is authenticated on Forno errors
+      try {
+        _isVerified = await isVerified(account, hashedPhoneNumber, getContractKit(), logger)
+      } catch {
+        logger.error('Forno error caught in handleGetContactMatches line 80') // Temporary for debugging
+        logger.error(ErrorMessage.CONTRACT_GET_FAILURE)
+      }
+      if (!_isVerified) {
         respondWithError(response, 403, WarningMessage.UNVERIFIED_USER_ATTEMPT_TO_MATCHMAKE, logger)
         return
       }
@@ -77,11 +96,18 @@ export async function handleGetContactMatches(request: Request, response: Respon
     // and fulfill the request as usual.
     let verifiedPhoneNumberDekSig: VerifiedPhoneNumberDekSignature | undefined
     if (signedUserPhoneNumber) {
-      const dekSigner = await getDataEncryptionKey(account, getContractKit(), logger).catch(() => {
+      // TODO: this error handling shouldn't be necessary here but there is a bug in the common package's
+      // error handling. Remove this or refactor once that bug is resolved.
+      let dekSigner = ''
+      try {
+        dekSigner = await getDataEncryptionKey(account, getContractKit(), logger)
+      } catch {
+        logger.error(ErrorMessage.CONTRACT_GET_FAILURE)
         logger.warn(
           'Failed to retrieve DEK to verify signedUserPhoneNumber. Request wont be recorded.'
         )
-      })
+        logger.error('Forno error caught in handleGetContactMatches line 109') // Temporary for debugging
+      }
       if (dekSigner) {
         if (!verifyDEKSignature(userPhoneNumber, signedUserPhoneNumber, dekSigner, logger)) {
           respondWithError(


### PR DESCRIPTION
### Description

Adds hotfix to combiner code to catch uncaught timeout errors caused by forno rate limiting.
Adds what is hopefully a fix for the forno error handling to the common package. This can be published and tested along with the next combiner release. 

My hypothesis for what is breaking the error handling is that previously we were accessing error.message in the catch block which sometimes fails since error is of type any. By switching to the try/catch syntax we are less likely to have subtle errors like this that go unnoticed. I should be able to test this theory by monitoring the logs during times when forno is causing timeouts. 

### Other changes

None

### Tested

Will be tested via monitoring in staging and alfajores before deploying to mainnet

### Related issues

- NA 

### Backwards compatibility

Yes

### Documentation

None