### PR TITLE
Change bitnami's helm chart repository.

### DIFF
--- a/packages/helm-charts/eksportisto/Chart.yaml
+++ b/packages/helm-charts/eksportisto/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
 dependencies:
 - name: redis
   version: 12.8.3
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami


### PR DESCRIPTION
### Description

Change bitnami's helm chart repository to the archived version, supporting old charts (as per https://github.com/bitnami/charts/issues/10539).

### Tested

Used to deploy rc1 eksportisto.