### PR TITLE
Checkout correct migrationConfig in check-versions

### DIFF
--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -44,8 +44,14 @@ OLD_BRANCH_BUILD_DIR=$BUILD_DIR
 build_tag $NEW_BRANCH $LOG_FILE
 NEW_BRANCH_BUILD_DIR=$BUILD_DIR
 
+# check-backward script uses migrationsConfig
+echo " - Checkout migrationsConfig.js at $NEW_BRANCH"
+git checkout $NEW_BRANCH -- migrationsConfig.js
+
 yarn ts-node scripts/check-backward.ts sem_check \
   --old_contracts $OLD_BRANCH_BUILD_DIR/contracts \
   --new_contracts $NEW_BRANCH_BUILD_DIR/contracts \
   --exclude $CONTRACT_EXCLUSION_REGEX \
   $REPORT_FLAG
+
+git checkout - -- migrationsConfig.js


### PR DESCRIPTION
When the old & new releases are being compared, it uses the migrationConfig from the new release to do the linked library checks. Previously, it just used the `migrationsConfig` at the branch HEAD, which caused (when adding a new contract that used the Signatures library) the checks to fail in earlier releases since it looked for contracts that weren't included in those releases.

(Looks like this may have been done before [this PR](https://github.com/celo-org/celo-monorepo/pull/7309/files) anyways, and was perhaps accidentally removed.)