### PR TITLE
Support removing attestation signer

### DIFF
--- a/packages/cli/src/commands/account/deauthorize.test.ts
+++ b/packages/cli/src/commands/account/deauthorize.test.ts
@@ -1,0 +1,57 @@
+import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import Web3 from 'web3'
+import Authorize from './authorize'
+import Deauthorize from './deauthorize'
+import Register from './register'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithGanache('account:deauthorize cmd', (web3: Web3) => {
+  test('can deauthorize attestation signer', async () => {
+    const accounts = await web3.eth.getAccounts()
+    await Register.run(['--from', accounts[0]])
+    await Authorize.run([
+      '--from',
+      accounts[0],
+      '--role',
+      'attestation',
+      '--signer',
+      accounts[1],
+      '--signature',
+      '0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb',
+    ])
+    await Deauthorize.run([
+      '--from',
+      accounts[0],
+      '--role',
+      'attestation',
+      '--signer',
+      accounts[1],
+    ])
+  })
+
+  test('cannot deauthorize role other than attestation', async () => {
+    const accounts = await web3.eth.getAccounts()
+    await Register.run(['--from', accounts[0]])
+    await Authorize.run([
+      '--from',
+      accounts[0],
+      '--role',
+      'vote',
+      '--signer',
+      accounts[1],
+      '--signature',
+      '0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb',
+    ])
+    await expect(
+      Deauthorize.run([
+        '--from',
+        accounts[0],
+        '--role',
+        'vote',
+        '--signer',
+        accounts[1],
+      ])
+    ).rejects.toThrow()
+  })
+})

--- a/packages/cli/src/commands/account/deauthorize.test.ts
+++ b/packages/cli/src/commands/account/deauthorize.test.ts
@@ -22,22 +22,4 @@ testWithGanache('account:deauthorize cmd', (web3: Web3) => {
     ])
     await Deauthorize.run(['--from', accounts[0], '--role', 'attestation', '--signer', accounts[1]])
   })
-
-  test('cannot deauthorize role other than attestation', async () => {
-    const accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
-    await Authorize.run([
-      '--from',
-      accounts[0],
-      '--role',
-      'vote',
-      '--signer',
-      accounts[1],
-      '--signature',
-      '0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb',
-    ])
-    await expect(
-      Deauthorize.run(['--from', accounts[0], '--role', 'vote', '--signer', accounts[1]])
-    ).rejects.toThrow()
-  })
 })

--- a/packages/cli/src/commands/account/deauthorize.test.ts
+++ b/packages/cli/src/commands/account/deauthorize.test.ts
@@ -20,14 +20,7 @@ testWithGanache('account:deauthorize cmd', (web3: Web3) => {
       '--signature',
       '0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb',
     ])
-    await Deauthorize.run([
-      '--from',
-      accounts[0],
-      '--role',
-      'attestation',
-      '--signer',
-      accounts[1],
-    ])
+    await Deauthorize.run(['--from', accounts[0], '--role', 'attestation', '--signer', accounts[1]])
   })
 
   test('cannot deauthorize role other than attestation', async () => {
@@ -44,14 +37,7 @@ testWithGanache('account:deauthorize cmd', (web3: Web3) => {
       '0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb',
     ])
     await expect(
-      Deauthorize.run([
-        '--from',
-        accounts[0],
-        '--role',
-        'vote',
-        '--signer',
-        accounts[1],
-      ])
+      Deauthorize.run(['--from', accounts[0], '--role', 'vote', '--signer', accounts[1]])
     ).rejects.toThrow()
   })
 })

--- a/packages/cli/src/commands/account/deauthorize.test.ts
+++ b/packages/cli/src/commands/account/deauthorize.test.ts
@@ -22,4 +22,13 @@ testWithGanache('account:deauthorize cmd', (web3: Web3) => {
     ])
     await Deauthorize.run(['--from', accounts[0], '--role', 'attestation', '--signer', accounts[1]])
   })
+
+  test('cannot deauthorize a non-authorized signer', async () => {
+    const accounts = await web3.eth.getAccounts()
+    await Register.run(['--from', accounts[0]])
+
+    await expect(
+      Deauthorize.run(['--from', accounts[0], '--role', 'attestation', '--signer', accounts[1]])
+    ).rejects.toThrow()
+  })
 })

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -35,14 +35,14 @@ export default class Deauthorize extends BaseCommand {
       return
     }
 
-    let attestationSigner = await accounts.getAttestationSigner(res.flags.from)
+    const attestationSigner = await accounts.getAttestationSigner(res.flags.from)
 
-    if (res.flags.signer != attestationSigner) {
+    if (res.flags.signer !== attestationSigner) {
       this.error(`Invalid signer provided`)
       return
     }
 
-    let tx = await accounts.removeAttestationSigner()
+    const tx = await accounts.removeAttestationSigner()
 
     await displaySendTx('deauthorizeTx', tx)
   }

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -1,9 +1,11 @@
 import { flags } from '@oclif/command'
 import { BaseCommand } from '../../base'
 import { displaySendTx } from '../../utils/cli'
+import { Flags } from '../../utils/command'
 
 export default class Deauthorize extends BaseCommand {
-  static description = 'Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer'
+  static description =
+    'Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer'
 
   static flags = {
     ...BaseCommand.flags,
@@ -27,7 +29,7 @@ export default class Deauthorize extends BaseCommand {
     const res = this.parse(Deauthorize)
 
     const accounts = await this.kit.contracts.getAccounts()
-    
+
     if (res.flags.role !== 'attestation') {
       this.error(`Invalid role provided`)
       return
@@ -35,7 +37,7 @@ export default class Deauthorize extends BaseCommand {
 
     let attestationSigner = await accounts.getAttestationSigner(res.flags.from)
 
-    if(res.flags.signer != attestationSigner){
+    if (res.flags.signer != attestationSigner) {
       this.error(`Invalid signer provided`)
       return
     }

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -10,7 +10,7 @@ export default class Deauthorize extends BaseCommand {
     from: Flags.address({ required: true }),
     role: flags.string({
       char: 'r',
-      options: ['vote', 'attestation'],
+      options: ['attestation'],
       description: 'Role to remove',
       required: true,
     }),
@@ -20,7 +20,6 @@ export default class Deauthorize extends BaseCommand {
   static args = []
 
   static examples = [
-    'deauthorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role vote --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb',
     'deauthorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role attestation --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb',
   ]
 
@@ -28,31 +27,22 @@ export default class Deauthorize extends BaseCommand {
     const res = this.parse(Deauthorize)
 
     const accounts = await this.kit.contracts.getAccounts()
-
-    let tx: any
-    let signer: any
-    if (res.flags.role === 'vote') {
-      signer = await accounts.getVoteSigner(res.flags.from)
-      
-      if(res.flags.signer != signer){
-        this.error(`Invalid signer provided`)
-        return
-      }
-
-      tx = await accounts.removeVoteSigner()
-    } else if (res.flags.role === 'attestation') {
-      signer = await accounts.getAttestationSigner(res.flags.from)
-
-      if(res.flags.signer != signer){
-        this.error(`Invalid signer provided`)
-        return
-      }
-
-      tx = await accounts.removeAttestationSigner()
-    } else {
+    
+    if (res.flags.role !== 'attestation') {
       this.error(`Invalid role provided`)
       return
     }
+
+    let attestationSigner = await accounts.getAttestationSigner(res.flags.from)
+
+    if(res.flags.signer != attestationSigner){
+      this.error(`Invalid signer provided`)
+      return
+    }
+
+    let tx = await accounts.removeAttestationSigner()
+
+
     await displaySendTx('deauthorizeTx', tx)
   }
 }

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -1,0 +1,41 @@
+import { flags } from '@oclif/command'
+import { BaseCommand } from '../../base'
+import { displaySendTx } from '../../utils/cli'
+
+export default class Deauthorize extends BaseCommand {
+  static description = 'Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer'
+
+  static flags = {
+    ...BaseCommand.flags,
+    role: flags.string({
+      char: 'r',
+      options: ['vote', 'attestation'],
+      description: 'Role to remove',
+      required: true,
+    }),
+  }
+
+  static args = []
+
+  static examples = [
+    'deauthorize --role vote',
+    'deauthorize --role attestation',
+  ]
+
+  async run() {
+    const res = this.parse(Deauthorize)
+
+    const accounts = await this.kit.contracts.getAccounts()
+    
+    let tx: any
+    if (res.flags.role === 'vote') {
+      tx = await accounts.removeVoteSigner()
+    } else if (res.flags.role === 'attestation') {
+      tx = await accounts.removeAttestationSigner()
+    } else {
+      this.error(`Invalid role provided`)
+      return
+    }
+    await displaySendTx('deauthorizeTx', tx)
+  }
+}

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -42,7 +42,6 @@ export default class Deauthorize extends BaseCommand {
 
     let tx = await accounts.removeAttestationSigner()
 
-
     await displaySendTx('deauthorizeTx', tx)
   }
 }

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -38,7 +38,9 @@ export default class Deauthorize extends BaseCommand {
     const attestationSigner = await accounts.getAttestationSigner(res.flags.from)
 
     if (res.flags.signer !== attestationSigner) {
-      this.error(`Invalid signer provided`)
+      this.error(
+        `Invalid signer argument: ${res.flags.signer}. The current signer for this role is: ${attestationSigner}`
+      )
       return
     }
 

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -5,7 +5,7 @@ import { Flags } from '../../utils/command'
 
 export default class Deauthorize extends BaseCommand {
   static description =
-    'Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer'
+    'Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer. Please note that Attestation Services are important to the health of the Celo network, and validators should only use this command when troubleshooting their service is not an option.'
 
   static flags = {
     ...BaseCommand.flags,

--- a/packages/cli/src/commands/account/deauthorize.ts
+++ b/packages/cli/src/commands/account/deauthorize.ts
@@ -7,30 +7,47 @@ export default class Deauthorize extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flags,
+    from: Flags.address({ required: true }),
     role: flags.string({
       char: 'r',
       options: ['vote', 'attestation'],
       description: 'Role to remove',
       required: true,
     }),
+    signer: Flags.address({ required: true }),
   }
 
   static args = []
 
   static examples = [
-    'deauthorize --role vote',
-    'deauthorize --role attestation',
+    'deauthorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role vote --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb',
+    'deauthorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role attestation --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb',
   ]
 
   async run() {
     const res = this.parse(Deauthorize)
 
     const accounts = await this.kit.contracts.getAccounts()
-    
+
     let tx: any
+    let signer: any
     if (res.flags.role === 'vote') {
+      signer = await accounts.getVoteSigner(res.flags.from)
+      
+      if(res.flags.signer != signer){
+        this.error(`Invalid signer provided`)
+        return
+      }
+
       tx = await accounts.removeVoteSigner()
     } else if (res.flags.role === 'attestation') {
+      signer = await accounts.getAttestationSigner(res.flags.from)
+
+      if(res.flags.signer != signer){
+        this.error(`Invalid signer provided`)
+        return
+      }
+
       tx = await accounts.removeAttestationSigner()
     } else {
       this.error(`Invalid role provided`)

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -301,6 +301,29 @@ EXAMPLE
 
 _See code: [src/commands/account/create-metadata.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/create-metadata.ts)_
 
+## `celocli account:deauthorize`
+
+Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer
+
+```
+Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer
+
+USAGE
+  $ celocli account:deauthorize
+
+OPTIONS
+  -r, --role=attestation                               (required) Role to remove
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Account Address
+  --globalHelp                                         View all available global flags
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
+
+EXAMPLE
+  deauthorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role attestation
+  --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb
+```
+
+_See code: [src/commands/account/deauthorize.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/deauthorize.ts)_
+
 ## `celocli account:get-metadata ADDRESS`
 
 Show information about an address. Retreives the metadata URL for an account from the on-chain, then fetches the metadata file off-chain and verifies proofs as able.

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -303,10 +303,10 @@ _See code: [src/commands/account/create-metadata.ts](https://github.com/celo-org
 
 ## `celocli account:deauthorize`
 
-Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer
+Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer. Please note that Attestation Services are important to the health of the Celo network, and validators should only use this command when troubleshooting their service is not an option.
 
 ```
-Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer
+Validators who can no longer serve Attestation Service requests should deauthorize their attestation signer. Please note that Attestation Services are important to the health of the Celo network, and validators should only use this command when troubleshooting their service is not an option.
 
 USAGE
   $ celocli account:deauthorize

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -69,7 +69,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const signer = accounts[1]
     await accountsInstance.createAccount()
     const sig = await getParsedSignatureOfAddress(account, signer)
-    await accountsInstance.authorizeAttestationSigner(account, sig)
+    await accountsInstance.authorizeAttestationSigner(signer, sig)
   })
 
   test('SBAT remove attestation key authorization', async () => {
@@ -77,7 +77,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const signer = accounts[1]
     await accountsInstance.createAccount()
     const sig = await getParsedSignatureOfAddress(account, signer)
-    await accountsInstance.authorizeAttestationSigner(account, sig)
+    await accountsInstance.authorizeAttestationSigner(signer, sig)
     await accountsInstance.removeAttestationSigner()
   })
 

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -64,6 +64,23 @@ testWithGanache('Accounts Wrapper', (web3) => {
       })
   }
 
+  test('SBAT authorize attestation key', async () => {
+    const account = accounts[0]
+    const signer = accounts[1]
+    await accountsInstance.createAccount()
+    const sig = await getParsedSignatureOfAddress(account, signer)
+    await accountsInstance.authorizeAttestationSigner(account, sig)
+  })
+
+  test('SBAT remove attestation key authorization', async () => {
+    const account = accounts[0]
+    const signer = accounts[1]
+    await accountsInstance.createAccount()
+    const sig = await getParsedSignatureOfAddress(account, signer)
+    await accountsInstance.authorizeAttestationSigner(account, sig)
+    await accountsInstance.removeAttestationSigner()
+  })
+
   test('SBAT authorize validator key when not a validator', async () => {
     const account = accounts[0]
     const signer = accounts[1]

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -67,18 +67,33 @@ testWithGanache('Accounts Wrapper', (web3) => {
   test('SBAT authorize attestation key', async () => {
     const account = accounts[0]
     const signer = accounts[1]
-    await accountsInstance.createAccount()
+    await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
     const sig = await getParsedSignatureOfAddress(account, signer)
-    await accountsInstance.authorizeAttestationSigner(signer, sig)
+    await (await accountsInstance.authorizeAttestationSigner(signer, sig)).sendAndWaitForReceipt({
+      from: account,
+    })
+    const attestationSigner = await accountsInstance.getAttestationSigner(account)
+    expect(attestationSigner).toEqual(signer)
   })
 
   test('SBAT remove attestation key authorization', async () => {
     const account = accounts[0]
     const signer = accounts[1]
-    await accountsInstance.createAccount()
+    await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
     const sig = await getParsedSignatureOfAddress(account, signer)
-    await accountsInstance.authorizeAttestationSigner(signer, sig)
-    await accountsInstance.removeAttestationSigner()
+    await (await accountsInstance.authorizeAttestationSigner(signer, sig)).sendAndWaitForReceipt({
+      from: account,
+    })
+
+    let attestationSigner = await accountsInstance.getAttestationSigner(account)
+    expect(attestationSigner).toEqual(signer)
+
+    await (await accountsInstance.removeAttestationSigner()).sendAndWaitForReceipt({
+      from: account,
+    })
+
+    attestationSigner = await accountsInstance.getAttestationSigner(account)
+    expect(attestationSigner).toEqual(account)
   })
 
   test('SBAT authorize validator key when not a validator', async () => {

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -325,17 +325,6 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
   }
 
   /**
-   * Removes the currently authorized vote signer for the account
-   * @returns A CeloTransactionObject
-   */
-   async removeVoteSigner(): Promise<CeloTransactionObject<void>> {
-    return toTransactionObject(
-      this.connection,
-      this.contract.methods.removeVoteSigner()
-    )
-  }
-
-  /**
    * Removes the currently authorized attestation signer for the account
    * @returns A CeloTransactionObject
    */

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -4,18 +4,18 @@ import {
   hashMessageWithPrefix,
   LocalSigner,
   parseSignature,
-  signedMessageToPublicKey
+  signedMessageToPublicKey,
 } from '@celo/utils/lib/signatureUtils'
 import { soliditySha3 } from '@celo/utils/lib/solidity'
 import { authorizeSigner as buildAuthorizeSignerTypedData } from '@celo/utils/lib/typed-data-constructors'
-import BN from 'bn.js'; // just the types
+import BN from 'bn.js' // just the types
 import { Accounts } from '../generated/Accounts'
 import { newContractVersion } from '../versions'
 import {
   proxyCall,
   proxySend,
   solidityBytesToString,
-  stringToSolidityBytes
+  stringToSolidityBytes,
 } from '../wrappers/BaseWrapper'
 import { BaseWrapper } from './BaseWrapper'
 interface AccountSummary {
@@ -329,10 +329,7 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
    * @returns A CeloTransactionObject
    */
   async removeAttestationSigner(): Promise<CeloTransactionObject<void>> {
-    return toTransactionObject(
-      this.connection,
-      this.contract.methods.removeAttestationSigner()
-    )
+    return toTransactionObject(this.connection, this.contract.methods.removeAttestationSigner())
   }
 
   async generateProofOfKeyPossession(account: Address, signer: Address) {

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -4,18 +4,18 @@ import {
   hashMessageWithPrefix,
   LocalSigner,
   parseSignature,
-  signedMessageToPublicKey,
+  signedMessageToPublicKey
 } from '@celo/utils/lib/signatureUtils'
 import { soliditySha3 } from '@celo/utils/lib/solidity'
 import { authorizeSigner as buildAuthorizeSignerTypedData } from '@celo/utils/lib/typed-data-constructors'
-import BN from 'bn.js' // just the types
+import BN from 'bn.js'; // just the types
 import { Accounts } from '../generated/Accounts'
 import { newContractVersion } from '../versions'
 import {
   proxyCall,
   proxySend,
   solidityBytesToString,
-  stringToSolidityBytes,
+  stringToSolidityBytes
 } from '../wrappers/BaseWrapper'
 import { BaseWrapper } from './BaseWrapper'
 interface AccountSummary {
@@ -321,6 +321,43 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
     return toTransactionObject(
       this.connection,
       this.contract.methods.completeSignerAuthorization(account, this.keccak256(role))
+    )
+  }
+
+  /**
+   * Removes signing authorization from the default signer associated with a particular role
+   * @param role the role that has been authorized for a signer
+   * @returns A CeloTransactionObject
+   */
+  async removeDefaultSigner(role: string): Promise<CeloTransactionObject<void>> {
+    return toTransactionObject(
+      this.connection,
+      this.contract.methods.removeDefaultSigner(this.keccak256(role))
+    )
+  }
+
+  /**
+   * Removes signing authorization from the indexed signer associated with a particular role
+   * @param role the role that has been authorized for a signer
+   * @returns A CeloTransactionObject
+   */
+  async removeIndexedSigner(role: string): Promise<CeloTransactionObject<void>> {
+    return toTransactionObject(
+      this.connection,
+      this.contract.methods.removeIndexedSigner(this.keccak256(role))
+    )
+  }
+
+  /**
+   * Removes the currently authorized signer for a particular role and if the signer is indexed, remove that as well
+   * @param signer the address of the signer
+   * @param role the role that has been authorized for a signer
+   * @returns A CeloTransactionObject
+   */
+  async removeSigner(signer: Address, role: string): Promise<CeloTransactionObject<void>> {
+    return toTransactionObject(
+      this.connection,
+      this.contract.methods.removeSigner(signer, this.keccak256(role))
     )
   }
 

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -325,39 +325,24 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
   }
 
   /**
-   * Removes signing authorization from the default signer associated with a particular role
-   * @param role the role that has been authorized for a signer
+   * Removes the currently authorized vote signer for the account
    * @returns A CeloTransactionObject
    */
-  async removeDefaultSigner(role: string): Promise<CeloTransactionObject<void>> {
+   async removeVoteSigner(): Promise<CeloTransactionObject<void>> {
     return toTransactionObject(
       this.connection,
-      this.contract.methods.removeDefaultSigner(this.keccak256(role))
+      this.contract.methods.removeVoteSigner()
     )
   }
 
   /**
-   * Removes signing authorization from the indexed signer associated with a particular role
-   * @param role the role that has been authorized for a signer
+   * Removes the currently authorized attestation signer for the account
    * @returns A CeloTransactionObject
    */
-  async removeIndexedSigner(role: string): Promise<CeloTransactionObject<void>> {
+  async removeAttestationSigner(): Promise<CeloTransactionObject<void>> {
     return toTransactionObject(
       this.connection,
-      this.contract.methods.removeIndexedSigner(this.keccak256(role))
-    )
-  }
-
-  /**
-   * Removes the currently authorized signer for a particular role and if the signer is indexed, remove that as well
-   * @param signer the address of the signer
-   * @param role the role that has been authorized for a signer
-   * @returns A CeloTransactionObject
-   */
-  async removeSigner(signer: Address, role: string): Promise<CeloTransactionObject<void>> {
-    return toTransactionObject(
-      this.connection,
-      this.contract.methods.removeSigner(signer, this.keccak256(role))
+      this.contract.methods.removeAttestationSigner()
     )
   }
 


### PR DESCRIPTION
This is a work in progress, please comment!

### Description

We are seeing that some validators are running broken Attestation Service setups and are failing to serve requests, therefore it is valuable to allow for these validators to deauthorize their attestation signers. This functionality already exists in the Accounts contract (`removeAttestationSigner`), however this functionality is not reflected in contractKit or celocli. This pull request would add this functionality to contractKit and celocli.

### Other changes

At the moment, there is no testing for the `authorizeAttestationSigner` function in contractKit, this pull request would add preliminary testing.

### Tested

Adds relevant tests for Accounts contract wrapper in contractKit as well as tests for the deauthorize cli command

### Related issues

While not in-scope for this PR, we should later expose the `removeVoteSigner` functionality. A ticket for this is specified below
- See issue #9612 

### Backwards compatibility

This pull request is backwards compatible because it simply exposes pre-existing functionality

### Documentation

TO-DO: add docs