### PR TITLE
Disallow a 0x0 address beneficiary

### DIFF
--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -326,6 +326,7 @@ contract Accounts is
    */
   function setPaymentDelegation(address beneficiary, uint256 fraction) public {
     require(isAccount(msg.sender), "Not an account");
+    require(beneficiary != address(0), "Beneficiary cannot be address 0x0");
     FixidityLib.Fraction memory f = FixidityLib.wrap(fraction);
     require(f.lte(FixidityLib.fixed1()), "Fraction must not be greater than 1");
     paymentDelegations[msg.sender] = PaymentDelegation(beneficiary, f);

--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -323,6 +323,7 @@ contract Accounts is
    * @param fraction The fraction of the validator's payment that should be
    * diverted to `beneficiary` every epoch, given as FixidyLib value. Must not
    * be greater than 1.
+   * @dev Use `deletePaymentDelegation` to unset the payment delegation.
    */
   function setPaymentDelegation(address beneficiary, uint256 fraction) public {
     require(isAccount(msg.sender), "Not an account");
@@ -333,6 +334,10 @@ contract Accounts is
     emit PaymentDelegationSet(beneficiary, fraction);
   }
 
+  /**
+   * @notice Removes a validator's payment delegation by setting benficiary and
+   * fraction to 0.
+   */
   function deletePaymentDelegation() public {
     paymentDelegations[msg.sender] = PaymentDelegation(address(0x0), FixidityLib.wrap(0));
     emit PaymentDelegationSet(address(0x0), 0);

--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -339,6 +339,7 @@ contract Accounts is
    * fraction to 0.
    */
   function deletePaymentDelegation() public {
+    require(isAccount(msg.sender), "Not an account");
     paymentDelegations[msg.sender] = PaymentDelegation(address(0x0), FixidityLib.wrap(0));
     emit PaymentDelegationSet(address(0x0), 0);
   }

--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -333,6 +333,11 @@ contract Accounts is
     emit PaymentDelegationSet(beneficiary, fraction);
   }
 
+  function deletePaymentDelegation() public {
+    paymentDelegations[msg.sender] = PaymentDelegation(address(0x0), FixidityLib.wrap(0));
+    emit PaymentDelegationSet(address(0x0), 0);
+  }
+
   /**
    * @notice Gets validator payment delegation settings.
    * @return Beneficiary address and fraction of payment delegated.

--- a/packages/protocol/specs/accountsPrivileged.spec
+++ b/packages/protocol/specs/accountsPrivileged.spec
@@ -25,6 +25,7 @@ definition knownAsNonPrivileged(method f) returns bool  = false
   || f.selector == removeSigner(address,bytes32).selector
   || f.selector == setEip712DomainSeparator().selector
   || f.selector == setPaymentDelegation(address,uint256).selector
+  || f.selector == deletePaymentDelegation().selector
   ; 
 
 rule privilegedOperation(method f, address privileged)

--- a/packages/protocol/test/common/accounts.ts
+++ b/packages/protocol/test/common/accounts.ts
@@ -504,6 +504,33 @@ contract('Accounts', (accounts: string[]) => {
     })
   })
 
+  describe('#deletePaymentDelegation', () => {
+    const beneficiary = accounts[1]
+    const fraction = toFixed(0.2)
+
+    beforeEach(async () => {
+      await accountsInstance.createAccount()
+      await accountsInstance.setPaymentDelegation(beneficiary, fraction)
+    })
+
+    it('should set the address and beneficiary to 0', async () => {
+      await accountsInstance.deletePaymentDelegation()
+      const [realBeneficiary, realFraction] = await accountsInstance.getPaymentDelegation.call(
+        accounts[0]
+      )
+      assert.equal(realBeneficiary, NULL_ADDRESS)
+      assertEqualBN(realFraction, new BigNumber(0))
+    })
+
+    it('emits a PaymentDelegationSet event', async () => {
+      const resp = await accountsInstance.deletePaymentDelegation()
+      assertLogMatches2(resp.logs[0], {
+        event: 'PaymentDelegationSet',
+        args: { beneficiary: NULL_ADDRESS, fraction: new BigNumber(0) },
+      })
+    })
+  })
+
   describe('#setName', () => {
     describe('when the account has not been created', () => {
       it('should revert', async () => {

--- a/packages/protocol/test/common/accounts.ts
+++ b/packages/protocol/test/common/accounts.ts
@@ -487,6 +487,13 @@ contract('Accounts', (accounts: string[]) => {
         )
       })
 
+      it('should not allow a beneficiary with address 0x0', async () => {
+        await assertRevertWithReason(
+          accountsInstance.setPaymentDelegation(NULL_ADDRESS, fraction),
+          'Beneficiary cannot be address 0x0'
+        )
+      })
+
       it('emits a PaymentDelegationSet event', async () => {
         const resp = await accountsInstance.setPaymentDelegation(beneficiary, fraction)
         assertLogMatches2(resp.logs[0], {

--- a/packages/protocol/test/common/accounts.ts
+++ b/packages/protocol/test/common/accounts.ts
@@ -513,6 +513,13 @@ contract('Accounts', (accounts: string[]) => {
       await accountsInstance.setPaymentDelegation(beneficiary, fraction)
     })
 
+    it('should not be callable by a non-account', async () => {
+      await assertRevertWithReason(
+        accountsInstance.setPaymentDelegation(beneficiary, fraction, { from: accounts[2] }),
+        'Not an account'
+      )
+    })
+
     it('should set the address and beneficiary to 0', async () => {
       await accountsInstance.deletePaymentDelegation()
       const [realBeneficiary, realFraction] = await accountsInstance.getPaymentDelegation.call(


### PR DESCRIPTION
### Description

The new validator payment delegation mechanism previously allowed a beneficiary of `0x0` with a non-0 fraction. The StableToken's `mint` function reverts when trying to mint to `0x0`. This could have led to a validator missing his entire epoch payment if payment delegation were accidentally misconfigured.

### Other changes

* Adds a `deletePaymentDelegation` function as the explicit mechanism for removing payment delegation settings.

### Tested

Unit tests

### Related issues

- Fixes #9240