### PR TITLE
[ASv2] update attestation hash

### DIFF
--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -44,7 +44,8 @@ contract FederatedAttestations is
   mapping(bytes32 => bool) public revokedAttestations;
 
   bytes32 public constant EIP712_OWNERSHIP_ATTESTATION_TYPEHASH = keccak256(
-    "OwnershipAttestation(bytes32 identifier,address issuer,address account,address signer,uint64 issuedOn)"
+    "OwnershipAttestation(bytes32 identifier,address issuer,\
+    address account,address signer,uint64 issuedOn)"
   );
   bytes32 public eip712DomainSeparator;
 

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -44,8 +44,10 @@ contract FederatedAttestations is
   mapping(bytes32 => bool) public revokedAttestations;
 
   bytes32 public constant EIP712_OWNERSHIP_ATTESTATION_TYPEHASH = keccak256(
-    "OwnershipAttestation(bytes32 identifier,address issuer,\
-    address account,address signer,uint64 issuedOn)"
+    abi.encodePacked(
+      "OwnershipAttestation(bytes32 identifier,address issuer,",
+      "address account,address signer,uint64 issuedOn)"
+    )
   );
   bytes32 public eip712DomainSeparator;
 

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -291,9 +291,7 @@ contract FederatedAttestations is
       getAccounts().attestationSignerToAccount(signer) == issuer,
       "Signer is not a currently authorized AttestationSigner for the issuer"
     );
-    bytes32 structHash = keccak256(
-      abi.encode(EIP712_OWNERSHIP_ATTESTATION_TYPEHASH, identifier, issuer, account, issuedOn)
-    );
+    bytes32 structHash = getUniqueAttestationHash(identifier, issuer, account, issuedOn);
     address guessedSigner = Signatures.getSignerOfTypedDataHash(
       eip712DomainSeparator,
       structHash,
@@ -308,10 +306,12 @@ contract FederatedAttestations is
     bytes32 identifier,
     address issuer,
     address account,
-    address signer,
     uint64 issuedOn
   ) public pure returns (bytes32) {
-    return keccak256(abi.encode(identifier, issuer, account, signer, issuedOn));
+    return
+      keccak256(
+        abi.encode(EIP712_OWNERSHIP_ATTESTATION_TYPEHASH, identifier, issuer, account, issuedOn)
+      );
   }
 
   /**
@@ -405,7 +405,7 @@ contract FederatedAttestations is
     uint64 issuedOn
   ) private {
     require(
-      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn)],
+      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, issuedOn)],
       "Attestation has been revoked"
     );
     for (uint256 i = 0; i < identifierToAttestations[identifier][issuer].length; i = i.add(1)) {
@@ -474,7 +474,6 @@ contract FederatedAttestations is
         identifier,
         issuer,
         account,
-        attestation.signer,
         attestation.issuedOn
       );
       revokedAttestations[attestationHash] = true;

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -482,7 +482,7 @@ contract FederatedAttestations is
         identifier,
         issuer,
         account,
-        signer,
+        attestation.signer,
         attestation.issuedOn
       );
       revokedAttestations[attestationHash] = true;

--- a/packages/protocol/contracts/identity/FederatedAttestations.sol
+++ b/packages/protocol/contracts/identity/FederatedAttestations.sol
@@ -44,7 +44,7 @@ contract FederatedAttestations is
   mapping(bytes32 => bool) public revokedAttestations;
 
   bytes32 public constant EIP712_OWNERSHIP_ATTESTATION_TYPEHASH = keccak256(
-    "OwnershipAttestation(bytes32 identifier,address issuer,address account,uint64 issuedOn)"
+    "OwnershipAttestation(bytes32 identifier,address issuer,address account,address signer,uint64 issuedOn)"
   );
   bytes32 public eip712DomainSeparator;
 
@@ -291,7 +291,7 @@ contract FederatedAttestations is
       getAccounts().attestationSignerToAccount(signer) == issuer,
       "Signer is not a currently authorized AttestationSigner for the issuer"
     );
-    bytes32 structHash = getUniqueAttestationHash(identifier, issuer, account, issuedOn);
+    bytes32 structHash = getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn);
     address guessedSigner = Signatures.getSignerOfTypedDataHash(
       eip712DomainSeparator,
       structHash,
@@ -306,11 +306,19 @@ contract FederatedAttestations is
     bytes32 identifier,
     address issuer,
     address account,
+    address signer,
     uint64 issuedOn
   ) public pure returns (bytes32) {
     return
       keccak256(
-        abi.encode(EIP712_OWNERSHIP_ATTESTATION_TYPEHASH, identifier, issuer, account, issuedOn)
+        abi.encode(
+          EIP712_OWNERSHIP_ATTESTATION_TYPEHASH,
+          identifier,
+          issuer,
+          account,
+          signer,
+          issuedOn
+        )
       );
   }
 
@@ -405,7 +413,7 @@ contract FederatedAttestations is
     uint64 issuedOn
   ) private {
     require(
-      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, issuedOn)],
+      !revokedAttestations[getUniqueAttestationHash(identifier, issuer, account, signer, issuedOn)],
       "Attestation has been revoked"
     );
     for (uint256 i = 0; i < identifierToAttestations[identifier][issuer].length; i = i.add(1)) {
@@ -474,6 +482,7 @@ contract FederatedAttestations is
         identifier,
         issuer,
         account,
+        signer,
         attestation.issuedOn
       );
       revokedAttestations[attestationHash] = true;

--- a/packages/protocol/lib/fed-attestations-utils.ts
+++ b/packages/protocol/lib/fed-attestations-utils.ts
@@ -8,6 +8,7 @@ export interface AttestationDetails{
   identifier: string,
   issuer: string,
   account: string,
+  signer: string,
   issuedOn: number,
 }
 
@@ -24,6 +25,7 @@ const getTypedData = (chainId: number, contractAddress: Address, message?: Attes
           { name: 'identifier', type: 'bytes32' },
           { name: 'issuer', type: 'address'},
           { name: 'account', type: 'address' },
+          { name: 'signer', type: 'address' },
           { name: 'issuedOn', type: 'uint64' },
       ],
     },
@@ -48,7 +50,7 @@ export const getSignatureForAttestation = async (
   chainId: number,
   contractAddress: string
 ) => {
-  const typedData = getTypedData(chainId, contractAddress, { identifier,issuer,account, issuedOn})
+  const typedData = getTypedData(chainId, contractAddress, { identifier,issuer,account, signer, issuedOn})
 
   const signature = await new Promise<string>((resolve, reject) => {
     web3.currentProvider.send(

--- a/packages/protocol/test/identity/federatedattestations.ts
+++ b/packages/protocol/test/identity/federatedattestations.ts
@@ -197,7 +197,7 @@ contract('FederatedAttestations', (accounts: string[]) => {
   describe('#EIP712_OWNERSHIP_ATTESTATION_TYPEHASH()', () => {
     it('should have set the right typehash', async () => {
       const expectedTypehash = keccak256(
-        'OwnershipAttestation(bytes32 identifier,address issuer,address account,uint64 issuedOn)'
+        'OwnershipAttestation(bytes32 identifier,address issuer,address account,address signer,uint64 issuedOn)'
       )
       assert.equal(
         await federatedAttestations.EIP712_OWNERSHIP_ATTESTATION_TYPEHASH(),


### PR DESCRIPTION
### Description
Using EIP712 hash to compute the unique attestation hash, as per [Victor's comment](https://github.com/celo-org/celo-monorepo/pull/9560#discussion_r903147943)