### PR TITLE
Get pending withdrawal

### DIFF
--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -81,7 +81,7 @@ contract LockedGold is
   * @return The storage, major, minor, and patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 2);
+    return (1, 1, 2, 0);
   }
 
   /**
@@ -282,6 +282,25 @@ contract LockedGold is
       timestamps[i] = pendingWithdrawal.timestamp;
     }
     return (values, timestamps);
+  }
+
+  /**
+   * @notice Returns the pending withdrawal at a given index for a given account.
+   * @param account The address of the account.
+   * @param index The index of the pending withdrawal.
+   * @return The value of the pending withdrawal.
+   * @return The timestamp of the pending withdrawal.
+   */
+  function getPendingWithdrawal(address account, uint256 index)
+    external
+    view
+    returns (uint256, uint256)
+  {
+    require(getAccounts().isAccount(account), "Unknown account");
+    require(index < balances[account].pendingWithdrawals.length, "Bad pending withdrawal index");
+    PendingWithdrawal memory pendingWithdrawal = (balances[account].pendingWithdrawals[index]);
+
+    return (pendingWithdrawal.value, pendingWithdrawal.timestamp);
   }
 
   /**

--- a/packages/protocol/test/governance/voting/lockedgold.ts
+++ b/packages/protocol/test/governance/voting/lockedgold.ts
@@ -203,11 +203,10 @@ contract('LockedGold', (accounts: string[]) => {
         })
 
         it('should add a pending withdrawal', async () => {
-          const [values, timestamps] = await lockedGold.getPendingWithdrawals(account)
-          assert.equal(values.length, 1)
-          assert.equal(timestamps.length, 1)
-          assertEqualBN(values[0], value)
-          assertEqualBN(timestamps[0], availabilityTime)
+          // Get the first pending withdrawal.
+          const [val, timestamp] = await lockedGold.getPendingWithdrawal(account, 0)
+          assertEqualBN(val, value)
+          assertEqualBN(timestamp, availabilityTime)
         })
 
         it("should decrease the account's nonvoting locked gold balance", async () => {

--- a/packages/protocol/test/governance/voting/lockedgold.ts
+++ b/packages/protocol/test/governance/voting/lockedgold.ts
@@ -203,10 +203,10 @@ contract('LockedGold', (accounts: string[]) => {
         })
 
         it('should add a pending withdrawal', async () => {
-          // Get the first pending withdrawal.
           const [val, timestamp] = await lockedGold.getPendingWithdrawal(account, 0)
           assertEqualBN(val, value)
           assertEqualBN(timestamp, availabilityTime)
+          await assertRevert(lockedGold.getPendingWithdrawal(account, 1))
         })
 
         it("should decrease the account's nonvoting locked gold balance", async () => {


### PR DESCRIPTION
### Description

LockedGold.sol currently provides a way to retrieve all pendingWithdrawals associated to a given account.

To be able to extract a pendingWithdrawal at specific index, one would need to first do getPendingWithdrawals and then loop through the result to find the record 0(n) and has a DOS vector as found by @tkporter 

### Tested

- [x] unit test


### Backwards compatibility

This change is backward compatible because it is completely transparent and does not modify existing function signatures etc
