### PR TITLE
Increase storage to 1500Gi for the rc1staging archive nodes

### DIFF
--- a/packages/helm-charts/celo-fullnode/rc1staging-archivenodes-values.yaml
+++ b/packages/helm-charts/celo-fullnode/rc1staging-archivenodes-values.yaml
@@ -29,5 +29,5 @@ geth:
 namespace: rc1staging
 replicaCount: 2
 storage:
-  size: 800Gi
+  size: 1500Gi
   storageClass: ssd


### PR DESCRIPTION
Because the blockchain is growing.

### Description

Upsize the SSD storage for the Blockscout archive nodes to 1500Gi (current usage is <65% with this size).

### Tested

Deployed in rc1staging and mainnet.
![Screenshot 2022-05-05 at 11 29 41](https://user-images.githubusercontent.com/4222953/166896729-df4360b9-5b0a-49c7-acd8-7bca3926610a.png)
![Screenshot 2022-05-05 at 11 29 09](https://user-images.githubusercontent.com/4222953/166896801-cf826b95-53c7-4c71-afb2-16089ec3e200.png)

