### PR TITLE
ASv2 registerAttestation unit tests

### DIFF
--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -193,9 +193,11 @@ contract FederatedAttestations is
     }
   }
 
-  modifier isValidUser(address issuer, address account, address signer) {
+  modifier isValidUser(address issuer, address account) {
     require(
-      msg.sender == account || msg.sender == issuer || msg.sender == signer,
+      msg.sender == account ||
+        msg.sender == issuer ||
+        getAccounts().attestationSignerToAccount(msg.sender) == issuer,
       "User does not have permission to perform this action"
     );
     _;
@@ -265,7 +267,7 @@ contract FederatedAttestations is
     uint8 v,
     bytes32 r,
     bytes32 s
-  ) public isValidUser(issuer, account, signer) {
+  ) public isValidUser(issuer, account) {
     require(
       isValidAttestation(identifier, issuer, account, issuedOn, signer, v, r, s),
       "Signature is invalid"

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -243,6 +243,19 @@ contract FederatedAttestations is
     return guessedSigner == signer;
   }
 
+  /**
+   * @notice Registers an attestation with a valid signature
+   * @param identifier Hash of the identifier to be attested
+   * @param issuer Address of the attestation issuer
+   * @param account Address of the account being mapped to the identifier
+   * @param issuedOn Time at which the issuer issued the attestation in Unix time 
+   * @param signer Address of the signer of the attestation
+   * @param v The recovery id of the incoming ECDSA signature
+   * @param r Output value r of the ECDSA signature
+   * @param s Output value s of the ECDSA signature
+   * @dev Throws if sender is not the issuer, account, or signer
+   * @dev Throws if an attestation with the same (identifier, issuer, account) already exists
+   */
   function registerAttestation(
     bytes32 identifier,
     address issuer,
@@ -257,7 +270,7 @@ contract FederatedAttestations is
       isValidAttestation(identifier, issuer, account, issuedOn, signer, v, r, s),
       "Signature is invalid"
     );
-    for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i++) {
+    for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i.add(1)) {
       // This enforces only one attestation to be uploaded for a given set of (identifier, issuer, account)
       // Editing/upgrading an attestation requires that it be deleted before a new one is registered
       require(

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -193,6 +193,7 @@ contract FederatedAttestations is
     }
   }
 
+  // TODO do we want to restrict permissions, or should anyone with a valid signature be able to register an attestation?
   modifier isValidUser(address issuer, address account) {
     require(
       msg.sender == account ||

--- a/packages/protocol/test/common/accounts.ts
+++ b/packages/protocol/test/common/accounts.ts
@@ -39,41 +39,6 @@ const assertStorageRoots = (rootsHex: string, lengths: BigNumber[], expectedRoot
   assert.equal(roots.length, currentIndex)
 }
 
-export const getSignatureForAuthorization = async (
-  _account: Address,
-  signer: Address,
-  role: string,
-  accountsContractAddress: string
-) => {
-  const typedData = buildAuthorizeSignerTypedData({
-    account: _account,
-    signer,
-    accountsContractAddress,
-    role,
-    chainId: 1,
-  })
-
-  const signature = await new Promise<string>((resolve, reject) => {
-    web3.currentProvider.send(
-      {
-        method: 'eth_signTypedData',
-        params: [signer, typedData],
-      },
-      (error, resp) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(resp.result)
-        }
-      }
-    )
-  })
-
-  const messageHash = ensureLeading0x(generateTypedDataHash(typedData).toString('hex'))
-  const parsedSignature = parseSignatureWithoutPrefix(messageHash, signature, signer)
-  return parsedSignature
-}
-
 contract('Accounts', (accounts: string[]) => {
   let accountsInstance: AccountsInstance
   let mockValidators: MockValidatorsInstance
@@ -560,6 +525,41 @@ contract('Accounts', (accounts: string[]) => {
       })
     })
   })
+
+  const getSignatureForAuthorization = async (
+    _account: Address,
+    signer: Address,
+    role: string,
+    accountsContractAddress: string
+  ) => {
+    const typedData = buildAuthorizeSignerTypedData({
+      account: _account,
+      signer,
+      accountsContractAddress,
+      role,
+      chainId: 1,
+    })
+
+    const signature = await new Promise<string>((resolve, reject) => {
+      web3.currentProvider.send(
+        {
+          method: 'eth_signTypedData',
+          params: [signer, typedData],
+        },
+        (error, resp) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(resp.result)
+          }
+        }
+      )
+    })
+
+    const messageHash = ensureLeading0x(generateTypedDataHash(typedData).toString('hex'))
+    const parsedSignature = parseSignatureWithoutPrefix(messageHash, signature, signer)
+    return parsedSignature
+  }
 
   describe('generic authorization', () => {
     const account2 = accounts[1]

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -239,6 +239,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
         )
       )
     })
+
+    it('should fail if the signer is revoked', () => {})
   })
 
   describe('#registerAttestation', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -1,6 +1,6 @@
 import {
   getDomainDigest,
-  getSignatureForAttestation,
+  getSignatureForAttestation
 } from '@celo/protocol/lib/fed-attestations-utils'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { assertLogMatches2, assertRevert } from '@celo/protocol/lib/test-utils'
@@ -11,7 +11,7 @@ import {
   FederatedAttestationsContract,
   FederatedAttestationsInstance,
   RegistryContract,
-  RegistryInstance,
+  RegistryInstance
 } from 'types'
 import { keccak256 } from 'web3-utils'
 

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -89,6 +89,22 @@ contract('FederatedAttestations', (accounts: string[]) => {
     it('should not be callable again', async () => {
       await assertRevert(federatedAttestations.initialize(registry.address))
     })
+
+    it.only('should have set the EIP-712 domain separator', async () => {
+      assert.equal(
+        await federatedAttestations.eip712DomainSeparator(),
+        getDomainDigest(federatedAttestations.address)
+      )
+    })
+
+    it('should emit the EIP712DomainSeparatorSet event', () => {
+      assertLogMatches2(initialize.logs[1], {
+        event: 'EIP712DomainSeparatorSet',
+        args: {
+          eip712DomainSeparator: getDomainDigest(federatedAttestations.address),
+        },
+      })
+    })
   })
 
   describe('#lookupAttestations', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -255,25 +255,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
         )
       )
     })
-
-    it('should revert if the signer is authorized as a different role by the issuer', async () => {
-      const role = keccak256('random')
-      await accountsInstance.authorizeSigner(signer, role, { from: issuer })
-      await accountsInstance.completeSignerAuthorization(issuer, role, { from: signer })
-
-      await assertRevert(
-        federatedAttestations.validateAttestation(
-          pnIdentifier,
-          issuer,
-          account,
-          issuedOn,
-          signer,
-          sig.v,
-          sig.r,
-          sig.s
-        )
-      )
-    })
   })
 
   describe('#registerAttestation', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -240,7 +240,24 @@ contract('FederatedAttestations', (accounts: string[]) => {
       )
     })
 
-    it('should fail if the signer is revoked', () => {})
+    it('should revert if the signer is authorized as a different role by the issuer', async () => {
+      const role = keccak256('random')
+      await accountsInstance.authorizeSigner(signer, role, { from: issuer })
+      await accountsInstance.completeSignerAuthorization(issuer, role, { from: signer })
+
+      await assertRevert(
+        federatedAttestations.validateAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          sig.v,
+          sig.r,
+          sig.s
+        )
+      )
+    })
   })
 
   describe('#registerAttestation', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -104,22 +104,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
     it('should not be callable again', async () => {
       await assertRevert(federatedAttestations.initialize(registry.address))
     })
-
-    it('should have set the EIP-712 domain separator', async () => {
-      assert.equal(
-        await federatedAttestations.eip712DomainSeparator(),
-        getDomainDigest(federatedAttestations.address)
-      )
-    })
-
-    it('should emit the EIP712DomainSeparatorSet event', () => {
-      assertLogMatches2(initialize.logs[2], {
-        event: 'EIP712DomainSeparatorSet',
-        args: {
-          eip712DomainSeparator: getDomainDigest(federatedAttestations.address),
-        },
-      })
-    })
   })
 
   describe('#lookupAttestations', () => {
@@ -152,7 +136,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
         )
       })
 
-      it('should revert if an invalid signature is provided', async () => {
+      it('should return false if an invalid signature is provided', async () => {
         const sig2 = await getSignatureForAttestation(
           pnIdentifier,
           issuer,

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -90,7 +90,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
       await assertRevert(federatedAttestations.initialize(registry.address))
     })
 
-    it.only('should have set the EIP-712 domain separator', async () => {
+    it('should have set the EIP-712 domain separator', async () => {
       assert.equal(
         await federatedAttestations.eip712DomainSeparator(),
         getDomainDigest(federatedAttestations.address)
@@ -98,7 +98,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
 
     it('should emit the EIP712DomainSeparatorSet event', () => {
-      assertLogMatches2(initialize.logs[1], {
+      assertLogMatches2(initialize.logs[2], {
         event: 'EIP712DomainSeparatorSet',
         args: {
           eip712DomainSeparator: getDomainDigest(federatedAttestations.address),

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -319,7 +319,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
         )
       })
 
-      it('should revert if the same attestation is uploaded again', async () => {
+      it('should revert if an attestation with the same (issuer, identifier, account) is uploaded again', async () => {
         // Upload the same attestation signed by a different signer, authorized under the same issuer
         const signer2 = accounts[4]
         await accountsInstance.authorizeSigner(signer2, signerRole, { from: issuer })
@@ -418,6 +418,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
         })
       })
 
+      // TODO figure out why this test results in an out of gas error
       // it.only('should succeed with a different account', async () => {
       //   const account2 = accounts[4]
       //   const sig2 = await getSignatureForAttestation(


### PR DESCRIPTION
### Description

Units tests for the `registerAttestation` function in the `federatedAttestations` contract

### Other changes

- Created modifier `isValidUser` to check if the `msg.sender` is a user with permission to edit the attestation
- emit an `AttestationRegistered` event when an attestation has successfully been registered

### Related issues

- Fixes #9478 
