### PR TITLE
TxLookupLimit default to infinite

### DIFF
--- a/packages/helm-charts/common/templates/_helpers.tpl
+++ b/packages/helm-charts/common/templates/_helpers.tpl
@@ -197,6 +197,7 @@ fi
       --vmodule={{ .Values.geth.vmodule }} \
       --datadir=/root/.celo \
       --ipcpath=geth.ipc \
+      --txlookuplimit {{ .Values.geth.txlookuplimit | default 0 }} \
       ${ADDITIONAL_FLAGS}
   env:
   - name: GETH_DEBUG


### PR DESCRIPTION
### Description

TxLookupLimit default to infinite (as it was before)

### Backwards compatibility

Yes
