### PR TITLE
Increase max and min alfajores blockscout api pods.

### DIFF
--- a/packages/helm-charts/blockscout/values-alfajores.yaml
+++ b/packages/helm-charts/blockscout/values-alfajores.yaml
@@ -24,7 +24,7 @@ blockscout:
           requests:
             memory: 250Mi
             cpu: 200m
-    pool_size: 15
+    pool_size: 25
     resources:
       requests:
         memory: 250Mi

--- a/packages/helm-charts/blockscout/values-alfajores.yaml
+++ b/packages/helm-charts/blockscout/values-alfajores.yaml
@@ -14,8 +14,8 @@ blockscout:
         cpu: 1500m
   api:
     autoscaling:
-        maxReplicas: 5
-        minReplicas: 2
+        maxReplicas: 8
+        minReplicas: 3
         target:
           cpu: 70
     db:

--- a/packages/helm-charts/blockscout/values-alfajores.yaml
+++ b/packages/helm-charts/blockscout/values-alfajores.yaml
@@ -14,7 +14,7 @@ blockscout:
         cpu: 1500m
   api:
     autoscaling:
-        maxReplicas: 8
+        maxReplicas: 6
         minReplicas: 3
         target:
           cpu: 70


### PR DESCRIPTION
Increases the min and max pods on alfajores to serve more requests. There are issues being reported on slack with too many 50x errors being returned from the endpoints and the main failure reasons is a lack of available db connections, so this again increases the amount of connections per pod + the amount of pods.

