### PR TITLE
specify RTD packages

### DIFF
--- a/packages/docs/sdk/requirements.txt
+++ b/packages/docs/sdk/requirements.txt
@@ -1,0 +1,3 @@
+jinja2==3.0.0
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,3 +3,8 @@ version: 2
 mkdocs:
   configuration: packages/docs/sdk/mkdocs.yml
   fail_on_warning: true
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: packages/docs/sdk/requirements.txt


### PR DESCRIPTION
### Description

Recent builds of the typedoc autogenerated docs have been failing because of some dependency upgrades. This PR specifies the packages for the read the docs site to use so the build will work.

Related issue, https://github.com/readthedocs/readthedocs.org/issues/9037