### PR TITLE
Increase connection pool + max api pods for alfajores blockscout api.

### DIFF
--- a/packages/helm-charts/blockscout/values-alfajores.yaml
+++ b/packages/helm-charts/blockscout/values-alfajores.yaml
@@ -14,7 +14,7 @@ blockscout:
         cpu: 1500m
   api:
     autoscaling:
-        maxReplicas: 3
+        maxReplicas: 5
         minReplicas: 2
         target:
           cpu: 70
@@ -24,7 +24,7 @@ blockscout:
           requests:
             memory: 250Mi
             cpu: 200m
-    pool_size: 10
+    pool_size: 15
     resources:
       requests:
         memory: 250Mi


### PR DESCRIPTION
### Description

Alfajores API pods are being restarted after dropping too many requests due to lack of database connections. The database currently seems under utilized with CPU not going above 40% and active connections being pretty low. 

This PR increases the amount of connections allocated to a single api pod and the overall max number of pods to allow for more requests to be served.

