### PR TITLE
Make cache paths relative to root

### DIFF
--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -16,13 +16,13 @@ jobs:
         id: foundry-cache
         uses: actions/cache@v3
         with:
-          path: ./cache
+          path: packages/protocol/cache
           key: ${{ runner.os }}-foundry-cache
       - name: Foundry out
         id: foundry-out
         uses: actions/cache@v3
         with:
-          path: ./out
+          path: packages/protocol/out
           key: ${{ runner.os }}-foundry-out
 
       - name: Install Foundry


### PR DESCRIPTION
### Description

The configuration for CI caching was wrong, resulting in this error:
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/304771/177504478-c2c3321f-02ca-4c44-8415-480cc062164e.png">

This was because the path was given relative to the current working dir, but should have been relative to the repo root.

Adding the `cache` shaves another ±20s off the CI time 🎉 .

### Other changes

`noop`

### Tested

`noop`

### Related issues

`noop`

### Backwards compatibility

`noop`

### Documentation

`noop`