### PR TITLE
force https:// so that building old dev chain works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             echo "Comparing against $RELEASE_TAG"
-            # Github is phasing out the git protocol so we ensure that we use
+            # Github has phased out the git protocol so we ensure that we use
             # https for all git operations that yarn may perform.
             git config --global url."https://github.com".insteadOf git://github.com
             yarn --cwd packages/protocol test:generate-old-devchain-and-build -b $RELEASE_TAG -d .tmp/released_chain -l /dev/stdout -g scripts/truffle/releaseGoldExampleConfigs.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,9 @@ jobs:
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             echo "Comparing against $RELEASE_TAG"
+            # Github is phasing out the git protocol so we ensure that we use
+            # https for all git operations that yarn may perform.
+            git config --global url."https://github.com".insteadOf git://github.com
             yarn --cwd packages/protocol test:generate-old-devchain-and-build -b $RELEASE_TAG -d .tmp/released_chain -l /dev/stdout -g scripts/truffle/releaseGoldExampleConfigs.json
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
### Description

The `pre-protocol-test-release` job on circle is not running because github no longer support un authenticated git. this tells it to use https

### Other changes

n/a
### Tested
blockchain repo does this already

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

just a build step
### Documentation

n/a