### PR TITLE
Convert migration job into a hook

### DIFF
--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -62,16 +62,6 @@ the `volumes` section.
   emptyDir: {}
 {{- end -}}
 
-{{- /* Defines init container awaiting for migrations to run. */ -}}
-{{- define "celo.blockscout.initContainer.blockscout-init" -}}
-- name: "blockscout-init"
-  image: "groundnuty/k8s-wait-for:1.3"
-  imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
-  args:
-  - job
-  - {{ .Release.Name }}-migration
-{{- end -}}
-
 {{- /* Defines init container copying secrets-init to the specified directory. */ -}}
 {{- define "celo.blockscout.initContainer.secrets-init" -}}
 - name: secrets-init

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -35,7 +35,6 @@ spec:
       serviceAccountName: {{ .Release.Name }}-rbac
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
-{{ include "celo.blockscout.initContainer.blockscout-init" . | indent 6 }}
       containers:
       - name: blockscout-api
         image: {{ .Values.blockscout.image.repository }}:api-{{ .Values.blockscout.image.tag }}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -36,7 +36,6 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.blockscout.indexer.terminationGracePeriodSeconds }}
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
-{{ include "celo.blockscout.initContainer.blockscout-init" . | indent 6 }}
       containers:
       - name: blockscout-indexer
         image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}

--- a/packages/helm-charts/blockscout/templates/blockscout-migration.hook.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-migration.hook.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
     component: blockscout-migration
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -35,7 +35,6 @@ spec:
       serviceAccountName: {{ .Release.Name }}-rbac
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
-{{ include "celo.blockscout.initContainer.blockscout-init" . | indent 6 }}
       containers:
       - name: blockscout-web
         image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}


### PR DESCRIPTION
### Description

Convert migration job into a hook.

### Tested

rc1staging

### Related issues

- Fixes https://github.com/celo-org/data-services/issues/100

### Backwards compatibility

Yes