### PR TITLE
Modify lookup functions to include publishedOn

### DIFF
--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -165,10 +165,12 @@ contract FederatedAttestations is
     // TODO reviewers: this is to get around a stack too deep error;
     // are there better ways of dealing with this?
     uint256[] memory countsPerIssuer;
-    (, countsPerIssuer) = getNumAttestations(identifier, trustedIssuers);
+    uint256 totalAttestations;
+    (totalAttestations, countsPerIssuer) = getNumAttestations(identifier, trustedIssuers);
     (address[] memory accounts, address[] memory signers, uint64[] memory issuedOns, uint64[] memory publishedOns) = _lookupAttestations(
       identifier,
-      trustedIssuers
+      trustedIssuers,
+      totalAttestations
     );
     return (countsPerIssuer, accounts, signers, issuedOns, publishedOns);
   }
@@ -187,14 +189,11 @@ contract FederatedAttestations is
    * @dev Adds attestation info to the arrays in order of provided trustedIssuers
    * @dev Expectation that only one attestation exists per (identifier, issuer, account)
    */
-  function _lookupAttestations(bytes32 identifier, address[] memory trustedIssuers)
-    internal
-    view
-    returns (address[] memory, address[] memory, uint64[] memory, uint64[] memory)
-  {
-    uint256 totalAttestations;
-    (totalAttestations, ) = getNumAttestations(identifier, trustedIssuers);
-
+  function _lookupAttestations(
+    bytes32 identifier,
+    address[] memory trustedIssuers,
+    uint256 totalAttestations
+  ) internal view returns (address[] memory, address[] memory, uint64[] memory, uint64[] memory) {
     address[] memory accounts = new address[](totalAttestations);
     address[] memory signers = new address[](totalAttestations);
     uint64[] memory issuedOns = new uint64[](totalAttestations);

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -167,6 +167,7 @@ contract FederatedAttestations is
     uint256[] memory countsPerIssuer;
     uint256 totalAttestations;
     (totalAttestations, countsPerIssuer) = getNumAttestations(identifier, trustedIssuers);
+    // solhint-disable-next-line max-line-length
     (address[] memory accounts, address[] memory signers, uint64[] memory issuedOns, uint64[] memory publishedOns) = _lookupAttestations(
       identifier,
       trustedIssuers,

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -223,7 +223,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
         assert.equal(actualAddresses[index], expectedAttestation.account)
         assert.equal(actualSigners[index], expectedAttestation.signer)
         assert.equal(actualIssuedOns[index].toNumber(), expectedAttestation.issuedOn)
-        assert.isAtMost(Math.abs(actualPublishedOns[index].toNumber() - expectedPublishedOn), 10)
+        assert.isAtLeast(actualPublishedOns[index].toNumber(), actualIssuedOns[index].toNumber())
+        assert.isAtMost(actualPublishedOns[index].toNumber(), expectedPublishedOn + 10)
       })
     }
 
@@ -289,7 +290,6 @@ contract('FederatedAttestations', (accounts: string[]) => {
       beforeEach(async () => {
         // Require consistent order for test cases
         await accountsInstance.createAccount({ from: issuer2 })
-        expectedPublishedOn = Math.floor(Date.now() / 1000)
         for (const { issuer, attestationsPerIssuer } of [
           { issuer: issuer1, attestationsPerIssuer: issuer1Attestations },
           { issuer: issuer2, attestationsPerIssuer: issuer2Attestations },
@@ -304,6 +304,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
             )
           }
         }
+        expectedPublishedOn = Math.floor(Date.now() / 1000)
       })
 
       it('should return empty count and list if no issuers specified', async () => {

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -204,10 +204,12 @@ contract('FederatedAttestations', (accounts: string[]) => {
     const checkAgainstExpectedAttestations = (
       expectedCountsPerIssuer: number[],
       expectedAttestations: AttestationTestCase[],
+      expectedPublishedOn: number,
       actualCountsPerIssuer: BigNumber[],
       actualAddresses: string[],
       actualSigners: string[],
-      actualIssuedOns: BigNumber[]
+      actualIssuedOns: BigNumber[],
+      actualPublishedOns: BigNumber[]
     ) => {
       // purposefully not checking publishedOn, as it is set onchain
       expect(actualCountsPerIssuer.map((count) => count.toNumber())).to.eql(expectedCountsPerIssuer)
@@ -215,11 +217,13 @@ contract('FederatedAttestations', (accounts: string[]) => {
       assert.lengthOf(actualAddresses, expectedAttestations.length)
       assert.lengthOf(actualSigners, expectedAttestations.length)
       assert.lengthOf(actualIssuedOns, expectedAttestations.length)
+      assert.lengthOf(actualPublishedOns, expectedAttestations.length)
 
       expectedAttestations.forEach((expectedAttestation, index) => {
         assert.equal(actualAddresses[index], expectedAttestation.account)
         assert.equal(actualSigners[index], expectedAttestation.signer)
         assert.equal(actualIssuedOns[index].toNumber(), expectedAttestation.issuedOn)
+        assert.isAtMost(Math.abs(actualPublishedOns[index].toNumber() - expectedPublishedOn), 10)
       })
     }
 
@@ -230,8 +234,18 @@ contract('FederatedAttestations', (accounts: string[]) => {
           addresses,
           signers,
           issuedOns,
+          publishedOns,
         ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
-        checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
+        checkAgainstExpectedAttestations(
+          [0],
+          [],
+          0,
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+          publishedOns
+        )
       })
     })
     describe('when identifier has been registered', () => {
@@ -270,9 +284,12 @@ contract('FederatedAttestations', (accounts: string[]) => {
         },
       ]
 
+      let expectedPublishedOn
+
       beforeEach(async () => {
         // Require consistent order for test cases
         await accountsInstance.createAccount({ from: issuer2 })
+        expectedPublishedOn = Math.floor(Date.now() / 1000)
         for (const { issuer, attestationsPerIssuer } of [
           { issuer: issuer1, attestationsPerIssuer: issuer1Attestations },
           { issuer: issuer2, attestationsPerIssuer: issuer2Attestations },
@@ -295,8 +312,18 @@ contract('FederatedAttestations', (accounts: string[]) => {
           addresses,
           signers,
           issuedOns,
+          publishedOns,
         ] = await federatedAttestations.lookupAttestations(identifier1, [])
-        checkAgainstExpectedAttestations([], [], countsPerIssuer, addresses, signers, issuedOns)
+        checkAgainstExpectedAttestations(
+          [],
+          [],
+          0,
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+          publishedOns
+        )
       })
 
       it('should return all attestations from one issuer', async () => {
@@ -305,14 +332,17 @@ contract('FederatedAttestations', (accounts: string[]) => {
           addresses,
           signers,
           issuedOns,
+          publishedOns,
         ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
         checkAgainstExpectedAttestations(
           [issuer1Attestations.length],
           issuer1Attestations,
+          expectedPublishedOn,
           countsPerIssuer,
           addresses,
           signers,
-          issuedOns
+          issuedOns,
+          publishedOns
         )
       })
 
@@ -322,8 +352,18 @@ contract('FederatedAttestations', (accounts: string[]) => {
           addresses,
           signers,
           issuedOns,
+          publishedOns,
         ] = await federatedAttestations.lookupAttestations(identifier1, [issuer3])
-        checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
+        checkAgainstExpectedAttestations(
+          [0],
+          [],
+          0,
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+          publishedOns
+        )
       })
 
       it('should return attestations from multiple issuers in correct order', async () => {
@@ -334,14 +374,17 @@ contract('FederatedAttestations', (accounts: string[]) => {
           addresses,
           signers,
           issuedOns,
+          publishedOns,
         ] = await federatedAttestations.lookupAttestations(identifier1, [issuer3, issuer2, issuer1])
         checkAgainstExpectedAttestations(
           expectedCountsPerIssuer,
           expectedAttestations,
+          expectedPublishedOn,
           countsPerIssuer,
           addresses,
           signers,
-          issuedOns
+          issuedOns,
+          publishedOns
         )
       })
     })
@@ -356,8 +399,18 @@ contract('FederatedAttestations', (accounts: string[]) => {
           addresses,
           signers,
           issuedOns,
+          publishedOns,
         ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
-        checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
+        checkAgainstExpectedAttestations(
+          [0],
+          [],
+          0,
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+          publishedOns
+        )
       })
     })
   })

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -194,7 +194,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
     })
   })
 
-  describe('looking up attestations', () => {
+  describe('#lookupAttestations', () => {
     interface AttestationTestCase {
       account: string
       signer: string
@@ -224,16 +224,14 @@ contract('FederatedAttestations', (accounts: string[]) => {
     }
 
     describe('when identifier has not been registered', () => {
-      describe('#lookupAttestations', () => {
-        it('should return empty list', async () => {
-          const [
-            countsPerIssuer,
-            addresses,
-            signers,
-            issuedOns,
-          ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
-          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
-        })
+      it('should return empty list', async () => {
+        const [
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+        ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
+        checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
       })
     })
     describe('when identifier has been registered', () => {
@@ -291,75 +289,80 @@ contract('FederatedAttestations', (accounts: string[]) => {
         }
       })
 
-      describe('#lookupAttestations', () => {
-        it('should return empty count and list if no issuers specified', async () => {
-          const [
-            countsPerIssuer,
-            addresses,
-            signers,
-            issuedOns,
-          ] = await federatedAttestations.lookupAttestations(identifier1, [])
-          checkAgainstExpectedAttestations([], [], countsPerIssuer, addresses, signers, issuedOns)
-        })
+      it('should return empty count and list if no issuers specified', async () => {
+        const [
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+        ] = await federatedAttestations.lookupAttestations(identifier1, [])
+        checkAgainstExpectedAttestations([], [], countsPerIssuer, addresses, signers, issuedOns)
+      })
 
-        it('should return all attestations from one issuer', async () => {
-          const [
-            countsPerIssuer,
-            addresses,
-            signers,
-            issuedOns,
-          ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
-          checkAgainstExpectedAttestations(
-            [issuer1Attestations.length],
-            issuer1Attestations,
-            countsPerIssuer,
-            addresses,
-            signers,
-            issuedOns
-          )
-        })
+      it('should return all attestations from one issuer', async () => {
+        const [
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+        ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
+        checkAgainstExpectedAttestations(
+          [issuer1Attestations.length],
+          issuer1Attestations,
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns
+        )
+      })
 
-        it('should return empty list if no attestations exist for an issuer', async () => {
-          const [
-            countsPerIssuer,
-            addresses,
-            signers,
-            issuedOns,
-          ] = await federatedAttestations.lookupAttestations(identifier1, [issuer3])
-          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
-        })
+      it('should return empty list if no attestations exist for an issuer', async () => {
+        const [
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+        ] = await federatedAttestations.lookupAttestations(identifier1, [issuer3])
+        checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
+      })
 
-        it('should return attestations from multiple issuers in correct order', async () => {
-          const expectedAttestations = issuer2Attestations.concat(issuer1Attestations)
-          const expectedCountsPerIssuer = [
-            0,
-            issuer2Attestations.length,
-            issuer1Attestations.length,
-          ]
-          const [
-            countsPerIssuer,
-            addresses,
-            signers,
-            issuedOns,
-          ] = await federatedAttestations.lookupAttestations(identifier1, [
-            issuer3,
-            issuer2,
-            issuer1,
-          ])
-          checkAgainstExpectedAttestations(
-            expectedCountsPerIssuer,
-            expectedAttestations,
-            countsPerIssuer,
-            addresses,
-            signers,
-            issuedOns
-          )
-        })
+      it('should return attestations from multiple issuers in correct order', async () => {
+        const expectedAttestations = issuer2Attestations.concat(issuer1Attestations)
+        const expectedCountsPerIssuer = [0, issuer2Attestations.length, issuer1Attestations.length]
+        const [
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+        ] = await federatedAttestations.lookupAttestations(identifier1, [issuer3, issuer2, issuer1])
+        checkAgainstExpectedAttestations(
+          expectedCountsPerIssuer,
+          expectedAttestations,
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns
+        )
+      })
+    })
+    describe('when identifier has been registered and then revoked', () => {
+      beforeEach(async () => {
+        await signAndRegisterAttestation(identifier1, issuer1, account1, nowUnixTime, signer1)
+        await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
+      })
+      it('should return empty list', async () => {
+        const [
+          countsPerIssuer,
+          addresses,
+          signers,
+          issuedOns,
+        ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
+        checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
       })
     })
   })
 
-  describe('looking up identifiers', () => {
+  describe('#lookupIdentifiers', () => {
     interface IdentifierTestCase {
       identifier: string
       signer: string
@@ -376,14 +379,12 @@ contract('FederatedAttestations', (accounts: string[]) => {
     }
 
     describe('when address has not been registered', () => {
-      describe('#lookupIdentifiers', () => {
-        it('should return empty list', async () => {
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1])
-          checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
-        })
+      it('should return empty list', async () => {
+        const [
+          actualCountsPerIssuer,
+          actualIdentifiers,
+        ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1])
+        checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
       })
     })
 
@@ -433,50 +434,61 @@ contract('FederatedAttestations', (accounts: string[]) => {
         }
       })
 
-      describe('#lookupIdentifiers', () => {
-        it('should return empty count if no issuers specified', async () => {
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupIdentifiers(account1, [])
-          checkAgainstExpectedIdCases([], [], actualCountsPerIssuer, actualIdentifiers)
-        })
+      it('should return empty count if no issuers specified', async () => {
+        const [
+          actualCountsPerIssuer,
+          actualIdentifiers,
+        ] = await federatedAttestations.lookupIdentifiers(account1, [])
+        checkAgainstExpectedIdCases([], [], actualCountsPerIssuer, actualIdentifiers)
+      })
 
-        it('should return all identifiers from one issuer', async () => {
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1])
-          checkAgainstExpectedIdCases(
-            [issuer1IdCases.length],
-            issuer1IdCases,
-            actualCountsPerIssuer,
-            actualIdentifiers
-          )
-        })
+      it('should return all identifiers from one issuer', async () => {
+        const [
+          actualCountsPerIssuer,
+          actualIdentifiers,
+        ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1])
+        checkAgainstExpectedIdCases(
+          [issuer1IdCases.length],
+          issuer1IdCases,
+          actualCountsPerIssuer,
+          actualIdentifiers
+        )
+      })
 
-        it('should return empty list if no identifiers exist for an (issuer,address)', async () => {
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupIdentifiers(account1, [issuer3])
-          checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
-        })
+      it('should return empty list if no identifiers exist for an (issuer,address)', async () => {
+        const [
+          actualCountsPerIssuer,
+          actualIdentifiers,
+        ] = await federatedAttestations.lookupIdentifiers(account1, [issuer3])
+        checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
+      })
 
-        it('should return identifiers from multiple issuers in correct order', async () => {
-          const expectedIdCases = issuer2IdCases.concat(issuer1IdCases)
-          const expectedCountsPerIssuer = [0, issuer2IdCases.length, issuer1IdCases.length]
-          const [
-            actualCountsPerIssuer,
-            actualIdentifiers,
-          ] = await federatedAttestations.lookupIdentifiers(account1, [issuer3, issuer2, issuer1])
-          checkAgainstExpectedIdCases(
-            expectedCountsPerIssuer,
-            expectedIdCases,
-            actualCountsPerIssuer,
-            actualIdentifiers
-          )
-        })
+      it('should return identifiers from multiple issuers in correct order', async () => {
+        const expectedIdCases = issuer2IdCases.concat(issuer1IdCases)
+        const expectedCountsPerIssuer = [0, issuer2IdCases.length, issuer1IdCases.length]
+        const [
+          actualCountsPerIssuer,
+          actualIdentifiers,
+        ] = await federatedAttestations.lookupIdentifiers(account1, [issuer3, issuer2, issuer1])
+        checkAgainstExpectedIdCases(
+          expectedCountsPerIssuer,
+          expectedIdCases,
+          actualCountsPerIssuer,
+          actualIdentifiers
+        )
+      })
+    })
+    describe('when identifier has been registered and then revoked', () => {
+      beforeEach(async () => {
+        await signAndRegisterAttestation(identifier1, issuer1, account1, nowUnixTime, signer1)
+        await federatedAttestations.revokeAttestation(identifier1, issuer1, account1)
+      })
+      it('should return empty list', async () => {
+        const [
+          actualCountsPerIssuer,
+          actualIdentifiers,
+        ] = await federatedAttestations.lookupIdentifiers(account1, [issuer1])
+        checkAgainstExpectedIdCases([0], [], actualCountsPerIssuer, actualIdentifiers)
       })
     })
   })

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -197,8 +197,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
   describe('looking up attestations', () => {
     interface AttestationTestCase {
       account: string
-      issuedOn: number
       signer: string
+      issuedOn: number
     }
 
     const checkAgainstExpectedAttestations = (
@@ -206,19 +206,20 @@ contract('FederatedAttestations', (accounts: string[]) => {
       expectedAttestations: AttestationTestCase[],
       actualCountsPerIssuer: BigNumber[],
       actualAddresses: string[],
-      actualIssuedOns: BigNumber[],
-      actualSigners: string[]
+      actualSigners: string[],
+      actualIssuedOns: BigNumber[]
     ) => {
+      // purposefully not checking publishedOn, as it is set onchain
       expect(actualCountsPerIssuer.map((count) => count.toNumber())).to.eql(expectedCountsPerIssuer)
 
       assert.lengthOf(actualAddresses, expectedAttestations.length)
-      assert.lengthOf(actualIssuedOns, expectedAttestations.length)
       assert.lengthOf(actualSigners, expectedAttestations.length)
+      assert.lengthOf(actualIssuedOns, expectedAttestations.length)
 
       expectedAttestations.forEach((expectedAttestation, index) => {
         assert.equal(actualAddresses[index], expectedAttestation.account)
-        assert.equal(actualIssuedOns[index].toNumber(), expectedAttestation.issuedOn)
         assert.equal(actualSigners[index], expectedAttestation.signer)
+        assert.equal(actualIssuedOns[index].toNumber(), expectedAttestation.issuedOn)
       })
     }
 
@@ -228,10 +229,10 @@ contract('FederatedAttestations', (accounts: string[]) => {
           const [
             countsPerIssuer,
             addresses,
-            issuedOns,
             signers,
+            issuedOns,
           ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
-          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, issuedOns, signers)
+          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
         })
       })
     })
@@ -246,28 +247,28 @@ contract('FederatedAttestations', (accounts: string[]) => {
       const issuer1Attestations: AttestationTestCase[] = [
         {
           account: account1,
-          issuedOn: nowUnixTime,
           signer: signer1,
+          issuedOn: nowUnixTime,
         },
         // Same issuer as [0], different account
         {
           account: account2,
-          issuedOn: nowUnixTime,
           signer: signer1,
+          issuedOn: nowUnixTime,
         },
       ]
       const issuer2Attestations: AttestationTestCase[] = [
         // Same account as issuer1Attestations[0], different issuer
         {
           account: account1,
-          issuedOn: nowUnixTime,
           signer: issuer2Signer,
+          issuedOn: nowUnixTime,
         },
         // Different account and signer
         {
           account: account2,
-          issuedOn: nowUnixTime,
           signer: issuer2Signer2,
+          issuedOn: nowUnixTime,
         },
       ]
 
@@ -295,26 +296,26 @@ contract('FederatedAttestations', (accounts: string[]) => {
           const [
             countsPerIssuer,
             addresses,
-            issuedOns,
             signers,
+            issuedOns,
           ] = await federatedAttestations.lookupAttestations(identifier1, [])
-          checkAgainstExpectedAttestations([], [], countsPerIssuer, addresses, issuedOns, signers)
+          checkAgainstExpectedAttestations([], [], countsPerIssuer, addresses, signers, issuedOns)
         })
 
         it('should return all attestations from one issuer', async () => {
           const [
             countsPerIssuer,
             addresses,
-            issuedOns,
             signers,
+            issuedOns,
           ] = await federatedAttestations.lookupAttestations(identifier1, [issuer1])
           checkAgainstExpectedAttestations(
             [issuer1Attestations.length],
             issuer1Attestations,
             countsPerIssuer,
             addresses,
-            issuedOns,
-            signers
+            signers,
+            issuedOns
           )
         })
 
@@ -322,10 +323,10 @@ contract('FederatedAttestations', (accounts: string[]) => {
           const [
             countsPerIssuer,
             addresses,
-            issuedOns,
             signers,
+            issuedOns,
           ] = await federatedAttestations.lookupAttestations(identifier1, [issuer3])
-          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, issuedOns, signers)
+          checkAgainstExpectedAttestations([0], [], countsPerIssuer, addresses, signers, issuedOns)
         })
 
         it('should return attestations from multiple issuers in correct order', async () => {
@@ -338,8 +339,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
           const [
             countsPerIssuer,
             addresses,
-            issuedOns,
             signers,
+            issuedOns,
           ] = await federatedAttestations.lookupAttestations(identifier1, [
             issuer3,
             issuer2,
@@ -350,8 +351,8 @@ contract('FederatedAttestations', (accounts: string[]) => {
             expectedAttestations,
             countsPerIssuer,
             addresses,
-            issuedOns,
-            signers
+            signers,
+            issuedOns
           )
         })
       })


### PR DESCRIPTION
### Description

Update the lookup functions to include `publishedOn`. Adding on the extra parameter resulted in a `stack too deep` error, so `countsPerIssuer` was abstracted out of `_lookupAttestations` into `lookupAttestations`

The lookups functions are also compatible with the individual revocation updates, as they no longer check signer revocation status, and separate functions for revoked/unrevoked lookups no longer exist. In the new paradigm, revoked attestations are deleted from onchain storage, so the lookup functions can assume that all stored attestations are not revoked

### Tested

Tests were updated to match contract changes

### Related issues

- Fixes #9597 