### PR TITLE
Remove ODIS  ACI container pull parameters

### DIFF
--- a/packages/phone-number-privacy/signer/azure-templates/container-template.json
+++ b/packages/phone-number-privacy/signer/azure-templates/container-template.json
@@ -88,7 +88,7 @@
                   {
                     "server": "celoprod.azurecr.io",
                     "username": "publicpuller",
-                    "password": "RMIToDOdx3llt0cEK/7mlY7kZ8XJL57l"
+                    "password": ""
                   }
                 ],
                 "restartPolicy": "[parameters('restartPolicy')]",


### PR DESCRIPTION
Removes credential from (currently unused) ACI template. This credential is not sensitive, but it makes sense to remove it to avoid concern / confusion for anyone reviewing this code in the future.