### PR TITLE
Add permissions for env_tests.yml

### DIFF
--- a/.github/workflows/env_tests.yml
+++ b/.github/workflows/env_tests.yml
@@ -8,6 +8,9 @@ on:
         description: 'Network to run env-tests against.  Possible values are (staging|baklava|alfajores|mainnet)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   env-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. 

The `Token-Permissions` category has a score of 0/10 in Scorecards.

This file was fixed automatically using the open-source tool https://github.com/step-security/secure-workflows. If you like the changes and merge them, please consider starring the repo. 