### PR TITLE
Fix newKit for providers via websocket in prep for AS v1.5.0

### DIFF
--- a/packages/attestation-service/package-lock.json
+++ b/packages/attestation-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/attestation-service",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/attestation-service/package.json
+++ b/packages/attestation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/attestation-service",
-  "version": "1.6.0-dev",
+  "version": "1.5.0",
   "description": "Issues attestation messages for Celo's identity protocol",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/attestation-service/package.json
+++ b/packages/attestation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/attestation-service",
-  "version": "1.5.0",
+  "version": "1.6.0-dev",
   "description": "Issues attestation messages for Celo's identity protocol",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/sdk/contractkit/src/kit.ts
+++ b/packages/sdk/contractkit/src/kit.ts
@@ -42,9 +42,14 @@ export const API_KEY_HEADER_KEY = 'apiKey'
  * @optional options to pass to the Web3 HttpProvider constructor
  */
 export function newKit(url: string, wallet?: ReadOnlyWallet, options?: HttpProviderOptions) {
-  const web3 = url.endsWith('.ipc')
-    ? new Web3(new Web3.providers.IpcProvider(url, net))
-    : new Web3(new Web3.providers.HttpProvider(url, options))
+  let web3: Web3
+  if (url.endsWith('.ipc')) {
+    web3 = new Web3(new Web3.providers.IpcProvider(url, net))
+  } else if (url.toLowerCase().startsWith('http')) {
+    web3 = new Web3(new Web3.providers.HttpProvider(url, options))
+  } else {
+    web3 = new Web3(url)
+  }
   return newKitFromWeb3(web3, wallet)
 }
 


### PR DESCRIPTION
### Description

Fixes a change to `newKit` that removed the default `Web3(url)` behavior and thus accidentally caused all WS connection attempts to fail. (This was then causing the alfajores attestation services to not be able to connect to their own light nodes via WS).

### Other changes
- Includes downgrade back to `1.5.0` in prep for attestation service release (and to not continue cluttering master with AS-release commits 🙈)

### Tested
- CI tests pass
- WS connections now work again, http connections still work