### PR TITLE
ASv2 validateAttestation functionality and unit tests

### DIFF
--- a/packages/protocol/contracts/common/interfaces/IAccounts.sol
+++ b/packages/protocol/contracts/common/interfaces/IAccounts.sol
@@ -46,4 +46,5 @@ interface IAccounts {
 
   function setPaymentDelegation(address, uint256) external;
   function getPaymentDelegation(address) external view returns (address, uint256);
+  function isSigner(address, address, bytes32) external view returns (bool);
 }

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -50,6 +50,9 @@ contract FederatedAttestations is
   );
   bytes32 public eip712DomainSeparator;
 
+  // TODO: should this be hardcoded here?
+  bytes32 constant signerRole = keccak256(abi.encodePacked("celo.org/core/attestation"));
+
   // TODO ASv2 Event declarations
 
   /**
@@ -193,8 +196,8 @@ contract FederatedAttestations is
     bytes32 r,
     bytes32 s
   ) public view returns (bool) {
-    // TODO check if signer is a valid signer of the account
     require(!revokedSigners[signer]);
+    require(getAccounts().isSigner(issuer, signer, signerRole));
     bytes32 structHash = keccak256(
       abi.encode(EIP712_VALIDATE_ATTESTATION_TYPEHASH, identifier, issuer, account, issuedOn)
     );
@@ -206,7 +209,6 @@ contract FederatedAttestations is
       s
     );
     return guessedSigner == signer;
-    // return guessedSigner
   }
 
   function registerAttestation(

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -210,8 +210,11 @@ contract FederatedAttestations is
     bytes32 r,
     bytes32 s
   ) public view returns (bool) {
-    require(!revokedSigners[signer]);
-    require(getAccounts().isSigner(issuer, signer, signerRole));
+    require(!revokedSigners[signer], "Signer has been revoked");
+    require(
+      getAccounts().isSigner(issuer, signer, signerRole),
+      "Signer has not been authorized as an AttestationSigner by the issuer"
+    );
     bytes32 structHash = keccak256(
       abi.encode(EIP712_VALIDATE_ATTESTATION_TYPEHASH, identifier, issuer, account, issuedOn)
     );

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -51,7 +51,7 @@ contract FederatedAttestations is
   bytes32 public eip712DomainSeparator;
 
   // TODO: should this be hardcoded here?
-  bytes32 constant SignerRole = keccak256(abi.encodePacked("celo.org/core/attestation"));
+  bytes32 constant SIGNER_ROLE = keccak256(abi.encodePacked("celo.org/core/attestation"));
 
   // TODO ASv2 Event declarations
   event EIP712DomainSeparatorSet(bytes32 eip712DomainSeparator);
@@ -214,7 +214,7 @@ contract FederatedAttestations is
   ) public view returns (bool) {
     require(!revokedSigners[signer], "Signer has been revoked");
     require(
-      getAccounts().isSigner(issuer, signer, SignerRole),
+      getAccounts().isSigner(issuer, signer, SIGNER_ROLE),
       "Signer has not been authorized as an AttestationSigner by the issuer"
     );
     bytes32 structHash = keccak256(

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -54,6 +54,7 @@ contract FederatedAttestations is
   bytes32 constant signerRole = keccak256(abi.encodePacked("celo.org/core/attestation"));
 
   // TODO ASv2 Event declarations
+  event EIP712DomainSeparatorSet(bytes32 eip712DomainSeparator);
 
   /**
    * @notice Sets initialized == true on implementation contracts
@@ -92,6 +93,7 @@ contract FederatedAttestations is
         address(this)
       )
     );
+    emit EIP712DomainSeparatorSet(eip712DomainSeparator);
   }
 
   /**
@@ -187,17 +189,17 @@ contract FederatedAttestations is
   }
 
   /**
-   * @notice Validates the given attestation code.
+   * @notice Validates the given attestation and signature
    * @param identifier Hash of the identifier to be attested
    * @param issuer Address of the attestation issuer
    * @param account Address of the account being mapped to the identifier
-   * @param issuedOn Time at which the attestation was issued by the issuer
+   * @param issuedOn Time at which the issuer issued the attestation in Unix time 
    * @param signer Address of the signer of the attestation
    * @param v The recovery id of the incoming ECDSA signature
    * @param r Output value r of the ECDSA signature
    * @param s Output value s of the ECDSA signature
    * @return Whether the signature is valid
-   * @dev Throwas if signer is revoked
+   * @dev Throws if signer is revoked
    * @dev Throws if signer is not an authorized AttestationSigner of the issuer
    */
   function validateAttestation(

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -186,6 +186,20 @@ contract FederatedAttestations is
     }
   }
 
+  /**
+   * @notice Validates the given attestation code.
+   * @param identifier Hash of the identifier to be attested
+   * @param issuer Address of the attestation issuer
+   * @param account Address of the account being mapped to the identifier
+   * @param issuedOn Time at which the attestation was issued by the issuer
+   * @param signer Address of the signer of the attestation
+   * @param v The recovery id of the incoming ECDSA signature
+   * @param r Output value r of the ECDSA signature
+   * @param s Output value s of the ECDSA signature
+   * @return Whether the signature is valid
+   * @dev Throwas if signer is revoked
+   * @dev Throws if signer is not an authorized AttestationSigner of the issuer
+   */
   function validateAttestation(
     bytes32 identifier,
     address issuer,

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -51,7 +51,7 @@ contract FederatedAttestations is
   bytes32 public eip712DomainSeparator;
 
   // TODO: should this be hardcoded here?
-  bytes32 constant signerRole = keccak256(abi.encodePacked("celo.org/core/attestation"));
+  bytes32 constant SignerRole = keccak256(abi.encodePacked("celo.org/core/attestation"));
 
   // TODO ASv2 Event declarations
   event EIP712DomainSeparatorSet(bytes32 eip712DomainSeparator);
@@ -202,7 +202,7 @@ contract FederatedAttestations is
    * @dev Throws if signer is revoked
    * @dev Throws if signer is not an authorized AttestationSigner of the issuer
    */
-  function validateAttestation(
+  function isValidAttestation(
     bytes32 identifier,
     address issuer,
     address account,
@@ -214,7 +214,7 @@ contract FederatedAttestations is
   ) public view returns (bool) {
     require(!revokedSigners[signer], "Signer has been revoked");
     require(
-      getAccounts().isSigner(issuer, signer, signerRole),
+      getAccounts().isSigner(issuer, signer, SignerRole),
       "Signer has not been authorized as an AttestationSigner by the issuer"
     );
     bytes32 structHash = keccak256(
@@ -235,7 +235,7 @@ contract FederatedAttestations is
     address issuer,
     IdentifierOwnershipAttestation memory attestation
   ) public {
-    // TODO call validateAttestation here
+    // TODO call isValidAttestation here
     require(
       msg.sender == attestation.account || msg.sender == issuer || msg.sender == attestation.signer
     );

--- a/packages/protocol/lib/fed-attestations-utils.ts
+++ b/packages/protocol/lib/fed-attestations-utils.ts
@@ -1,0 +1,64 @@
+import { ensureLeading0x } from '@celo/base'
+import { generateTypedDataHash } from '@celo/utils/src/sign-typed-data-utils'
+import { parseSignatureWithoutPrefix } from '@celo/utils/src/signatureUtils'
+
+export const getSignatureForAttestation = async (
+  identifier: string,
+  issuer: string,
+  account: string,
+  issuedOn: number,
+  signer: string,
+  chainId: number,
+  contractAddress: string
+) => {
+  const typedData =  {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256'},  // consider removing
+        { name: 'verifyingContract', type: 'address'}, // consider removing
+      ],
+      IdentifierOwnershipAttestation: [
+          { name: 'identifier', type: 'bytes32' },
+          { name: 'issuer', type: 'address'},
+          { name: 'account', type: 'address' },
+          { name: 'issuedOn', type: 'uint256' },
+          // Consider including a nonce (which could also be used as an ID)
+      ],
+    },
+    primaryType: 'IdentifierOwnershipAttestation',
+    domain: {
+      name: 'FederatedAttestations',
+      version: '1.0',
+      chainId,
+      verifyingContract: contractAddress
+    },
+    message: {
+      identifier, 
+      issuer,
+      account, 
+      issuedOn, 
+    },
+  }
+
+  const signature = await new Promise<string>((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        method: 'eth_signTypedData',
+        params: [signer, typedData],
+      },
+      (error, resp) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(resp.result)
+        }
+      }
+    )
+  })
+
+  const messageHash = ensureLeading0x(generateTypedDataHash(typedData).toString('hex'))
+  const parsedSignature = parseSignatureWithoutPrefix(messageHash, signature, signer)
+  return parsedSignature
+}

--- a/packages/protocol/migrationsConfig.js
+++ b/packages/protocol/migrationsConfig.js
@@ -638,6 +638,7 @@ const linkedLibraries = {
     'LockedGold',
     'Escrow',
     'MetaTransactionWallet',
+    'FederatedAttestations',
   ],
 }
 

--- a/packages/protocol/test/common/accounts.ts
+++ b/packages/protocol/test/common/accounts.ts
@@ -39,41 +39,6 @@ const assertStorageRoots = (rootsHex: string, lengths: BigNumber[], expectedRoot
   assert.equal(roots.length, currentIndex)
 }
 
-export const getSignatureForAuthorization = async (
-  _account: Address,
-  signer: Address,
-  role: string,
-  accountsContractAddress: string
-) => {
-  const typedData = buildAuthorizeSignerTypedData({
-    account: _account,
-    signer,
-    accountsContractAddress,
-    role,
-    chainId: 1,
-  })
-
-  const signature = await new Promise<string>((resolve, reject) => {
-    web3.currentProvider.send(
-      {
-        method: 'eth_signTypedData',
-        params: [signer, typedData],
-      },
-      (error, resp) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(resp.result)
-        }
-      }
-    )
-  })
-
-  const messageHash = ensureLeading0x(generateTypedDataHash(typedData).toString('hex'))
-  const parsedSignature = parseSignatureWithoutPrefix(messageHash, signature, signer)
-  return parsedSignature
-}
-
 contract('Accounts', (accounts: string[]) => {
   let accountsInstance: AccountsInstance
   let mockValidators: MockValidatorsInstance
@@ -560,6 +525,41 @@ contract('Accounts', (accounts: string[]) => {
       })
     })
   })
+
+  const getSignatureForAuthorization = async (
+    _account: Address,
+    signer: Address,
+    role: string,
+    accountsContractAddress: string
+  ) => {
+    const typedData = buildAuthorizeSignerTypedData({
+      account: _account,
+      signer,
+      accountsContractAddress,
+      role,
+      chainId: 1,
+    })
+
+    const signature = await new Promise<string>((resolve, reject) => {
+      web3.currentProvider.send(
+        {
+          method: 'eth_signTypedData',
+          params: [signer, typedData],
+        },
+        (error, resp) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(resp.result)
+          }
+        }
+      )
+    })
+
+    const messageHash = ensureLeading0x(generateTypedDataHash(typedData).toString('hex'))
+    const parsedSignature = parseSignatureWithoutPrefix(messageHash, signature, signer)
+    return parsedSignature
+  }
 
   describe('generic authorization', () => {
     const account2 = accounts[1]

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -32,6 +32,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
   const pnIdentifier: string = getPhoneHash(phoneNumber)
 
   const getCurrentUnixTime = () => Math.floor(Date.now() / 1000)
+  const chainId = 1
 
   beforeEach('FederatedAttestations setup', async () => {
     accountsInstance = await Accounts.new(true)
@@ -106,7 +107,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
         account,
         issuedOn,
         signer,
-        1,
+        chainId,
         federatedAttestations.address
       )
       await accountsInstance.createAccount({ from: issuer })
@@ -141,7 +142,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
           account,
           issuedOn,
           accounts[3],
-          1,
+          chainId,
           federatedAttestations.address
         ))
         assert.isFalse(

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -92,7 +92,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     it('should', async () => {})
   })
 
-  describe('#validateAttestation', async () => {
+  describe('#isValidAttestation', async () => {
     const issuer = accounts[0]
     const signer = accounts[1]
     const account = accounts[2]
@@ -121,7 +121,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
 
       it('should return true if a valid signature is used', async () => {
         assert.isTrue(
-          await federatedAttestations.validateAttestation(
+          await federatedAttestations.isValidAttestation(
             pnIdentifier,
             issuer,
             account,
@@ -145,7 +145,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
           federatedAttestations.address
         ))
         assert.isFalse(
-          await federatedAttestations.validateAttestation(
+          await federatedAttestations.isValidAttestation(
             pnIdentifier,
             issuer,
             account,
@@ -172,11 +172,11 @@ contract('FederatedAttestations', (accounts: string[]) => {
 
           if (arg == 'issuer' || arg == 'signer') {
             await assertRevert(
-              federatedAttestations.validateAttestation.apply(this, args),
+              federatedAttestations.isValidAttestation.apply(this, args),
               'Signer has not been authorized as an AttestationSigner by the issuer'
             )
           } else {
-            assert.isFalse(await federatedAttestations.validateAttestation.apply(this, args))
+            assert.isFalse(await federatedAttestations.isValidAttestation.apply(this, args))
           }
         })
       })
@@ -184,7 +184,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
       it('should revert if the signer is revoked', async () => {
         await federatedAttestations.revokeSigner(signer)
         await assertRevert(
-          federatedAttestations.validateAttestation(
+          federatedAttestations.isValidAttestation(
             pnIdentifier,
             issuer,
             account,
@@ -201,7 +201,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
 
     it('should revert if the signer is not authorized as an AttestationSigner by the issuer', async () => {
       await assertRevert(
-        federatedAttestations.validateAttestation(
+        federatedAttestations.isValidAttestation(
           pnIdentifier,
           issuer,
           account,
@@ -220,7 +220,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
       await accountsInstance.completeSignerAuthorization(issuer, role, { from: signer })
 
       await assertRevert(
-        federatedAttestations.validateAttestation(
+        federatedAttestations.isValidAttestation(
           pnIdentifier,
           issuer,
           account,

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -35,10 +35,10 @@ contract('FederatedAttestations', (accounts: string[]) => {
     registry = await Registry.new(true)
     await accountsInstance.initialize(registry.address)
     await registry.setAddressFor(CeloContractName.Accounts, accountsInstance.address)
-    // await registry.setAddressFor(
-    //   CeloContractName.FederatedAttestations,
-    //   federatedAttestations.address
-    // )
+    await registry.setAddressFor(
+      CeloContractName.FederatedAttestations,
+      federatedAttestations.address
+    )
 
     await federatedAttestations.initialize(registry.address)
     await federatedAttestations.setEip712DomainSeparator()

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -45,7 +45,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
     )
 
     initialize = await federatedAttestations.initialize(registry.address)
-    // await federatedAttestations.setEip712DomainSeparator()
   })
 
   describe('#EIP712_VALIDATE_ATTESTATION_TYPEHASH()', () => {
@@ -68,7 +67,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
       assert(federatedAttestations)
     })
 
-    it.only('should have set the EIP-712 domain separator', async () => {
+    it('should have set the EIP-712 domain separator', async () => {
       assert.equal(
         await federatedAttestations.eip712DomainSeparator(),
         getDomainDigest(federatedAttestations.address)
@@ -76,7 +75,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
 
     it('should emit the EIP712DomainSeparatorSet event', () => {
-      assertLogMatches2(initialize.logs[1], {
+      assertLogMatches2(initialize.logs[2], {
         event: 'EIP712DomainSeparatorSet',
         args: {
           eip712DomainSeparator: getDomainDigest(federatedAttestations.address),


### PR DESCRIPTION
### Description

Adds functionality to the `validateAttestation` function to check the validity of an EIP712 signature of an attestation

### Other changes

Changes signer revocation to a boolean instead of a time that the signer was revoked. 

### Related issues

- Fixes #9446 and #9480 

