### PR TITLE
Upgrade ingress-nginx to Helm Chart v4.2.0

### DIFF
--- a/packages/celotool/src/lib/blockscout.ts
+++ b/packages/celotool/src/lib/blockscout.ts
@@ -164,8 +164,10 @@ export async function createDefaultIngressIfNotExists(celoEnv: string, ingressNa
   if (!ingressExists) {
     console.info(`Creating ingress ${celoEnv}-blockscout-web-ingress`)
     const ingressFilePath = `/tmp/${celoEnv}-blockscout-web-ingress.yaml`
+    // TODO: the ingress needs a spec.ingressClassName fiedl set to nginx when
+    // the nginx ingress gets updated to 4.2.0
     const ingressResource = `
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/packages/celotool/src/lib/cluster.ts
+++ b/packages/celotool/src/lib/cluster.ts
@@ -17,7 +17,7 @@ import { outputIncludes, switchToProjectFromEnv } from './utils'
 import { networkName } from './vm-testnet-utils'
 
 const SYSTEM_HELM_RELEASES = [
-  'nginx-ingress-release',
+  'nginx-ingress-release', // TODO: rename to nginx-ingress
   'kube-lego-release',
   'cert-manager-cluster-issuers',
 ]

--- a/packages/celotool/src/lib/helm_deploy.ts
+++ b/packages/celotool/src/lib/helm_deploy.ts
@@ -271,7 +271,8 @@ export async function installCertManagerAndNginx(
   celoEnv: string,
   clusterConfig?: BaseClusterConfig
 ) {
-  const nginxChartVersion = '3.9.0'
+  // k8s version >=1.20.0-0
+  const nginxChartVersion = '4.2.0'
   const nginxChartNamespace = 'default'
 
   // Check if cert-manager is installed in any namespace
@@ -328,8 +329,6 @@ async function nginxHelmParameters(
 controller:
   autoscaling:
     enabled: "true"
-    minReplicas: 1
-    maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
   config:

--- a/packages/helm-charts/blockscout/values-rc1staging.yaml
+++ b/packages/helm-charts/blockscout/values-rc1staging.yaml
@@ -1,3 +1,4 @@
+ingressClassName: nginx
 blockscout:
   indexer:
     db:

--- a/packages/helm-charts/grafana/templates/ingress.yaml
+++ b/packages/helm-charts/grafana/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+{{- if .Values.ingressClassName }}
+  ingressClassName: {{ .Values.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/packages/helm-charts/grafana/values-clabs.yaml
+++ b/packages/helm-charts/grafana/values-clabs.yaml
@@ -23,6 +23,8 @@ grafana.ini:
     token_url: https://accounts.google.com/o/oauth2/token
 ingress:
   annotations:
+    # convert to spec.ingressClassName in the future (needs a version upgrade)
+    kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
   enabled: true
   path: /


### PR DESCRIPTION
### Description

The updated version: https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx/4.2.0

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Relates to https://github.com/celo-org/infrastructure/issues/231

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_