### PR TITLE
Fix azure oracle deployment.

### DIFF
--- a/packages/celotool/src/lib/azure.ts
+++ b/packages/celotool/src/lib/azure.ts
@@ -108,7 +108,7 @@ export async function getAKSServicePrincipalObjectId(clusterConfig: AksClusterCo
     return ''
   }
   const [rawObjectId] = await execCmdWithExitOnFailure(
-    `az ad sp show --id ${servicePrincipalClientId} --query objectId -o tsv`
+    `az ad sp show --id ${servicePrincipalClientId} --query id -o tsv`
   )
   return rawObjectId.trim()
 }


### PR DESCRIPTION
### Description

Azure CLI has been updated to support Microsoft's Graph Query API (https://github.com/Azure/azure-cli/issues/12946), and the old "az ad sp show" query no longer works.

### Tested

Deployed to baklava (centralus).

### Backwards compatibility

The new query is not backwards compatible, but the old API is no longer available.