### PR TITLE
Reduce quota timestamp precision to seconds in #9161

### DIFF
--- a/packages/phone-number-privacy/signer/src/database/models/domainState.ts
+++ b/packages/phone-number-privacy/signer/src/database/models/domainState.ts
@@ -30,7 +30,8 @@ export class DomainStateRecord<D extends Domain = Domain> {
       disabled: this[DOMAIN_STATE_COLUMNS.disabled],
       counter: this[DOMAIN_STATE_COLUMNS.counter],
       timer: this[DOMAIN_STATE_COLUMNS.timer],
-      now: attemptTime ?? Date.now() / 1000,
+      // Timestamp precision is lowered to seconds to reduce the chance of effective timing attacks.
+      now: attemptTime ?? Math.floor(Date.now() / 1000),
     }
   }
 }

--- a/packages/phone-number-privacy/signer/src/signer/domain/quota.service.ts
+++ b/packages/phone-number-privacy/signer/src/signer/domain/quota.service.ts
@@ -26,7 +26,8 @@ export class DomainQuotaService implements IQuotaService<QuotaDependentDomainReq
     attemptTime?: number
   ): Promise<OdisQuotaStatusResult<QuotaDependentDomainRequest>> {
     const { domain } = session.request.body
-    attemptTime = attemptTime ?? Date.now() / 1000 // Convert ms to seconds.
+    // Timestamp precision is lowered to seconds to reduce the chance of effective timing attacks.
+    attemptTime = attemptTime ?? Math.floor(Date.now() / 1000)
     if (isSequentialDelayDomain(domain)) {
       const result = checkSequentialDelayRateLimit(
         domain,


### PR DESCRIPTION
### Description

I realised that currently the timestamps returned by ODIS go out to the millisecond precision. This
is not much of a benefit to the user and increases the chance that a discovered timing attack could
be exploitable. This PR reduces the timing precision to mitigate this.
