### PR TITLE
Automate closing of stale issue

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '40 14 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale: Marked for Closing'
+        stale-pr-message: 'Stale: Marked for Closing'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        exempt-issue-labels: 'do-not-close'
+        exempt-pr-labels: 'do-not-close'
+        days-before-stale: 120
+        days-before-close: 30
+  

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,10 +23,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale: Marked for Closing'
         stale-pr-message: 'Stale: Marked for Closing'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
         exempt-issue-labels: 'do-not-close'
         exempt-pr-labels: 'do-not-close'
         days-before-stale: 120
+        days-before-issue-stale: 270
         days-before-close: 30
-  
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale: Marked for Closing'
-        stale-pr-message: 'Stale: Marked for Closing'
+        stale-issue-message: 'This issue is stale and will be closed in 30 days without activity'
+        stale-pr-message: 'This PR is stale and will be closed in 30 days without activity'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'do-not-close'


### PR DESCRIPTION
### Description

Monorepo has open PRs that are in some cases over 2 years old And thousands of open issues. By using this action we can automate the marking of stale issues and PRs for closing. 

#### Rules:

Unless labeled as `do-not-close` 
Marked issue as  `stale` after 270 days without activity (9 months)
Marked PR as  `stale` after 120 days without activity (4 months)

After marked as `stale` will close if 30 days go by without activity



Eventually these numbers could be tightened up. 



### Related issues
All

### Backwards compatibility

n/a
### Documentation

n/a