### PR TITLE
Use solhint-disable-next-line in derived Proxy contracts

### DIFF
--- a/packages/protocol/contracts/common/proxies/AccountsProxy.sol
+++ b/packages/protocol/contracts/common/proxies/AccountsProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract AccountsProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/FeeCurrencyWhitelistProxy.sol
+++ b/packages/protocol/contracts/common/proxies/FeeCurrencyWhitelistProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract FeeCurrencyWhitelistProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/FreezerProxy.sol
+++ b/packages/protocol/contracts/common/proxies/FreezerProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract FreezerProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/GasPriceMinimumProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GasPriceMinimumProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract GasPriceMinimumProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/GoldTokenProxy.sol
+++ b/packages/protocol/contracts/common/proxies/GoldTokenProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract GoldTokenProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/MetaTransactionWalletDeployerProxy.sol
+++ b/packages/protocol/contracts/common/proxies/MetaTransactionWalletDeployerProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.3;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract MetaTransactionWalletDeployerProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/MetaTransactionWalletProxy.sol
+++ b/packages/protocol/contracts/common/proxies/MetaTransactionWalletProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.3;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract MetaTransactionWalletProxy is Proxy {}

--- a/packages/protocol/contracts/common/proxies/RegistryProxy.sol
+++ b/packages/protocol/contracts/common/proxies/RegistryProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract RegistryProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/BlockchainParametersProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/BlockchainParametersProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract BlockchainParametersProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/DoubleSigningSlasherProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/DoubleSigningSlasherProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract DoubleSigningSlasherProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/DowntimeSlasherProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/DowntimeSlasherProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract DowntimeSlasherProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/ElectionProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ElectionProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ElectionProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/EpochRewardsProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/EpochRewardsProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract EpochRewardsProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/GovernanceApproverMultiSigProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/GovernanceApproverMultiSigProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract GovernanceApproverMultiSigProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/GovernanceProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/GovernanceProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract GovernanceProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/GovernanceSlasherProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/GovernanceSlasherProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract GovernanceSlasherProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/LockedGoldProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/LockedGoldProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract LockedGoldProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/ReleaseGoldMultiSigProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ReleaseGoldMultiSigProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ReleaseGoldMultiSigProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/ReleaseGoldProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ReleaseGoldProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ReleaseGoldProxy is Proxy {}

--- a/packages/protocol/contracts/governance/proxies/ValidatorsProxy.sol
+++ b/packages/protocol/contracts/governance/proxies/ValidatorsProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ValidatorsProxy is Proxy {}

--- a/packages/protocol/contracts/identity/proxies/AttestationsProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/AttestationsProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract AttestationsProxy is Proxy {}

--- a/packages/protocol/contracts/identity/proxies/EscrowProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/EscrowProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract EscrowProxy is Proxy {}

--- a/packages/protocol/contracts/identity/proxies/RandomProxy.sol
+++ b/packages/protocol/contracts/identity/proxies/RandomProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract RandomProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/ExchangeBRLProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ExchangeBRLProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ExchangeBRLProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/ExchangeEURProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ExchangeEURProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ExchangeEURProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/ExchangeProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ExchangeProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ExchangeProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/GrandaMentoProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/GrandaMentoProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract GrandaMentoProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/ReserveProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ReserveProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ReserveProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/ReserveSpenderMultiSigProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/ReserveSpenderMultiSigProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract ReserveSpenderMultiSigProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/SortedOraclesProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/SortedOraclesProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract SortedOraclesProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/StableTokenBRLProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/StableTokenBRLProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract StableTokenBRLProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/StableTokenEURProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/StableTokenEURProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract StableTokenEURProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/StableTokenProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/StableTokenProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract StableTokenProxy is Proxy {}

--- a/packages/protocol/contracts/stability/proxies/StableTokenRegistryProxy.sol
+++ b/packages/protocol/contracts/stability/proxies/StableTokenRegistryProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "../../common/Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract StableTokenRegistryProxy is Proxy {}

--- a/packages/protocol/test/resources/compatibility/contracts_linked_libraries_upgraded_contract/TestContractProxy.sol
+++ b/packages/protocol/test/resources/compatibility/contracts_linked_libraries_upgraded_contract/TestContractProxy.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.13;
 
 import "./Proxy.sol";
 
-/* solhint-disable no-empty-blocks */
+/* solhint-disable-next-line no-empty-blocks */
 contract TestContractProxy is Proxy {}


### PR DESCRIPTION
### Description

When disabling solhint for a single line, solhint-disable-next-line should be used.
