### PR TITLE
Don't retry failed blockscout data migration jobs

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-data-migration.job.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-data-migration.job.yaml
@@ -30,7 +30,7 @@ spec:
             args:
             - |
               trap "touch /tmp/pod/main-terminated" EXIT
-              iex --name data-migration@0.0.0.0 -S mix data_migrate
+              iex --name data-migration@0.0.0.0 -S mix data_migrate --no-compile
             resources:
               requests:
                 memory: 2Gi
@@ -47,3 +47,4 @@ spec:
 {{ include "celo.blockscout-env-vars" .  | indent 14 }}
 {{ include "celo.blockscout-db-terminating-sidecar" .  | indent 10 }}
           restartPolicy: Never
+      backoffLimit: 0  

--- a/packages/helm-charts/blockscout/templates/blockscout-migration.job.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-migration.job.yaml
@@ -22,7 +22,7 @@ spec:
         - |
            trap "touch /tmp/pod/main-terminated" EXIT
            [ ${DROP_DB} == "true" ] && mix do ecto.drop, ecto.create
-           mix do ecto.migrate
+           mix do ecto.migrate --no-compile
         resources:
           requests:
             memory: 250M


### PR DESCRIPTION
### Description

Data migration jobs were being retried on failure which is not desirable. This adds a `backoffLimit` with a value 0 to prevent retries, similar to schema migration jobs.

### Other changes

* add the `--no-compile` flag to the migration commands, as the container has precompiled code

