### PR TITLE
Add Payment Delegation Commands to CLI

### DIFF
--- a/packages/cli/src/commands/account/delete-payment-delegation.ts
+++ b/packages/cli/src/commands/account/delete-payment-delegation.ts
@@ -1,0 +1,17 @@
+import { BaseCommand } from '../../base'
+
+export default class DeletePaymentDelegation extends BaseCommand {
+  static description =
+    "Removes a validator's payment delegation by setting benficiary and fraction to 0."
+
+  static examples = ['delete-payment-delegation']
+
+  async run() {
+    //const res = this.parse(DeletePaymentDelegation);
+    const accounts = await this.kit.contracts.getAccounts()
+
+    await accounts.deletePaymentDelegation()
+
+    console.log('Deleted payment delegation.')
+  }
+}

--- a/packages/cli/src/commands/account/delete-payment-delegation.ts
+++ b/packages/cli/src/commands/account/delete-payment-delegation.ts
@@ -1,16 +1,29 @@
 import { BaseCommand } from '../../base'
+import { displaySendTx } from '../../utils/cli'
+import { Flags } from '../../utils/command'
 
 export default class DeletePaymentDelegation extends BaseCommand {
   static description =
     "Removes a validator's payment delegation by setting benficiary and fraction to 0."
 
-  static examples = ['delete-payment-delegation']
+  static flags = {
+    ...BaseCommand.flags,
+    account: Flags.address({ required: true }),
+  }
+
+  static args = []
+
+  static examples = [
+    'delete-payment-delegation --account 0x5409ED021D9299bf6814279A6A1411A7e866A631',
+  ]
 
   async run() {
-    //const res = this.parse(DeletePaymentDelegation);
+    const res = this.parse(DeletePaymentDelegation)
+    this.kit.defaultAccount = res.flags.account
     const accounts = await this.kit.contracts.getAccounts()
 
-    await accounts.deletePaymentDelegation()
+    // await accounts.deletePaymentDelegation()
+    await displaySendTx('deletePaymentDelegation', accounts.deletePaymentDelegation())
 
     console.log('Deleted payment delegation.')
   }

--- a/packages/cli/src/commands/account/delete-payment-delegation.ts
+++ b/packages/cli/src/commands/account/delete-payment-delegation.ts
@@ -22,7 +22,6 @@ export default class DeletePaymentDelegation extends BaseCommand {
     this.kit.defaultAccount = res.flags.account
     const accounts = await this.kit.contracts.getAccounts()
 
-    // await accounts.deletePaymentDelegation()
     await displaySendTx('deletePaymentDelegation', accounts.deletePaymentDelegation())
 
     console.log('Deleted payment delegation.')

--- a/packages/cli/src/commands/account/get-payment-delegation.ts
+++ b/packages/cli/src/commands/account/get-payment-delegation.ts
@@ -1,0 +1,33 @@
+import BigNumber from 'bignumber.js'
+import { cli } from 'cli-ux'
+import { BaseCommand } from '../../base'
+import { Flags } from '../../utils/command'
+
+export default class GetPaymentDelegation extends BaseCommand {
+  static description =
+    "Get the payment delegation account beneficiary and fraction allocated from a validator's payment each epoch. The fraction is given as FixidityLib value and cannot be greater than 1."
+
+  static flags = {
+    ...BaseCommand.flags,
+    account: Flags.address({ required: true }),
+    ...(cli.table.flags() as object),
+  }
+
+  static args = []
+
+  static examples = ['get-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631']
+
+  async run() {
+    const res = this.parse(GetPaymentDelegation)
+    this.kit.defaultAccount = res.flags.account
+    const accounts = await this.kit.contracts.getAccounts()
+
+    console.log('Payment delegation beneficiary and fraction are: \n')
+    const retval = await accounts.getPaymentDelegation(res.flags.account)
+
+    const beneficiary = retval[0]
+    const fraction = new BigNumber(retval[1]).shiftedBy(-24).toNumber()
+
+    console.log(beneficiary, fraction)
+  }
+}

--- a/packages/cli/src/commands/account/get-payment-delegation.ts
+++ b/packages/cli/src/commands/account/get-payment-delegation.ts
@@ -5,7 +5,7 @@ import { Flags } from '../../utils/command'
 
 export default class GetPaymentDelegation extends BaseCommand {
   static description =
-    "Get the payment delegation account beneficiary and fraction allocated from a validator's payment each epoch. The fraction is given as FixidityLib value and cannot be greater than 1."
+    "Get the payment delegation account beneficiary and fraction allocated from a validator's payment each epoch. The fraction cannot be greater than 1."
 
   static flags = {
     ...BaseCommand.flags,

--- a/packages/cli/src/commands/account/get-payment-delegation.ts
+++ b/packages/cli/src/commands/account/get-payment-delegation.ts
@@ -26,6 +26,8 @@ export default class GetPaymentDelegation extends BaseCommand {
     const retval = await accounts.getPaymentDelegation(res.flags.account)
 
     const beneficiary = retval[0]
+
+    // translate fixidity value to human readable fraction
     const fraction = new BigNumber(retval[1]).shiftedBy(-24).toNumber()
 
     console.log(beneficiary, fraction)

--- a/packages/cli/src/commands/account/set-payment-delegation.ts
+++ b/packages/cli/src/commands/account/set-payment-delegation.ts
@@ -1,0 +1,35 @@
+import { valueToFixidityString } from '@celo/contractkit/src/wrappers/BaseWrapper'
+import { flags } from '@oclif/command'
+import { BaseCommand } from '../../base'
+import { newCheckBuilder } from '../../utils/checks'
+import { displaySendTx } from '../../utils/cli'
+import { Flags } from '../../utils/command'
+
+export default class SetPaymentDelegation extends BaseCommand {
+  static description =
+    "Sets a payment delegation beneficiary, an account address to receive a fraction of the validator's payment every epoch. The fraction is given as FixidityLib value and must not be greater than 1."
+
+  static flags = {
+    ...BaseCommand.flags,
+    beneficiary: Flags.address({ required: true }),
+    fraction: flags.string({ required: true }),
+  }
+
+  static args = []
+
+  static examples = [
+    'set-payment-delegation --beneficiary 0x5409ed021d9299bf6814279a6a1411a7e866a631 --fraction 0.1',
+  ]
+
+  async run() {
+    const res = this.parse(SetPaymentDelegation)
+    this.kit.defaultAccount = res.flags.beneficiary
+    const accounts = await this.kit.contracts.getAccounts()
+
+    await newCheckBuilder(this).isAccount(res.flags.beneficiary).runChecks()
+    await displaySendTx(
+      'setPaymentDelegation',
+      accounts.setPaymentDelgation(res.flags.beneficiary, valueToFixidityString(res.flags.fraction))
+    )
+  }
+}

--- a/packages/cli/src/commands/account/set-payment-delegation.ts
+++ b/packages/cli/src/commands/account/set-payment-delegation.ts
@@ -11,6 +11,7 @@ export default class SetPaymentDelegation extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flags,
+    account: Flags.address({ required: true }),
     beneficiary: Flags.address({ required: true }),
     fraction: flags.string({ required: true }),
   }
@@ -18,18 +19,21 @@ export default class SetPaymentDelegation extends BaseCommand {
   static args = []
 
   static examples = [
-    'set-payment-delegation --beneficiary 0x5409ed021d9299bf6814279a6a1411a7e866a631 --fraction 0.1',
+    'set-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --beneficiary 0x5409ed021d9299bf6814279a6a1411a7e866a631 --fraction 0.1',
   ]
 
   async run() {
     const res = this.parse(SetPaymentDelegation)
-    this.kit.defaultAccount = res.flags.beneficiary
+    this.kit.defaultAccount = res.flags.account
     const accounts = await this.kit.contracts.getAccounts()
 
     await newCheckBuilder(this).isAccount(res.flags.beneficiary).runChecks()
     await displaySendTx(
       'setPaymentDelegation',
-      accounts.setPaymentDelgation(res.flags.beneficiary, valueToFixidityString(res.flags.fraction))
+      accounts.setPaymentDelegation(
+        res.flags.beneficiary,
+        valueToFixidityString(res.flags.fraction)
+      )
     )
   }
 }

--- a/packages/cli/src/commands/account/set-payment-delegation.ts
+++ b/packages/cli/src/commands/account/set-payment-delegation.ts
@@ -19,7 +19,7 @@ export default class SetPaymentDelegation extends BaseCommand {
   static args = []
 
   static examples = [
-    'set-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --beneficiary 0x5409ed021d9299bf6814279a6a1411a7e866a631 --fraction 0.1',
+    'set-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --beneficiary 0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb --fraction 0.1',
   ]
 
   async run() {

--- a/packages/cli/src/commands/account/set-payment-delegation.ts
+++ b/packages/cli/src/commands/account/set-payment-delegation.ts
@@ -7,7 +7,7 @@ import { Flags } from '../../utils/command'
 
 export default class SetPaymentDelegation extends BaseCommand {
   static description =
-    "Sets a payment delegation beneficiary, an account address to receive a fraction of the validator's payment every epoch. The fraction is given as FixidityLib value and must not be greater than 1."
+    "Sets a payment delegation beneficiary, an account address to receive a fraction of the validator's payment every epoch. The fraction must not be greater than 1."
 
   static flags = {
     ...BaseCommand.flags,

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -324,6 +324,26 @@ EXAMPLE
 
 _See code: [src/commands/account/deauthorize.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/deauthorize.ts)_
 
+## `celocli account:delete-payment-delegation`
+
+Removes a validator's payment delegation by setting benficiary and fraction to 0.
+
+```
+Removes a validator's payment delegation by setting benficiary and fraction to 0.
+
+USAGE
+  $ celocli account:delete-payment-delegation
+
+OPTIONS
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
+  --globalHelp                                          View all available global flags
+
+EXAMPLE
+  delete-payment-delegation --account 0x5409ED021D9299bf6814279A6A1411A7e866A631
+```
+
+_See code: [src/commands/account/delete-payment-delegation.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/delete-payment-delegation.ts)_
+
 ## `celocli account:get-metadata ADDRESS`
 
 Show information about an address. Retreives the metadata URL for an account from the on-chain, then fetches the metadata file off-chain and verifies proofs as able.
@@ -353,6 +373,48 @@ EXAMPLE
 ```
 
 _See code: [src/commands/account/get-metadata.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/get-metadata.ts)_
+
+## `celocli account:get-payment-delegation`
+
+Get the payment delegation account beneficiary and fraction allocated from a validator's payment each epoch. The fraction cannot be greater than 1.
+
+```
+Get the payment delegation account beneficiary and fraction allocated from a validator's payment each epoch. The fraction cannot be greater than 1.
+
+USAGE
+  $ celocli account:get-payment-delegation
+
+OPTIONS
+  -x, --extended                                        show extra columns
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
+
+  --columns=columns                                     only show provided columns
+                                                        (comma-separated)
+
+  --csv                                                 output is csv format [alias:
+                                                        --output=csv]
+
+  --filter=filter                                       filter property by partial
+                                                        string matching, ex: name=foo
+
+  --globalHelp                                          View all available global flags
+
+  --no-header                                           hide table header from output
+
+  --no-truncate                                         do not truncate output to fit
+                                                        screen
+
+  --output=csv|json|yaml                                output in a more machine
+                                                        friendly format
+
+  --sort=sort                                           property to sort by (prepend '-'
+                                                        for descending)
+
+EXAMPLE
+  get-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631
+```
+
+_See code: [src/commands/account/get-payment-delegation.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/get-payment-delegation.ts)_
 
 ## `celocli account:list`
 
@@ -728,6 +790,31 @@ EXAMPLE
 ```
 
 _See code: [src/commands/account/set-name.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/set-name.ts)_
+
+## `celocli account:set-payment-delegation`
+
+Sets a payment delegation beneficiary, an account address to receive a fraction of the validator's payment every epoch. The fraction must not be greater than 1.
+
+```
+Sets a payment delegation beneficiary, an account address to receive a fraction of the validator's payment every epoch. The fraction must not be greater than 1.
+
+USAGE
+  $ celocli account:set-payment-delegation
+
+OPTIONS
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
+  --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
+  --fraction=fraction                                       (required)
+
+  --globalHelp                                              View all available global
+                                                            flags
+
+EXAMPLE
+  set-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631
+  --beneficiary 0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb --fraction 0.1
+```
+
+_See code: [src/commands/account/set-payment-delegation.ts](https://github.com/celo-org/celo-monorepo/tree/master/packages/cli/src/commands/account/set-payment-delegation.ts)_
 
 ## `celocli account:set-wallet`
 

--- a/packages/sdk/contractkit/src/contract-cache.ts
+++ b/packages/sdk/contractkit/src/contract-cache.ts
@@ -193,6 +193,11 @@ export class WrapperCache implements ContractCacheType {
   getMultiSig(address: string) {
     return this.getContract(CeloContract.MultiSig, address)
   }
+
+  getPaymentDelegation() {
+    return this.getContract(CeloContract.Accounts)
+  }
+
   getReserve() {
     return this.getContract(CeloContract.Reserve)
   }

--- a/packages/sdk/contractkit/src/contract-cache.ts
+++ b/packages/sdk/contractkit/src/contract-cache.ts
@@ -194,10 +194,6 @@ export class WrapperCache implements ContractCacheType {
     return this.getContract(CeloContract.MultiSig, address)
   }
 
-  getPaymentDelegation() {
-    return this.getContract(CeloContract.Accounts)
-  }
-
   getReserve() {
     return this.getContract(CeloContract.Reserve)
   }

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -438,6 +438,33 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
   setMetadataURL = proxySend(this.connection, this.contract.methods.setMetadataURL)
 
   /**
+   * Sets validator payment delegation settings.
+   * @param beneficiary The address that should receive a portion of validator
+   * payments.
+   * @param fraction The fraction of the validator's payment that should be
+   * diverted to `beneficiary` every epoch, given as FixidityLib value. Must not
+   * be greater than 1.
+   * @dev Use `deletePaymentDelegation` to unset the payment delegation.
+   */
+  setPaymentDelgation = proxySend(this.connection, this.contract.methods.setPaymentDelegation)
+
+  /**
+   * Removes a validator's payment delegation by setting benficiary and
+   * fraction to 0.
+   */
+  deletePaymentDelegation = proxySend(
+    this.connection,
+    this.contract.methods.deletePaymentDelegation
+  )
+
+  /**
+   * Gets validator payment delegation settings.
+   * @param account Account of the validator.
+   * @return Beneficiary address and fraction of payment delegated.
+   */
+  getPaymentDelegation = proxyCall(this.contract.methods.getPaymentDelegation)
+
+  /**
    * Sets the wallet address for the account
    * @param address The address to set
    */

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -438,7 +438,7 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
   setMetadataURL = proxySend(this.connection, this.contract.methods.setMetadataURL)
 
   /**
-   * Sets validator payment delegation settings.
+   * Set a validator's payment delegation settings.
    * @param beneficiary The address that should receive a portion of validator
    * payments.
    * @param fraction The fraction of the validator's payment that should be
@@ -446,10 +446,10 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
    * be greater than 1.
    * @dev Use `deletePaymentDelegation` to unset the payment delegation.
    */
-  setPaymentDelgation = proxySend(this.connection, this.contract.methods.setPaymentDelegation)
+  setPaymentDelegation = proxySend(this.connection, this.contract.methods.setPaymentDelegation)
 
   /**
-   * Removes a validator's payment delegation by setting benficiary and
+   * Remove a validator's payment delegation by setting benficiary and
    * fraction to 0.
    */
   deletePaymentDelegation = proxySend(
@@ -458,7 +458,7 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
   )
 
   /**
-   * Gets validator payment delegation settings.
+   * Get a validator's payment delegation settings.
    * @param account Account of the validator.
    * @return Beneficiary address and fraction of payment delegated.
    */


### PR DESCRIPTION
### Description

Allow validator payment delegation to be managed via the CLI

* add support to allocate a fraction of rewards by delegating to a named
  beneficiary from the cli
* new cli commands for get, set, and delete within account
* add cli documentation
* expose functionality available in Accounts.so

### Other changes

None

### Demo
[Here is a video demo of this pull request](https://www.loom.com/share/99d3329837204147be21ba4fbb353ccc)

### Testing

1. Exploratory testing against a local development node to run each newly introduced cli command and can successfully set and then get the fraction associated with an account, delete clears. See demo above.
2. Added unit tests to match the flow described above and demo. 

![image](https://user-images.githubusercontent.com/275252/181266777-2fbdc1ef-15ba-4fb2-88c8-94e0a72efce8.png)

### Related issues

See this [pull request](https://github.com/celo-org/celo-monorepo/pull/8993/files#) introduced by @m-chrzan which are the contract methods the cli calls into

### Backwards compatibility

NA No existing code was edited

### Documentation

The following ```docs``` fork will be updated to reflect all functionality here and a PR opened once this PR has been merged.
https://github.com/spiralsprotocol/celo-org-docs/tree/spirals/expose-payment-delegation-in-cli