### PR TITLE
[ASv2] direct attestations from issuers

### DIFF
--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -279,7 +279,6 @@ contract FederatedAttestations is
    * @param v The recovery id of the incoming ECDSA signature
    * @param r Output value r of the ECDSA signature
    * @param s Output value s of the ECDSA signature
-   * @return Whether the signature is valid and the signer is authorized to make attestations.
    * @dev Throws if attestation has been revoked
    * @dev Throws if signer is not an authorized AttestationSigner of the issuer
    */
@@ -292,7 +291,7 @@ contract FederatedAttestations is
     uint8 v,
     bytes32 r,
     bytes32 s
-  ) public view returns (bool) {
+  ) public view {
     require(
       getAccounts().attestationSignerToAccount(signer) == issuer,
       "Signer has not been authorized as an AttestationSigner by the issuer"
@@ -311,7 +310,7 @@ contract FederatedAttestations is
   }
 
   /**
-   * @notice Helper function for registering attestations
+   * @notice Registers an attestation
    * @param identifier Hash of the identifier to be attested
    * @param issuer Address of the attestation issuer
    * @param account Address of the account being mapped to the identifier
@@ -359,7 +358,7 @@ contract FederatedAttestations is
    * @param signer Address of the signer of the attestation
    * @dev Throws if an attestation with the same (identifier, issuer, account) already exists
    */
-  function registerAttestationAsIssuer(
+  function registerAttestation(
     bytes32 identifier,
     address issuer,
     address account,

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -366,7 +366,7 @@ contract FederatedAttestations is
    * @param identifier Hash of the identifier to be revoked
    * @param issuer Address of the attestation issuer
    * @param account Address of the account mapped to the identifier
-   * @dev Throws if sender is not TODO
+   * @dev Throws if sender is not the issuer, signer, or account
    */
   // TODO should we pass in the issuedOn/signer parameter? ie. only revoke if the sender knows
   // the issuedOn/signer for the unique attestation
@@ -378,7 +378,7 @@ contract FederatedAttestations is
         address signer = attestation.signer;
         uint64 issuedOn = attestation.issuedOn;
         require(
-          signer == msg.sender || issuer == msg.sender,
+          signer == msg.sender || issuer == msg.sender || account == msg.sender,
           "Sender does not have permission to revoke this attestation"
         );
         // This is meant to delete the attestation in the array
@@ -408,6 +408,8 @@ contract FederatedAttestations is
           signer,
           issuedOn
         );
+        // Should never be able to re-revoke an attestation
+        assert(!revokedAttestations[attestationHash]);
         revokedAttestations[attestationHash] = true;
 
         emit AttestationRevoked(identifier, issuer, account, signer, issuedOn);

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -365,7 +365,7 @@ contract FederatedAttestations is
    * @param signer Address of the signer of the attestation
    * @dev Throws if an attestation with the same (identifier, issuer, account) already exists
    */
-  function registerAttestation(
+  function registerAttestationAsIssuer(
     bytes32 identifier,
     address issuer,
     address account,

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -28,8 +28,10 @@ contract FederatedAttestations is
 
   struct OwnershipAttestation {
     address account;
-    uint256 issuedOn;
     address signer;
+    uint64 issuedOn;
+    uint64 publishedOn;
+    // using uint64 to allow for extra space to add parameters
   }
 
   // TODO ASv2 revisit linting issues & all solhint-disable-next-line max-line-length
@@ -38,11 +40,11 @@ contract FederatedAttestations is
   mapping(bytes32 => mapping(address => OwnershipAttestation[])) public identifierToAttestations;
   // account -> issuer -> identifiers
   mapping(address => mapping(address => bytes32[])) public addressToIdentifiers;
-  // signer => isRevoked
-  mapping(address => bool) public revokedSigners;
+  // unique attestation hash -> isRevoked
+  mapping(bytes32 => bool) public revokedAttestations;
 
   bytes32 public constant EIP712_VALIDATE_ATTESTATION_TYPEHASH = keccak256(
-    "OwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)"
+    "OwnershipAttestation(bytes32 identifier,address issuer,address account,uint64 issuedOn)"
   );
   bytes32 public eip712DomainSeparator;
 
@@ -51,13 +53,15 @@ contract FederatedAttestations is
     bytes32 indexed identifier,
     address indexed issuer,
     address indexed account,
-    uint256 issuedOn,
-    address signer
+    address signer,
+    uint64 issuedOn,
+    uint64 publishedOn
   );
-  event AttestationDeleted(
+  event AttestationRevoked(
     bytes32 indexed identifier,
     address indexed issuer,
-    address indexed account
+    address indexed account,
+    uint64 issuedOn
   );
 
   /**
@@ -107,444 +111,431 @@ contract FederatedAttestations is
     return (1, 1, 0, 0);
   }
 
-  /**
-   * @notice Helper function for _lookupAttestations to calculate the
-             total number of attestations completed for an identifier
-             by each trusted issuer, from unrevoked signers only
-   * @param identifier Hash of the identifier
-   * @param trustedIssuers Array of n issuers whose attestations will be included
-   * @return [0] Sum total of attestations found
-   *         [1] Array of number of attestations found per issuer
-   */
-  function getNumUnrevokedAttestations(bytes32 identifier, address[] memory trustedIssuers)
-    internal
-    view
-    returns (uint256, uint256[] memory)
-  {
-    uint256 totalAttestations = 0;
-    uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
+  // /**
+  //  * @notice Helper function for _lookupAttestations to calculate the
+  //            total number of attestations completed for an identifier
+  //            by each trusted issuer, from unrevoked signers only
+  //  * @param identifier Hash of the identifier
+  //  * @param trustedIssuers Array of n issuers whose attestations will be included
+  //  * @return [0] Sum total of attestations found
+  //  *         [1] Array of number of attestations found per issuer
+  //  */
+  // function getNumUnrevokedAttestations(bytes32 identifier, address[] memory trustedIssuers)
+  //   internal
+  //   view
+  //   returns (uint256, uint256[] memory)
+  // {
+  //   uint256 totalAttestations = 0;
+  //   uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
 
-    for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
-      // solhint-disable-next-line max-line-length
-      OwnershipAttestation[] storage attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
-      for (uint256 j = 0; j < attestationsPerIssuer.length; j = j.add(1)) {
-        if (revokedSigners[attestationsPerIssuer[j].signer]) {
-          continue;
-        }
-        totalAttestations = totalAttestations.add(1);
-        countsPerIssuer[i] = countsPerIssuer[i].add(1);
-      }
-    }
-    return (totalAttestations, countsPerIssuer);
-  }
+  //   for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
+  //     // solhint-disable-next-line max-line-length
+  //     OwnershipAttestation[] storage attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
+  //     for (uint256 j = 0; j < attestationsPerIssuer.length; j = j.add(1)) {
+  //       if (revokedSigners[attestationsPerIssuer[j].signer]) {
+  //         continue;
+  //       }
+  //       totalAttestations = totalAttestations.add(1);
+  //       countsPerIssuer[i] = countsPerIssuer[i].add(1);
+  //     }
+  //   }
+  //   return (totalAttestations, countsPerIssuer);
+  // }
 
-  /**
-   * @notice Helper function for _lookupAttestations to calculate the
-             total number of attestations completed for an identifier
-             by each trusted issuer
-   * @param identifier Hash of the identifier
-   * @param trustedIssuers Array of n issuers whose attestations will be included
-   * @return [0] Sum total of attestations found
-   *         [1] Array of number of attestations found per issuer
-   */
-  function getNumAttestations(bytes32 identifier, address[] memory trustedIssuers)
-    internal
-    view
-    returns (uint256, uint256[] memory)
-  {
-    uint256 totalAttestations = 0;
-    uint256 numAttestationsForIssuer;
-    uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
+  // /**
+  //  * @notice Helper function for _lookupAttestations to calculate the
+  //            total number of attestations completed for an identifier
+  //            by each trusted issuer
+  //  * @param identifier Hash of the identifier
+  //  * @param trustedIssuers Array of n issuers whose attestations will be included
+  //  * @return [0] Sum total of attestations found
+  //  *         [1] Array of number of attestations found per issuer
+  //  */
+  // function getNumAttestations(bytes32 identifier, address[] memory trustedIssuers)
+  //   internal
+  //   view
+  //   returns (uint256, uint256[] memory)
+  // {
+  //   uint256 totalAttestations = 0;
+  //   uint256 numAttestationsForIssuer;
+  //   uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
 
-    for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
-      numAttestationsForIssuer = identifierToAttestations[identifier][trustedIssuers[i]].length;
-      totalAttestations = totalAttestations.add(numAttestationsForIssuer);
-      countsPerIssuer[i] = numAttestationsForIssuer;
-    }
-    return (totalAttestations, countsPerIssuer);
-  }
+  //   for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
+  //     numAttestationsForIssuer = identifierToAttestations[identifier][trustedIssuers[i]].length;
+  //     totalAttestations = totalAttestations.add(numAttestationsForIssuer);
+  //     countsPerIssuer[i] = numAttestationsForIssuer;
+  //   }
+  //   return (totalAttestations, countsPerIssuer);
+  // }
 
-  /**
-   * @notice Returns info about up to `maxAttestations` attestations for
-   *   `identifier` produced by unrevoked signers of `trustedIssuers`
-   * @param identifier Hash of the identifier
-   * @param trustedIssuers Array of n issuers whose attestations will be included
-   * @param maxAttestations Limit the number of attestations that will be returned
-   * @return [0] Array of number of attestations returned per issuer
-   * @return [1 - 3] for m (== sum([0])) found attestations, m <= maxAttestations:
-   *         [
-   *           Array of m accounts,
-   *           Array of m issuedOns,
-   *           Array of m signers
-   *         ]; index corresponds to the same attestation
-   * @dev Adds attestation info to the arrays in order of provided trustedIssuers
-   * @dev Expectation that only one attestation exists per (identifier, issuer, account)
-   */
-  // TODO reviewers: is it preferable to return an array of `trustedIssuer` indices
-  // (indicating issuer per attestation) instead of counts per attestation?
-  function lookupUnrevokedAttestations(
-    bytes32 identifier,
-    address[] calldata trustedIssuers,
-    uint256 maxAttestations
-  ) external view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
-    // TODO reviewers: this is to get around a stack too deep error;
-    // are there better ways of dealing with this?
-    return _lookupUnrevokedAttestations(identifier, trustedIssuers, maxAttestations);
-  }
+  // /**
+  //  * @notice Returns info about up to `maxAttestations` attestations for
+  //  *   `identifier` produced by unrevoked signers of `trustedIssuers`
+  //  * @param identifier Hash of the identifier
+  //  * @param trustedIssuers Array of n issuers whose attestations will be included
+  //  * @param maxAttestations Limit the number of attestations that will be returned
+  //  * @return [0] Array of number of attestations returned per issuer
+  //  * @return [1 - 3] for m (== sum([0])) found attestations, m <= maxAttestations:
+  //  *         [
+  //  *           Array of m accounts,
+  //  *           Array of m issuedOns,
+  //  *           Array of m signers
+  //  *         ]; index corresponds to the same attestation
+  //  * @dev Adds attestation info to the arrays in order of provided trustedIssuers
+  //  * @dev Expectation that only one attestation exists per (identifier, issuer, account)
+  //  */
+  // // TODO reviewers: is it preferable to return an array of `trustedIssuer` indices
+  // // (indicating issuer per attestation) instead of counts per attestation?
+  // function lookupUnrevokedAttestations(
+  //   bytes32 identifier,
+  //   address[] calldata trustedIssuers,
+  //   uint256 maxAttestations
+  // ) external view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
+  //   // TODO reviewers: this is to get around a stack too deep error;
+  //   // are there better ways of dealing with this?
+  //   return _lookupUnrevokedAttestations(identifier, trustedIssuers, maxAttestations);
+  // }
 
-  /**
-   * @notice Helper function for lookupUnrevokedAttestations to get around stack too deep
-   * @param identifier Hash of the identifier
-   * @param trustedIssuers Array of n issuers whose attestations will be included
-   * @param maxAttestations Limit the number of attestations that will be returned
-   * @return [0] Array of number of attestations returned per issuer
-   * @return [1 - 3] for m (== sum([0])) found attestations, m <= maxAttestations:
-   *         [
-   *           Array of m accounts,
-   *           Array of m issuedOns,
-   *           Array of m signers
-   *         ]; index corresponds to the same attestation
-   * @dev Adds attestation info to the arrays in order of provided trustedIssuers
-   * @dev Expectation that only one attestation exists per (identifier, issuer, account)
-   */
-  function _lookupUnrevokedAttestations(
-    bytes32 identifier,
-    address[] memory trustedIssuers,
-    uint256 maxAttestations
-  ) internal view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
-    uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
+  // /**
+  //  * @notice Helper function for lookupUnrevokedAttestations to get around stack too deep
+  //  * @param identifier Hash of the identifier
+  //  * @param trustedIssuers Array of n issuers whose attestations will be included
+  //  * @param maxAttestations Limit the number of attestations that will be returned
+  //  * @return [0] Array of number of attestations returned per issuer
+  //  * @return [1 - 3] for m (== sum([0])) found attestations, m <= maxAttestations:
+  //  *         [
+  //  *           Array of m accounts,
+  //  *           Array of m issuedOns,
+  //  *           Array of m signers
+  //  *         ]; index corresponds to the same attestation
+  //  * @dev Adds attestation info to the arrays in order of provided trustedIssuers
+  //  * @dev Expectation that only one attestation exists per (identifier, issuer, account)
+  //  */
+  // function _lookupUnrevokedAttestations(
+  //   bytes32 identifier,
+  //   address[] memory trustedIssuers,
+  //   uint256 maxAttestations
+  // ) internal view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
+  //   uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
 
-    // Pre-computing length of unrevoked attestations requires many storage lookups.
-    // Allow users to call that first and pass this in as maxAttestations.
-    // Same index corresponds to same attestation
-    address[] memory accounts = new address[](maxAttestations);
-    uint256[] memory issuedOns = new uint256[](maxAttestations);
-    address[] memory signers = new address[](maxAttestations);
+  //   // Pre-computing length of unrevoked attestations requires many storage lookups.
+  //   // Allow users to call that first and pass this in as maxAttestations.
+  //   // Same index corresponds to same attestation
+  //   address[] memory accounts = new address[](maxAttestations);
+  //   uint256[] memory issuedOns = new uint256[](maxAttestations);
+  //   address[] memory signers = new address[](maxAttestations);
 
-    uint256 currIndex = 0;
-    OwnershipAttestation[] memory attestationsPerIssuer;
+  //   uint256 currIndex = 0;
+  //   OwnershipAttestation[] memory attestationsPerIssuer;
 
-    for (uint256 i = 0; i < trustedIssuers.length && currIndex < maxAttestations; i = i.add(1)) {
-      attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
-      for (
-        uint256 j = 0;
-        j < attestationsPerIssuer.length && currIndex < maxAttestations;
-        j = j.add(1)
-      ) {
-        if (revokedSigners[attestationsPerIssuer[j].signer]) {
-          continue;
-        }
-        accounts[currIndex] = attestationsPerIssuer[j].account;
-        issuedOns[currIndex] = attestationsPerIssuer[j].issuedOn;
-        signers[currIndex] = attestationsPerIssuer[j].signer;
-        currIndex = currIndex.add(1);
-        countsPerIssuer[i] = countsPerIssuer[i].add(1);
-      }
-    }
+  //   for (uint256 i = 0; i < trustedIssuers.length && currIndex < maxAttestations; i = i.add(1)) {
+  //     attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
+  //     for (
+  //       uint256 j = 0;
+  //       j < attestationsPerIssuer.length && currIndex < maxAttestations;
+  //       j = j.add(1)
+  //     ) {
+  //       if (revokedSigners[attestationsPerIssuer[j].signer]) {
+  //         continue;
+  //       }
+  //       accounts[currIndex] = attestationsPerIssuer[j].account;
+  //       issuedOns[currIndex] = attestationsPerIssuer[j].issuedOn;
+  //       signers[currIndex] = attestationsPerIssuer[j].signer;
+  //       currIndex = currIndex.add(1);
+  //       countsPerIssuer[i] = countsPerIssuer[i].add(1);
+  //     }
+  //   }
 
-    if (currIndex >= maxAttestations) {
-      return (countsPerIssuer, accounts, issuedOns, signers);
-    }
+  //   if (currIndex >= maxAttestations) {
+  //     return (countsPerIssuer, accounts, issuedOns, signers);
+  //   }
 
-    // Trim returned structs if necessary
-    address[] memory trimmedAccounts = new address[](currIndex);
-    uint256[] memory trimmedIssuedOns = new uint256[](currIndex);
-    address[] memory trimmedSigners = new address[](currIndex);
+  //   // Trim returned structs if necessary
+  //   address[] memory trimmedAccounts = new address[](currIndex);
+  //   uint256[] memory trimmedIssuedOns = new uint256[](currIndex);
+  //   address[] memory trimmedSigners = new address[](currIndex);
 
-    for (uint256 i = 0; i < currIndex; i = i.add(1)) {
-      trimmedAccounts[i] = accounts[i];
-      trimmedIssuedOns[i] = issuedOns[i];
-      trimmedSigners[i] = signers[i];
-    }
-    return (countsPerIssuer, trimmedAccounts, trimmedIssuedOns, trimmedSigners);
-  }
+  //   for (uint256 i = 0; i < currIndex; i = i.add(1)) {
+  //     trimmedAccounts[i] = accounts[i];
+  //     trimmedIssuedOns[i] = issuedOns[i];
+  //     trimmedSigners[i] = signers[i];
+  //   }
+  //   return (countsPerIssuer, trimmedAccounts, trimmedIssuedOns, trimmedSigners);
+  // }
 
-  /**
-   * @notice Similar to lookupUnrevokedAttestations but returns all attestations
-   *   for `identifier` produced by `trustedIssuers`,
-   *   either including or excluding attestations from revoked signers
-   * @param identifier Hash of the identifier
-   * @param trustedIssuers Array of n issuers whose attestations will be included
-   * @param includeRevoked Whether to include attestations produced by revoked signers
-   * @return [0] Array of number of attestations returned per issuer
-   * @return [1 - 3] for m (== sum([0])) found attestations:
-   *         [
-   *           Array of m accounts,
-   *           Array of m issuedOns,
-   *           Array of m signers
-   *         ]; index corresponds to the same attestation
-   * @dev Adds attestation info to the arrays in order of provided trustedIssuers
-   * @dev Expectation that only one attestation exists per (identifier, issuer, account)
-   */
-  function lookupAttestations(
-    bytes32 identifier,
-    address[] calldata trustedIssuers,
-    bool includeRevoked
-  ) external view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
-    // TODO reviewers: this is to get around a stack too deep error;
-    // are there better ways of dealing with this?
-    return _lookupAttestations(identifier, trustedIssuers, includeRevoked);
-  }
+  // /**
+  //  * @notice Similar to lookupUnrevokedAttestations but returns all attestations
+  //  *   for `identifier` produced by `trustedIssuers`,
+  //  *   either including or excluding attestations from revoked signers
+  //  * @param identifier Hash of the identifier
+  //  * @param trustedIssuers Array of n issuers whose attestations will be included
+  //  * @param includeRevoked Whether to include attestations produced by revoked signers
+  //  * @return [0] Array of number of attestations returned per issuer
+  //  * @return [1 - 3] for m (== sum([0])) found attestations:
+  //  *         [
+  //  *           Array of m accounts,
+  //  *           Array of m issuedOns,
+  //  *           Array of m signers
+  //  *         ]; index corresponds to the same attestation
+  //  * @dev Adds attestation info to the arrays in order of provided trustedIssuers
+  //  * @dev Expectation that only one attestation exists per (identifier, issuer, account)
+  //  */
+  // function lookupAttestations(
+  //   bytes32 identifier,
+  //   address[] calldata trustedIssuers,
+  //   bool includeRevoked
+  // ) external view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
+  //   // TODO reviewers: this is to get around a stack too deep error;
+  //   // are there better ways of dealing with this?
+  //   return _lookupAttestations(identifier, trustedIssuers, includeRevoked);
+  // }
 
-  /**
-   * @notice Helper function for lookupAttestations to get around stack too deep
-   * @param identifier Hash of the identifier
-   * @param trustedIssuers Array of n issuers whose attestations will be included
-   * @param includeRevoked Whether to include attestations produced by revoked signers
-   * @return [0] Array of number of attestations returned per issuer
-   * @return [1 - 3] for m (== sum([0])) found attestations:
-   *         [
-   *           Array of m accounts,
-   *           Array of m issuedOns,
-   *           Array of m signers
-   *         ]; index corresponds to the same attestation
-   * @dev Adds attestation info to the arrays in order of provided trustedIssuers
-   * @dev Expectation that only one attestation exists per (identifier, issuer, account)
-   */
-  function _lookupAttestations(
-    bytes32 identifier,
-    address[] memory trustedIssuers,
-    bool includeRevoked
-  ) internal view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
-    uint256 totalAttestations;
-    uint256[] memory countsPerIssuer;
+  // /**
+  //  * @notice Helper function for lookupAttestations to get around stack too deep
+  //  * @param identifier Hash of the identifier
+  //  * @param trustedIssuers Array of n issuers whose attestations will be included
+  //  * @param includeRevoked Whether to include attestations produced by revoked signers
+  //  * @return [0] Array of number of attestations returned per issuer
+  //  * @return [1 - 3] for m (== sum([0])) found attestations:
+  //  *         [
+  //  *           Array of m accounts,
+  //  *           Array of m issuedOns,
+  //  *           Array of m signers
+  //  *         ]; index corresponds to the same attestation
+  //  * @dev Adds attestation info to the arrays in order of provided trustedIssuers
+  //  * @dev Expectation that only one attestation exists per (identifier, issuer, account)
+  //  */
+  // function _lookupAttestations(
+  //   bytes32 identifier,
+  //   address[] memory trustedIssuers,
+  //   bool includeRevoked
+  // ) internal view returns (uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
+  //   uint256 totalAttestations;
+  //   uint256[] memory countsPerIssuer;
 
-    (totalAttestations, countsPerIssuer) = includeRevoked
-      ? getNumAttestations(identifier, trustedIssuers)
-      : getNumUnrevokedAttestations(identifier, trustedIssuers);
+  //   (totalAttestations, countsPerIssuer) = includeRevoked
+  //     ? getNumAttestations(identifier, trustedIssuers)
+  //     : getNumUnrevokedAttestations(identifier, trustedIssuers);
 
-    address[] memory accounts = new address[](totalAttestations);
-    uint256[] memory issuedOns = new uint256[](totalAttestations);
-    address[] memory signers = new address[](totalAttestations);
+  //   address[] memory accounts = new address[](totalAttestations);
+  //   uint256[] memory issuedOns = new uint256[](totalAttestations);
+  //   address[] memory signers = new address[](totalAttestations);
 
-    OwnershipAttestation[] memory attestationsPerIssuer;
-    // Reset this and use as current index to get around stack-too-deep
-    // TODO reviewers: is it preferable to pack two uint256 counters into a struct
-    // and use one for total (above) & one for currIndex (below)?
-    totalAttestations = 0;
+  //   OwnershipAttestation[] memory attestationsPerIssuer;
+  //   // Reset this and use as current index to get around stack-too-deep
+  //   // TODO reviewers: is it preferable to pack two uint256 counters into a struct
+  //   // and use one for total (above) & one for currIndex (below)?
+  //   totalAttestations = 0;
 
-    for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
-      attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
-      for (uint256 j = 0; j < attestationsPerIssuer.length; j = j.add(1)) {
-        if (!includeRevoked && revokedSigners[attestationsPerIssuer[j].signer]) {
-          continue;
-        }
-        accounts[totalAttestations] = attestationsPerIssuer[j].account;
-        issuedOns[totalAttestations] = attestationsPerIssuer[j].issuedOn;
-        signers[totalAttestations] = attestationsPerIssuer[j].signer;
-        totalAttestations = totalAttestations.add(1);
-      }
-    }
-    return (countsPerIssuer, accounts, issuedOns, signers);
-  }
+  //   for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
+  //     attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
+  //     for (uint256 j = 0; j < attestationsPerIssuer.length; j = j.add(1)) {
+  //       if (!includeRevoked && revokedSigners[attestationsPerIssuer[j].signer]) {
+  //         continue;
+  //       }
+  //       accounts[totalAttestations] = attestationsPerIssuer[j].account;
+  //       issuedOns[totalAttestations] = attestationsPerIssuer[j].issuedOn;
+  //       signers[totalAttestations] = attestationsPerIssuer[j].signer;
+  //       totalAttestations = totalAttestations.add(1);
+  //     }
+  //   }
+  //   return (countsPerIssuer, accounts, issuedOns, signers);
+  // }
 
-  /**
-    * @notice Helper function for lookupIdentifiers to calculate the
-             total number of identifiers completed for an identifier
-             by each trusted issuer, from unrevoked signers only
-   * @param account Address of the account
-   * @param trustedIssuers Array of n issuers whose identifiers will be included
-   * @return [0] Sum total of identifiers found
-   *         [1] Array of number of identifiers found per issuer
-   */
-  function getNumUnrevokedIdentifiers(address account, address[] memory trustedIssuers)
-    internal
-    view
-    returns (uint256, uint256[] memory)
-  {
-    uint256 totalIdentifiers = 0;
-    uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
+  // /**
+  //   * @notice Helper function for lookupIdentifiers to calculate the
+  //            total number of identifiers completed for an identifier
+  //            by each trusted issuer, from unrevoked signers only
+  //  * @param account Address of the account
+  //  * @param trustedIssuers Array of n issuers whose identifiers will be included
+  //  * @return [0] Sum total of identifiers found
+  //  *         [1] Array of number of identifiers found per issuer
+  //  */
+  // function getNumUnrevokedIdentifiers(address account, address[] memory trustedIssuers)
+  //   internal
+  //   view
+  //   returns (uint256, uint256[] memory)
+  // {
+  //   uint256 totalIdentifiers = 0;
+  //   uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
 
-    OwnershipAttestation[] memory attestationsPerIssuer;
-    bytes32[] memory identifiersPerIssuer;
+  //   OwnershipAttestation[] memory attestationsPerIssuer;
+  //   bytes32[] memory identifiersPerIssuer;
 
-    for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
-      identifiersPerIssuer = addressToIdentifiers[account][trustedIssuers[i]];
-      for (uint256 j = 0; j < identifiersPerIssuer.length; j = j.add(1)) {
-        bytes32 identifier = identifiersPerIssuer[j];
-        // Check if the mapping was produced by a revoked signer
-        attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
-        for (uint256 k = 0; k < attestationsPerIssuer.length; k = k.add(1)) {
-          OwnershipAttestation memory attestation = attestationsPerIssuer[k];
-          // (identifier, account, issuer) tuples are checked for uniqueness on registration
-          if (!(attestation.account == account) || revokedSigners[attestation.signer]) {
-            continue;
-          }
-          totalIdentifiers = totalIdentifiers.add(1);
-          countsPerIssuer[i] = countsPerIssuer[i].add(1);
-          break;
-        }
-      }
-    }
-    return (totalIdentifiers, countsPerIssuer);
-  }
+  //   for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
+  //     identifiersPerIssuer = addressToIdentifiers[account][trustedIssuers[i]];
+  //     for (uint256 j = 0; j < identifiersPerIssuer.length; j = j.add(1)) {
+  //       bytes32 identifier = identifiersPerIssuer[j];
+  //       // Check if the mapping was produced by a revoked signer
+  //       attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
+  //       for (uint256 k = 0; k < attestationsPerIssuer.length; k = k.add(1)) {
+  //         OwnershipAttestation memory attestation = attestationsPerIssuer[k];
+  //         // (identifier, account, issuer) tuples are checked for uniqueness on registration
+  //         if (!(attestation.account == account) || revokedSigners[attestation.signer]) {
+  //           continue;
+  //         }
+  //         totalIdentifiers = totalIdentifiers.add(1);
+  //         countsPerIssuer[i] = countsPerIssuer[i].add(1);
+  //         break;
+  //       }
+  //     }
+  //   }
+  //   return (totalIdentifiers, countsPerIssuer);
+  // }
 
-  /**
-   * @notice Helper function for lookupIdentifiers to calculate the
-             total number of identifiers completed for an identifier
-             by each trusted issuer
-   * @param account Address of the account
-   * @param trustedIssuers Array of n issuers whose identifiers will be included
-   * @return [0] Sum total of identifiers found
-   *         [1] Array of number of identifiers found per issuer
-   */
-  function getNumIdentifiers(address account, address[] memory trustedIssuers)
-    internal
-    view
-    returns (uint256, uint256[] memory)
-  {
-    uint256 totalIdentifiers = 0;
-    uint256 numIdentifiersForIssuer;
-    uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
+  // /**
+  //  * @notice Helper function for lookupIdentifiers to calculate the
+  //            total number of identifiers completed for an identifier
+  //            by each trusted issuer
+  //  * @param account Address of the account
+  //  * @param trustedIssuers Array of n issuers whose identifiers will be included
+  //  * @return [0] Sum total of identifiers found
+  //  *         [1] Array of number of identifiers found per issuer
+  //  */
+  // function getNumIdentifiers(address account, address[] memory trustedIssuers)
+  //   internal
+  //   view
+  //   returns (uint256, uint256[] memory)
+  // {
+  //   uint256 totalIdentifiers = 0;
+  //   uint256 numIdentifiersForIssuer;
+  //   uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
 
-    for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
-      numIdentifiersForIssuer = addressToIdentifiers[account][trustedIssuers[i]].length;
-      totalIdentifiers = totalIdentifiers.add(numIdentifiersForIssuer);
-      countsPerIssuer[i] = numIdentifiersForIssuer;
-    }
-    return (totalIdentifiers, countsPerIssuer);
-  }
+  //   for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
+  //     numIdentifiersForIssuer = addressToIdentifiers[account][trustedIssuers[i]].length;
+  //     totalIdentifiers = totalIdentifiers.add(numIdentifiersForIssuer);
+  //     countsPerIssuer[i] = numIdentifiersForIssuer;
+  //   }
+  //   return (totalIdentifiers, countsPerIssuer);
+  // }
 
-  /**
-   * @notice Returns up to `maxIdentifiers` identifiers mapped to `account`
-   *   by unrevoked signers of `trustedIssuers`
-   * @param account Address of the account
-   * @param trustedIssuers Array of n issuers whose identifier mappings will be used
-   * @param maxIdentifiers Limit the number of identifiers that will be returned
-   * @return [0] Array of number of identifiers returned per issuer
-   * @return [1] Array (length == sum([0]) <= maxIdentifiers) of identifiers
-   * @dev Adds identifier info to the arrays in order of provided trustedIssuers
-   * @dev Expectation that only one attestation exists per (identifier, issuer, account)
-   */
-  function lookupUnrevokedIdentifiers(
-    address account,
-    address[] calldata trustedIssuers,
-    uint256 maxIdentifiers
-  ) external view returns (uint256[] memory, bytes32[] memory) {
-    uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
-    // Same as for the other lookup, preallocate and then trim for now
-    uint256 currIndex = 0;
-    bytes32[] memory identifiers = new bytes32[](maxIdentifiers);
+  // /**
+  //  * @notice Returns up to `maxIdentifiers` identifiers mapped to `account`
+  //  *   by unrevoked signers of `trustedIssuers`
+  //  * @param account Address of the account
+  //  * @param trustedIssuers Array of n issuers whose identifier mappings will be used
+  //  * @param maxIdentifiers Limit the number of identifiers that will be returned
+  //  * @return [0] Array of number of identifiers returned per issuer
+  //  * @return [1] Array (length == sum([0]) <= maxIdentifiers) of identifiers
+  //  * @dev Adds identifier info to the arrays in order of provided trustedIssuers
+  //  * @dev Expectation that only one attestation exists per (identifier, issuer, account)
+  //  */
+  // function lookupUnrevokedIdentifiers(
+  //   address account,
+  //   address[] calldata trustedIssuers,
+  //   uint256 maxIdentifiers
+  // ) external view returns (uint256[] memory, bytes32[] memory) {
+  //   uint256[] memory countsPerIssuer = new uint256[](trustedIssuers.length);
+  //   // Same as for the other lookup, preallocate and then trim for now
+  //   uint256 currIndex = 0;
+  //   bytes32[] memory identifiers = new bytes32[](maxIdentifiers);
 
-    OwnershipAttestation[] memory attestationsPerIssuer;
-    bytes32[] memory identifiersPerIssuer;
+  //   OwnershipAttestation[] memory attestationsPerIssuer;
+  //   bytes32[] memory identifiersPerIssuer;
 
-    for (uint256 i = 0; i < trustedIssuers.length && currIndex < maxIdentifiers; i = i.add(1)) {
-      identifiersPerIssuer = addressToIdentifiers[account][trustedIssuers[i]];
-      for (
-        uint256 j = 0;
-        j < identifiersPerIssuer.length && currIndex < maxIdentifiers;
-        j = j.add(1)
-      ) {
-        bytes32 identifier = identifiersPerIssuer[j];
-        // Check if the mapping was produced by a revoked signer
-        attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
-        for (uint256 k = 0; k < attestationsPerIssuer.length; k = k.add(1)) {
-          // (identifier, account, issuer) tuples are checked for uniqueness on registration
-          if (
-            !(attestationsPerIssuer[k].account == account) ||
-            revokedSigners[attestationsPerIssuer[k].signer]
-          ) {
-            continue;
-          }
-          identifiers[currIndex] = identifier;
-          currIndex = currIndex.add(1);
-          countsPerIssuer[i] = countsPerIssuer[i].add(1);
-          break;
-        }
-      }
-    }
-    if (currIndex >= maxIdentifiers) {
-      return (countsPerIssuer, identifiers);
-    }
-    // Allocate and fill properly-sized array
-    bytes32[] memory trimmedIdentifiers = new bytes32[](currIndex);
-    for (uint256 i = 0; i < currIndex; i = i.add(1)) {
-      trimmedIdentifiers[i] = identifiers[i];
-    }
-    return (countsPerIssuer, trimmedIdentifiers);
-  }
+  //   for (uint256 i = 0; i < trustedIssuers.length && currIndex < maxIdentifiers; i = i.add(1)) {
+  //     identifiersPerIssuer = addressToIdentifiers[account][trustedIssuers[i]];
+  //     for (
+  //       uint256 j = 0;
+  //       j < identifiersPerIssuer.length && currIndex < maxIdentifiers;
+  //       j = j.add(1)
+  //     ) {
+  //       bytes32 identifier = identifiersPerIssuer[j];
+  //       // Check if the mapping was produced by a revoked signer
+  //       attestationsPerIssuer = identifierToAttestations[identifier][trustedIssuers[i]];
+  //       for (uint256 k = 0; k < attestationsPerIssuer.length; k = k.add(1)) {
+  //         // (identifier, account, issuer) tuples are checked for uniqueness on registration
+  //         if (
+  //           !(attestationsPerIssuer[k].account == account) ||
+  //           revokedSigners[attestationsPerIssuer[k].signer]
+  //         ) {
+  //           continue;
+  //         }
+  //         identifiers[currIndex] = identifier;
+  //         currIndex = currIndex.add(1);
+  //         countsPerIssuer[i] = countsPerIssuer[i].add(1);
+  //         break;
+  //       }
+  //     }
+  //   }
+  //   if (currIndex >= maxIdentifiers) {
+  //     return (countsPerIssuer, identifiers);
+  //   }
+  //   // Allocate and fill properly-sized array
+  //   bytes32[] memory trimmedIdentifiers = new bytes32[](currIndex);
+  //   for (uint256 i = 0; i < currIndex; i = i.add(1)) {
+  //     trimmedIdentifiers[i] = identifiers[i];
+  //   }
+  //   return (countsPerIssuer, trimmedIdentifiers);
+  // }
 
-  /**
-   * @notice Similar to lookupUnrevokedIdentifiers but returns all identifiers
-   *   mapped to an address with attestations from a list of issuers,
-   *   either including or excluding attestations from revoked signers
-   * @param account Address of the account
-   * @param trustedIssuers Array of n issuers whose identifier mappings will be used
-   * @param includeRevoked Whether to include identifiers attested by revoked signers
-   * @return [0] Array of number of identifiers returned per issuer
-   * @return [1] Array (length == sum([0])) of identifiers
-   * @dev Adds identifier info to the arrays in order of provided trustedIssuers
-   * @dev Expectation that only one attestation exists per (identifier, issuer, account)
-   */
-  function lookupIdentifiers(
-    address account,
-    address[] calldata trustedIssuers,
-    bool includeRevoked
-  ) external view returns (uint256[] memory, bytes32[] memory) {
-    uint256 totalIdentifiers;
-    uint256[] memory countsPerIssuer;
+  // /**
+  //  * @notice Similar to lookupUnrevokedIdentifiers but returns all identifiers
+  //  *   mapped to an address with attestations from a list of issuers,
+  //  *   either including or excluding attestations from revoked signers
+  //  * @param account Address of the account
+  //  * @param trustedIssuers Array of n issuers whose identifier mappings will be used
+  //  * @param includeRevoked Whether to include identifiers attested by revoked signers
+  //  * @return [0] Array of number of identifiers returned per issuer
+  //  * @return [1] Array (length == sum([0])) of identifiers
+  //  * @dev Adds identifier info to the arrays in order of provided trustedIssuers
+  //  * @dev Expectation that only one attestation exists per (identifier, issuer, account)
+  //  */
+  // function lookupIdentifiers(
+  //   address account,
+  //   address[] calldata trustedIssuers,
+  //   bool includeRevoked
+  // ) external view returns (uint256[] memory, bytes32[] memory) {
+  //   uint256 totalIdentifiers;
+  //   uint256[] memory countsPerIssuer;
 
-    (totalIdentifiers, countsPerIssuer) = includeRevoked
-      ? getNumIdentifiers(account, trustedIssuers)
-      : getNumUnrevokedIdentifiers(account, trustedIssuers);
+  //   (totalIdentifiers, countsPerIssuer) = includeRevoked
+  //     ? getNumIdentifiers(account, trustedIssuers)
+  //     : getNumUnrevokedIdentifiers(account, trustedIssuers);
 
-    bytes32[] memory identifiers = new bytes32[](totalIdentifiers);
-    bytes32[] memory identifiersPerIssuer;
+  //   bytes32[] memory identifiers = new bytes32[](totalIdentifiers);
+  //   bytes32[] memory identifiersPerIssuer;
 
-    uint256 currIndex = 0;
+  //   uint256 currIndex = 0;
 
-    for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
-      identifiersPerIssuer = addressToIdentifiers[account][trustedIssuers[i]];
-      for (uint256 j = 0; j < identifiersPerIssuer.length; j = j.add(1)) {
-        if (
-          !includeRevoked &&
-          !foundUnrevokedAttestation(account, identifiersPerIssuer[j], trustedIssuers[i])
-        ) {
-          continue;
-        }
-        identifiers[currIndex] = identifiersPerIssuer[j];
-        currIndex = currIndex.add(1);
-      }
-    }
-    return (countsPerIssuer, identifiers);
-  }
+  //   for (uint256 i = 0; i < trustedIssuers.length; i = i.add(1)) {
+  //     identifiersPerIssuer = addressToIdentifiers[account][trustedIssuers[i]];
+  //     for (uint256 j = 0; j < identifiersPerIssuer.length; j = j.add(1)) {
+  //       if (
+  //         !includeRevoked &&
+  //         !foundUnrevokedAttestation(account, identifiersPerIssuer[j], trustedIssuers[i])
+  //       ) {
+  //         continue;
+  //       }
+  //       identifiers[currIndex] = identifiersPerIssuer[j];
+  //       currIndex = currIndex.add(1);
+  //     }
+  //   }
+  //   return (countsPerIssuer, identifiers);
+  // }
 
-  /**
-   * @notice Helper function for lookupIdentifiers to search through the
-   *   attestations from `issuer` for one with an unrevoked signer
-   *   that maps `account` -> `identifier
-   * @param account Address of the account
-   * @param identifier Hash of the identifier
-   * @param issuer Issuer whose attestations to search
-   * @return Whether or not an unrevoked attestation is found establishing the mapping
-   */
-  function foundUnrevokedAttestation(address account, bytes32 identifier, address issuer)
-    internal
-    view
-    returns (bool)
-  {
-    OwnershipAttestation[] memory attestations = identifierToAttestations[identifier][issuer];
-    for (uint256 i = 0; i < attestations.length; i = i.add(1)) {
-      if (attestations[i].account == account && !revokedSigners[attestations[i].signer]) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // TODO do we want to restrict permissions, or should anyone
-  // with a valid signature be able to register an attestation?
-  modifier isValidUser(address issuer, address account) {
-    require(
-      msg.sender == account ||
-        msg.sender == issuer ||
-        getAccounts().attestationSignerToAccount(msg.sender) == issuer,
-      "User does not have permission to perform this action"
-    );
-    require(!revokedSigners[msg.sender], "User has been revoked ");
-    _;
-  }
+  // /**
+  //  * @notice Helper function for lookupIdentifiers to search through the
+  //  *   attestations from `issuer` for one with an unrevoked signer
+  //  *   that maps `account` -> `identifier
+  //  * @param account Address of the account
+  //  * @param identifier Hash of the identifier
+  //  * @param issuer Issuer whose attestations to search
+  //  * @return Whether or not an unrevoked attestation is found establishing the mapping
+  //  */
+  // function foundUnrevokedAttestation(address account, bytes32 identifier, address issuer)
+  //   internal
+  //   view
+  //   returns (bool)
+  // {
+  //   OwnershipAttestation[] memory attestations = identifierToAttestations[identifier][issuer];
+  //   for (uint256 i = 0; i < attestations.length; i = i.add(1)) {
+  //     if (attestations[i].account == account && !revokedSigners[attestations[i].signer]) {
+  //       return true;
+  //     }
+  //   }
+  //   return false;
+  // }
 
   /**
    * @notice Validates the given attestation and signature
@@ -556,21 +547,24 @@ contract FederatedAttestations is
    * @param v The recovery id of the incoming ECDSA signature
    * @param r Output value r of the ECDSA signature
    * @param s Output value s of the ECDSA signature
-   * @return Whether the signature is valid
-   * @dev Throws if signer is revoked
+   * @return Whether the signature is valid and the signer is authorized to make attestations.
+   * @dev Throws if attestation has been revoked
    * @dev Throws if signer is not an authorized AttestationSigner of the issuer
    */
   function isValidAttestation(
     bytes32 identifier,
     address issuer,
     address account,
-    uint256 issuedOn,
+    uint64 issuedOn,
     address signer,
     uint8 v,
     bytes32 r,
     bytes32 s
   ) public view returns (bool) {
-    require(!revokedSigners[signer], "Signer has been revoked");
+    require(
+      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn)],
+      "Attestation has been revoked"
+    );
     require(
       getAccounts().attestationSignerToAccount(signer) == issuer,
       "Signer has not been authorized as an AttestationSigner by the issuer"
@@ -585,7 +579,7 @@ contract FederatedAttestations is
       r,
       s
     );
-    return guessedSigner == signer;
+    require(guessedSigner == signer, "Signature is invalid");
   }
 
   /**
@@ -598,62 +592,69 @@ contract FederatedAttestations is
    * @param v The recovery id of the incoming ECDSA signature
    * @param r Output value r of the ECDSA signature
    * @param s Output value s of the ECDSA signature
-   * @dev Throws if sender is not the issuer, account, or an authorized AttestationSigner
    * @dev Throws if an attestation with the same (identifier, issuer, account) already exists
    */
   function registerAttestation(
     bytes32 identifier,
     address issuer,
     address account,
-    uint256 issuedOn,
+    uint64 issuedOn,
     address signer,
     uint8 v,
     bytes32 r,
     bytes32 s
-  ) public isValidUser(issuer, account) {
-    require(
-      isValidAttestation(identifier, issuer, account, issuedOn, signer, v, r, s),
-      "Signature is invalid"
-    );
+  ) external {
+    // TODO allow for updating existing attestation by only updating signer and publishedOn
+    isValidAttestation(identifier, issuer, account, issuedOn, signer, v, r, s);
     for (uint256 i = 0; i < identifierToAttestations[identifier][issuer].length; i = i.add(1)) {
       // This enforces only one attestation to be uploaded
       // for a given set of (identifier, issuer, account)
-      // Editing/upgrading an attestation requires that it be deleted before a new one is registered
+      // Editing/upgrading an attestation requires that it be revoked before a new one is registered
       require(
         identifierToAttestations[identifier][issuer][i].account != account,
         "Attestation for this account already exists"
       );
     }
-    OwnershipAttestation memory attestation = OwnershipAttestation(account, issuedOn, signer);
+    uint64 publishedOn = uint64(now);
+    OwnershipAttestation memory attestation = OwnershipAttestation(
+      account,
+      signer,
+      issuedOn,
+      publishedOn
+    );
     identifierToAttestations[identifier][issuer].push(attestation);
     addressToIdentifiers[account][issuer].push(identifier);
-    emit AttestationRegistered(identifier, issuer, account, issuedOn, signer);
+    emit AttestationRegistered(identifier, issuer, account, signer, issuedOn, publishedOn);
   }
 
   /**
-   * @notice Deletes an attestation 
-   * @param identifier Hash of the identifier to be deleted
+   * @notice Revokes an attestation 
+   * @param identifier Hash of the identifier to be revoked
    * @param issuer Address of the attestation issuer
    * @param account Address of the account mapped to the identifier
-   * @dev Throws if sender is not the issuer, account, or an authorized AttestationSigner
+   * @dev Throws if sender is not TODO
    */
-  function deleteAttestation(bytes32 identifier, address issuer, address account)
-    public
-    isValidUser(issuer, account)
-  {
+  // TODO should we pass in the issuedOn/signer parameter? ie. only revoke if the sender knows
+  // the issuedOn/signer for the unique attestation
+  function revokeAttestation(bytes32 identifier, address issuer, address account) external {
     OwnershipAttestation[] memory attestations = identifierToAttestations[identifier][issuer];
     for (uint256 i = 0; i < attestations.length; i = i.add(1)) {
       OwnershipAttestation memory attestation = attestations[i];
       if (attestation.account == account) {
+        address signer = attestation.signer;
+        uint64 issuedOn = attestation.issuedOn;
+        require(
+          signer == msg.sender || issuer == msg.sender,
+          "Sender does not have permission to revoke this attestation"
+        );
         // This is meant to delete the attestation in the array
         // and then move the last element in the array to that empty spot,
         // to avoid having empty elements in the array
-        // TODO reviewers: is there a better way of doing this?
+        // TODO benchmark gas cost saving to check if array is of length 1
         identifierToAttestations[identifier][issuer][i] = attestations[attestations.length - 1];
         identifierToAttestations[identifier][issuer].pop();
 
         bool deletedIdentifier = false;
-
         bytes32[] memory identifiers = addressToIdentifiers[account][issuer];
         for (uint256 j = 0; j < identifiers.length; j = j.add(1)) {
           if (identifiers[j] == identifier) {
@@ -666,17 +667,29 @@ contract FederatedAttestations is
         // Should never be false - both mappings should always be updated in unison
         assert(deletedIdentifier);
 
-        emit AttestationDeleted(identifier, issuer, account);
+        bytes32 attestationHash = getUniqueAttestationHash(
+          identifier,
+          issuer,
+          account,
+          signer,
+          issuedOn
+        );
+        revokedAttestations[attestationHash] = true;
+
+        emit AttestationRevoked(identifier, issuer, account, issuedOn);
         return;
       }
     }
-    revert("Attestion to be deleted does not exist");
+    revert("Attestion to be revoked does not exist");
   }
 
-  function revokeSigner(address signer) public {
-    // TODO ASv2 add constraints on who has permissions to revoke a signer
-    // TODO ASv2 consider whether to check if the signer is an authorized signer
-    // or to allow any address to be revoked
-    revokedSigners[signer] = true;
+  function getUniqueAttestationHash(
+    bytes32 identifier,
+    address issuer,
+    address account,
+    address signer,
+    uint64 issuedOn
+  ) public pure returns (bytes32) {
+    return keccak256(abi.encode(identifier, issuer, account, signer, issuedOn));
   }
 }

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -329,8 +329,8 @@ contract FederatedAttestations is
     bytes32 identifier,
     address issuer,
     address account,
-    uint64 issuedOn,
-    address signer
+    address signer,
+    uint64 issuedOn
   ) private {
     require(
       !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn)],
@@ -370,12 +370,12 @@ contract FederatedAttestations is
     bytes32 identifier,
     address issuer,
     address account,
-    uint64 issuedOn,
-    address signer
+    address signer,
+    uint64 issuedOn
   ) external {
     // TODO allow for updating existing attestation by only updating signer and publishedOn
     require(issuer == msg.sender);
-    _registerAttestation(identifier, issuer, account, issuedOn, signer);
+    _registerAttestation(identifier, issuer, account, signer, issuedOn);
   }
 
   /**
@@ -394,15 +394,15 @@ contract FederatedAttestations is
     bytes32 identifier,
     address issuer,
     address account,
-    uint64 issuedOn,
     address signer,
+    uint64 issuedOn,
     uint8 v,
     bytes32 r,
     bytes32 s
   ) external {
     // TODO allow for updating existing attestation by only updating signer and publishedOn
-    validateAttestationSig(identifier, issuer, account, issuedOn, signer, v, r, s);
-    _registerAttestation(identifier, issuer, account, issuedOn, signer);
+    validateAttestationSig(identifier, issuer, account, signer, issuedOn, v, r, s);
+    _registerAttestation(identifier, issuer, account, signer, issuedOn);
   }
 
   /**

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -283,7 +283,7 @@ contract FederatedAttestations is
    * @dev Throws if attestation has been revoked
    * @dev Throws if signer is not an authorized AttestationSigner of the issuer
    */
-  function validateAttestation(
+  function validateAttestationSig(
     bytes32 identifier,
     address issuer,
     address account,
@@ -293,10 +293,6 @@ contract FederatedAttestations is
     bytes32 r,
     bytes32 s
   ) public view returns (bool) {
-    require(
-      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn)],
-      "Attestation has been revoked"
-    );
     require(
       getAccounts().attestationSignerToAccount(signer) == issuer,
       "Signer has not been authorized as an AttestationSigner by the issuer"
@@ -329,6 +325,10 @@ contract FederatedAttestations is
     uint64 issuedOn,
     address signer
   ) private {
+    require(
+      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn)],
+      "Attestation has been revoked"
+    );
     for (uint256 i = 0; i < identifierToAttestations[identifier][issuer].length; i = i.add(1)) {
       // This enforces only one attestation to be uploaded
       // for a given set of (identifier, issuer, account)
@@ -359,7 +359,7 @@ contract FederatedAttestations is
    * @param signer Address of the signer of the attestation
    * @dev Throws if an attestation with the same (identifier, issuer, account) already exists
    */
-  function registerIssuerAttestation(
+  function registerAttestationAsIssuer(
     bytes32 identifier,
     address issuer,
     address account,
@@ -367,10 +367,6 @@ contract FederatedAttestations is
     address signer
   ) external {
     // TODO allow for updating existing attestation by only updating signer and publishedOn
-    require(
-      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn)],
-      "Attestation has been revoked"
-    );
     require(issuer == msg.sender);
     _registerAttestation(identifier, issuer, account, issuedOn, signer);
   }
@@ -398,7 +394,7 @@ contract FederatedAttestations is
     bytes32 s
   ) external {
     // TODO allow for updating existing attestation by only updating signer and publishedOn
-    validateAttestation(identifier, issuer, account, issuedOn, signer, v, r, s);
+    validateAttestationSig(identifier, issuer, account, issuedOn, signer, v, r, s);
     _registerAttestation(identifier, issuer, account, issuedOn, signer);
   }
 

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -155,6 +155,8 @@ contract FederatedAttestations is
    */
   // TODO reviewers: is it preferable to return an array of `trustedIssuer` indices
   // (indicating issuer per attestation) instead of counts per attestation?
+  // TODO: change issuedOn type, change the order of return values to match across the file,
+  // add publishedOn to returned lookups
   function lookupAttestations(bytes32 identifier, address[] calldata trustedIssuers)
     external
     view
@@ -179,6 +181,8 @@ contract FederatedAttestations is
    * @dev Adds attestation info to the arrays in order of provided trustedIssuers
    * @dev Expectation that only one attestation exists per (identifier, issuer, account)
    */
+  // TODO: change issuedOn type, change the order of return values to match across the file,
+  // add publishedOn to returned lookups
   function _lookupAttestations(bytes32 identifier, address[] memory trustedIssuers)
     internal
     view
@@ -338,7 +342,7 @@ contract FederatedAttestations is
     bytes32 r,
     bytes32 s
   ) external {
-    // TODO allow for updating existing attestation by only updating signer and publishedOn
+    // TODO allow for updating existing attestation by only updating signer/publishedOn/issuedOn
     validateAttestation(identifier, issuer, account, issuedOn, signer, v, r, s);
     for (uint256 i = 0; i < identifierToAttestations[identifier][issuer].length; i = i.add(1)) {
       // This enforces only one attestation to be uploaded

--- a/packages/protocol/lib/fed-attestations-utils.ts
+++ b/packages/protocol/lib/fed-attestations-utils.ts
@@ -24,7 +24,7 @@ const getTypedData = (chainId: number, contractAddress: Address, message?: Attes
           { name: 'identifier', type: 'bytes32' },
           { name: 'issuer', type: 'address'},
           { name: 'account', type: 'address' },
-          { name: 'issuedOn', type: 'uint256' },
+          { name: 'issuedOn', type: 'uint64' },
           // TODO ASv2 Consider including a nonce (which could also be used as an ID)
       ],
     },

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -76,8 +76,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
       identifier,
       issuer,
       account,
-      issuedOn,
       signer,
+      issuedOn,
       attestationSignature.v,
       attestationSignature.r,
       attestationSignature.s,
@@ -96,7 +96,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     signer: string,
     identifierIndex: number
   ) => {
-    const attestation = await federatedAttestations.identifierToAddresses(
+    const attestation = await federatedAttestations.identifierToAttestations(
       identifier,
       issuer,
       attestationIndex
@@ -120,7 +120,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     identifierIndex: number
   ) => {
     await assertThrowsAsync(
-      federatedAttestations.identifierToAddresses(identifier, issuer, addressIndex)
+      federatedAttestations.identifierToAttestations(identifier, issuer, addressIndex)
     )
     await assertThrowsAsync(
       federatedAttestations.addressToIdentifiers(account, issuer, identifierIndex)
@@ -153,7 +153,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
   describe('#EIP712_VALIDATE_ATTESTATION_TYPEHASH()', () => {
     it('should have set the right typehash', async () => {
       const expectedTypehash = keccak256(
-        'OwnershipAttestation(bytes32 identifier,address issuer,address account,uint256 issuedOn)'
+        'OwnershipAttestation(bytes32 identifier,address issuer,address account,uint64 issuedOn)'
       )
       assert.equal(
         await federatedAttestations.EIP712_VALIDATE_ATTESTATION_TYPEHASH(),
@@ -223,17 +223,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
     }
 
     describe('when identifier has not been registered', () => {
-      describe('#lookupUnrevokedAttestations', () => {
-        it('should return empty list', async () => {
-          const [
-            countsPerIssuer,
-            addresses,
-            issuedOns,
-            signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(identifier1, [issuer1], 1)
-          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, issuedOns, signers)
-        })
-      })
       describe('#lookupAttestations', () => {
         ;[true, false].forEach((includeRevoked) => {
           describe(`includeRevoked = ${includeRevoked}`, () => {
@@ -243,7 +232,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
                 addresses,
                 issuedOns,
                 signers,
-              ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1], true)
+              ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
               checkAgainstExpectedAttestations(
                 [0],
                 [],
@@ -312,14 +301,14 @@ contract('FederatedAttestations', (accounts: string[]) => {
         }
       })
 
-      describe('#lookupUnrevokedAttestations', () => {
-        it('should return empty count if no issuers specified', async () => {
+      describe('#lookupAttestations', () => {
+        it('should return empty count and list if no issuers specified', async () => {
           const [
             countsPerIssuer,
             addresses,
             issuedOns,
             signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(identifier1, [], 1)
+          ] = await federatedAttestations.lookupAttestations(identifier1, [])
           checkAgainstExpectedAttestations([], [], countsPerIssuer, addresses, issuedOns, signers)
         })
 
@@ -329,12 +318,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
             addresses,
             issuedOns,
             signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(
-            identifier1,
-            [issuer1],
-            // Do not allow for maxAttestations to coincidentally limit incorrect output
-            issuer1Attestations.length + 1
-          )
+          ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
           checkAgainstExpectedAttestations(
             [issuer1Attestations.length],
             issuer1Attestations,
@@ -351,7 +335,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
             addresses,
             issuedOns,
             signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(identifier1, [issuer3], 1)
+          ] = await federatedAttestations.lookupAttestations(identifier1, [issuer3])
           checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, issuedOns, signers)
         })
 
@@ -367,11 +351,11 @@ contract('FederatedAttestations', (accounts: string[]) => {
             addresses,
             issuedOns,
             signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(
-            identifier1,
-            [issuer3, issuer2, issuer1],
-            expectedAttestations.length + 1
-          )
+          ] = await federatedAttestations.lookupAttestations(identifier1, [
+            issuer3,
+            issuer2,
+            issuer1,
+          ])
           checkAgainstExpectedAttestations(
             expectedCountsPerIssuer,
             expectedAttestations,
@@ -382,209 +366,29 @@ contract('FederatedAttestations', (accounts: string[]) => {
           )
         })
 
-        it('should return empty list if maxAttestations == 0', async () => {
-          const [
-            countsPerIssuer,
-            addresses,
-            issuedOns,
-            signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(identifier1, [issuer1], 0)
-          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, issuedOns, signers)
-        })
-
-        it('should only return maxAttestations attestations when more are present', async () => {
-          const expectedAttestations = issuer1Attestations.slice(0, -1)
-          const expectedCountsPerIssuer = [expectedAttestations.length]
-          const [
-            countsPerIssuer,
-            addresses,
-            issuedOns,
-            signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(
-            identifier1,
-            [issuer1],
-            expectedAttestations.length
-          )
-          checkAgainstExpectedAttestations(
-            expectedCountsPerIssuer,
-            expectedAttestations,
-            countsPerIssuer,
-            addresses,
-            issuedOns,
-            signers
-          )
-        })
-
-        it('should not return attestations from revoked signers', async () => {
-          const attestationToRevoke = issuer2Attestations[0]
-          await federatedAttestations.revokeSigner(attestationToRevoke.signer)
-          const expectedAttestations = issuer2Attestations.slice(1)
-          const expectedCountsPerIssuer = [expectedAttestations.length]
-          const [
-            countsPerIssuer,
-            addresses,
-            issuedOns,
-            signers,
-          ] = await federatedAttestations.lookupUnrevokedAttestations(
-            identifier1,
-            [issuer2],
-            issuer2Attestations.length
-          )
-          checkAgainstExpectedAttestations(
-            expectedCountsPerIssuer,
-            expectedAttestations,
-            countsPerIssuer,
-            addresses,
-            issuedOns,
-            signers
-          )
-        })
-      })
-
-      describe('#lookupAttestations', () => {
-        ;[true, false].forEach((includeRevoked) => {
-          describe(`includeRevoked = ${includeRevoked}`, () => {
-            it('should return empty count and list if no issuers specified', async () => {
-              const [
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers,
-              ] = await federatedAttestations.lookupAttestations(identifier1, [], includeRevoked)
-              checkAgainstExpectedAttestations(
-                [],
-                [],
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers
-              )
-            })
-
-            it('should return all attestations from one issuer', async () => {
-              const [
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers,
-              ] = await federatedAttestations.lookupAttestations(
-                identifier1,
-                [issuer1],
-                includeRevoked
-              )
-              checkAgainstExpectedAttestations(
-                [issuer1Attestations.length],
-                issuer1Attestations,
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers
-              )
-            })
-
-            it('should return empty list if no attestations exist for an issuer', async () => {
-              const [
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers,
-              ] = await federatedAttestations.lookupAttestations(
-                identifier1,
-                [issuer3],
-                includeRevoked
-              )
-              checkAgainstExpectedAttestations(
-                [0],
-                [],
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers
-              )
-            })
-
-            it('should return attestations from multiple issuers in correct order', async () => {
-              const expectedAttestations = issuer2Attestations.concat(issuer1Attestations)
-              const expectedCountsPerIssuer = [
-                0,
-                issuer2Attestations.length,
-                issuer1Attestations.length,
-              ]
-              const [
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers,
-              ] = await federatedAttestations.lookupAttestations(
-                identifier1,
-                [issuer3, issuer2, issuer1],
-                includeRevoked
-              )
-              checkAgainstExpectedAttestations(
-                expectedCountsPerIssuer,
-                expectedAttestations,
-                countsPerIssuer,
-                addresses,
-                issuedOns,
-                signers
-              )
-            })
-
-            if (includeRevoked) {
-              it('should return attestations from revoked and unrevoked signers', async () => {
-                await federatedAttestations.revokeSigner(issuer1Attestations[0].signer)
-                const expectedAttestations = issuer1Attestations.concat(issuer2Attestations)
-                const expectedCountsPerIssuer = [
-                  issuer1Attestations.length,
-                  issuer2Attestations.length,
-                ]
-                const [
-                  countsPerIssuer,
-                  addresses,
-                  issuedOns,
-                  signers,
-                ] = await federatedAttestations.lookupAttestations(
-                  identifier1,
-                  [issuer1, issuer2],
-                  includeRevoked
-                )
-                checkAgainstExpectedAttestations(
-                  expectedCountsPerIssuer,
-                  expectedAttestations,
-                  countsPerIssuer,
-                  addresses,
-                  issuedOns,
-                  signers
-                )
-              })
-            } else {
-              it('should not return attestations from revoked signers', async () => {
-                const attestationToRevoke = issuer2Attestations[0]
-                await federatedAttestations.revokeSigner(attestationToRevoke.signer)
-                const expectedAttestations = issuer2Attestations.slice(1)
-                const expectedCountsPerIssuer = [expectedAttestations.length]
-                const [
-                  countsPerIssuer,
-                  addresses,
-                  issuedOns,
-                  signers,
-                ] = await federatedAttestations.lookupAttestations(
-                  identifier1,
-                  [issuer2],
-                  includeRevoked
-                )
-                checkAgainstExpectedAttestations(
-                  expectedCountsPerIssuer,
-                  expectedAttestations,
-                  countsPerIssuer,
-                  addresses,
-                  issuedOns,
-                  signers
-                )
-              })
-            }
-          })
-        })
+        // it('should not return attestations from revoked signers', async () => {
+        //   const attestationToRevoke = issuer2Attestations[0]
+        //   await federatedAttestations.revokeSigner(attestationToRevoke.signer)
+        //   const expectedAttestations = issuer2Attestations.slice(1)
+        //   const expectedCountsPerIssuer = [expectedAttestations.length]
+        //   const [
+        //     countsPerIssuer,
+        //     addresses,
+        //     issuedOns,
+        //     signers,
+        //   ] = await federatedAttestations.lookupAttestations(
+        //     identifier1,
+        //     [issuer2]
+        //   )
+        //   checkAgainstExpectedAttestations(
+        //     expectedCountsPerIssuer,
+        //     expectedAttestations,
+        //     countsPerIssuer,
+        //     addresses,
+        //     issuedOns,
+        //     signers
+        //   )
+        // })
       })
     })
   })
@@ -606,15 +410,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
     }
 
     describe('when address has not been registered', () => {
-      describe('#lookupUnrevokedIdentifiers', () => {
-        it('should return empty list', async () => {
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(account1, [issuer1], 1)
-          checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
-        })
-      })
       describe('#lookupIdentifiers', () => {
         ;[true, false].forEach((includeRevoked) => {
           describe(`includeRevoked = ${includeRevoked}`, () => {
@@ -622,7 +417,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
               const [
                 actualCountsPerIssuer,
                 actualIdentifiers,
-              ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1], true)
+              ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1])
               checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
             })
           })
@@ -676,12 +471,12 @@ contract('FederatedAttestations', (accounts: string[]) => {
         }
       })
 
-      describe('#lookupUnrevokedIdentifiers', () => {
+      describe('#lookupIdentifiers', () => {
         it('should return empty count if no issuers specified', async () => {
           const [
             actualCountsPerIssuer,
             actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(account1, [], 1)
+          ] = await federatedAttestations.lookupIdentifiers(account1, [])
           checkAgainstExpectedIdCases([], [], actualCountsPerIssuer, actualIdentifiers)
         })
 
@@ -689,11 +484,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
           const [
             actualCountsPerIssuer,
             actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(
-            account1,
-            [issuer1],
-            issuer1IdCases.length + 1
-          )
+          ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1])
           checkAgainstExpectedIdCases(
             [issuer1IdCases.length],
             issuer1IdCases,
@@ -706,7 +497,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
           const [
             actualCountsPerIssuer,
             actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(account1, [issuer3], 1)
+          ] = await federatedAttestations.lookupIdentifiers(account1, [issuer3])
           checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
         })
 
@@ -716,11 +507,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
           const [
             actualCountsPerIssuer,
             actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(
-            account1,
-            [issuer3, issuer2, issuer1],
-            expectedIdCases.length + 1
-          )
+          ] = await federatedAttestations.lookupIdentifiers(account1, [issuer3, issuer2, issuer1])
           checkAgainstExpectedIdCases(
             expectedCountsPerIssuer,
             expectedIdCases,
@@ -729,164 +516,40 @@ contract('FederatedAttestations', (accounts: string[]) => {
           )
         })
 
-        it('should return empty list if maxIdentifiers == 0', async () => {
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(account1, [issuer1], 0)
-          checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
-        })
+        // it('should not return identifiers from revoked signers', async () => {
+        //   await federatedAttestations.revokeSigner(issuer2IdCases[0].signer)
+        //   const expectedIdCases = issuer2IdCases.slice(1)
+        //   const expectedCountsPerIssuer = [expectedIdCases.length]
 
-        it('should only return maxIdentifiers identifiers when more are present', async () => {
-          const expectedIdCases = issuer2IdCases.concat(issuer1IdCases).slice(0, -1)
-          const expectedCountsPerIssuer = [
-            issuer2IdCases.length,
-            expectedIdCases.length - issuer2IdCases.length,
-          ]
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(
-            account1,
-            [issuer2, issuer1],
-            expectedIdCases.length
-          )
-          checkAgainstExpectedIdCases(
-            expectedCountsPerIssuer,
-            expectedIdCases,
-            actualCountsPerIssuer,
-            actualIdentifiers
-          )
-        })
-
-        it('should not return identifiers from revoked signers', async () => {
-          await federatedAttestations.revokeSigner(issuer2IdCases[0].signer)
-          const expectedIdCases = issuer2IdCases.slice(1)
-          const expectedCountsPerIssuer = [expectedIdCases.length]
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupUnrevokedIdentifiers(
-            account1,
-            [issuer2],
-            expectedIdCases.length + 1
-          )
-          checkAgainstExpectedIdCases(
-            expectedCountsPerIssuer,
-            expectedIdCases,
-            actualCountsPerIssuer,
-            actualIdentifiers
-          )
-        })
-      })
-
-      describe('#lookupIdentifiers', () => {
-        ;[true, false].forEach((includeRevoked) => {
-          describe(`includeRevoked = ${includeRevoked}`, () => {
-            it('should return empty count if no issuers specified', async () => {
-              const [
-                actualCountsPerIssuer,
-                actualIdentifiers,
-              ] = await federatedAttestations.lookupIdentifiers(account1, [], includeRevoked)
-              checkAgainstExpectedIdCases([], [], actualCountsPerIssuer, actualIdentifiers)
-            })
-
-            it('should return all identifiers from one issuer', async () => {
-              const [
-                actualCountsPerIssuer,
-                actualIdentifiers,
-              ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1], includeRevoked)
-              checkAgainstExpectedIdCases(
-                [issuer1IdCases.length],
-                issuer1IdCases,
-                actualCountsPerIssuer,
-                actualIdentifiers
-              )
-            })
-
-            it('should return empty list if no identifiers exist for an (issuer,address)', async () => {
-              const [
-                actualCountsPerIssuer,
-                actualIdentifiers,
-              ] = await federatedAttestations.lookupIdentifiers(account1, [issuer3], includeRevoked)
-              checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
-            })
-
-            it('should return identifiers from multiple issuers in correct order', async () => {
-              const expectedIdCases = issuer2IdCases.concat(issuer1IdCases)
-              const expectedCountsPerIssuer = [0, issuer2IdCases.length, issuer1IdCases.length]
-              const [
-                actualCountsPerIssuer,
-                actualIdentifiers,
-              ] = await federatedAttestations.lookupIdentifiers(
-                account1,
-                [issuer3, issuer2, issuer1],
-                includeRevoked
-              )
-              checkAgainstExpectedIdCases(
-                expectedCountsPerIssuer,
-                expectedIdCases,
-                actualCountsPerIssuer,
-                actualIdentifiers
-              )
-            })
-
-            if (includeRevoked) {
-              it('should return identifiers from revoked and unrevoked signers', async () => {
-                await federatedAttestations.revokeSigner(issuer2IdCases[0].signer)
-                const [
-                  actualCountsPerIssuer,
-                  actualIdentifiers,
-                ] = await federatedAttestations.lookupIdentifiers(
-                  account1,
-                  [issuer2],
-                  includeRevoked
-                )
-                checkAgainstExpectedIdCases(
-                  [issuer2IdCases.length],
-                  issuer2IdCases,
-                  actualCountsPerIssuer,
-                  actualIdentifiers
-                )
-              })
-            } else {
-              it('should not return identifiers from revoked signers', async () => {
-                await federatedAttestations.revokeSigner(issuer2IdCases[0].signer)
-                const expectedIdCases = issuer2IdCases.slice(1)
-                const expectedCountsPerIssuer = [expectedIdCases.length]
-
-                const [
-                  actualCountsPerIssuer,
-                  actualIdentifiers,
-                ] = await federatedAttestations.lookupIdentifiers(
-                  account1,
-                  [issuer2],
-                  includeRevoked
-                )
-                checkAgainstExpectedIdCases(
-                  expectedCountsPerIssuer,
-                  expectedIdCases,
-                  actualCountsPerIssuer,
-                  actualIdentifiers
-                )
-              })
-            }
-          })
-        })
+        //   const [
+        //     actualCountsPerIssuer,
+        //     actualIdentifiers,
+        //   ] = await federatedAttestations.lookupIdentifiers(
+        //     account1,
+        //     [issuer2],
+        //     includeRevoked
+        //   )
+        //   checkAgainstExpectedIdCases(
+        //     expectedCountsPerIssuer,
+        //     expectedIdCases,
+        //     actualCountsPerIssuer,
+        //     actualIdentifiers
+        //   )
+        // })
       })
     })
   })
 
-  describe('#isValidAttestation', async () => {
+  describe('#validateAttestation', async () => {
     describe('with an authorized AttestationSigner', async () => {
       beforeEach(async () => {
         await accountsInstance.authorizeSigner(signer1, signerRole, { from: issuer1 })
         await accountsInstance.completeSignerAuthorization(issuer1, signerRole, { from: signer1 })
       })
 
-      it('should return true if a valid signature is used', async () => {
-        assert.isTrue(
-          await federatedAttestations.isValidAttestation(
+      it('should return successfully if a valid signature is used', async () => {
+        assert.isOk(
+          await federatedAttestations.validateAttestation(
             identifier1,
             issuer1,
             account1,
@@ -909,8 +572,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           chainId,
           federatedAttestations.address
         )
-        assert.isFalse(
-          await federatedAttestations.isValidAttestation(
+        await assertRevert(
+          federatedAttestations.validateAttestation(
             identifier1,
             issuer1,
             account1,
@@ -934,19 +597,15 @@ contract('FederatedAttestations', (accounts: string[]) => {
         it(`should fail if the provided ${arg} is different from the attestation`, async () => {
           const args = [identifier1, issuer1, account1, nowUnixTime, signer1, sig.v, sig.r, sig.s]
           args[index] = wrongValue
-
-          if (arg === 'issuer' || arg === 'signer') {
-            await assertRevert(federatedAttestations.isValidAttestation.apply(this, args))
-          } else {
-            assert.isFalse(await federatedAttestations.isValidAttestation.apply(this, args))
-          }
+          await assertRevert(federatedAttestations.validateAttestation.apply(this, args))
         })
       })
 
-      it('should revert if the signer is revoked', async () => {
-        await federatedAttestations.revokeSigner(signer1)
-        await assertRevertWithReason(
-          federatedAttestations.isValidAttestation(
+      it('should revert if the attestation is revoked', async () => {
+        await signAndRegisterAttestation(identifier1, issuer1, account1, nowUnixTime, signer1)
+        await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
+        await assertRevert(
+          federatedAttestations.validateAttestation(
             identifier1,
             issuer1,
             account1,
@@ -955,15 +614,14 @@ contract('FederatedAttestations', (accounts: string[]) => {
             sig.v,
             sig.r,
             sig.s
-          ),
-          'Signer has been revoked'
+          )
         )
       })
     })
 
     it('should revert if the signer is not authorized as an AttestationSigner by the issuer', async () => {
       await assertRevert(
-        federatedAttestations.isValidAttestation(
+        federatedAttestations.validateAttestation(
           identifier1,
           issuer1,
           account1,
@@ -982,7 +640,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
       await accountsInstance.completeSignerAuthorization(issuer1, role, { from: signer1 })
 
       await assertRevert(
-        federatedAttestations.isValidAttestation(
+        federatedAttestations.validateAttestation(
           identifier1,
           issuer1,
           account1,
@@ -1007,20 +665,22 @@ contract('FederatedAttestations', (accounts: string[]) => {
         identifier1,
         issuer1,
         account1,
-        nowUnixTime,
         signer1,
+        nowUnixTime,
         sig.v,
         sig.r,
         sig.s
       )
+      const publishedOn = Math.floor(Date.now() / 1000)
       assertLogMatches2(register.logs[0], {
         event: 'AttestationRegistered',
         args: {
           identifier: identifier1,
           issuer: issuer1,
           account: account1,
-          issuedOn: nowUnixTime,
           signer: signer1,
+          issuedOn: nowUnixTime,
+          publishedOn,
         },
       })
     })
@@ -1045,8 +705,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          nowUnixTime,
           signer1,
+          nowUnixTime,
           sig2.v,
           sig2.r,
           sig2.s
@@ -1054,20 +714,21 @@ contract('FederatedAttestations', (accounts: string[]) => {
       )
     })
 
-    it('should revert if signer has been revoked', async () => {
-      await federatedAttestations.revokeSigner(signer1)
+    it('should revert if attestation has been revoked', async () => {
+      await signAndRegisterAttestation(identifier1, issuer1, account1, nowUnixTime, signer1)
+      await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
       await assertRevertWithReason(
         federatedAttestations.registerAttestation(
           identifier1,
           issuer1,
           account1,
-          nowUnixTime,
           signer1,
+          nowUnixTime,
           sig.v,
           sig.r,
           sig.s
         ),
-        'Signer has been revoked'
+        'Attestation has been revoked'
       )
     })
 
@@ -1084,8 +745,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          nowUnixTime,
           signer1,
+          nowUnixTime,
           sig.v,
           sig.r,
           sig.s
@@ -1120,8 +781,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
             identifier1,
             issuer1,
             account1,
-            nowUnixTime,
             signer2,
+            nowUnixTime,
             sig2.v,
             sig2.r,
             sig2.s
@@ -1149,14 +810,14 @@ contract('FederatedAttestations', (accounts: string[]) => {
       })
     })
 
-    it('should revert if an invalid user attempts to register the attestation', async () => {
-      await assertRevert(
-        federatedAttestations.registerAttestation(
+    it('should succeed if any user attempts to register the attestation', async () => {
+      assert.isOk(
+        await federatedAttestations.registerAttestation(
           identifier1,
           issuer1,
           account1,
-          nowUnixTime,
           signer1,
+          nowUnixTime,
           sig.v,
           sig.r,
           sig.s,
@@ -1173,8 +834,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
         identifier1,
         issuer1,
         account1,
-        nowUnixTime,
         signer1,
+        nowUnixTime,
         sig.v,
         sig.r,
         sig.s,
@@ -1184,7 +845,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
   })
 
-  describe('#deleteAttestation', () => {
+  describe('#revokeAttestation', () => {
     beforeEach(async () => {
       await accountsInstance.authorizeSigner(signer1, signerRole, { from: issuer1 })
       await accountsInstance.completeSignerAuthorization(issuer1, signerRole, { from: signer1 })
@@ -1192,38 +853,40 @@ contract('FederatedAttestations', (accounts: string[]) => {
         identifier1,
         issuer1,
         account1,
-        nowUnixTime,
         signer1,
+        nowUnixTime,
         sig.v,
         sig.r,
         sig.s
       )
     })
 
-    it('should emit an AttestationDeleted event after successfully deleting', async () => {
-      const deleteAttestation = await federatedAttestations.deleteAttestation(
+    it('should emit an AttestationRevoked event after successfully revoking', async () => {
+      const deleteAttestation = await federatedAttestations.revokeAttestation(
         identifier1,
         issuer1,
         account1
       )
       assertLogMatches2(deleteAttestation.logs[0], {
-        event: 'AttestationDeleted',
+        event: 'AttestationRevoked',
         args: {
           identifier: identifier1,
           issuer: issuer1,
           account: account1,
+          signer: signer1,
+          issuedOn: nowUnixTime,
         },
       })
     })
 
-    it("should revert when deleting an attestation that doesn't exist", async () => {
-      await assertRevert(federatedAttestations.deleteAttestation(identifier1, issuer1, accounts[4]))
+    it("should revert when revoking an attestation that doesn't exist", async () => {
+      await assertRevert(federatedAttestations.revokeAttestation(identifier1, issuer1, accounts[4]))
     })
 
     it('should succeed when >1 attestations are registered for (identifier, issuer)', async () => {
       const account2 = accounts[3]
       await signAndRegisterAttestation(identifier1, issuer1, account2, nowUnixTime, signer1)
-      await federatedAttestations.deleteAttestation(identifier1, issuer1, account2, {
+      await federatedAttestations.revokeAttestation(identifier1, issuer1, account2, {
         from: account2,
       })
       await assertAttestationNotInStorage(identifier1, issuer1, account2, 1, 0)
@@ -1232,64 +895,65 @@ contract('FederatedAttestations', (accounts: string[]) => {
 
     it('should succeed when >1 identifiers are registered for (account, issuer)', async () => {
       await signAndRegisterAttestation(identifier2, issuer1, account1, nowUnixTime, signer1)
-      await federatedAttestations.deleteAttestation(identifier2, issuer1, account1, {
+      await federatedAttestations.revokeAttestation(identifier2, issuer1, account1, {
         from: account1,
       })
       await assertAttestationNotInStorage(identifier2, issuer1, account1, 0, 1)
       await assertAttestationInStorage(identifier1, issuer1, 0, account1, nowUnixTime, signer1, 0)
     })
 
-    it('should revert if an invalid user attempts to delete the attestation', async () => {
+    it('should revert if an invalid user attempts to revoke the attestation', async () => {
       await assertRevert(
-        federatedAttestations.deleteAttestation(identifier1, issuer1, account1, {
+        federatedAttestations.revokeAttestation(identifier1, issuer1, account1, {
           from: accounts[4],
         })
       )
     })
 
-    it('should revert if a revoked signer attempts to delete the attestation', async () => {
-      await federatedAttestations.revokeSigner(signer1)
-      await assertRevert(
-        federatedAttestations.deleteAttestation(identifier1, issuer1, account1, { from: signer1 })
-      )
-    })
+    // it('should revert if a revoked signer attempts to delete the attestation', async () => {
+    //   await federatedAttestations.revokeSigner(signer1)
+    //   await assertRevert(
+    //     federatedAttestations.revokeAttestation(identifier1, issuer1, account1, { from: signer1 })
+    //   )
+    // })
 
-    it('should successfully delete an attestation with a revoked signer', async () => {
-      await federatedAttestations.revokeSigner(signer1)
-      await federatedAttestations.deleteAttestation(identifier1, issuer1, account1)
-      await assertAttestationNotInStorage(identifier1, issuer1, account1, 0, 1)
-    })
+    // it('should successfully delete an attestation with a revoked signer', async () => {
+    //   await federatedAttestations.revokeSigner(signer1)
+    //   await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
+    //   await assertAttestationNotInStorage(identifier1, issuer1, account1, 0, 1)
+    // })
 
-    it('should fail registering same attestation but succeed after deleting it', async () => {
+    it('should fail registering same attestation and fail again after revoking it', async () => {
       await assertRevert(
         federatedAttestations.registerAttestation(
           identifier1,
           issuer1,
           account1,
-          nowUnixTime,
           signer1,
+          nowUnixTime,
           sig.v,
           sig.r,
           sig.s
         )
       )
-      await federatedAttestations.deleteAttestation(identifier1, issuer1, account1)
-      await federatedAttestations.registerAttestation(
-        identifier1,
-        issuer1,
-        account1,
-        nowUnixTime,
-        signer1,
-        sig.v,
-        sig.r,
-        sig.s
+      await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
+      await assertRevert(
+        federatedAttestations.registerAttestation(
+          identifier1,
+          issuer1,
+          account1,
+          signer1,
+          nowUnixTime,
+          sig.v,
+          sig.r,
+          sig.s
+        )
       )
-      await assertAttestationInStorage(identifier1, issuer1, 0, account1, nowUnixTime, signer1, 0)
     })
 
     it('should modify identifierToAddresses and addresstoIdentifiers accordingly', async () => {
       await assertAttestationInStorage(identifier1, issuer1, 0, account1, nowUnixTime, signer1, 0)
-      await federatedAttestations.deleteAttestation(identifier1, issuer1, account1)
+      await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
       await assertAttestationNotInStorage(identifier1, issuer1, account1, 0, 0)
     })
   })

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -76,8 +76,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
       identifier,
       issuer,
       account,
-      signer,
       issuedOn,
+      signer,
       attestationSignature.v,
       attestationSignature.r,
       attestationSignature.s,
@@ -665,8 +665,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
         identifier1,
         issuer1,
         account1,
-        signer1,
         nowUnixTime,
+        signer1,
         sig.v,
         sig.r,
         sig.s
@@ -705,8 +705,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          signer1,
           nowUnixTime,
+          signer1,
           sig2.v,
           sig2.r,
           sig2.s
@@ -722,8 +722,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          signer1,
           nowUnixTime,
+          signer1,
           sig.v,
           sig.r,
           sig.s
@@ -745,8 +745,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          signer1,
           nowUnixTime,
+          signer1,
           sig.v,
           sig.r,
           sig.s
@@ -781,8 +781,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
             identifier1,
             issuer1,
             account1,
-            signer2,
             nowUnixTime,
+            signer2,
             sig2.v,
             sig2.r,
             sig2.s
@@ -816,8 +816,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          signer1,
           nowUnixTime,
+          signer1,
           sig.v,
           sig.r,
           sig.s,
@@ -834,8 +834,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
         identifier1,
         issuer1,
         account1,
-        signer1,
         nowUnixTime,
+        signer1,
         sig.v,
         sig.r,
         sig.s,
@@ -845,7 +845,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
 
     it('should succeed if the issuer submits the attestation directly', async () => {
-      await federatedAttestations.registerAttestation(
+      await federatedAttestations.registerAttestationAsIssuer(
         identifier1,
         issuer1,
         account1,
@@ -857,7 +857,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
 
     it('should revert if a non-issuer submits an attestation with no signature', async () => {
-      await federatedAttestations.registerAttestation(
+      await federatedAttestations.registerAttestationAsIssuer(
         identifier1,
         issuer1,
         account1,
@@ -877,8 +877,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
         identifier1,
         issuer1,
         account1,
-        signer1,
         nowUnixTime,
+        signer1,
         sig.v,
         sig.r,
         sig.s
@@ -956,8 +956,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          signer1,
           nowUnixTime,
+          signer1,
           sig.v,
           sig.r,
           sig.s
@@ -969,8 +969,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           identifier1,
           issuer1,
           account1,
-          signer1,
           nowUnixTime,
+          signer1,
           sig.v,
           sig.r,
           sig.s

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -902,6 +902,22 @@ contract('FederatedAttestations', (accounts: string[]) => {
       await assertAttestationInStorage(identifier1, issuer1, 0, account1, nowUnixTime, signer1, 0)
     })
 
+    const newAttestation = [
+      [0, 'identifier', identifier2],
+      // skipping issuer as it requires a different signer as well
+      [2, 'account', accounts[3]],
+      [3, 'issuedOn', nowUnixTime + 1],
+      [4, 'signer', accounts[3]],
+    ]
+    newAttestation.forEach(([index, arg, newVal]) => {
+      it(`after revoking an attestation, should succeed in registering new attestation with different ${arg}`, async () => {
+        await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
+        const args = [identifier1, issuer1, account1, nowUnixTime, signer1]
+        args[index] = newVal
+        assert.isOk(signAndRegisterAttestation.apply(this, args))
+      })
+    })
+
     it('should revert if an invalid user attempts to revoke the attestation', async () => {
       await assertRevert(
         federatedAttestations.revokeAttestation(identifier1, issuer1, account1, {
@@ -909,19 +925,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
         })
       )
     })
-
-    // it('should revert if a revoked signer attempts to delete the attestation', async () => {
-    //   await federatedAttestations.revokeSigner(signer1)
-    //   await assertRevert(
-    //     federatedAttestations.revokeAttestation(identifier1, issuer1, account1, { from: signer1 })
-    //   )
-    // })
-
-    // it('should successfully delete an attestation with a revoked signer', async () => {
-    //   await federatedAttestations.revokeSigner(signer1)
-    //   await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
-    //   await assertAttestationNotInStorage(identifier1, issuer1, account1, 0, 1)
-    // })
 
     it('should fail registering same attestation and fail again after revoking it', async () => {
       await assertRevert(

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -1182,6 +1182,30 @@ contract('FederatedAttestations', (accounts: string[]) => {
       )
       await assertAttestationInStorage(identifier1, issuer1, 0, account1, nowUnixTime, signer1, 0)
     })
+
+    it('should succeed if the issuer submits the attestation directly', async () => {
+      await federatedAttestations.registerAttestation(
+        identifier1,
+        issuer1,
+        account1,
+        nowUnixTime,
+        issuer1,
+        { from: issuer1 }
+      )
+      await assertAttestationInStorage(identifier1, issuer1, 0, account1, nowUnixTime, issuer1, 0)
+    })
+
+    it('should revert if a non-issuer submits an attestation with no signature', async () => {
+      await federatedAttestations.registerAttestation(
+        identifier1,
+        issuer1,
+        account1,
+        nowUnixTime,
+        signer1,
+        { from: signer1 }
+      )
+      await assertAttestationNotInStorage(identifier1, issuer1, account1, 0, 0)
+    })
   })
 
   describe('#deleteAttestation', () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -807,7 +807,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
 
     it('should revert if a non-issuer submits an attestation with no signature', async () => {
-      assertRevert(
+      await assertRevert(
         federatedAttestations.registerAttestationAsIssuer(
           identifier1,
           issuer1,

--- a/packages/sdk/utils/src/sign-typed-data-utils.ts
+++ b/packages/sdk/utils/src/sign-typed-data-utils.ts
@@ -43,7 +43,9 @@ export const EIP712_ATOMIC_TYPES = [
   'bytes1',
   'bytes32',
   'uint8',
+  'uint64',
   'uint256',
+  // This list should technically include all types from uint8 to uint256, and int8 to int256
   'int8',
   'int256',
   'bool',
@@ -153,6 +155,7 @@ function findDependencies(primaryType: string, types: EIP712Types, found: string
 
   // If this is not a builtin and is not defined, we cannot correctly construct a type encoding.
   if (types[primaryType] === undefined) {
+    console.log(types)
     throw new Error(`Unrecognized type ${primaryType} is not included in the EIP-712 type list`)
   }
 


### PR DESCRIPTION
### Description

This PR would allow issuers to directly register attestations (with no signature) to the Federated Attestations contract.

### Other changes



### Tested



### Related issues



### Backwards compatibility



### Documentation

