### PR TITLE
Add BTC implicit pair to CELO/USD oracles.

### DIFF
--- a/packages/helm-charts/oracle/CELOUSD.yaml
+++ b/packages/helm-charts/oracle/CELOUSD.yaml
@@ -11,7 +11,21 @@ oracle:
     prometheusPort: 9090
   apiRequestTimeoutMs: 5000
   circuitBreakerPriceChangeThreshold: 0.25
-  priceSources: "[[{exchange: 'BITTREX', symbol: 'CELOUSD', toInvert: false}],[{exchange: 'COINBASE', symbol: 'CELOUSD', toInvert: false}],[{exchange: 'OKCOIN', symbol: 'CELOUSD', toInvert: false}]]"
+  priceSources: "[
+      [
+        {exchange: 'BITTREX', symbol: 'CELOUSD', toInvert: false}
+      ],
+      [
+        {exchange: 'COINBASE', symbol: 'CELOUSD', toInvert: false}
+      ],
+      [
+        {exchange: 'OKCOIN', symbol: 'CELOUSD', toInvert: false}
+      ],
+      [
+        {exchange: 'BINANCE', symbol: 'CELOBTC', toInvert: false},
+        {exchange: 'COINBASE', symbol: 'BTCUSD', toInvert: false}
+      ]
+    ]"
   minPriceSourceCount: 2
   reportStrategy: BLOCK_BASED
   reporter:


### PR DESCRIPTION
### Description

Configures the CELO/USD oracles to use a (Binance, CELOBTC)x(Coinbase, BTCUSD) implicit pair as a price source.

### Tested

[PENDING] Deployed to Alfajores.