### PR TITLE
Hotfix: disable empty blocks sanitizer

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -89,6 +89,8 @@ spec:
           value: {{ .Values.blockscout.indexer.pool_size | quote }}
         - name: METRICS_ENABLED
           value: "{{.Values.blockscout.metrics.enabled}}"
+        - name: INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER
+          value: "true"
 {{ include "celo.blockscout-env-vars" . | indent 8 }}
 {{- $data := dict "Values" .Values "Database" .Values.blockscout.indexer.db }}
 {{ include "celo.blockscout-db-sidecar" $data | indent 6 }}


### PR DESCRIPTION
### Description

We need to disable empty blocks sanitizer because it causes load issues.