### PR TITLE
Implement unit tests for FederatedAttestations

### DIFF
--- a/packages/protocol/contracts/common/interfaces/IAccounts.sol
+++ b/packages/protocol/contracts/common/interfaces/IAccounts.sol
@@ -46,4 +46,5 @@ interface IAccounts {
 
   function setPaymentDelegation(address, uint256) external;
   function getPaymentDelegation(address) external view returns (address, uint256);
+  function isSigner(address, address, bytes32) external view returns (bool);
 }

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -347,20 +347,20 @@ contract FederatedAttestations is
     isValidUser(issuer, account)
   {
     OwnershipAttestation[] memory attestations = identifierToAddresses[identifier][issuer];
-    for (uint256 i = 0; i < attestations.length; i.add(1)) {
+    for (uint256 i = 0; i < attestations.length; i = i.add(1)) {
       OwnershipAttestation memory attestation = attestations[i];
       if (attestation.account == account) {
         // This is meant to delete the attestation in the array
         // and then move the last element in the array to that empty spot,
         // to avoid having empty elements in the array
-        // Not sure if this is needed
+        // TODO reviewers: is there a better way of doing this?
         identifierToAddresses[identifier][issuer][i] = attestations[attestations.length - 1];
         identifierToAddresses[identifier][issuer].pop();
 
         bool deletedIdentifier = false;
 
         bytes32[] memory identifiers = addressToIdentifiers[account][issuer];
-        for (uint256 j = 0; j < identifiers.length; j.add(1)) {
+        for (uint256 j = 0; j < identifiers.length; j = j.add(1)) {
           if (identifiers[j] == identifier) {
             addressToIdentifiers[account][issuer][j] = identifiers[identifiers.length - 1];
             addressToIdentifiers[account][issuer].pop();

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -42,10 +42,19 @@ contract FederatedAttestations is
   mapping(bytes32 => mapping(address => IdentifierOwnershipAttestation[])) public identifierToAddresses;
   // account -> issuer -> identifiers
   mapping(address => mapping(address => bytes32[])) public addressToIdentifiers;
-  // signer => revocation time
-  mapping(address => uint256) public revokedSigners;
+  // signer => isRevoked
+  mapping(address => bool) public revokedSigners;
+
+  bytes32 public constant EIP712_VALIDATE_ATTESTATION_TYPEHASH = keccak256(
+    "IdentifierOwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)"
+  );
+  bytes32 public eip712DomainSeparator;
+
+  // TODO: should this be hardcoded here?
+  bytes32 constant SIGNER_ROLE = keccak256(abi.encodePacked("celo.org/core/attestation"));
 
   // TODO ASv2 Event declarations
+  event EIP712DomainSeparatorSet(bytes32 eip712DomainSeparator);
 
   /**
    * @notice Sets initialized == true on implementation contracts
@@ -60,7 +69,31 @@ contract FederatedAttestations is
   function initialize(address registryAddress) external initializer {
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
+    setEip712DomainSeparator();
     // TODO ASv2 initialize any other variables here
+  }
+
+  /**
+   * @notice Sets the EIP712 domain separator for the Celo FederatedAttestations abstraction.
+   */
+  function setEip712DomainSeparator() public {
+    uint256 chainId;
+    assembly {
+      chainId := chainid
+    }
+
+    eip712DomainSeparator = keccak256(
+      abi.encode(
+        keccak256(
+          "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        ),
+        keccak256(bytes("FederatedAttestations")),
+        keccak256("1.0"),
+        chainId,
+        address(this)
+      )
+    );
+    emit EIP712DomainSeparatorSet(eip712DomainSeparator);
   }
 
   /**
@@ -69,13 +102,6 @@ contract FederatedAttestations is
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);
-  }
-
-  function _isRevoked(address signer, uint256 time) internal view returns (bool) {
-    if (revokedSigners[signer] > 0 && revokedSigners[signer] >= time) {
-      return true;
-    }
-    return false;
   }
 
   function lookupAttestations(
@@ -96,7 +122,7 @@ contract FederatedAttestations is
         // Only create and push new attestation if we haven't hit max
         if (currIndex < maxAttestations) {
           IdentifierOwnershipAttestation memory attestation = identifierToAddresses[identifier][trustedIssuer][j];
-          if (!_isRevoked(attestation.signer, attestation.issuedOn)) {
+          if (!revokedSigners[attestation.signer]) {
             attestations[currIndex] = attestation;
             currIndex++;
           }
@@ -139,10 +165,7 @@ contract FederatedAttestations is
             // For now, just take the first published, unrevoked signer that matches
             // TODO redo this to take into account either recency or the "correct" identifier
             // based on the index
-            if (
-              attestation.account == account &&
-              !_isRevoked(attestation.signer, attestation.issuedOn)
-            ) {
+            if (attestation.account == account && !revokedSigners[attestation.signer]) {
               identifiers[currIndex] = identifier;
               currIndex++;
               break;
@@ -165,15 +188,46 @@ contract FederatedAttestations is
     }
   }
 
-  function validateAttestation(
+  /**
+   * @notice Validates the given attestation and signature
+   * @param identifier Hash of the identifier to be attested
+   * @param issuer Address of the attestation issuer
+   * @param account Address of the account being mapped to the identifier
+   * @param issuedOn Time at which the issuer issued the attestation in Unix time 
+   * @param signer Address of the signer of the attestation
+   * @param v The recovery id of the incoming ECDSA signature
+   * @param r Output value r of the ECDSA signature
+   * @param s Output value s of the ECDSA signature
+   * @return Whether the signature is valid
+   * @dev Throws if signer is revoked
+   * @dev Throws if signer is not an authorized AttestationSigner of the issuer
+   */
+  function isValidAttestation(
     bytes32 identifier,
     address issuer,
-    IdentifierOwnershipAttestation memory attestation,
+    address account,
+    uint256 issuedOn,
+    address signer,
     uint8 v,
     bytes32 r,
     bytes32 s
-  ) public view returns (address) {
-    // TODO check if signer is revoked and is a valid signer of the account
+  ) public view returns (bool) {
+    require(!revokedSigners[signer], "Signer has been revoked");
+    require(
+      getAccounts().isSigner(issuer, signer, SIGNER_ROLE),
+      "Signer has not been authorized as an AttestationSigner by the issuer"
+    );
+    bytes32 structHash = keccak256(
+      abi.encode(EIP712_VALIDATE_ATTESTATION_TYPEHASH, identifier, issuer, account, issuedOn)
+    );
+    address guessedSigner = Signatures.getSignerOfTypedDataHash(
+      eip712DomainSeparator,
+      structHash,
+      v,
+      r,
+      s
+    );
+    return guessedSigner == signer;
   }
 
   function registerAttestation(
@@ -181,7 +235,7 @@ contract FederatedAttestations is
     address issuer,
     IdentifierOwnershipAttestation memory attestation
   ) public {
-    // TODO call validateAttestation here
+    // TODO call isValidAttestation here
     require(
       msg.sender == attestation.account || msg.sender == issuer || msg.sender == attestation.signer
     );
@@ -229,8 +283,8 @@ contract FederatedAttestations is
     }
   }
 
-  function revokeSigner(address signer, uint256 revokedOn) public {
-    // TODO ASv2 add constraints on who can revoke a signer
-    revokedSigners[signer] = revokedOn;
+  function revokeSigner(address signer) public {
+    // TODO ASv2 add constraints on who has permissions to revoke a signer
+    revokedSigners[signer] = true;
   }
 }

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -45,15 +45,13 @@ contract FederatedAttestations is
   // signer => isRevoked
   mapping(address => bool) public revokedSigners;
 
+  // TODO: should this be hardcoded here?
+  bytes32 constant SIGNER_ROLE = keccak256(abi.encodePacked("celo.org/core/attestation"));
   bytes32 public constant EIP712_VALIDATE_ATTESTATION_TYPEHASH = keccak256(
     "IdentifierOwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)"
   );
   bytes32 public eip712DomainSeparator;
 
-  // TODO: should this be hardcoded here?
-  bytes32 constant SIGNER_ROLE = keccak256(abi.encodePacked("celo.org/core/attestation"));
-
-  // TODO ASv2 Event declarations
   event EIP712DomainSeparatorSet(bytes32 eip712DomainSeparator);
 
   /**

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -53,6 +53,13 @@ contract FederatedAttestations is
   bytes32 public eip712DomainSeparator;
 
   event EIP712DomainSeparatorSet(bytes32 eip712DomainSeparator);
+  event AttestationRegistered(
+    bytes32 indexed identifier,
+    address indexed issuer,
+    address indexed account,
+    uint256 issuedOn,
+    address signer
+  );
 
   /**
    * @notice Sets initialized == true on implementation contracts
@@ -186,6 +193,17 @@ contract FederatedAttestations is
     }
   }
 
+  // TODO do we want to restrict permissions, or should anyone with a valid signature be able to register an attestation?
+  modifier isValidUser(address issuer, address account) {
+    require(
+      msg.sender == account ||
+        msg.sender == issuer ||
+        getAccounts().attestationSignerToAccount(msg.sender) == issuer,
+      "User does not have permission to perform this action"
+    );
+    _;
+  }
+
   /**
    * @notice Validates the given attestation and signature
    * @param identifier Hash of the identifier to be attested
@@ -228,22 +246,49 @@ contract FederatedAttestations is
     return guessedSigner == signer;
   }
 
+  /**
+   * @notice Registers an attestation with a valid signature
+   * @param identifier Hash of the identifier to be attested
+   * @param issuer Address of the attestation issuer
+   * @param account Address of the account being mapped to the identifier
+   * @param issuedOn Time at which the issuer issued the attestation in Unix time 
+   * @param signer Address of the signer of the attestation
+   * @param v The recovery id of the incoming ECDSA signature
+   * @param r Output value r of the ECDSA signature
+   * @param s Output value s of the ECDSA signature
+   * @dev Throws if sender is not the issuer, account, or signer
+   * @dev Throws if an attestation with the same (identifier, issuer, account) already exists
+   */
   function registerAttestation(
     bytes32 identifier,
     address issuer,
-    IdentifierOwnershipAttestation memory attestation
-  ) public {
-    // TODO call isValidAttestation here
+    address account,
+    uint256 issuedOn,
+    address signer,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) public isValidUser(issuer, account) {
     require(
-      msg.sender == attestation.account || msg.sender == issuer || msg.sender == attestation.signer
+      isValidAttestation(identifier, issuer, account, issuedOn, signer, v, r, s),
+      "Signature is invalid"
     );
-    for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i++) {
+    for (uint256 i = 0; i < identifierToAddresses[identifier][issuer].length; i.add(1)) {
       // This enforces only one attestation to be uploaded for a given set of (identifier, issuer, account)
       // Editing/upgrading an attestation requires that it be deleted before a new one is registered
-      require(identifierToAddresses[identifier][issuer][i].account != attestation.account);
+      require(
+        identifierToAddresses[identifier][issuer][i].account != account,
+        "Attestation for this account already exists"
+      );
     }
+    IdentifierOwnershipAttestation memory attestation = IdentifierOwnershipAttestation(
+      account,
+      issuedOn,
+      signer
+    );
     identifierToAddresses[identifier][issuer].push(attestation);
-    addressToIdentifiers[attestation.account][issuer].push(identifier);
+    addressToIdentifiers[account][issuer].push(identifier);
+    emit AttestationRegistered(identifier, issuer, account, issuedOn, signer);
   }
 
   function deleteAttestation(bytes32 identifier, address issuer, address account) public {

--- a/packages/protocol/lib/fed-attestations-utils.ts
+++ b/packages/protocol/lib/fed-attestations-utils.ts
@@ -17,15 +17,15 @@ const getTypedData = (chainId: number, contractAddress: Address, message?: Attes
       EIP712Domain: [
         { name: 'name', type: 'string' },
         { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256'},  // consider removing
-        { name: 'verifyingContract', type: 'address'}, // consider removing
+        { name: 'chainId', type: 'uint256'},  // TODO ASv2 consider removing
+        { name: 'verifyingContract', type: 'address'}, // TODO ASv2 consider removing
       ],
       IdentifierOwnershipAttestation: [
           { name: 'identifier', type: 'bytes32' },
           { name: 'issuer', type: 'address'},
           { name: 'account', type: 'address' },
           { name: 'issuedOn', type: 'uint256' },
-          // Consider including a nonce (which could also be used as an ID)
+          // TODO ASv2 Consider including a nonce (which could also be used as an ID)
       ],
     },
     primaryType: 'IdentifierOwnershipAttestation',

--- a/packages/protocol/lib/fed-attestations-utils.ts
+++ b/packages/protocol/lib/fed-attestations-utils.ts
@@ -1,0 +1,80 @@
+import { ensureLeading0x } from '@celo/base'
+import { Address } from '@celo/utils/lib/address'
+import { structHash } from '@celo/utils/lib/sign-typed-data-utils'
+import { generateTypedDataHash } from '@celo/utils/src/sign-typed-data-utils'
+import { parseSignatureWithoutPrefix } from '@celo/utils/src/signatureUtils'
+
+export interface AttestationDetails{
+  identifier: string,
+  issuer: string,
+  account: string,
+  issuedOn: number,
+}
+
+const getTypedData = (chainId: number, contractAddress: Address, message?: AttestationDetails) => {
+  const typedData =  {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256'},  // consider removing
+        { name: 'verifyingContract', type: 'address'}, // consider removing
+      ],
+      IdentifierOwnershipAttestation: [
+          { name: 'identifier', type: 'bytes32' },
+          { name: 'issuer', type: 'address'},
+          { name: 'account', type: 'address' },
+          { name: 'issuedOn', type: 'uint256' },
+          // Consider including a nonce (which could also be used as an ID)
+      ],
+    },
+    primaryType: 'IdentifierOwnershipAttestation',
+    domain: {
+      name: 'FederatedAttestations',
+      version: '1.0',
+      chainId,
+      verifyingContract: contractAddress
+    },
+    message: message ? message : {}
+  }
+  return typedData
+}
+
+export const getSignatureForAttestation = async (
+  identifier: string,
+  issuer: string,
+  account: string,
+  issuedOn: number,
+  signer: string,
+  chainId: number,
+  contractAddress: string
+) => {
+  const typedData = getTypedData(chainId, contractAddress, { identifier,issuer,account, issuedOn})
+
+  const signature = await new Promise<string>((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        method: 'eth_signTypedData',
+        params: [signer, typedData],
+      },
+      (error, resp) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(resp.result)
+        }
+      }
+    )
+  })
+
+  const messageHash = ensureLeading0x(generateTypedDataHash(typedData).toString('hex'))
+  const parsedSignature = parseSignatureWithoutPrefix(messageHash, signature, signer)
+  return parsedSignature
+}
+
+export const getDomainDigest = (contractAddress: Address) => {
+  const typedData = getTypedData(1, contractAddress)
+  return ensureLeading0x(
+    structHash('EIP712Domain', typedData.domain, typedData.types).toString('hex')
+  )
+}

--- a/packages/protocol/lib/fed-attestations-utils.ts
+++ b/packages/protocol/lib/fed-attestations-utils.ts
@@ -17,10 +17,10 @@ const getTypedData = (chainId: number, contractAddress: Address, message?: Attes
       EIP712Domain: [
         { name: 'name', type: 'string' },
         { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256'},  // TODO ASv2 consider removing
-        { name: 'verifyingContract', type: 'address'}, // TODO ASv2 consider removing
+        { name: 'chainId', type: 'uint256'}, 
+        { name: 'verifyingContract', type: 'address'}, 
       ],
-      IdentifierOwnershipAttestation: [
+      OwnershipAttestation: [
           { name: 'identifier', type: 'bytes32' },
           { name: 'issuer', type: 'address'},
           { name: 'account', type: 'address' },
@@ -28,7 +28,7 @@ const getTypedData = (chainId: number, contractAddress: Address, message?: Attes
           // TODO ASv2 Consider including a nonce (which could also be used as an ID)
       ],
     },
-    primaryType: 'IdentifierOwnershipAttestation',
+    primaryType: 'OwnershipAttestation',
     domain: {
       name: 'FederatedAttestations',
       version: '1.0',

--- a/packages/protocol/migrationsConfig.js
+++ b/packages/protocol/migrationsConfig.js
@@ -638,6 +638,7 @@ const linkedLibraries = {
     'LockedGold',
     'Escrow',
     'MetaTransactionWallet',
+    'FederatedAttestations',
   ],
 }
 

--- a/packages/protocol/test/common/accounts.ts
+++ b/packages/protocol/test/common/accounts.ts
@@ -13,6 +13,7 @@ import { parseSolidityStringArray } from '@celo/utils/lib/parsing'
 import { authorizeSigner as buildAuthorizeSignerTypedData } from '@celo/utils/lib/typed-data-constructors'
 import { generateTypedDataHash } from '@celo/utils/src/sign-typed-data-utils'
 import { parseSignatureWithoutPrefix } from '@celo/utils/src/signatureUtils'
+import BigNumber from 'bignumber.js'
 import {
   AccountsContract,
   AccountsInstance,
@@ -21,8 +22,6 @@ import {
   RegistryContract,
 } from 'types'
 import { keccak256 } from 'web3-utils'
-
-import BigNumber from 'bignumber.js'
 
 const Accounts: AccountsContract = artifacts.require('Accounts')
 const Registry: RegistryContract = artifacts.require('Registry')

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -610,6 +610,23 @@ contract('FederatedAttestations', (accounts: string[]) => {
       )
     })
 
+    it('should revert if signer has been revoked', async () => {
+      await federatedAttestations.revokeSigner(signer1)
+      await assertRevertWithReason(
+        federatedAttestations.registerAttestation(
+          identifier1,
+          issuer1,
+          account1,
+          nowUnixTime,
+          signer1,
+          sig.v,
+          sig.r,
+          sig.s
+        ),
+        'Signer has been revoked'
+      )
+    })
+
     describe('when registering a second attestation', () => {
       beforeEach(async () => {
         // register first attestation

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -27,12 +27,17 @@ contract('FederatedAttestations', (accounts: string[]) => {
   let registry: RegistryInstance
   let initialize
 
-  const caller: string = accounts[0]
   const phoneNumber: string = '+18005551212'
   const pnIdentifier: string = getPhoneHash(phoneNumber)
-
   const getCurrentUnixTime = () => Math.floor(Date.now() / 1000)
   const chainId = 1
+
+  const issuer = accounts[0]
+  const signer = accounts[1]
+  const account = accounts[2]
+  const issuedOn = getCurrentUnixTime()
+  const signerRole = keccak256('celo.org/core/attestation')
+  let sig
 
   beforeEach('FederatedAttestations setup', async () => {
     accountsInstance = await Accounts.new(true)
@@ -43,8 +48,18 @@ contract('FederatedAttestations', (accounts: string[]) => {
       CeloContractName.FederatedAttestations,
       federatedAttestations.address
     )
-
     initialize = await federatedAttestations.initialize(registry.address)
+
+    await accountsInstance.createAccount({ from: issuer })
+    sig = await getSignatureForAttestation(
+      pnIdentifier,
+      issuer,
+      account,
+      issuedOn,
+      signer,
+      chainId,
+      federatedAttestations.address
+    )
   })
 
   describe('#EIP712_VALIDATE_ATTESTATION_TYPEHASH()', () => {
@@ -62,7 +77,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
   describe('#initialize()', () => {
     it('should have set the owner', async () => {
       const owner: string = await federatedAttestations.owner()
-      assert.equal(owner, caller)
+      assert.equal(owner, issuer)
     })
 
     it('should have set the registry address', async () => {
@@ -100,30 +115,10 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#isValidAttestation', async () => {
-    const issuer = accounts[0]
-    const signer = accounts[1]
-    const account = accounts[2]
-    const issuedOn = getCurrentUnixTime()
-    let sig
-
-    beforeEach(async () => {
-      sig = await getSignatureForAttestation(
-        pnIdentifier,
-        issuer,
-        account,
-        issuedOn,
-        signer,
-        chainId,
-        federatedAttestations.address
-      )
-      await accountsInstance.createAccount({ from: issuer })
-    })
-
     describe('with an authorized AttestationSigner', async () => {
       beforeEach(async () => {
-        const role = keccak256('celo.org/core/attestation')
-        await accountsInstance.authorizeSigner(signer, role, { from: issuer })
-        await accountsInstance.completeSignerAuthorization(issuer, role, { from: signer })
+        await accountsInstance.authorizeSigner(signer, signerRole, { from: issuer })
+        await accountsInstance.completeSignerAuthorization(issuer, signerRole, { from: signer })
       })
 
       it('should return true if a valid signature is used', async () => {
@@ -142,7 +137,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
       })
 
       it('should return false if an invalid signature is provided', async () => {
-        const sig2 = (sig = await getSignatureForAttestation(
+        const sig2 = await getSignatureForAttestation(
           pnIdentifier,
           issuer,
           account,
@@ -150,7 +145,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
           accounts[3],
           chainId,
           federatedAttestations.address
-        ))
+        )
         assert.isFalse(
           await federatedAttestations.isValidAttestation(
             pnIdentifier,
@@ -242,7 +237,249 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#registerAttestation', () => {
-    it('should', async () => {})
+    beforeEach(async () => {
+      await accountsInstance.authorizeSigner(signer, signerRole, { from: issuer })
+      await accountsInstance.completeSignerAuthorization(issuer, signerRole, { from: signer })
+    })
+    it('should emit AttestationRegistered for a valid attestation', async () => {
+      const register = await federatedAttestations.registerAttestation(
+        pnIdentifier,
+        issuer,
+        account,
+        issuedOn,
+        signer,
+        sig.v,
+        sig.r,
+        sig.s
+      )
+      assertLogMatches2(register.logs[0], {
+        event: 'AttestationRegistered',
+        args: {
+          identifier: pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+        },
+      })
+    })
+
+    it('should revert if an invalid signature is provided', async () => {
+      const sig2 = await getSignatureForAttestation(
+        pnIdentifier,
+        issuer,
+        account,
+        issuedOn,
+        accounts[3],
+        chainId,
+        federatedAttestations.address
+      )
+      await assertRevert(
+        federatedAttestations.registerAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          sig2.v,
+          sig2.r,
+          sig2.s
+        )
+      )
+    })
+
+    describe('when registering a second attestation', () => {
+      beforeEach(async () => {
+        // register first attestation
+        await federatedAttestations.registerAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          sig.v,
+          sig.r,
+          sig.s
+        )
+      })
+
+      it('should revert if an attestation with the same (issuer, identifier, account) is uploaded again', async () => {
+        // Upload the same attestation signed by a different signer, authorized under the same issuer
+        const signer2 = accounts[4]
+        await accountsInstance.authorizeSigner(signer2, signerRole, { from: issuer })
+        await accountsInstance.completeSignerAuthorization(issuer, signerRole, { from: signer2 })
+        const sig2 = await getSignatureForAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn + 1,
+          signer2,
+          1,
+          federatedAttestations.address
+        )
+        await assertRevert(
+          federatedAttestations.registerAttestation(
+            pnIdentifier,
+            issuer,
+            account,
+            issuedOn,
+            signer2,
+            sig2.v,
+            sig2.r,
+            sig2.s
+          )
+        )
+      })
+
+      it('should succeed with a different identifier', async () => {
+        const identifier2 = getPhoneHash('+19199199919')
+        const sig2 = await getSignatureForAttestation(
+          identifier2,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          chainId,
+          federatedAttestations.address
+        )
+        const register2 = await federatedAttestations.registerAttestation(
+          identifier2,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          sig2.v,
+          sig2.r,
+          sig2.s
+        )
+        assertLogMatches2(register2.logs[0], {
+          event: 'AttestationRegistered',
+          args: {
+            identifier: identifier2,
+            issuer,
+            account,
+            issuedOn,
+            signer,
+          },
+        })
+      })
+
+      it('should succeed with a different issuer', async () => {
+        const issuer2 = accounts[4]
+        const signer2 = accounts[5]
+        await accountsInstance.createAccount({ from: issuer2 })
+        await accountsInstance.authorizeSigner(signer2, signerRole, { from: issuer2 })
+        await accountsInstance.completeSignerAuthorization(issuer2, signerRole, { from: signer2 })
+        const sig2 = await getSignatureForAttestation(
+          pnIdentifier,
+          issuer2,
+          account,
+          issuedOn,
+          signer2,
+          chainId,
+          federatedAttestations.address
+        )
+        const register2 = await federatedAttestations.registerAttestation(
+          pnIdentifier,
+          issuer2,
+          account,
+          issuedOn,
+          signer2,
+          sig2.v,
+          sig2.r,
+          sig2.s,
+          { from: issuer2 }
+        )
+        assertLogMatches2(register2.logs[0], {
+          event: 'AttestationRegistered',
+          args: {
+            identifier: pnIdentifier,
+            issuer: issuer2,
+            account,
+            issuedOn,
+            signer: signer2,
+          },
+        })
+      })
+
+      // TODO figure out why this test results in an out of gas error
+      // it.only('should succeed with a different account', async () => {
+      //   const account2 = accounts[4]
+      //   const sig2 = await getSignatureForAttestation(
+      //     pnIdentifier,
+      //     issuer,
+      //     account2,
+      //     issuedOn,
+      //     signer,
+      //     chainId,
+      //     federatedAttestations.address
+      //   )
+      //   const register2 = await federatedAttestations.registerAttestation(
+      //     pnIdentifier,
+      //     issuer,
+      //     account2,
+      //     issuedOn,
+      //     signer,
+      //     sig2.v,
+      //     sig2.r,
+      //     sig2.s,
+      //     { from: issuer, gasPrice: 0 }
+      //   )
+      //   assertLogMatches2(register2.logs[0], {
+      //     event: 'AttestationRegistered',
+      //     args: {
+      //       identifier: pnIdentifier,
+      //       issuer,
+      //       account: account2,
+      //       issuedOn,
+      //       signer,
+      //     },
+      //   })
+      // })
+    })
+
+    it('should revert if an invalid user attempts to register the attestation', async () => {
+      await assertRevert(
+        federatedAttestations.registerAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          sig.v,
+          sig.r,
+          sig.s,
+          { from: accounts[4] }
+        )
+      )
+    })
+
+    it('should succeed if a different AttestationSigner authorized by the same issuer registers the attestation', async () => {
+      const signer2 = accounts[4]
+      await accountsInstance.authorizeSigner(signer2, signerRole, { from: issuer })
+      await accountsInstance.completeSignerAuthorization(issuer, signerRole, { from: signer2 })
+      const register = await federatedAttestations.registerAttestation(
+        pnIdentifier,
+        issuer,
+        account,
+        issuedOn,
+        signer,
+        sig.v,
+        sig.r,
+        sig.s,
+        { from: signer2 }
+      )
+      assertLogMatches2(register.logs[0], {
+        event: 'AttestationRegistered',
+        args: {
+          identifier: pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+        },
+      })
+    })
   })
 
   describe('#deleteAttestation', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -561,8 +561,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
       await accountsInstance.completeSignerAuthorization(issuer1, signerRole, { from: signer1 })
     })
 
-    // TODO ASv2: add case for when issuer == signer
-
     it('should emit AttestationRegistered for a valid attestation', async () => {
       const register = await federatedAttestations.registerAttestation(
         identifier1,
@@ -582,6 +580,38 @@ contract('FederatedAttestations', (accounts: string[]) => {
           account: account1,
           issuedOn: nowUnixTime,
           signer: signer1,
+        },
+      })
+    })
+
+    it('should succeed if issuer == signer', async () => {
+      const issuerSig = await getSignatureForAttestation(
+        identifier1,
+        issuer1,
+        account1,
+        nowUnixTime,
+        issuer1,
+        chainId,
+        federatedAttestations.address
+      )
+      const register = await federatedAttestations.registerAttestation(
+        identifier1,
+        issuer1,
+        account1,
+        nowUnixTime,
+        issuer1,
+        issuerSig.v,
+        issuerSig.r,
+        issuerSig.s
+      )
+      assertLogMatches2(register.logs[0], {
+        event: 'AttestationRegistered',
+        args: {
+          identifier: identifier1,
+          issuer: issuer1,
+          account: account1,
+          issuedOn: nowUnixTime,
+          signer: issuer1,
         },
       })
     })

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -15,7 +15,7 @@ const FederatedAttestations: FederatedAttestationsContract = artifacts.require(
 )
 const Registry: RegistryContract = artifacts.require('Registry')
 
-contract('Attestations', (accounts: string[]) => {
+contract('FederatedAttestations', (accounts: string[]) => {
   let accountsInstance: AccountsInstance
   let federatedAttestations: FederatedAttestationsInstance
   let registry: RegistryInstance
@@ -39,5 +39,25 @@ contract('Attestations', (accounts: string[]) => {
       assert(caller)
       assert(federatedAttestations)
     })
+  })
+
+  describe('#lookupAttestations', () => {
+    it('should', async () => {})
+  })
+
+  describe('#lookupIdentifiersByAddress', () => {
+    it('should', async () => {})
+  })
+
+  describe('#validateAttestation', () => {
+    it('should', async () => {})
+  })
+
+  describe('#registerAttestation', () => {
+    it('should', async () => {})
+  })
+
+  describe('#deleteAttestation', () => {
+    it('should', async () => {})
   })
 })

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -1,5 +1,10 @@
+import {
+  getDomainDigest,
+  getSignatureForAttestation,
+} from '@celo/protocol/lib/fed-attestations-utils'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
-// import { getPhoneHash } from '@celo/utils/lib/phoneNumbers'
+import { assertLogMatches2, assertRevert } from '@celo/protocol/lib/test-utils'
+import { getPhoneHash } from '@celo/utils/lib/phoneNumbers'
 import {
   AccountsContract,
   AccountsInstance,
@@ -8,6 +13,7 @@ import {
   RegistryContract,
   RegistryInstance,
 } from 'types'
+import { keccak256 } from 'web3-utils'
 
 const Accounts: AccountsContract = artifacts.require('Accounts')
 const FederatedAttestations: FederatedAttestationsContract = artifacts.require(
@@ -19,10 +25,14 @@ contract('FederatedAttestations', (accounts: string[]) => {
   let accountsInstance: AccountsInstance
   let federatedAttestations: FederatedAttestationsInstance
   let registry: RegistryInstance
+  let initialize
 
   const caller: string = accounts[0]
-  // const phoneNumber: string = '+18005551212'
-  // const phoneHash: string = getPhoneHash(phoneNumber)
+  const phoneNumber: string = '+18005551212'
+  const pnIdentifier: string = getPhoneHash(phoneNumber)
+
+  const getCurrentUnixTime = () => Math.floor(Date.now() / 1000)
+  const chainId = 1
 
   beforeEach('FederatedAttestations setup', async () => {
     accountsInstance = await Accounts.new(true)
@@ -30,14 +40,48 @@ contract('FederatedAttestations', (accounts: string[]) => {
     registry = await Registry.new(true)
     await accountsInstance.initialize(registry.address)
     await registry.setAddressFor(CeloContractName.Accounts, accountsInstance.address)
-    await federatedAttestations.initialize(registry.address)
+    await registry.setAddressFor(
+      CeloContractName.FederatedAttestations,
+      federatedAttestations.address
+    )
+
+    initialize = await federatedAttestations.initialize(registry.address)
+  })
+
+  describe('#EIP712_VALIDATE_ATTESTATION_TYPEHASH()', () => {
+    it('should have set the right typehash', async () => {
+      const expectedTypehash = keccak256(
+        'IdentifierOwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)'
+      )
+      assert.equal(
+        await federatedAttestations.EIP712_VALIDATE_ATTESTATION_TYPEHASH(),
+        expectedTypehash
+      )
+    })
   })
 
   describe('#initialize()', () => {
+    // TODO more intialize tests
     it('TODO ASv2', async () => {
       // TODO ASv2
       assert(caller)
       assert(federatedAttestations)
+    })
+
+    it('should have set the EIP-712 domain separator', async () => {
+      assert.equal(
+        await federatedAttestations.eip712DomainSeparator(),
+        getDomainDigest(federatedAttestations.address)
+      )
+    })
+
+    it('should emit the EIP712DomainSeparatorSet event', () => {
+      assertLogMatches2(initialize.logs[2], {
+        event: 'EIP712DomainSeparatorSet',
+        args: {
+          eip712DomainSeparator: getDomainDigest(federatedAttestations.address),
+        },
+      })
     })
   })
 
@@ -49,8 +93,146 @@ contract('FederatedAttestations', (accounts: string[]) => {
     it('should', async () => {})
   })
 
-  describe('#validateAttestation', () => {
-    it('should', async () => {})
+  describe('#isValidAttestation', async () => {
+    const issuer = accounts[0]
+    const signer = accounts[1]
+    const account = accounts[2]
+    const issuedOn = getCurrentUnixTime()
+    let sig
+
+    beforeEach(async () => {
+      sig = await getSignatureForAttestation(
+        pnIdentifier,
+        issuer,
+        account,
+        issuedOn,
+        signer,
+        chainId,
+        federatedAttestations.address
+      )
+      await accountsInstance.createAccount({ from: issuer })
+    })
+
+    describe('with an authorized AttestationSigner', async () => {
+      beforeEach(async () => {
+        const role = keccak256('celo.org/core/attestation')
+        await accountsInstance.authorizeSigner(signer, role, { from: issuer })
+        await accountsInstance.completeSignerAuthorization(issuer, role, { from: signer })
+      })
+
+      it('should return true if a valid signature is used', async () => {
+        assert.isTrue(
+          await federatedAttestations.isValidAttestation(
+            pnIdentifier,
+            issuer,
+            account,
+            issuedOn,
+            signer,
+            sig.v,
+            sig.r,
+            sig.s
+          )
+        )
+      })
+
+      it('should return false if an invalid signature is provided', async () => {
+        const sig2 = (sig = await getSignatureForAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          accounts[3],
+          chainId,
+          federatedAttestations.address
+        ))
+        assert.isFalse(
+          await federatedAttestations.isValidAttestation(
+            pnIdentifier,
+            issuer,
+            account,
+            issuedOn,
+            signer,
+            sig2.v,
+            sig2.r,
+            sig2.s
+          )
+        )
+      })
+
+      const wrongArgs = [
+        [0, 'identifier', getPhoneHash('+14169483397')],
+        [1, 'issuer', accounts[3]],
+        [2, 'account', accounts[3]],
+        [3, 'issuedOn', issuedOn - 1],
+        [4, 'signer', accounts[3]],
+      ]
+      wrongArgs.forEach(([index, arg, wrongValue]) => {
+        it(`should fail if the provided ${arg} is different from the attestation`, async () => {
+          let args = [pnIdentifier, issuer, account, issuedOn, signer, sig.v, sig.r, sig.s]
+          args[index] = wrongValue
+
+          if (arg == 'issuer' || arg == 'signer') {
+            await assertRevert(
+              federatedAttestations.isValidAttestation.apply(this, args),
+              'Signer has not been authorized as an AttestationSigner by the issuer'
+            )
+          } else {
+            assert.isFalse(await federatedAttestations.isValidAttestation.apply(this, args))
+          }
+        })
+      })
+
+      it('should revert if the signer is revoked', async () => {
+        await federatedAttestations.revokeSigner(signer)
+        await assertRevert(
+          federatedAttestations.isValidAttestation(
+            pnIdentifier,
+            issuer,
+            account,
+            issuedOn,
+            signer,
+            sig.v,
+            sig.r,
+            sig.s
+          ),
+          'Signer has been revoked'
+        )
+      })
+    })
+
+    it('should revert if the signer is not authorized as an AttestationSigner by the issuer', async () => {
+      await assertRevert(
+        federatedAttestations.isValidAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          sig.v,
+          sig.r,
+          sig.s
+        )
+      )
+    })
+
+    it('should revert if the signer is authorized as a different role by the issuer', async () => {
+      const role = keccak256('random')
+      await accountsInstance.authorizeSigner(signer, role, { from: issuer })
+      await accountsInstance.completeSignerAuthorization(issuer, role, { from: signer })
+
+      await assertRevert(
+        federatedAttestations.isValidAttestation(
+          pnIdentifier,
+          issuer,
+          account,
+          issuedOn,
+          signer,
+          sig.v,
+          sig.r,
+          sig.s
+        )
+      )
+    })
   })
 
   describe('#registerAttestation', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -38,7 +38,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
     accountsInstance = await Accounts.new(true)
     federatedAttestations = await FederatedAttestations.new(true)
     registry = await Registry.new(true)
-    await accountsInstance.initialize(registry.address)
     await registry.setAddressFor(CeloContractName.Accounts, accountsInstance.address)
     await registry.setAddressFor(
       CeloContractName.FederatedAttestations,
@@ -61,11 +60,14 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#initialize()', () => {
-    // TODO more intialize tests
-    it('TODO ASv2', async () => {
-      // TODO ASv2
-      assert(caller)
-      assert(federatedAttestations)
+    it('should have set the owner', async () => {
+      const owner: string = await federatedAttestations.owner()
+      assert.equal(owner, caller)
+    })
+
+    it('should have set the registry address', async () => {
+      const registryAddress: string = await federatedAttestations.registry()
+      assert.equal(registryAddress, registry.address)
     })
 
     it('should have set the EIP-712 domain separator', async () => {
@@ -82,6 +84,10 @@ contract('FederatedAttestations', (accounts: string[]) => {
           eip712DomainSeparator: getDomainDigest(federatedAttestations.address),
         },
       })
+    })
+
+    it('should not be callable again', async () => {
+      await assertRevert(federatedAttestations.initialize(registry.address))
     })
   })
 

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -3,7 +3,11 @@ import {
   getSignatureForAttestation,
 } from '@celo/protocol/lib/fed-attestations-utils'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
-import { assertLogMatches2, assertRevert } from '@celo/protocol/lib/test-utils'
+import {
+  assertLogMatches2,
+  assertRevert,
+  assertRevertWithReason,
+} from '@celo/protocol/lib/test-utils'
 import { getPhoneHash } from '@celo/utils/lib/phoneNumbers'
 import BigNumber from 'bignumber.js'
 import {
@@ -108,7 +112,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
   describe('#EIP712_VALIDATE_ATTESTATION_TYPEHASH()', () => {
     it('should have set the right typehash', async () => {
       const expectedTypehash = keccak256(
-        'IdentifierOwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)'
+        'OwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)'
       )
       assert.equal(
         await federatedAttestations.EIP712_VALIDATE_ATTESTATION_TYPEHASH(),
@@ -491,10 +495,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
           args[index] = wrongValue
 
           if (arg === 'issuer' || arg === 'signer') {
-            await assertRevert(
-              federatedAttestations.isValidAttestation.apply(this, args),
-              'Signer has not been authorized as an AttestationSigner by the issuer'
-            )
+            await assertRevert(federatedAttestations.isValidAttestation.apply(this, args))
           } else {
             assert.isFalse(await federatedAttestations.isValidAttestation.apply(this, args))
           }
@@ -503,7 +504,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
 
       it('should revert if the signer is revoked', async () => {
         await federatedAttestations.revokeSigner(signer1)
-        await assertRevert(
+        await assertRevertWithReason(
           federatedAttestations.isValidAttestation(
             identifier1,
             issuer1,
@@ -802,9 +803,103 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#deleteAttestation', () => {
-    it('should', async () => {
-      // Fix lint checks until these tests are here
-      assert(true)
+    beforeEach(async () => {
+      await accountsInstance.authorizeSigner(signer1, signerRole, { from: issuer1 })
+      await accountsInstance.completeSignerAuthorization(issuer1, signerRole, { from: signer1 })
+      await federatedAttestations.registerAttestation(
+        identifier1,
+        issuer1,
+        account1,
+        nowUnixTime,
+        signer1,
+        sig.v,
+        sig.r,
+        sig.s
+      )
+    })
+
+    it('should emit an AttestationDeleted event after successfully deleting', async () => {
+      const deleteAttestation = await federatedAttestations.deleteAttestation(
+        identifier1,
+        issuer1,
+        account1
+      )
+      assertLogMatches2(deleteAttestation.logs[0], {
+        event: 'AttestationDeleted',
+        args: {
+          identifier: identifier1,
+          issuer: issuer1,
+          account: account1,
+        },
+      })
+    })
+
+    it('should revert if an invalid user attempts to delete the attestation', async () => {
+      await assertRevert(
+        federatedAttestations.deleteAttestation(identifier1, issuer1, account1, {
+          from: accounts[4],
+        })
+      )
+    })
+
+    it('should revert if a revoked signer attempts to delete the attestation', async () => {
+      await federatedAttestations.revokeSigner(signer1)
+      await assertRevert(
+        federatedAttestations.deleteAttestation(identifier1, issuer1, account1, { from: signer1 })
+      )
+    })
+
+    it('should successfully delete an attestation with a revoked signer', async () => {
+      await federatedAttestations.revokeSigner(signer1)
+      const deleteAttestation = await federatedAttestations.deleteAttestation(
+        identifier1,
+        issuer1,
+        account1
+      )
+      assertLogMatches2(deleteAttestation.logs[0], {
+        event: 'AttestationDeleted',
+        args: {
+          identifier: identifier1,
+          issuer: issuer1,
+          account: account1,
+        },
+      })
+    })
+
+    it('should fail registering same attestation but succeed after deleting it', async () => {
+      await assertRevert(
+        federatedAttestations.registerAttestation(
+          identifier1,
+          issuer1,
+          account1,
+          nowUnixTime,
+          signer1,
+          sig.v,
+          sig.r,
+          sig.s
+        )
+      )
+      await federatedAttestations.deleteAttestation(identifier1, issuer1, account1)
+      const register = await federatedAttestations.registerAttestation(
+        identifier1,
+        issuer1,
+        account1,
+        nowUnixTime,
+        signer1,
+        sig.v,
+        sig.r,
+        sig.s
+      )
+      assertLogMatches2(register.logs[0], {
+        event: 'AttestationRegistered',
+        args: {
+          identifier: identifier1,
+          issuer: issuer1,
+          account: account1,
+          issuedOn: nowUnixTime,
+          signer: signer1,
+        },
+      })
     })
   })
 })

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -803,6 +803,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
   })
 
   describe('#deleteAttestation', () => {
+    // TODO ASv2 check that the actual entries were deleted in both mappings
+    // (for identifiers and attestations)
     beforeEach(async () => {
       await accountsInstance.authorizeSigner(signer1, signerRole, { from: issuer1 })
       await accountsInstance.completeSignerAuthorization(issuer1, signerRole, { from: signer1 })
@@ -828,6 +830,47 @@ contract('FederatedAttestations', (accounts: string[]) => {
         event: 'AttestationDeleted',
         args: {
           identifier: identifier1,
+          issuer: issuer1,
+          account: account1,
+        },
+      })
+    })
+
+    it('should succeed when >1 attestations are registered for (identifier, issuer)', async () => {
+      const account2 = accounts[3]
+      await signAndRegisterAttestation(identifier1, issuer1, account2, nowUnixTime, signer1)
+      const deleteAttestation = await federatedAttestations.deleteAttestation(
+        identifier1,
+        issuer1,
+        account2,
+        {
+          from: account2,
+        }
+      )
+      assertLogMatches2(deleteAttestation.logs[0], {
+        event: 'AttestationDeleted',
+        args: {
+          identifier: identifier1,
+          issuer: issuer1,
+          account: account2,
+        },
+      })
+    })
+
+    it('should succeed when >1 identifiers are registered for (account, issuer)', async () => {
+      await signAndRegisterAttestation(identifier2, issuer1, account1, nowUnixTime, signer1)
+      const deleteAttestation = await federatedAttestations.deleteAttestation(
+        identifier2,
+        issuer1,
+        account1,
+        {
+          from: account1,
+        }
+      )
+      assertLogMatches2(deleteAttestation.logs[0], {
+        event: 'AttestationDeleted',
+        args: {
+          identifier: identifier2,
           issuer: issuer1,
           account: account1,
         },


### PR DESCRIPTION
Summary of changes (for documentation)
- add unit tests cases
- implement EIP712 parsing and validation
- change revocation to be based on signer only (not on `issuedOn`)
- fixes lint checks
- add function natspecs

Issues related:
- Closes #9447 
- Closes #9481 
- Closes #9476 
- Closes #9477

Summary of test cases added (copied from running tests):
- #EIP712_VALIDATE_ATTESTATION_TYPEHASH()
  - should have set the right typehash
- #initialize()
  - should have set the owner
  - should have set the registry address
  - should have set the EIP-712 domain separator
  - should emit the EIP712DomainSeparatorSet event
  - should not be callable again
- #lookupAttestations
  - when identifier has not been registered
    - should return empty list
  - when identifier has been registered
    - should return all attestations from one issuer
    - should return empty list if no attestations exist for an issuer
    - should return attestations from multiple issuers in correct order
    - should return empty list if maxAttestations == 0
    - should only return maxAttestations attestations when more are present
    - should not return attestations from revoked signers
- #lookupIdentifiersByAddress
  - when address has not been registered
    - should return empty list
  - when address has been registered
    - should return all identifiers from one issuer
    - should return empty list if no identifiers exist for an (issuer,address)
    - should return identifiers from multiple issuers in correct order
    - should return empty list if maxIdentifiers == 0
    - should only return maxIdentifiers identifiers when more are present
    - should not return identifiers from revoked signers
- #isValidAttestation
  - should revert if the signer is not authorized as an AttestationSigner by the issuer
  - should revert if the signer is authorized as a different role by the issuer
  - with an authorized AttestationSigner
    - should return true if a valid signature is used
    - should return false if an invalid signature is provided
    - should fail if the provided identifier is different from the attestation
    - should fail if the provided issuer is different from the attestation
    - should fail if the provided account is different from the attestation
    - should fail if the provided issuedOn is different from the attestation
    - should fail if the provided signer is different from the attestation
    - should revert if the signer is revoked
- #registerAttestation
  - should emit AttestationRegistered for a valid attestation
  - should succeed if issuer == signer
  - should revert if an invalid signature is provided
  - should revert if signer has been revoked
  - should revert if an invalid user attempts to register the attestation
  - should succeed if a different AttestationSigner authorized by the same issuer registers the attestation
  - when registering a second attestation
    - should revert if an attestation with the same (issuer, identifier, account) is uploaded again
    - should succeed with a different identifier
    - should succeed with a different issuer
    - should succeed with a different account
- #deleteAttestation
  - should emit an AttestationDeleted event after successfully deleting
  - should succeed when >1 attestations are registered for (identifier, issuer)
  - should succeed when >1 identifiers are registered for (account, issuer)
  - should revert if an invalid user attempts to delete the attestation
  - should revert if a revoked signer attempts to delete the attestation
  - should successfully delete an attestation with a revoked signer
  - should fail registering same attestation but succeed after deleting it
