### PR TITLE
Change deprecated 'debug' geth flag to 'log.debug'

### DIFF
--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -1012,7 +1012,7 @@ export async function startGeth(
     datadir,
     '--syncmode',
     syncmode,
-    '--debug',
+    '--log.debug',
     '--metrics',
     '--port',
     port.toString(),


### PR DESCRIPTION
Remove deprecated flag from geth, update it with the new flag