### PR TITLE
Slow down scale down of Blockscout web and api pods

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.autoscale.yaml
@@ -21,7 +21,7 @@ spec:
         averageUtilization: {{ .Values.blockscout.api.autoscaling.target.cpu }}
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 600
+      stabilizationWindowSeconds: 3600
       policies:
       - type: Percent
         value: 20

--- a/packages/helm-charts/blockscout/templates/blockscout-web.autoscale.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.autoscale.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-web
@@ -16,4 +16,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.blockscout.web.autoscaling.target.cpu }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.blockscout.web.autoscaling.target.cpu }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 3600


### PR DESCRIPTION
### Description

Down remove hpa web and api pods for 1h after creation.
This will help reduce flapping and spending time initialising the pods, especially DB operations, at the tradeoff of a lower utilisation and hence more resource waste.

### Other changes

N/A

### Tested

`celotooljs deploy upgrade blockscout -e rc1staging --tag <current-version> --verbose --helmdryrun` produces the expected diff for the hpa configuration (plus not yet deployed changes)

### Related issues

N/A