### PR TITLE
Remove oracle check

### DIFF
--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -89,7 +89,7 @@ contract Reserve is
    * @return The storage, major, minor, and patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 2, 1);
+    return (1, 1, 2, 2);
   }
 
   function() external payable {} // solhint-disable no-empty-blocks

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -225,13 +225,6 @@ contract Reserve is
    */
   function addToken(address token) external onlyOwner nonReentrant returns (bool) {
     require(!isToken[token], "token addr already registered");
-    // Require an exchange rate between the new token and Gold exists.
-    address sortedOraclesAddress = registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID);
-    ISortedOracles sortedOracles = ISortedOracles(sortedOraclesAddress);
-    uint256 tokenAmount;
-    uint256 goldAmount;
-    (tokenAmount, goldAmount) = sortedOracles.medianRate(token);
-    require(goldAmount > 0, "median rate returned 0 gold");
     isToken[token] = true;
     _tokens.push(token);
     emit TokenAdded(token);


### PR DESCRIPTION
### Description

A check in the Reserve's `addToken` function appeared to be a blocker for getting quicker, single-proposal stable token deployments. The check may have been important in the past, back when the Reserve was responsible for minting/burning stable tokens, and the `isToken` mapping set in the `addToken` function was used for permissioning these behaviors. However, looking at both the monorepo contracts and celo-blockchain, the `isToken` mapping and `_tokens` list of tokens are not used anywhere, thus the check is safe to remove. See [here](https://github.com/celo-org/celo-monorepo/issues/9195#issuecomment-1057942027) for more details.

### Tested

Tests still pass. 

### Related issues

- Fixes #9197