### PR TITLE
Fix type errors in #9161 due to indistinguishable request types

### DIFF
--- a/packages/phone-number-privacy/combiner/src/combiner/domain/sign.io.ts
+++ b/packages/phone-number-privacy/combiner/src/combiner/domain/sign.io.ts
@@ -8,10 +8,12 @@ import {
   DomainRestrictedSignatureResponseSuccess,
   DomainSchema,
   DomainState,
-  ErrorType, getSignerEndpoint, OdisResponse,
+  ErrorType,
+  getSignerEndpoint,
   send,
-  SequentialDelayDomainStateSchema, verifyDomainRestrictedSignatureRequestAuthenticity,
-  WarningMessage
+  SequentialDelayDomainStateSchema,
+  verifyDomainRestrictedSignatureRequestAuthenticity,
+  WarningMessage,
 } from '@celo/phone-number-privacy-common'
 import { Request, Response } from 'express'
 import { VERSION } from '../../config'
@@ -24,7 +26,7 @@ export class DomainSignIO extends IOAbstract<DomainRestrictedSignatureRequest> {
 
   async init(
     request: Request<{}, {}, unknown>,
-    response: Response<OdisResponse<DomainRestrictedSignatureRequest>> // @victor type weirdness here
+    response: Response<DomainRestrictedSignatureResponse>
   ): Promise<Session<DomainRestrictedSignatureRequest> | null> {
     if (!super.inputChecks(request, response)) {
       return null

--- a/packages/phone-number-privacy/common/src/interfaces/requests.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/requests.ts
@@ -112,9 +112,8 @@ export type PhoneNumberPrivacyRequest = SignMessageRequest | MatchmakingRequest 
  * Domain restricted signature request to get a pOPRF evaluation on the given message in a given
  * domain, as specified by CIP-40.
  *
- * @remarks Concrete request types are created by specifying the type parameters for Domain and
- * DomainOptions. If the specified Domain has associated options, then the options field is
- * required. If not, it must not be provided.
+ * @remarks Concrete request types are created by specifying the type parameter for Domain. If a
+ * domain has no options, an empty struct should be used.
  */
 export type DomainRestrictedSignatureRequest<D extends Domain = Domain> = {
   /** Domain specification. Selects the PRF domain and rate limiting rules. */
@@ -138,9 +137,8 @@ export type DomainRestrictedSignatureRequest<D extends Domain = Domain> = {
  * Options may be provided for authentication in case the quota state is non-public information.
  * E.g. Quota state may reveal whether or not a user has attempted to recover a given account.
  *
- * @remarks Concrete request types are created by specifying the type parameters for Domain and
- * DomainOptions. If the specified Domain has associated options, then the options field is
- * required. If not, it must not be provided.
+ * @remarks Concrete request types are created by specifying the type parameter for Domain. If a
+ * domain has no options, an empty struct should be used.
  */
 export type DomainQuotaStatusRequest<D extends Domain = Domain> = {
   /** Domain specification. Selects the PRF domain and rate limiting rules. */
@@ -158,9 +156,8 @@ export type DomainQuotaStatusRequest<D extends Domain = Domain> = {
  *
  * Options may be provided for authentication to prevent unintended parties from disabling a domain.
  *
- * @remarks Concrete request types are created by specifying the type parameters for Domain and
- * DomainOptions. If the specified Domain has associated options, then the options field is
- * required. If not, it must not be provided.
+ * @remarks Concrete request types are created by specifying the type parameter for Domain. If a
+ * domain has no options, an empty struct should be used.
  */
 export type DisableDomainRequest<D extends Domain = Domain> = {
   /** Domain specification. Selects the PRF domain and rate limiting rules. */

--- a/packages/phone-number-privacy/common/src/interfaces/requests.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/requests.ts
@@ -108,6 +108,12 @@ export const PnpQuotaRequestSchema: t.Type<PnpQuotaRequest> = t.type({
 
 export type PhoneNumberPrivacyRequest = SignMessageRequest | MatchmakingRequest | PnpQuotaRequest
 
+export enum DomainRequestTypeTag {
+  SIGN = 'DomainRestrictedSignatureRequest',
+  QUOTA = 'DomainQuotaStatusRequest',
+  DISABLE = 'DisableDomainRequest',
+}
+
 /**
  * Domain restricted signature request to get a pOPRF evaluation on the given message in a given
  * domain, as specified by CIP-40.
@@ -116,6 +122,8 @@ export type PhoneNumberPrivacyRequest = SignMessageRequest | MatchmakingRequest 
  * domain has no options, an empty struct should be used.
  */
 export type DomainRestrictedSignatureRequest<D extends Domain = Domain> = {
+  /** Request type tag to ensure this type can be distinguished from other request objects. */
+  type: DomainRequestTypeTag.SIGN
   /** Domain specification. Selects the PRF domain and rate limiting rules. */
   domain: D
   /**
@@ -141,6 +149,8 @@ export type DomainRestrictedSignatureRequest<D extends Domain = Domain> = {
  * domain has no options, an empty struct should be used.
  */
 export type DomainQuotaStatusRequest<D extends Domain = Domain> = {
+  /** Request type tag to ensure this type can be distinguished from other request objects. */
+  type: DomainRequestTypeTag.QUOTA
   /** Domain specification. Selects the PRF domain and rate limiting rules. */
   domain: D
   /** Domain-specific options. */
@@ -160,6 +170,8 @@ export type DomainQuotaStatusRequest<D extends Domain = Domain> = {
  * domain has no options, an empty struct should be used.
  */
 export type DisableDomainRequest<D extends Domain = Domain> = {
+  /** Request type tag to ensure this type can be distinguished from other request objects. */
+  type: DomainRequestTypeTag.DISABLE
   /** Domain specification. Selects the PRF domain and rate limiting rules. */
   domain: D
   /** Domain-specific options. */
@@ -187,6 +199,7 @@ export function domainRestrictedSignatureRequestSchema<D extends Domain = Domain
   // domain and options fields. We wrap the schema below to add a consistency check.
   const schema = t.strict({
     domain,
+    type: t.literal(DomainRequestTypeTag.SIGN),
     options: t.unknown,
     blindedMessage: t.string,
     sessionID: eip712OptionalSchema(t.string),
@@ -232,6 +245,7 @@ export function domainQuotaStatusRequestSchema<D extends Domain = Domain>(
   // domain and options fields. We wrap the schema below to add a consistency check.
   const schema = t.strict({
     domain,
+    type: t.literal(DomainRequestTypeTag.QUOTA),
     options: t.unknown,
     sessionID: eip712OptionalSchema(t.string),
   })
@@ -273,6 +287,7 @@ export function disableDomainRequestSchema<D extends Domain = Domain>(
   // domain and options fields. We wrap the schema below to add a consistency check.
   const schema = t.strict({
     domain,
+    type: t.literal(DomainRequestTypeTag.DISABLE),
     options: t.unknown,
     sessionID: eip712OptionalSchema(t.string),
   })
@@ -315,9 +330,9 @@ export function domainRestrictedSignatureRequestEIP712<D extends Domain>(
   return {
     types: {
       DomainRestrictedSignatureRequest: [
+        { name: 'type', type: 'string' },
         { name: 'blindedMessage', type: 'string' },
         { name: 'domain', type: domainTypes.primaryType },
-        // Only include the `options` field in the EIP-712 type if there are options.
         { name: 'options', type: optionsTypes.primaryType },
         { name: 'sessionID', type: 'Optional<string>' },
       ],
@@ -347,8 +362,8 @@ export function domainQuotaStatusRequestEIP712<D extends Domain>(
   return {
     types: {
       DomainQuotaStatusRequest: [
+        { name: 'type', type: 'string' },
         { name: 'domain', type: domainTypes.primaryType },
-        // Only include the `options` field in the EIP-712 type if there are options.
         { name: 'options', type: optionsTypes.primaryType },
         { name: 'sessionID', type: 'Optional<string>' },
       ],
@@ -378,8 +393,8 @@ export function disableDomainRequestEIP712<D extends Domain>(
   return {
     types: {
       DisableDomainRequest: [
+        { name: 'type', type: 'string' },
         { name: 'domain', type: domainTypes.primaryType },
-        // Only include the `options` field in the EIP-712 type if there are options.
         { name: 'options', type: optionsTypes.primaryType },
         { name: 'sessionID', type: 'Optional<string>' },
       ],

--- a/packages/phone-number-privacy/common/src/interfaces/responses.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/responses.ts
@@ -177,7 +177,7 @@ export type DisableDomainResponse = DisableDomainResponseSuccess | DisableDomain
 export type DomainResponse<
   R extends DomainRequest = DomainRequest
 > = 
-  | R extends DomainRestrictedSignatureRequest ? DomainRestrictedSignatureResponse : never
+  | R extends DomainRestrictedSignatureRequest<infer D> ? DomainRestrictedSignatureResponse<D> : never
   | R extends DomainQuotaStatusRequest<infer D> ? DomainQuotaStatusResponse<D> : never
   | R extends DisableDomainRequest ? DisableDomainResponse : never
 

--- a/packages/phone-number-privacy/common/test/interfaces/requests.test.ts
+++ b/packages/phone-number-privacy/common/test/interfaces/requests.test.ts
@@ -20,6 +20,7 @@ import {
   DomainQuotaStatusRequest,
   domainQuotaStatusRequestEIP712,
   domainQuotaStatusRequestSchema,
+  DomainRequestTypeTag,
   DomainRestrictedSignatureRequest,
   domainRestrictedSignatureRequestEIP712,
   domainRestrictedSignatureRequestSchema,
@@ -46,6 +47,7 @@ TEST_DISABLE_DOMAIN_REQUEST_IS_EIP712 = ({} as unknown) as DisableDomainRequest<
 describe('domainRestrictedSignatureRequestEIP712()', () => {
   it('should generate the correct type data for request with SequentialDelayDomain', () => {
     const request: DomainRestrictedSignatureRequest<SequentialDelayDomain> = {
+      type: DomainRequestTypeTag.SIGN,
       domain: {
         name: DomainIdentifiers.SequentialDelay,
         version: '1',
@@ -60,7 +62,7 @@ describe('domainRestrictedSignatureRequestEIP712()', () => {
       blindedMessage: '<blinded message>',
       sessionID: noString,
     }
-    const expectedHash = 'bc958fdbf83dfa7253b9ad1d9a8c5a803617f7acbed9684ff4fda669647956b5'
+    const expectedHash = '9914e6bc3bd0d63727eeae4008654920b9879654f7159b1d5ab33768e61f56df'
     const typedData = domainRestrictedSignatureRequestEIP712(request)
     // console.debug(JSON.stringify(typedData, null, 2))
     expect(generateTypedDataHash(typedData).toString('hex')).toEqual(expectedHash)
@@ -70,6 +72,7 @@ describe('domainRestrictedSignatureRequestEIP712()', () => {
 describe('domainQuotaStatusRequestEIP712()', () => {
   it('should generate the correct type data for request with SequentialDelayDomain', () => {
     const request: DomainQuotaStatusRequest<SequentialDelayDomain> = {
+      type: DomainRequestTypeTag.QUOTA,
       domain: {
         name: DomainIdentifiers.SequentialDelay,
         version: '1',
@@ -83,7 +86,7 @@ describe('domainQuotaStatusRequestEIP712()', () => {
       },
       sessionID: noString,
     }
-    const expectedHash = '7fcd55bc848bb89bb14cee5f5b08a4ae3224b26fbffb86385e2b64056862de62'
+    const expectedHash = '0c1545b83f28d8d0f24886fa0d21ac540af706dd6f9ee6d045bac17780a2656e'
     const typedData = domainQuotaStatusRequestEIP712(request)
     //console.debug(JSON.stringify(typedData, null, 2))
     expect(generateTypedDataHash(typedData).toString('hex')).toEqual(expectedHash)
@@ -93,6 +96,7 @@ describe('domainQuotaStatusRequestEIP712()', () => {
 describe('disableDomainRequestEIP712()', () => {
   it('should generate the correct type data for request with SequentialDelayDomain', () => {
     const request: DisableDomainRequest<SequentialDelayDomain> = {
+      type: DomainRequestTypeTag.DISABLE,
       domain: {
         name: DomainIdentifiers.SequentialDelay,
         version: '1',
@@ -106,7 +110,7 @@ describe('disableDomainRequestEIP712()', () => {
       },
       sessionID: noString,
     }
-    const expectedHash = '150d96add3ad0c9ec4f72638fd1e452fb477c7aedde09bc3c67fa2611cbdc581'
+    const expectedHash = 'd30be7d1b1bb3a9a0b2b2148d9ea3fcae7775dc31ce984d658f90295887a323a'
     const typedData = disableDomainRequestEIP712(request)
     console.debug(JSON.stringify(typedData, null, 2))
     expect(generateTypedDataHash(typedData).toString('hex')).toEqual(expectedHash)
@@ -144,6 +148,7 @@ const manipulatedDomain: SequentialDelayDomain = {
 }
 
 const signatureRequest: DomainRestrictedSignatureRequest<SequentialDelayDomain> = {
+  type: DomainRequestTypeTag.SIGN,
   domain: authenticatedDomain,
   options: {
     signature: noString,
@@ -154,6 +159,7 @@ const signatureRequest: DomainRestrictedSignatureRequest<SequentialDelayDomain> 
 }
 
 const quotaRequest: DomainQuotaStatusRequest<SequentialDelayDomain> = {
+  type: DomainRequestTypeTag.QUOTA,
   domain: authenticatedDomain,
   options: {
     signature: noString,
@@ -163,6 +169,7 @@ const quotaRequest: DomainQuotaStatusRequest<SequentialDelayDomain> = {
 }
 
 const disableRequest: DisableDomainRequest<SequentialDelayDomain> = {
+  type: DomainRequestTypeTag.DISABLE,
   domain: authenticatedDomain,
   options: {
     signature: noString,

--- a/packages/phone-number-privacy/signer/src/signer/domain/disable.action.ts
+++ b/packages/phone-number-privacy/signer/src/signer/domain/disable.action.ts
@@ -40,7 +40,7 @@ export class DomainDisableAction implements IAction<DisableDomainRequest> {
 
       this.io.sendSuccess(
         res.status,
-        session.response, // @victor this is the weird type error I mentioned seemingly caused by DomainQuotaStatusRequest and DisableDomainRequest having the same structure
+        session.response,
         res.domainStateRecord.toSequentialDelayDomainState()
       )
     } catch (error) {

--- a/packages/phone-number-privacy/signer/src/signer/domain/quota.io.ts
+++ b/packages/phone-number-privacy/signer/src/signer/domain/quota.io.ts
@@ -1,12 +1,12 @@
 import {
   DomainQuotaStatusRequest,
   domainQuotaStatusRequestSchema,
+  DomainQuotaStatusResponse,
   DomainQuotaStatusResponseFailure,
   DomainQuotaStatusResponseSuccess,
   DomainSchema,
   DomainState,
   ErrorType,
-  OdisResponse,
   send,
   SignerEndpoint,
   verifyDomainQuotaStatusRequestAuthenticity,
@@ -23,7 +23,7 @@ export class DomainQuotaIO extends IOAbstract<DomainQuotaStatusRequest> {
 
   async init(
     request: Request<{}, {}, unknown>,
-    response: Response<OdisResponse<DomainQuotaStatusRequest>> // @victor I'm seeing some weird type stuff here if I use DomainQuotaStatusResponse
+    response: Response<DomainQuotaStatusResponse>
   ): Promise<DomainSession<DomainQuotaStatusRequest> | null> {
     if (!super.inputChecks(request, response)) {
       return null

--- a/packages/phone-number-privacy/signer/src/signer/domain/sign.io.ts
+++ b/packages/phone-number-privacy/signer/src/signer/domain/sign.io.ts
@@ -1,13 +1,13 @@
 import {
   DomainRestrictedSignatureRequest,
   domainRestrictedSignatureRequestSchema,
+  DomainRestrictedSignatureResponse,
   DomainRestrictedSignatureResponseFailure,
   DomainRestrictedSignatureResponseSuccess,
   DomainSchema,
   DomainState,
   ErrorType,
   KEY_VERSION_HEADER,
-  OdisResponse,
   send,
   SignerEndpoint,
   verifyDomainRestrictedSignatureRequestAuthenticity,
@@ -25,7 +25,7 @@ export class DomainSignIO extends IOAbstract<DomainRestrictedSignatureRequest> {
 
   async init(
     request: Request<{}, {}, unknown>,
-    response: Response<OdisResponse<DomainRestrictedSignatureRequest>> // @victor type weirdness here
+    response: Response<DomainRestrictedSignatureResponse>
   ): Promise<DomainSession<DomainRestrictedSignatureRequest> | null> {
     if (!super.inputChecks(request, response)) {
       return null

--- a/packages/phone-number-privacy/signer/src/signer/quota.interface.ts
+++ b/packages/phone-number-privacy/signer/src/signer/quota.interface.ts
@@ -10,13 +10,10 @@ import { DomainStateRecord } from '../database/models/domainState'
 import { Session } from './action.interface'
 import { PnpQuotaStatus } from './pnp/quota.service'
 
-export type OdisQuotaStatus<R extends OdisRequest> = R extends
-  | DomainQuotaStatusRequest // @victor do you know how to prevent this weird auto formatting?
-  | DomainRestrictedSignatureRequest
-  ? DomainStateRecord
-  : never | R extends SignMessageRequest | PnpQuotaRequest
-  ? PnpQuotaStatus
-  : never
+// prettier-ignore
+export type OdisQuotaStatus<R extends OdisRequest> =
+  | R extends DomainQuotaStatusRequest | DomainRestrictedSignatureRequest ? DomainStateRecord : never
+  | R extends SignMessageRequest | PnpQuotaRequest ? PnpQuotaStatus : never
 
 export interface OdisQuotaStatusResult<R extends OdisRequest> {
   sufficient: boolean

--- a/packages/sdk/encrypted-backup/src/backup.test.ts
+++ b/packages/sdk/encrypted-backup/src/backup.test.ts
@@ -168,7 +168,12 @@ describe('createBackup', () => {
       body: {
         success: true,
         version: 'mock',
-        status: { timer: Date.now() / 1000 + 3600, counter: 0, disabled: false },
+        status: {
+          timer: Date.now() / 1000 + 3600,
+          counter: 0,
+          disabled: false,
+          now: Date.now() / 1000,
+        },
       },
     })
     const result = await createBackup({
@@ -369,7 +374,12 @@ describe('openBackup', () => {
       body: {
         success: true,
         version: 'mock',
-        status: { timer: Date.now() / 1000 + 3600, counter: 0, disabled: false },
+        status: {
+          timer: Date.now() / 1000 + 3600,
+          counter: 0,
+          disabled: false,
+          now: Date.now() / 1000,
+        },
       },
     })
     const result = await openBackup({

--- a/packages/sdk/encrypted-backup/src/odis.mock.ts
+++ b/packages/sdk/encrypted-backup/src/odis.mock.ts
@@ -27,7 +27,7 @@ export class MockOdis {
 
   state: Record<string, SequentialDelayDomainState> = {}
 
-  private now = () => Date.now() / 1000
+  private now = () => Math.floor(Date.now() / 1000)
 
   private domainState(hash: Buffer) {
     return (
@@ -130,7 +130,7 @@ export class MockOdis {
           const res = this.quota(
             JSON.parse(req.body) as DomainQuotaStatusRequest<SequentialDelayDomain>
           )
-          debug('Mocking request', { url, req, res })
+          debug('Mocking request', JSON.stringify({ url, req, res }))
           return res
         })
     )
@@ -147,7 +147,7 @@ export class MockOdis {
           const res = this.sign(
             JSON.parse(req.body) as DomainRestrictedSignatureRequest<SequentialDelayDomain>
           )
-          debug('Mocking request', { url, req, res })
+          debug('Mocking request', JSON.stringify({ url, req, res }))
           return res
         })
     )

--- a/packages/sdk/encrypted-backup/src/odis.ts
+++ b/packages/sdk/encrypted-backup/src/odis.ts
@@ -15,6 +15,7 @@ import {
   DomainQuotaStatusResponse,
   domainQuotaStatusResponseSchema,
   DomainQuotaStatusResponseSuccess,
+  DomainRequestTypeTag,
   DomainRestrictedSignatureRequest,
   domainRestrictedSignatureRequestEIP712,
   DomainRestrictedSignatureResponse,
@@ -175,6 +176,7 @@ async function requestOdisQuotaStatus(
   wallet?: EIP712Wallet
 ): Promise<Result<DomainQuotaStatusResponseSuccess, BackupError>> {
   const quotaStatusReq: DomainQuotaStatusRequest<SequentialDelayDomain> = {
+    type: DomainRequestTypeTag.QUOTA,
     domain,
     options: {
       signature: noString,
@@ -230,6 +232,7 @@ async function requestOdisDomainSignature(
   wallet?: EIP712Wallet
 ): Promise<Result<DomainRestrictedSignatureResponseSuccess, BackupError>> {
   const signatureReq: DomainRestrictedSignatureRequest<SequentialDelayDomain> = {
+    type: DomainRequestTypeTag.SIGN,
     domain,
     options: {
       signature: noString,


### PR DESCRIPTION
### Description

Of the ODIS domain requests, the quota and disable requests are indistinguishable in JS as runtime.
As a result, there were some errors with type handling. After some thought, I decided the best
solution is to add a `type` tag field to the requests to ensure they are distingushable.
