### PR TITLE
Explantation on bytes32 issue.

### DIFF
--- a/packages/protocol/contracts/stability/StableTokenRegistry.sol
+++ b/packages/protocol/contracts/stability/StableTokenRegistry.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../common/Initializable.sol";
@@ -27,8 +28,8 @@ contract StableTokenRegistry is Initializable, Ownable {
    * @param existingStableTokenContractNames Collection of stable token smart contract names.
    */
   function initialize(
-    bytes32[] calldata existingFiatTickers,
-    bytes32[] calldata existingStableTokenContractNames
+    bytes[] calldata existingFiatTickers,
+    bytes[] calldata existingStableTokenContractNames
   ) external initializer {
     require(
       existingFiatTickers.length == existingStableTokenContractNames.length,
@@ -36,10 +37,7 @@ contract StableTokenRegistry is Initializable, Ownable {
     );
     _transferOwnership(msg.sender);
     for (uint256 i = 0; i < existingFiatTickers.length; i++) {
-      addNewStableToken(
-        abi.encodePacked(existingFiatTickers[i]),
-        abi.encodePacked(existingStableTokenContractNames[i])
-      );
+      addNewStableToken(existingFiatTickers[i], existingStableTokenContractNames[i]);
     }
   }
 

--- a/packages/protocol/test/stability/stabletokenregistry.ts
+++ b/packages/protocol/test/stability/stabletokenregistry.ts
@@ -49,7 +49,6 @@ contract('StableTokenRegistry', (accounts: string[]) => {
     })
 
     it('only allows owner', async () => {
-      await strc.addNewStableToken(fiatTicker, stableTokenContractName)
       await assertRevert(strc.removeStableToken(fiatTicker, 0, { from: nonOwner }))
     })
 
@@ -103,6 +102,7 @@ contract('StableTokenRegistry', (accounts: string[]) => {
     })
 
     it('does not allow duplicate values', async () => {
+      await assertRevert(strc.addNewStableToken(fiatTicker, stableTokenContractName))
       await assertRevert(strc.addNewStableToken(fiatTicker, stableTokenContractName))
     })
 


### PR DESCRIPTION
You have this issue because you are passing `bytes32` to the initializer and then `abi.encodePacked` them when passing to the `addNewStableToken`, but when calling the function directly you just passed in `bytes` so those keys ended up looking slightly different. I added an event with the key and value and this is what it looks like for that test when it's failing:
```

    StableTokenRegistry.StableTokenRegistered(
      key: hex'6355534400000000000000000000000000000000000000000000000000000000' (type: bytes),
      value: hex'537461626c65546f6b656e000000000000000000000000000000000000000000' (type: bytes)
    )

    StableTokenRegistry.StableTokenRegistered(
      key: hex'6345555200000000000000000000000000000000000000000000000000000000' (type: bytes),
      value: hex'537461626c65546f6b656e455552000000000000000000000000000000000000' (type: bytes)
    )

    StableTokenRegistry.StableTokenRegistered(
      key: hex'63555344' (type: bytes),
      value: hex'537461626c65546f6b656e' (type: bytes)
    )
```


And this is how events are emitted with the changes I made:

```

    StableTokenRegistry.StableTokenRegistered(
      key: hex'63555344' (type: bytes),
      value: hex'537461626c65546f6b656e' (type: bytes)
    )

    StableTokenRegistry.StableTokenRegistered(
      key: hex'63455552' (type: bytes),
      value: hex'537461626c65546f6b656e455552' (type: bytes)
    )
```

Basically the javascript side pads `hex'63455552'` with zeros until 32 bytes when the initializer is bytes32 and that actually ends up looking different. Also, tho in practice there shouldn't be issues because we won't see too big strings it feels dangerous to assume `bytes32` is ok for the initializer but have the mapping keys as `bytes`.

---

That being said I'm not really a big fan of what's happening here. I struggle to see the real point for this / what it would be used for. It feels like we're adding too many levels of indirection which just waste gas for nothing. Converting "USD" to "StableToken" and then that to a contract address that's static anyway because it's a proxy :-/.