### PR TITLE
Integrate POPRF cryptography implementation into ODIS client and server

### DIFF
--- a/packages/sdk/encrypted-backup/package.json
+++ b/packages/sdk/encrypted-backup/package.json
@@ -28,7 +28,7 @@
     "@celo/base":  "1.5.3-dev",
     "@celo/identity":  "1.5.3-dev",
     "@celo/phone-number-privacy-common": "1.0.40-dev",
-    "@celo/poprf": "^0.1.0",
+    "@celo/poprf": "^0.1.2",
     "@celo/utils":  "1.5.3-dev",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",

--- a/packages/sdk/encrypted-backup/package.json
+++ b/packages/sdk/encrypted-backup/package.json
@@ -28,6 +28,7 @@
     "@celo/base":  "1.5.3-dev",
     "@celo/identity":  "1.5.3-dev",
     "@celo/phone-number-privacy-common": "1.0.40-dev",
+    "@celo/poprf": "^0.1.0",
     "@celo/utils":  "1.5.3-dev",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",

--- a/packages/sdk/encrypted-backup/src/poprf.ts
+++ b/packages/sdk/encrypted-backup/src/poprf.ts
@@ -1,0 +1,47 @@
+import { randomBytes } from 'crypto'
+// TODO(victor): This will only initially work in Node environments. If we want to have this work in
+// ReactNative and browser environments, some work will need to be done in @celo/poprf or here.
+import * as poprf from '@celo/poprf'
+
+export class PoprfClient {
+  /** Secret blinding factor used for blinding and response verification. */
+  private readonly blindingFactor: Buffer
+
+  /** Blinded message to be sent to the POPRF server for evaluation */
+  public readonly blindedMessage: Buffer
+
+  constructor(
+    readonly publicKey: Buffer,
+    readonly tag: Buffer,
+    readonly message: Buffer,
+    readonly seed?: Buffer
+  ) {
+    const blinded = poprf.blindMsg(message, seed ?? randomBytes(32))
+
+    // Save the blinding factor to the class state so that unblind can use it.
+    this.blindingFactor = Buffer.from(blinded.blindingFactor)
+    this.blindedMessage = Buffer.from(blinded.message)
+  }
+
+  public unblindResponse(response: Buffer): Buffer {
+    return Buffer.from(poprf.unblindResp(this.publicKey, this.blindingFactor, this.tag, response))
+  }
+}
+
+export class PoprfCombiner {
+  public static blindAggregate(responses: Array<Buffer>): Buffer {}
+}
+
+export class PoprfServer {
+  constructor(readonly privateKey: Buffer) {}
+
+  /** Evaluates the POPRF function over the tag and blinded message with the (complete) private key */
+  public blindEval(tag: Buffer, blindedMessage: Buffer): Buffer {
+    return Buffer.from(poprf.blindEval(this.privateKey, tag, blindedMessage))
+  }
+
+  /** Evaluates the POPRF function over the tag and blinded message with the private key share */
+  public blindPartialEval(tag: Buffer, blindedMessage: Buffer): Buffer {
+    return Buffer.from(poprf.blindPartialEval(this.privateKey, tag, blindedMessage))
+  }
+}

--- a/packages/sdk/encrypted-backup/src/poprf.ts
+++ b/packages/sdk/encrypted-backup/src/poprf.ts
@@ -5,11 +5,25 @@ import * as poprf from '@celo/poprf'
 
 export class PoprfClient {
   /** Secret blinding factor used for blinding and response verification. */
-  private readonly blindingFactor: Buffer
+  protected readonly blindingFactor: Buffer
 
-  /** Blinded message to be sent to the POPRF server for evaluation */
+  /** Blinded message to be sent to the POPRF service for evaluation */
   public readonly blindedMessage: Buffer
 
+  /**
+   * Constructs POPRF client state, blinding the given message and saving the public key, blinding
+   * factor, and tag for use in verification and unbinding of the response.
+   *
+   * Note that this client represents the client-side of a single protocol exchange.
+   *
+   * @param publicKey Public key for the POPRF service for use in verification.
+   * @param tag A plaintext tag which will be sent to the service along with the message.
+   * @param message A plaintext message which you want to blind and send to the POPRF service.
+   * @param seed Seed for the blinding factor. Provided if deterministic blinding is needed.
+   *   Note that, by design, if the same seed and message is used twice, the blinded message will be
+   *   the same. This allows for linking between the two blinded messages and so only should be used
+   *   if this is intended (e.g. to provide for retries of requests without consuming quota).
+   */
   constructor(
     readonly publicKey: Buffer,
     readonly tag: Buffer,
@@ -20,28 +34,128 @@ export class PoprfClient {
 
     // Save the blinding factor to the class state so that unblind can use it.
     this.blindingFactor = Buffer.from(blinded.blindingFactor)
-    this.blindedMessage = Buffer.from(blinded.message)
+    this.blindedMessage = Buffer.from(blinded.blindedMessage)
   }
 
+  /**
+   * Given a blinded evaluation response, unblind and verify the evaluation, returning the result.
+   *
+   * @param response A blinded evaluation response.
+   * @returns a buffer with the final POPRF output.
+   *
+   * @throws If the given response is invalid or cannot be verified against the public key, tag, and
+   * blinding state present in this client.
+   */
   public unblindResponse(response: Buffer): Buffer {
     return Buffer.from(poprf.unblindResp(this.publicKey, this.blindingFactor, this.tag, response))
   }
 }
 
 export class PoprfCombiner {
-  public static blindAggregate(responses: Array<Buffer>): Buffer {}
+  readonly blindedResponses: Buffer[] = []
+
+  constructor(readonly threshold: number) {
+    if (threshold % 1 !== 0) {
+      throw new Error('POPRF threshold must be an integer')
+    }
+  }
+
+  /**
+   * Adds the given blinded partial response(s) to the array of responses held on this object.
+   */
+  public addBlindedResponse(...responses: Buffer[]) {
+    this.blindedResponses.push(...responses)
+  }
+
+  /**
+   * If there are enough responses added to this combiner instance, aggregates the current
+   * collection of blind partial evaluations to a single blind threshold evaluation.
+   *
+   * @remarks This method does not verify any of the responses. Verification only occurs during
+   * unblinding.
+   *
+   * @returns A buffer with a blind aggregated POPRF evaluation response, or undefined if there are
+   * less than the threshold number of responses available.
+   */
+  public blindAggregate(): Buffer | undefined {
+    if (this.blindedResponses.length < this.threshold) {
+      return undefined
+    }
+
+    return Buffer.from(poprf.blindAggregate(this.threshold, Buffer.concat(this.blindedResponses)))
+  }
+}
+
+// TODO(victor) Combine this class with the functionality from the combiner to create a POPRF client
+// that can handle expunging bad partial evaluations from a set of responses.
+export class ThresholdPoprfClient extends PoprfClient {
+  /**
+   * Constructs POPRF client state, blinding the given message and saving the public keys, blinding
+   * factor, and tag for use in verification and unbinding of the response.
+   *
+   * Note that this client represents the client-side of a single protocol exchange.
+   *
+   * @param publicKey Public key for the POPRF service for use in verification.
+   * @param polynomial Public key polynomial for the individual POPRF servers for use in verification.
+   * @param tag A plaintext tag which will be sent to the service along with the message.
+   * @param message A plaintext message which you want to blind and send to the POPRF service.
+   * @param seed Seed for the blinding factor. Provided if deterministic blinding is needed.
+   *   Note that, by design, if the same seed and message is used twice, the blinded message will be
+   *   the same. This allows for linking between the two blinded messages and so only should be used
+   *   if this is intended (e.g. to provide for retries of requests without consuming quota).
+   */
+  constructor(
+    readonly publicKey: Buffer,
+    readonly polynomial: Buffer,
+    readonly tag: Buffer,
+    readonly message: Buffer,
+    readonly seed?: Buffer
+  ) {
+    super(publicKey, tag, message, seed)
+  }
+
+  /**
+   * Given a blinded partial evaluation response, unblind and verify the evaluation share, returning the result.
+   *
+   * @param response A blinded partial evaluation response.
+   * @returns a buffer with unblinded partial evaluation.
+   *
+   * @throws If the given response is invalid or cannot be verified against the public key, tag, and
+   * blinding state present in this client.
+   */
+  public unblindPartialResponse(response: Buffer): Buffer {
+    return Buffer.from(
+      poprf.unblindPartialResp(this.polynomial, this.blindingFactor, this.tag, response)
+    )
+  }
 }
 
 export class PoprfServer {
   constructor(readonly privateKey: Buffer) {}
 
-  /** Evaluates the POPRF function over the tag and blinded message with the (complete) private key */
+  /**
+   * Evaluates the POPRF function over the tag and blinded message with the (complete) private key
+   *
+   * @param tag plaintext tag buffer to be combined with the blinded message in the POPRF.
+   *
+   * @returns a serialized blinded evaluation response.
+   */
   public blindEval(tag: Buffer, blindedMessage: Buffer): Buffer {
     return Buffer.from(poprf.blindEval(this.privateKey, tag, blindedMessage))
   }
+}
 
-  /** Evaluates the POPRF function over the tag and blinded message with the private key share */
+export class ThresholdPoprfServer {
+  constructor(readonly privateKeyShare: Buffer) {}
+
+  /**
+   * Evaluates the POPRF function over the tag and blinded message with the private key share.
+   *
+   * @param tag plaintext tag buffer to be combined with the blinded message in the POPRF.
+   *
+   * @returns a serialized blinded partial evaluation response.
+   */
   public blindPartialEval(tag: Buffer, blindedMessage: Buffer): Buffer {
-    return Buffer.from(poprf.blindPartialEval(this.privateKey, tag, blindedMessage))
+    return Buffer.from(poprf.blindPartialEval(this.privateKeyShare, tag, blindedMessage))
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,10 +1475,10 @@
     elliptic "^6.5.4"
     is-base64 "^1.1.0"
 
-"@celo/poprf@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@celo/poprf/-/poprf-0.1.0.tgz#031ece3dd8bb5beaa403ef77c2afcc640f2d779b"
-  integrity sha512-J3+wMnB2fwOXGWYHti6rMzirmGuNvkUV0Rp6yDazOrkyH9OJw/8mxmQLduPq6iVoam3L0rxg8wtf7I5o63GlsA==
+"@celo/poprf@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@celo/poprf/-/poprf-0.1.2.tgz#3715470c62f53f287d9f7a9a18fbc78d89e1a0c8"
+  integrity sha512-LeEzE/eIYbSjdIh5cKegqwZKgU3LRbk43g5oI0clPsvxnjhV798L/nK9q+vZ6SKK/phSFZsrKbBad2yQuU5Mrw==
 
 "@celo/typechain-target-web3-v1-celo@0.2.0":
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,6 +1475,11 @@
     elliptic "^6.5.4"
     is-base64 "^1.1.0"
 
+"@celo/poprf@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@celo/poprf/-/poprf-0.1.0.tgz#031ece3dd8bb5beaa403ef77c2afcc640f2d779b"
+  integrity sha512-J3+wMnB2fwOXGWYHti6rMzirmGuNvkUV0Rp6yDazOrkyH9OJw/8mxmQLduPq6iVoam3L0rxg8wtf7I5o63GlsA==
+
 "@celo/typechain-target-web3-v1-celo@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@celo/typechain-target-web3-v1-celo/-/typechain-target-web3-v1-celo-0.2.0.tgz#2560b470e348d2628debe899885724ce5b218bc3"


### PR DESCRIPTION
### Description

Integrate POPRF cryptography code into ODIS client and server.

### Notes on this feature

An interface to the POPRF functionality is included in `@celo/phone-number-privacy-common`. The WASM module is currently fairly large, around 360kB all in, and so to prevent is from bloating `@celo/identity` and increasing module load times, it is loaded lazily and only included as a dev dependency.

As a result, packages that want to use this functionality need to add `@celo/poprf` to their own dependencies.
