### PR TITLE
Restart eksportisto indexers every 30 minutes.

### DIFF
--- a/packages/helm-charts/eksportisto/templates/statefulset-indexer.yaml
+++ b/packages/helm-charts/eksportisto/templates/statefulset-indexer.yaml
@@ -50,6 +50,19 @@ spec:
           - "indexer"
           - "--config=/var/config/config.yaml"
           - "--celo-node-uri=http://rc1-fullnodes-rpc-internal-lb:8545"
+        livenessProbe:
+          exec:
+            # "eksportisto monitor" expects more parameters and will always
+            # fail when invoked like this. This is on purpose, as the
+            # livenessProbe is being used to restart the container every
+            # initialDelaySeconds seconds. The eksportisto binary is being
+            # used as it's the only binary present on the container image
+            # (regular user-space tools are not available).
+            command:
+              - /app/eksportisto
+              - monitor
+          initialDelaySeconds: 1800
+          failureThreshold: 1
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/var/config/service-account.json"


### PR DESCRIPTION
### Description

Useful as they might be stuck, potentially due to goroutine leaks.
Instead of implement a health check, a readiness probe with a 1800 secs
delay was used. This means the process will restart every 30 minutes,
regardless of being frozen or not.

### Tested

Deployed.