### PR TITLE
Implement FederatedAttestations lookup* unit tests

### DIFF
--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -1,6 +1,4 @@
 pragma solidity ^0.5.13;
-// TODO ASv2 come back to this and possibly flatten structs as arg params
-pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -74,7 +74,7 @@ contract FederatedAttestations is
   function _isRevoked(address signer, uint256 time) internal view returns (bool) {
     require(time >= 0);
     uint256 revokedOn = revokedSigners[signer];
-    return revokedOn > 0 && revokedOn <= time ? true : false;
+    return revokedOn > 0 && revokedOn <= time;
   }
 
   /**

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -73,10 +73,9 @@ contract FederatedAttestations is
   }
 
   function _isRevoked(address signer, uint256 time) internal view returns (bool) {
-    if (revokedSigners[signer] > 0 && revokedSigners[signer] >= time) {
-      return true;
-    }
-    return false;
+    require(time >= 0);
+    uint256 revokedOn = revokedSigners[signer];
+    return revokedOn > 0 && revokedOn <= time ? true : false;
   }
 
   /**

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -79,7 +79,8 @@ contract FederatedAttestations is
   }
 
   /**
-   * @notice Returns attestations for an identifier produced by a list of issuers
+   * @notice Returns info about attestations (with unrevoked signers)
+   *   for an identifier produced by a list of issuers
    * @param identifier Hash of the identifier
    * @param trustedIssuers Array of n issuers whose attestations will be included
    * @param maxAttestations Limit the number of attestations that will be returned
@@ -90,8 +91,7 @@ contract FederatedAttestations is
    *           Array of m signers
    *         ]; index corresponds to the same attestation
    * @dev Adds attestation info to the arrays in order of provided trustedIssuers
-   * @dev Adds all attestations produced by unrevoked signers for an
-   * (identifier, issuer) pair; i.e. not only the most recent attestation.
+   * @dev Expectation that only one attestation exists per (identifier, issuer, account)
    */
 
   // TODO ASv2 consider also returning an array with counts of attestations per issuer

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -110,15 +110,11 @@ contract FederatedAttestations is
     uint256 currIndex = 0;
 
     for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
-      address trustedIssuer = trustedIssuers[i];
-      for (
-        uint256 j = 0;
-        j < identifierToAddresses[identifier][trustedIssuer].length;
-        j = j.add(1)
-      ) {
+      uint256 numTrustedIssuers = identifierToAddresses[identifier][trustedIssuers[i]].length;
+      for (uint256 j = 0; j < numTrustedIssuers; j = j.add(1)) {
         // Only create and push new attestation if we haven't hit max
         if (currIndex < maxAttestations) {
-          IdentifierOwnershipAttestation memory attestation = identifierToAddresses[identifier][trustedIssuer][j];
+          IdentifierOwnershipAttestation memory attestation = identifierToAddresses[identifier][trustedIssuers[i]][j];
           if (!_isRevoked(attestation.signer, attestation.issuedOn)) {
             accounts[currIndex] = attestation.account;
             issuedOns[currIndex] = attestation.issuedOn;
@@ -172,17 +168,15 @@ contract FederatedAttestations is
 
     for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
       address trustedIssuer = trustedIssuers[i];
-      for (uint256 j = 0; j < addressToIdentifiers[account][trustedIssuer].length; j = j.add(1)) {
+      uint256 numIssuersForAddress = addressToIdentifiers[account][trustedIssuer].length;
+      for (uint256 j = 0; j < numIssuersForAddress; j = j.add(1)) {
         // Iterate through the list of identifiers
         if (currIndex < maxIdentifiers) {
           bytes32 identifier = addressToIdentifiers[account][trustedIssuer][j];
           // Check if the mapping was produced by a revoked signer
-          for (
-            uint256 k = 0;
-            k < identifierToAddresses[identifier][trustedIssuer].length;
-            k = k.add(1)
-          ) {
-            IdentifierOwnershipAttestation memory attestation = identifierToAddresses[identifier][trustedIssuer][k];
+          IdentifierOwnershipAttestation[] memory attestationsForIssuer = identifierToAddresses[identifier][trustedIssuer];
+          for (uint256 k = 0; k < attestationsForIssuer.length; k = k.add(1)) {
+            IdentifierOwnershipAttestation memory attestation = attestationsForIssuer[k];
             // (identifier, account, issuer) tuples should be unique
             if (
               attestation.account == account &&

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -313,7 +313,7 @@ contract FederatedAttestations is
       isValidAttestation(identifier, issuer, account, issuedOn, signer, v, r, s),
       "Signature is invalid"
     );
-    for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i.add(1)) {
+    for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i = i.add(1)) {
       // This enforces only one attestation to be uploaded for a given set of (identifier, issuer, account)
       // Editing/upgrading an attestation requires that it be deleted before a new one is registered
       require(

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -36,7 +36,11 @@ contract FederatedAttestations is
     uint256 issuedOn;
     address signer;
   }
+
+  // TODO ASv2 revisit linting issues & all solhint-disable-next-line max-line-length
+
   // identifier -> issuer -> attestations
+  // solhint-disable-next-line max-line-length
   mapping(bytes32 => mapping(address => IdentifierOwnershipAttestation[])) public identifierToAddresses;
   // account -> issuer -> identifiers
   mapping(address => mapping(address => bytes32[])) public addressToIdentifiers;
@@ -46,6 +50,7 @@ contract FederatedAttestations is
   // TODO: should this be hardcoded here?
   bytes32 constant SIGNER_ROLE = keccak256(abi.encodePacked("celo.org/core/attestation"));
   bytes32 public constant EIP712_VALIDATE_ATTESTATION_TYPEHASH = keccak256(
+    // solhint-disable-next-line max-line-length
     "IdentifierOwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)"
   );
   bytes32 public eip712DomainSeparator;
@@ -144,6 +149,7 @@ contract FederatedAttestations is
       for (uint256 j = 0; j < numTrustedIssuers; j = j.add(1)) {
         // Only create and push new attestation if we haven't hit max
         if (currIndex < maxAttestations) {
+          // solhint-disable-next-line max-line-length
           IdentifierOwnershipAttestation memory attestation = identifierToAddresses[identifier][trustedIssuers[i]][j];
           if (!revokedSigners[attestation.signer]) {
             accounts[currIndex] = attestation.account;
@@ -204,6 +210,7 @@ contract FederatedAttestations is
         if (currIndex < maxIdentifiers) {
           bytes32 identifier = addressToIdentifiers[account][trustedIssuer][j];
           // Check if the mapping was produced by a revoked signer
+          // solhint-disable-next-line max-line-length
           IdentifierOwnershipAttestation[] memory attestationsForIssuer = identifierToAddresses[identifier][trustedIssuer];
           for (uint256 k = 0; k < attestationsForIssuer.length; k = k.add(1)) {
             IdentifierOwnershipAttestation memory attestation = attestationsForIssuer[k];
@@ -231,7 +238,8 @@ contract FederatedAttestations is
     }
   }
 
-  // TODO do we want to restrict permissions, or should anyone with a valid signature be able to register an attestation?
+  // TODO do we want to restrict permissions, or should anyone
+  // with a valid signature be able to register an attestation?
   modifier isValidUser(address issuer, address account) {
     require(
       msg.sender == account ||
@@ -267,6 +275,11 @@ contract FederatedAttestations is
     bytes32 s
   ) public view returns (bool) {
     require(!revokedSigners[signer], "Signer has been revoked");
+    // TODO ASv2 consider this solution instead since it allows the issuer to be the signer as well
+    // require(
+    //   getAccounts().attestationSignerToAccount(signer) == issuer,
+    //   "Signer has not been authorized as an AttestationSigner by the issuer"
+    // );
     require(
       getAccounts().isSigner(issuer, signer, SIGNER_ROLE),
       "Signer has not been authorized as an AttestationSigner by the issuer"
@@ -312,7 +325,8 @@ contract FederatedAttestations is
       "Signature is invalid"
     );
     for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i = i.add(1)) {
-      // This enforces only one attestation to be uploaded for a given set of (identifier, issuer, account)
+      // This enforces only one attestation to be uploaded
+      // for a given set of (identifier, issuer, account)
       // Editing/upgrading an attestation requires that it be deleted before a new one is registered
       require(
         identifierToAddresses[identifier][issuer][i].account != account,
@@ -330,25 +344,35 @@ contract FederatedAttestations is
   }
 
   function deleteAttestation(bytes32 identifier, address issuer, address account) public {
-    // TODO ASv2 this should short-circuit, but double check (i.e. succeeds if msg.sender == account)
     require(
       msg.sender == account || getAccounts().attestationSignerToAccount(msg.sender) == issuer
     );
 
+    // TODO ASv2 store the intermeidate arrays where possible to prevent
+    // repeated storage lookups for same values
+
     for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i++) {
+      // solhint-disable-next-line max-line-length
       IdentifierOwnershipAttestation memory attestation = identifierToAddresses[identifier][issuer][i];
       if (attestation.account == account) {
-        // This is meant to delete the attestation in the array and then move the last element in the array to that empty spot, to avoid having empty elements in the array
+        // This is meant to delete the attestation in the array
+        // and then move the last element in the array to that empty spot,
+        // to avoid having empty elements in the array
         // Not sure if this is needed and if the added gas costs from the complexity is worth it
+
+        // solhint-disable-next-line max-line-length
         identifierToAddresses[identifier][issuer][i] = identifierToAddresses[identifier][issuer][identifierToAddresses[identifier][issuer]
           .length -
           1];
         identifierToAddresses[identifier][issuer].pop();
 
-        // TODO revisit if deletedIdentifier check is necessary - not sure if there would ever be a situation where the matching identifier is not present
+        // TODO revisit if deletedIdentifier check is necessary
+        // - not sure if there would ever be a situation where the
+        // matching identifier is not present
         bool deletedIdentifier = false;
         for (uint256 j = 0; j < addressToIdentifiers[account][issuer].length; j++) {
           if (addressToIdentifiers[account][issuer][j] == identifier) {
+            // solhint-disable-next-line max-line-length
             addressToIdentifiers[account][issuer][j] = addressToIdentifiers[account][issuer][addressToIdentifiers[account][issuer]
               .length -
               1];

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -1,4 +1,3 @@
-// TODO figure out if we can use a new solidity version for just this one contract
 pragma solidity ^0.5.13;
 // TODO ASv2 come back to this and possibly flatten structs as arg params
 pragma experimental ABIEncoderV2;

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -171,8 +171,6 @@ contract FederatedAttestations is
     uint256 currIndex = 0;
     bytes32[] memory identifiers = new bytes32[](maxIdentifiers);
 
-    // TODO safemath
-
     for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
       address trustedIssuer = trustedIssuers[i];
       for (uint256 j = 0; j < addressToIdentifiers[account][trustedIssuer].length; j = j.add(1)) {

--- a/packages/protocol/lib/fed-attestations-utils.ts
+++ b/packages/protocol/lib/fed-attestations-utils.ts
@@ -17,15 +17,15 @@ const getTypedData = (chainId: number, contractAddress: Address, message?: Attes
       EIP712Domain: [
         { name: 'name', type: 'string' },
         { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256'},  // consider removing
-        { name: 'verifyingContract', type: 'address'}, // consider removing
+        { name: 'chainId', type: 'uint256'},  // TODO ASv2 consider removing
+        { name: 'verifyingContract', type: 'address'}, // TODO ASv2 consider removing
       ],
       IdentifierOwnershipAttestation: [
           { name: 'identifier', type: 'bytes32' },
           { name: 'issuer', type: 'address'},
           { name: 'account', type: 'address' },
           { name: 'issuedOn', type: 'uint256' },
-          // Consider including a nonce (which could also be used as an ID)
+          // TODO ASv2 Consider including a nonce (which could also be used as an ID)
       ],
     },
     primaryType: 'IdentifierOwnershipAttestation',

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -54,13 +54,13 @@ contract('FederatedAttestations', (accounts: string[]) => {
     const issuer3 = accounts[4]
     const issuer2Signer = accounts[5]
 
-    type attestationTestCase = {
+    interface AttestationTestCase {
       account: string
       issuedOn: number
       signer: string
     }
 
-    const issuer1Attestations: attestationTestCase[] = [
+    const issuer1Attestations: AttestationTestCase[] = [
       {
         account: account1,
         issuedOn: nowUnixTime,
@@ -73,7 +73,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
         signer: issuer1,
       },
     ]
-    const issuer2Attestations: attestationTestCase[] = [
+    const issuer2Attestations: AttestationTestCase[] = [
       // Same account as issuer1Attestations[0], different issuer
       {
         account: account1,
@@ -103,7 +103,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
 
     const checkAgainstExpectedAttestations = (
-      expectedAttestations: attestationTestCase[],
+      expectedAttestations: AttestationTestCase[],
       actualAddresses: string[],
       actualIssuedOns: BigNumber[],
       actualSigners: string[]
@@ -191,19 +191,19 @@ contract('FederatedAttestations', (accounts: string[]) => {
 
     const pnIdentifier2 = getPhoneHash(phoneNumber, 'dummySalt')
 
-    type identifierTestCase = {
+    interface IdentifierTestCase {
       pnIdentifier: string
       signer: string
     }
 
     const checkAgainstExpectedIdCases = (
-      expectedIdentifiers: identifierTestCase[],
+      expectedIdentifiers: IdentifierTestCase[],
       actualIdentifiers: string[]
     ) => {
       expect(expectedIdentifiers.map((idCase) => idCase.pnIdentifier)).to.eql(actualIdentifiers)
     }
 
-    const issuer1IdCases: identifierTestCase[] = [
+    const issuer1IdCases: IdentifierTestCase[] = [
       {
         pnIdentifier: pnIdentifier1,
         signer: issuer1,
@@ -213,7 +213,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
         signer: issuer1,
       },
     ]
-    const issuer2IdCases: identifierTestCase[] = [
+    const issuer2IdCases: IdentifierTestCase[] = [
       {
         pnIdentifier: pnIdentifier1,
         signer: issuer2,

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -487,10 +487,10 @@ contract('FederatedAttestations', (accounts: string[]) => {
       ]
       wrongArgs.forEach(([index, arg, wrongValue]) => {
         it(`should fail if the provided ${arg} is different from the attestation`, async () => {
-          let args = [identifier1, issuer1, account1, nowUnixTime, signer1, sig.v, sig.r, sig.s]
+          const args = [identifier1, issuer1, account1, nowUnixTime, signer1, sig.v, sig.r, sig.s]
           args[index] = wrongValue
 
-          if (arg == 'issuer' || arg == 'signer') {
+          if (arg === 'issuer' || arg === 'signer') {
             await assertRevert(
               federatedAttestations.isValidAttestation.apply(this, args),
               'Signer has not been authorized as an AttestationSigner by the issuer'
@@ -802,6 +802,9 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#deleteAttestation', () => {
-    it('should', async () => {})
+    it('should', async () => {
+      // Fix lint checks until these tests are here
+      assert(true)
+    })
   })
 })

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -1,5 +1,6 @@
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
-// import { getPhoneHash } from '@celo/utils/lib/phoneNumbers'
+import { getPhoneHash } from '@celo/utils/lib/phoneNumbers'
+import BigNumber from 'bignumber.js'
 import {
   AccountsContract,
   AccountsInstance,
@@ -21,8 +22,11 @@ contract('FederatedAttestations', (accounts: string[]) => {
   let registry: RegistryInstance
 
   const caller: string = accounts[0]
-  // const phoneNumber: string = '+18005551212'
-  // const phoneHash: string = getPhoneHash(phoneNumber)
+  const phoneNumber: string = '+18005551212'
+  // TODO ASv2 possibly rename to pnIdentifier
+  const phoneHash: string = getPhoneHash(phoneNumber)
+
+  const getCurrentUnixTime = () => Math.floor(Date.now() / 1000)
 
   beforeEach('FederatedAttestations setup', async () => {
     accountsInstance = await Accounts.new(true)
@@ -30,6 +34,10 @@ contract('FederatedAttestations', (accounts: string[]) => {
     registry = await Registry.new(true)
     await accountsInstance.initialize(registry.address)
     await registry.setAddressFor(CeloContractName.Accounts, accountsInstance.address)
+    await registry.setAddressFor(
+      CeloContractName.FederatedAttestations,
+      federatedAttestations.address
+    )
     await federatedAttestations.initialize(registry.address)
   })
 
@@ -42,7 +50,158 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#lookupAttestations', () => {
-    it('should', async () => {})
+    const issuer1 = accounts[1]
+    const nowUnixTime = getCurrentUnixTime()
+    const issuer2 = accounts[2]
+    const issuer3 = accounts[3]
+    const caller2 = accounts[4]
+    const issuer2Signer = accounts[5]
+
+    type testAttestation = {
+      account: string
+      issuedOn: number
+      signer: string
+    }
+
+    const issuer1Attestations: testAttestation[] = [
+      {
+        account: caller,
+        issuedOn: nowUnixTime,
+        signer: issuer1,
+      },
+      // Same issuer as [0], different account
+      {
+        account: caller2,
+        issuedOn: nowUnixTime,
+        signer: issuer1,
+      },
+    ]
+
+    const issuer2Attestations: testAttestation[] = [
+      // Same account as issuer1Attestations[0], different issuer
+      {
+        account: caller,
+        issuedOn: nowUnixTime,
+        signer: issuer2,
+      },
+      // Different account and signer
+      {
+        account: caller2,
+        issuedOn: nowUnixTime,
+        signer: issuer2Signer,
+      },
+    ]
+
+    beforeEach(async () => {
+      for (const { issuer, attestationsPerIssuer } of [
+        { issuer: issuer1, attestationsPerIssuer: issuer1Attestations },
+        { issuer: issuer2, attestationsPerIssuer: issuer2Attestations },
+      ]) {
+        for (const attestation of attestationsPerIssuer) {
+          // Require consistent order for test cases
+          await federatedAttestations.registerAttestation(phoneHash, issuer, attestation, {
+            from: attestation.account,
+          })
+        }
+      }
+    })
+
+    const runLookupAttestationsTestCase = async (
+      phoneHash: string,
+      trustedIssuers: string[],
+      maxAttestations: number,
+      expectedAttestations: testAttestation[]
+    ) => {
+      const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+        phoneHash,
+        trustedIssuers,
+        maxAttestations
+      )
+      checkAgainstExpectedAttestations(expectedAttestations, addresses, issuedOns, signers)
+    }
+
+    const checkAgainstExpectedAttestations = (
+      expectedAttestations: testAttestation[],
+      actualAddresses: string[],
+      actualIssuedOns: BigNumber[],
+      actualSigners: string[]
+    ) => {
+      assert.lengthOf(actualAddresses, expectedAttestations.length)
+      assert.lengthOf(actualIssuedOns, expectedAttestations.length)
+      assert.lengthOf(actualSigners, expectedAttestations.length)
+
+      expectedAttestations.forEach((expectedAttestation, index) => {
+        assert.equal(expectedAttestation.account, actualAddresses[index])
+        assert.equal(expectedAttestation.issuedOn, actualIssuedOns[index].toNumber())
+        assert.equal(expectedAttestation.signer, actualSigners[index])
+      })
+    }
+
+    it('should return all attestations from one issuer', async () => {
+      await runLookupAttestationsTestCase(
+        phoneHash,
+        [issuer1],
+        issuer1Attestations.length,
+        issuer1Attestations
+      )
+    })
+
+    it('should return attestations from multiple issuers', async () => {
+      const expectedAttestations = issuer1Attestations.concat(issuer2Attestations)
+      await runLookupAttestationsTestCase(
+        phoneHash,
+        [issuer1, issuer2],
+        expectedAttestations.length,
+        expectedAttestations
+      )
+    })
+    it('should return attestations ordered by issuer', async () => {
+      const expectedAttestations = issuer2Attestations.concat(issuer1Attestations)
+      await runLookupAttestationsTestCase(
+        phoneHash,
+        [issuer2, issuer1],
+        expectedAttestations.length,
+        expectedAttestations
+      )
+    })
+    it('should return empty list if maxAttestations == 0', async () => {
+      await runLookupAttestationsTestCase(phoneHash, [issuer1], 0, [])
+    })
+    it('should succeed when maxAttestations > available attestations', async () => {
+      await runLookupAttestationsTestCase(
+        phoneHash,
+        [issuer1],
+        issuer1Attestations.length + 1,
+        issuer1Attestations
+      )
+    })
+    it('should only return maxAttestations attestations when more are present', async () => {
+      const expectedAttestations = issuer1Attestations.slice(0, -1)
+      await runLookupAttestationsTestCase(
+        phoneHash,
+        [issuer1],
+        expectedAttestations.length,
+        expectedAttestations
+      )
+    })
+    it('should return none if no attestations exist for an issuer', async () => {
+      await runLookupAttestationsTestCase(phoneHash, [issuer3], 0, [])
+    })
+    it('should not return attestations from revoked signers', async () => {
+      const attestationToRevoke = issuer2Attestations[1]
+      const revokedOn = attestationToRevoke.issuedOn - 10
+      await federatedAttestations.revokeSigner(attestationToRevoke.signer, revokedOn)
+      const expectedAttestations = issuer2Attestations.filter(
+        (attestation) =>
+          attestation.signer != attestationToRevoke.signer || attestation.issuedOn < revokedOn
+      )
+      await runLookupAttestationsTestCase(
+        phoneHash,
+        [issuer2],
+        issuer2Attestations.length, // Do not limit by maxAttestations
+        expectedAttestations
+      )
+    })
   })
 
   describe('#lookupIdentifiersByAddress', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -48,59 +48,11 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#lookupAttestations', () => {
-    const account2 = accounts[2]
-
-    const issuer2 = accounts[3]
-    const issuer3 = accounts[4]
-    const issuer2Signer = accounts[5]
-
     interface AttestationTestCase {
       account: string
       issuedOn: number
       signer: string
     }
-
-    const issuer1Attestations: AttestationTestCase[] = [
-      {
-        account: account1,
-        issuedOn: nowUnixTime,
-        signer: issuer1,
-      },
-      // Same issuer as [0], different account
-      {
-        account: account2,
-        issuedOn: nowUnixTime,
-        signer: issuer1,
-      },
-    ]
-    const issuer2Attestations: AttestationTestCase[] = [
-      // Same account as issuer1Attestations[0], different issuer
-      {
-        account: account1,
-        issuedOn: nowUnixTime,
-        signer: issuer2,
-      },
-      // Different account and signer
-      {
-        account: account2,
-        issuedOn: nowUnixTime,
-        signer: issuer2Signer,
-      },
-    ]
-
-    beforeEach(async () => {
-      for (const { issuer, attestationsPerIssuer } of [
-        { issuer: issuer1, attestationsPerIssuer: issuer1Attestations },
-        { issuer: issuer2, attestationsPerIssuer: issuer2Attestations },
-      ]) {
-        for (const attestation of attestationsPerIssuer) {
-          // Require consistent order for test cases
-          await federatedAttestations.registerAttestation(pnIdentifier1, issuer, attestation, {
-            from: attestation.account,
-          })
-        }
-      }
-    })
 
     const checkAgainstExpectedAttestations = (
       expectedAttestations: AttestationTestCase[],
@@ -119,191 +71,264 @@ contract('FederatedAttestations', (accounts: string[]) => {
       })
     }
 
-    it('should return all attestations from one issuer', async () => {
-      const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
-        pnIdentifier1,
-        [issuer1],
-        // Do not allow for maxAttestations to coincidentally limit incorrect output
-        issuer1Attestations.length + 1
-      )
-      checkAgainstExpectedAttestations(issuer1Attestations, addresses, issuedOns, signers)
+    describe('when identifier has not been registered', () => {
+      it('should return empty list', async () => {
+        const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+          pnIdentifier1,
+          [issuer1],
+          1
+        )
+        checkAgainstExpectedAttestations([], addresses, issuedOns, signers)
+      })
     })
 
-    it('should return attestations from multiple issuers in correct order', async () => {
-      const expectedAttestations = issuer2Attestations.concat(issuer1Attestations)
-      const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
-        pnIdentifier1,
-        [issuer2, issuer1],
-        expectedAttestations.length + 1
-      )
-      checkAgainstExpectedAttestations(expectedAttestations, addresses, issuedOns, signers)
-    })
+    describe('when identifier has been registered', () => {
+      const account2 = accounts[2]
 
-    it('should return empty list if maxAttestations == 0', async () => {
-      const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
-        pnIdentifier1,
-        [issuer1],
-        0
-      )
-      checkAgainstExpectedAttestations([], addresses, issuedOns, signers)
-    })
+      const issuer2 = accounts[3]
+      const issuer3 = accounts[4]
+      const issuer2Signer = accounts[5]
 
-    it('should only return maxAttestations attestations when more are present', async () => {
-      const expectedAttestations = issuer1Attestations.slice(0, -1)
-      const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
-        pnIdentifier1,
-        [issuer1],
-        expectedAttestations.length
-      )
-      checkAgainstExpectedAttestations(expectedAttestations, addresses, issuedOns, signers)
-    })
+      const issuer1Attestations: AttestationTestCase[] = [
+        {
+          account: account1,
+          issuedOn: nowUnixTime,
+          signer: issuer1,
+        },
+        // Same issuer as [0], different account
+        {
+          account: account2,
+          issuedOn: nowUnixTime,
+          signer: issuer1,
+        },
+      ]
+      const issuer2Attestations: AttestationTestCase[] = [
+        // Same account as issuer1Attestations[0], different issuer
+        {
+          account: account1,
+          issuedOn: nowUnixTime,
+          signer: issuer2,
+        },
+        // Different account and signer
+        {
+          account: account2,
+          issuedOn: nowUnixTime,
+          signer: issuer2Signer,
+        },
+      ]
 
-    it('should return none if no attestations exist for an issuer', async () => {
-      const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
-        pnIdentifier1,
-        [issuer3],
-        1
-      )
-      checkAgainstExpectedAttestations([], addresses, issuedOns, signers)
-    })
+      beforeEach(async () => {
+        for (const { issuer, attestationsPerIssuer } of [
+          { issuer: issuer1, attestationsPerIssuer: issuer1Attestations },
+          { issuer: issuer2, attestationsPerIssuer: issuer2Attestations },
+        ]) {
+          for (const attestation of attestationsPerIssuer) {
+            // Require consistent order for test cases
+            await federatedAttestations.registerAttestation(pnIdentifier1, issuer, attestation, {
+              from: attestation.account,
+            })
+          }
+        }
+      })
 
-    it('should not return attestations from revoked signers', async () => {
-      const attestationToRevoke = issuer2Attestations[0]
-      await federatedAttestations.revokeSigner(
-        attestationToRevoke.signer,
-        attestationToRevoke.issuedOn - 1
-      )
-      const expectedAttestations = issuer2Attestations.slice(1)
+      it('should return all attestations from one issuer', async () => {
+        const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+          pnIdentifier1,
+          [issuer1],
+          // Do not allow for maxAttestations to coincidentally limit incorrect output
+          issuer1Attestations.length + 1
+        )
+        checkAgainstExpectedAttestations(issuer1Attestations, addresses, issuedOns, signers)
+      })
 
-      const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
-        pnIdentifier1,
-        [issuer2],
-        issuer2Attestations.length
-      )
-      checkAgainstExpectedAttestations(expectedAttestations, addresses, issuedOns, signers)
+      it('should return empty list if no attestations exist for an issuer', async () => {
+        const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+          pnIdentifier1,
+          [issuer3],
+          1
+        )
+        checkAgainstExpectedAttestations([], addresses, issuedOns, signers)
+      })
+
+      it('should return attestations from multiple issuers in correct order', async () => {
+        const expectedAttestations = issuer2Attestations.concat(issuer1Attestations)
+        const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+          pnIdentifier1,
+          [issuer3, issuer2, issuer1],
+          expectedAttestations.length + 1
+        )
+        checkAgainstExpectedAttestations(expectedAttestations, addresses, issuedOns, signers)
+      })
+
+      it('should return empty list if maxAttestations == 0', async () => {
+        const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+          pnIdentifier1,
+          [issuer1],
+          0
+        )
+        checkAgainstExpectedAttestations([], addresses, issuedOns, signers)
+      })
+
+      it('should only return maxAttestations attestations when more are present', async () => {
+        const expectedAttestations = issuer1Attestations.slice(0, -1)
+        const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+          pnIdentifier1,
+          [issuer1],
+          expectedAttestations.length
+        )
+        checkAgainstExpectedAttestations(expectedAttestations, addresses, issuedOns, signers)
+      })
+
+      it('should not return attestations from revoked signers', async () => {
+        const attestationToRevoke = issuer2Attestations[0]
+        await federatedAttestations.revokeSigner(
+          attestationToRevoke.signer,
+          attestationToRevoke.issuedOn - 1
+        )
+        const expectedAttestations = issuer2Attestations.slice(1)
+
+        const [addresses, issuedOns, signers] = await federatedAttestations.lookupAttestations(
+          pnIdentifier1,
+          [issuer2],
+          issuer2Attestations.length
+        )
+        checkAgainstExpectedAttestations(expectedAttestations, addresses, issuedOns, signers)
+      })
     })
   })
 
   describe('#lookupIdentifiersByAddress', () => {
-    const issuer2 = accounts[2]
-    const issuer2Signer = accounts[3]
-    const issuer3 = accounts[4]
+    describe('when address has not been registered', () => {
+      it('should return empty list', async () => {
+        const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
+          account1,
+          [issuer1],
+          1
+        )
+        assert.equal(actualIdentifiers.length, 0)
+      })
+    })
 
-    const pnIdentifier2 = getPhoneHash(phoneNumber, 'dummySalt')
-
-    interface IdentifierTestCase {
-      pnIdentifier: string
-      signer: string
-    }
-
-    const checkAgainstExpectedIdCases = (
-      expectedIdentifiers: IdentifierTestCase[],
-      actualIdentifiers: string[]
-    ) => {
-      expect(expectedIdentifiers.map((idCase) => idCase.pnIdentifier)).to.eql(actualIdentifiers)
-    }
-
-    const issuer1IdCases: IdentifierTestCase[] = [
-      {
-        pnIdentifier: pnIdentifier1,
-        signer: issuer1,
-      },
-      {
-        pnIdentifier: pnIdentifier2,
-        signer: issuer1,
-      },
-    ]
-    const issuer2IdCases: IdentifierTestCase[] = [
-      {
-        pnIdentifier: pnIdentifier1,
-        signer: issuer2,
-      },
-      {
-        pnIdentifier: pnIdentifier2,
-        signer: issuer2Signer,
-      },
-    ]
-
-    beforeEach(async () => {
-      // Require consistent order for test cases
-      for (const { issuer, idCasesPerIssuer } of [
-        { issuer: issuer1, idCasesPerIssuer: issuer1IdCases },
-        { issuer: issuer2, idCasesPerIssuer: issuer2IdCases },
-      ]) {
-        for (const idCase of idCasesPerIssuer) {
-          const attestation = {
-            account: account1,
-            issuedOn: nowUnixTime,
-            signer: idCase.signer,
-          }
-          await federatedAttestations.registerAttestation(
-            idCase.pnIdentifier,
-            issuer,
-            attestation,
-            {
-              from: attestation.account,
-            }
-          )
-        }
+    describe('when address has been registered', () => {
+      interface IdentifierTestCase {
+        pnIdentifier: string
+        signer: string
       }
-    })
 
-    it('should return all identifiers from one issuer', async () => {
-      const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
-        account1,
-        [issuer1],
-        issuer1IdCases.length + 1
-      )
-      checkAgainstExpectedIdCases(issuer1IdCases, actualIdentifiers)
-    })
+      const checkAgainstExpectedIdCases = (
+        expectedIdentifiers: IdentifierTestCase[],
+        actualIdentifiers: string[]
+      ) => {
+        expect(expectedIdentifiers.map((idCase) => idCase.pnIdentifier)).to.eql(actualIdentifiers)
+      }
 
-    it('should return identifiers from multiple issuers in correct order', async () => {
-      const expectedIdCases = issuer2IdCases.concat(issuer1IdCases)
-      const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
-        account1,
-        [issuer2, issuer1],
-        expectedIdCases.length + 1
-      )
-      checkAgainstExpectedIdCases(expectedIdCases, actualIdentifiers)
-    })
+      const issuer2 = accounts[2]
+      const issuer2Signer = accounts[3]
+      const issuer3 = accounts[4]
+      const pnIdentifier2 = getPhoneHash(phoneNumber, 'dummySalt')
 
-    it('should return empty list if maxIdentifiers == 0', async () => {
-      const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
-        account1,
-        [issuer1],
-        0
-      )
-      assert.equal(actualIdentifiers.length, 0)
-    })
+      const issuer1IdCases: IdentifierTestCase[] = [
+        {
+          pnIdentifier: pnIdentifier1,
+          signer: issuer1,
+        },
+        {
+          pnIdentifier: pnIdentifier2,
+          signer: issuer1,
+        },
+      ]
+      const issuer2IdCases: IdentifierTestCase[] = [
+        {
+          pnIdentifier: pnIdentifier1,
+          signer: issuer2,
+        },
+        {
+          pnIdentifier: pnIdentifier2,
+          signer: issuer2Signer,
+        },
+      ]
 
-    it('should only return maxIdentifiers identifiers when more are present', async () => {
-      const expectedIdCases = issuer2IdCases.concat(issuer1IdCases).slice(0, -1)
-      const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
-        account1,
-        [issuer2, issuer1],
-        expectedIdCases.length
-      )
-      checkAgainstExpectedIdCases(expectedIdCases, actualIdentifiers)
-    })
+      beforeEach(async () => {
+        // Require consistent order for test cases
+        for (const { issuer, idCasesPerIssuer } of [
+          { issuer: issuer1, idCasesPerIssuer: issuer1IdCases },
+          { issuer: issuer2, idCasesPerIssuer: issuer2IdCases },
+        ]) {
+          for (const idCase of idCasesPerIssuer) {
+            const attestation = {
+              account: account1,
+              issuedOn: nowUnixTime,
+              signer: idCase.signer,
+            }
+            await federatedAttestations.registerAttestation(
+              idCase.pnIdentifier,
+              issuer,
+              attestation,
+              {
+                from: attestation.account,
+              }
+            )
+          }
+        }
+      })
 
-    it('should return none if no identifiers exist for an (issuer,address)', async () => {
-      const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
-        account1,
-        [issuer3],
-        1
-      )
-      assert.equal(actualIdentifiers.length, 0)
-    })
+      it('should return all identifiers from one issuer', async () => {
+        const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
+          account1,
+          [issuer1],
+          issuer1IdCases.length + 1
+        )
+        checkAgainstExpectedIdCases(issuer1IdCases, actualIdentifiers)
+      })
 
-    it('should not return identifiers from revoked signers', async () => {
-      await federatedAttestations.revokeSigner(issuer2IdCases[0].signer, nowUnixTime)
-      const expectedIdCases = issuer2IdCases.slice(1)
-      const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
-        account1,
-        [issuer2],
-        expectedIdCases.length + 1
-      )
-      checkAgainstExpectedIdCases(expectedIdCases, actualIdentifiers)
+      it('should return empty list if no identifiers exist for an (issuer,address)', async () => {
+        const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
+          account1,
+          [issuer3],
+          1
+        )
+        assert.equal(actualIdentifiers.length, 0)
+      })
+
+      it('should return identifiers from multiple issuers in correct order', async () => {
+        const expectedIdCases = issuer2IdCases.concat(issuer1IdCases)
+        const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
+          account1,
+          [issuer3, issuer2, issuer1],
+          expectedIdCases.length + 1
+        )
+        checkAgainstExpectedIdCases(expectedIdCases, actualIdentifiers)
+      })
+
+      it('should return empty list if maxIdentifiers == 0', async () => {
+        const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
+          account1,
+          [issuer1],
+          0
+        )
+        assert.equal(actualIdentifiers.length, 0)
+      })
+
+      it('should only return maxIdentifiers identifiers when more are present', async () => {
+        const expectedIdCases = issuer2IdCases.concat(issuer1IdCases).slice(0, -1)
+        const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
+          account1,
+          [issuer2, issuer1],
+          expectedIdCases.length
+        )
+        checkAgainstExpectedIdCases(expectedIdCases, actualIdentifiers)
+      })
+
+      it('should not return identifiers from revoked signers', async () => {
+        await federatedAttestations.revokeSigner(issuer2IdCases[0].signer, nowUnixTime)
+        const expectedIdCases = issuer2IdCases.slice(1)
+        const actualIdentifiers = await federatedAttestations.lookupIdentifiersByAddress(
+          account1,
+          [issuer2],
+          expectedIdCases.length + 1
+        )
+        checkAgainstExpectedIdCases(expectedIdCases, actualIdentifiers)
+      })
     })
   })
 


### PR DESCRIPTION
## Changes
For `lookupIdentifiersByAddress` and `lookupAttestations`:
- Adds docstrings
- Fixes implementation to use safemath
- Changes function signature (for `lookupAttestations` only) in preparation for getting rid of `ABIEncoderV2`
- Implements unit tests, cases listed at the bottom for easier overview

For `_isRevoked`:
- Fixes direction of comparison for `issuedOn`; this will likely be removed altogether later due to the decision to not use `issuedOn` in revocation logic, but for now this ensures that the revoked attestation/identifier lookup test cases succeed
- We can optionally decide to move these test cases to the revocation describe block later; I think they can fit under both

## For PR Reviewers
General comments/feedback welcome, especially:
- Are there any test cases that are missing or not covered?
- Are the tests readable/stylistically make sense? (Happy to receive TS style nits as well on this!)
- Would it make sense for the lookup functions to return an array with the number of identifiers per issuer returned?

## remaining TODOs
Will need to update the test setup for both lookup functions once signature validation has been implemented, but no changes should be required for this in the actual test cases

## test cases - updated
(for easier overview of all current cases)
`lookupAttestations`
  - when identifier has not been registered
    - should return empty list
  - when identifier has been registered
    - should return all attestations from one issuer
    - should return empty list if no attestations exist for an issuer
    - should return attestations from multiple issuers in correct order
    - should return empty list if maxAttestations == 0
    - should only return maxAttestations attestations when more are present
    - should not return attestations from revoked signers
`lookupIdentifiersByAddress`
  - when address has not been registered
    - should return empty list
  - when address has been registered
    - should return all identifiers from one issuer
    - should return empty list if no identifiers exist for an (issuer,address)
    - should return identifiers from multiple issuers in correct order
    - should return empty list if maxIdentifiers == 0
    - should only return maxIdentifiers identifiers when more are present
    - should not return identifiers from revoked signers
