### PR TITLE
Format @return NatSpecs correctly

### DIFF
--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -123,10 +123,10 @@ contract Accounts is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 4, 0);
@@ -290,8 +290,8 @@ contract Accounts is
   /**
    * @notice Returns the full list of offchain storage roots for an account.
    * @param account The account whose storage roots to return.
-   * @return bytes Bytes of list of storage root URLs.
-   * @return lenght Length of list of storage root URLs.
+   * @return Bytes of list of storage root URLs.
+   * @return Length of list of storage root URLs.
    */
   function getOffchainStorageRoots(address account)
     external
@@ -351,8 +351,8 @@ contract Accounts is
   /**
    * @notice Gets validator payment delegation settings.
    * @param account Account of the validator.
-   * @return beneficiary Beneficiary address of payment delegated.
-   * @return fraction Fraction of payment delegated.
+   * @return Beneficiary address of payment delegated.
+   * @return Fraction of payment delegated.
    */
   function getPaymentDelegation(address account) external view returns (address, uint256) {
     PaymentDelegation storage delegation = paymentDelegations[account];
@@ -951,8 +951,8 @@ contract Accounts is
   /**
    * @notice Getter for the metadata of multiple accounts.
    * @param accountsToQuery The addresses of the accounts to get the metadata for.
-   * @return stringLengths[] The length of each string in bytes.
-   * @return data All strings concatenated.
+   * @return The length of each string in bytes.
+   * @return All strings concatenated.
    */
   function batchGetMetadataURL(address[] calldata accountsToQuery)
     external

--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -123,7 +123,10 @@ contract Accounts is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 4, 0);
@@ -287,7 +290,8 @@ contract Accounts is
   /**
    * @notice Returns the full list of offchain storage roots for an account.
    * @param account The account whose storage roots to return.
-   * @return List of storage root URLs.
+   * @return bytes Bytes of list of storage root URLs.
+   * @return lenght Length of list of storage root URLs.
    */
   function getOffchainStorageRoots(address account)
     external
@@ -347,7 +351,8 @@ contract Accounts is
   /**
    * @notice Gets validator payment delegation settings.
    * @param account Account of the validator.
-   * @return Beneficiary address and fraction of payment delegated.
+   * @return beneficiary Beneficiary address of payment delegated.
+   * @return fraction Fraction of payment delegated.
    */
   function getPaymentDelegation(address account) external view returns (address, uint256) {
     PaymentDelegation storage delegation = paymentDelegations[account];
@@ -946,9 +951,8 @@ contract Accounts is
   /**
    * @notice Getter for the metadata of multiple accounts.
    * @param accountsToQuery The addresses of the accounts to get the metadata for.
-   * @return (stringLengths[] - the length of each string in bytes
-   *          data - all strings concatenated
-   *         )
+   * @return stringLengths[] The length of each string in bytes.
+   * @return data All strings concatenated.
    */
   function batchGetMetadataURL(address[] calldata accountsToQuery)
     external

--- a/packages/protocol/contracts/common/Accounts.sol
+++ b/packages/protocol/contracts/common/Accounts.sol
@@ -290,8 +290,8 @@ contract Accounts is
   /**
    * @notice Returns the full list of offchain storage roots for an account.
    * @param account The account whose storage roots to return.
-   * @return Bytes of list of storage root URLs.
-   * @return Length of list of storage root URLs.
+   * @return Concatenated storage root URLs.
+   * @return Lengths of storage root URLs.
    */
   function getOffchainStorageRoots(address account)
     external

--- a/packages/protocol/contracts/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts/common/GasPriceMinimum.sol
@@ -45,7 +45,10 @@ contract GasPriceMinimum is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);

--- a/packages/protocol/contracts/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts/common/GasPriceMinimum.sol
@@ -45,10 +45,10 @@ contract GasPriceMinimum is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -45,10 +45,10 @@ contract GoldToken is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 1);

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -45,7 +45,10 @@ contract GoldToken is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 1);

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -70,10 +70,10 @@ contract MetaTransactionWallet is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 1);

--- a/packages/protocol/contracts/common/MetaTransactionWallet.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWallet.sol
@@ -70,7 +70,10 @@ contract MetaTransactionWallet is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 1);
@@ -260,7 +263,8 @@ contract MetaTransactionWallet is
    * @param values The CELO value to be sent with each transaction.
    * @param data The concatenated data to be sent in each transaction.
    * @param dataLengths The length of each transaction's data.
-   * @return The return values of all transactions appended as bytes and an array of the length
+   * @return All transactions appended as bytes
+   * @return An array of the length
    *         of each transaction output which will be 0 if a transaction had no output 
    */
   function executeTransactions(

--- a/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
@@ -8,8 +8,11 @@ contract MetaTransactionWalletDeployer is IMetaTransactionWalletDeployer, ICeloV
   event WalletDeployed(address indexed owner, address indexed wallet, address implementation);
 
   /**
-     * @notice Returns the storage, major, minor, and patch version of the contract.
-     * @return The storage, major, minor, and patch version of the contract.
+     * @notice Returns the storage, major, minor, and patch version of the contract.     
+     * @return storage Storage version of the contract.
+     * @return major Major version of the contract.
+     * @return minor Minor version of the contract.
+     * @return patch Patch version of the contract.
      */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 1);

--- a/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
+++ b/packages/protocol/contracts/common/MetaTransactionWalletDeployer.sol
@@ -9,10 +9,10 @@ contract MetaTransactionWalletDeployer is IMetaTransactionWalletDeployer, ICeloV
 
   /**
      * @notice Returns the storage, major, minor, and patch version of the contract.     
-     * @return storage Storage version of the contract.
-     * @return major Major version of the contract.
-     * @return minor Minor version of the contract.
-     * @return patch Patch version of the contract.
+     * @return Storage version of the contract.
+     * @return Major version of the contract.
+     * @return Minor version of the contract.
+     * @return Patch version of the contract.
      */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 1);

--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -25,8 +25,8 @@ contract UsingPrecompiles {
    * @param bDenominator Denominator of exponentiated fraction
    * @param exponent exponent to raise b to
    * @param _decimals precision
-   * @return numerator Numerator of the computed quantity (not reduced).
-   * @return denominator Denominator of the computed quantity (not reduced).
+   * @return Numerator of the computed quantity (not reduced).
+   * @return Denominator of the computed quantity (not reduced).
    */
   function fractionMulExp(
     uint256 aNumerator,

--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -25,7 +25,8 @@ contract UsingPrecompiles {
    * @param bDenominator Denominator of exponentiated fraction
    * @param exponent exponent to raise b to
    * @param _decimals precision
-   * @return numerator/denominator of the computed quantity (not reduced).
+   * @return numerator Numerator of the computed quantity (not reduced).
+   * @return denominator Denominator of the computed quantity (not reduced).
    */
   function fractionMulExp(
     uint256 aNumerator,

--- a/packages/protocol/contracts/common/interfaces/ICeloVersionedContract.sol
+++ b/packages/protocol/contracts/common/interfaces/ICeloVersionedContract.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.5.13;
 interface ICeloVersionedContract {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-    * @return storage Storage version of the contract.
-    * @return major Major version of the contract.
-    * @return minor Minor version of the contract.
-    * @return patch Patch version of the contract.
+    * @return Storage version of the contract.
+    * @return Major version of the contract.
+    * @return Minor version of the contract.
+    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256);
 }

--- a/packages/protocol/contracts/common/interfaces/ICeloVersionedContract.sol
+++ b/packages/protocol/contracts/common/interfaces/ICeloVersionedContract.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.5.13;
 interface ICeloVersionedContract {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+    * @return storage Storage version of the contract.
+    * @return major Major version of the contract.
+    * @return minor Minor version of the contract.
+    * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256);
 }

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
@@ -88,8 +88,8 @@ library AddressSortedLinkedList {
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @return Keys of nn unpacked list of elements from largest to smallest.
-   * @return Values of an unpacked list of elements from largest to smallest.
+   * @return Array of all keys in the list.
+   * @return Values corresponding to keys, which will be ordered largest to smallest.
    */
   function getElements(SortedLinkedList.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
@@ -88,8 +88,8 @@ library AddressSortedLinkedList {
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @return keys Keys of nn unpacked list of elements from largest to smallest.
-   * @return values Values of an unpacked list of elements from largest to smallest.
+   * @return Keys of nn unpacked list of elements from largest to smallest.
+   * @return Values of an unpacked list of elements from largest to smallest.
    */
   function getElements(SortedLinkedList.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedList.sol
@@ -88,7 +88,8 @@ library AddressSortedLinkedList {
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @return An unpacked list of elements from largest to smallest.
+   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @return values Values of an unpacked list of elements from largest to smallest.
    */
   function getElements(SortedLinkedList.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
@@ -149,9 +149,9 @@ library AddressSortedLinkedListWithMedian {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return keys Keys of nn unpacked list of elements from largest to smallest.
-   * @return Values of an unpacked list of elements from largest to smallest.
-   * @return Relations of an unpacked list of elements from largest to smallest.
+   * @return Array of all keys in the list.
+   * @return Values corresponding to keys, which will be ordered largest to smallest.
+   * @return Array of relations to median of corresponding list elements.
    */
   function getElements(SortedLinkedListWithMedian.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
@@ -149,7 +149,9 @@ library AddressSortedLinkedListWithMedian {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return An unpacked list of elements from largest to smallest.
+   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @return values Values of an unpacked list of elements from largest to smallest.
+   * @return relations Relations of an unpacked list of elements from largest to smallest.
    */
   function getElements(SortedLinkedListWithMedian.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol
@@ -150,8 +150,8 @@ library AddressSortedLinkedListWithMedian {
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
    * @return keys Keys of nn unpacked list of elements from largest to smallest.
-   * @return values Values of an unpacked list of elements from largest to smallest.
-   * @return relations Relations of an unpacked list of elements from largest to smallest.
+   * @return Values of an unpacked list of elements from largest to smallest.
+   * @return Relations of an unpacked list of elements from largest to smallest.
    */
   function getElements(SortedLinkedListWithMedian.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
@@ -104,8 +104,8 @@ library IntegerSortedLinkedList {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return Keys of nn unpacked list of elements from largest to smallest.
-   * @return Values of an unpacked list of elements from largest to smallest.
+   * @return Array of all keys in the list.
+   * @return Values corresponding to keys, which will be ordered largest to smallest.
    */
   function getElements(SortedLinkedList.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
@@ -104,8 +104,8 @@ library IntegerSortedLinkedList {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return keys Keys of nn unpacked list of elements from largest to smallest.
-   * @return values Values of an unpacked list of elements from largest to smallest.
+   * @return Keys of nn unpacked list of elements from largest to smallest.
+   * @return Values of an unpacked list of elements from largest to smallest.
    */
   function getElements(SortedLinkedList.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/IntegerSortedLinkedList.sol
@@ -104,7 +104,8 @@ library IntegerSortedLinkedList {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return An unpacked list of elements from largest to smallest.
+   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @return values Values of an unpacked list of elements from largest to smallest.
    */
   function getElements(SortedLinkedList.List storage list)
     public

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
@@ -124,8 +124,8 @@ library SortedLinkedList {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return keys Keys of nn unpacked list of elements from largest to smallest.
-   * @return values Values of an unpacked list of elements from largest to smallest.
+   * @return Keys of nn unpacked list of elements from largest to smallest.
+   * @return Values of an unpacked list of elements from largest to smallest.
    */
   function getElements(List storage list)
     internal
@@ -166,8 +166,8 @@ library SortedLinkedList {
    * @param value The element value.
    * @param lesserKey The key of the element which could be just left of the new value.
    * @param greaterKey The key of the element which could be just right of the new value.
-   * @return lesserKey The correct lesserKey keys.
-   * @return greaterKey The correct greaterKey keys.
+   * @return The correct lesserKey keys.
+   * @return The correct greaterKey keys.
    */
   function getLesserAndGreater(
     List storage list,

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
@@ -124,7 +124,8 @@ library SortedLinkedList {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return An unpacked list of elements from largest to smallest.
+   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @return values Values of an unpacked list of elements from largest to smallest.
    */
   function getElements(List storage list)
     internal
@@ -165,7 +166,8 @@ library SortedLinkedList {
    * @param value The element value.
    * @param lesserKey The key of the element which could be just left of the new value.
    * @param greaterKey The key of the element which could be just right of the new value.
-   * @return The correct lesserKey/greaterKey keys.
+   * @return lesserKey The correct lesserKey keys.
+   * @return greaterKey The correct greaterKey keys.
    */
   function getLesserAndGreater(
     List storage list,

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedList.sol
@@ -124,8 +124,8 @@ library SortedLinkedList {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return Keys of nn unpacked list of elements from largest to smallest.
-   * @return Values of an unpacked list of elements from largest to smallest.
+   * @return Array of all keys in the list.
+   * @return Values corresponding to keys, which will be ordered largest to smallest.
    */
   function getElements(List storage list)
     internal

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
@@ -219,9 +219,9 @@ library SortedLinkedListWithMedian {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return keys Keys of nn unpacked list of elements from largest to smallest.
-   * @return values Values of an unpacked list of elements from largest to smallest.
-   * @return relations Relations of an unpacked list of elements from largest to smallest.
+   * @return Keys of nn unpacked list of elements from largest to smallest.
+   * @return Values of an unpacked list of elements from largest to smallest.
+   * @return Relations of an unpacked list of elements from largest to smallest.
    */
   function getElements(List storage list)
     internal

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
@@ -219,9 +219,9 @@ library SortedLinkedListWithMedian {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return Keys of nn unpacked list of elements from largest to smallest.
-   * @return Values of an unpacked list of elements from largest to smallest.
-   * @return Relations of an unpacked list of elements from largest to smallest.
+   * @return Array of all keys in the list.
+   * @return Values corresponding to keys, which will be ordered largest to smallest.
+   * @return Array of relations to median of corresponding list elements.
    */
   function getElements(List storage list)
     internal

--- a/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts/common/linkedlists/SortedLinkedListWithMedian.sol
@@ -219,7 +219,9 @@ library SortedLinkedListWithMedian {
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param list A storage pointer to the underlying list.
-   * @return An unpacked list of elements from largest to smallest.
+   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @return values Values of an unpacked list of elements from largest to smallest.
+   * @return relations Relations of an unpacked list of elements from largest to smallest.
    */
   function getElements(List storage list)
     internal

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -68,7 +68,10 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 0, 0);
@@ -147,8 +150,10 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   }
 
   /**
-   * @notice Query minimum client version.
-   * @return Returns major, minor, and patch version numbers.
+   * @notice Query minimum client version.   
+   * @return major Returns major version numbers.
+   * @return minor Returns minor version numbers.
+   * @return patch Returns patch version numbers.
    */
   function getMinimumClientVersion()
     external

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -151,9 +151,9 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
 
   /**
    * @notice Query minimum client version.   
-   * @return Return major version numbers.
-   * @return Return minor version numbers.
-   * @return Return patch version numbers.
+   * @return Major version number.
+   * @return Minor version number.
+   * @return Patch version number.
    */
   function getMinimumClientVersion()
     external

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -68,10 +68,10 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 0, 0);
@@ -151,9 +151,9 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
 
   /**
    * @notice Query minimum client version.   
-   * @return major Returns major version numbers.
-   * @return minor Returns minor version numbers.
-   * @return patch Returns patch version numbers.
+   * @return Returns major version numbers.
+   * @return Returns minor version numbers.
+   * @return Returns patch version numbers.
    */
   function getMinimumClientVersion()
     external

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -151,9 +151,9 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
 
   /**
    * @notice Query minimum client version.   
-   * @return Returns major version numbers.
-   * @return Returns minor version numbers.
-   * @return Returns patch version numbers.
+   * @return Return major version numbers.
+   * @return Return minor version numbers.
+   * @return Return patch version numbers.
    */
   function getMinimumClientVersion()
     external

--- a/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
+++ b/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
@@ -16,10 +16,10 @@ contract DoubleSigningSlasher is ICeloVersionedContract, SlasherUtil {
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);

--- a/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
+++ b/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
@@ -16,7 +16,10 @@ contract DoubleSigningSlasher is ICeloVersionedContract, SlasherUtil {
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);

--- a/packages/protocol/contracts/governance/DowntimeSlasher.sol
+++ b/packages/protocol/contracts/governance/DowntimeSlasher.sol
@@ -33,7 +33,10 @@ contract DowntimeSlasher is ICeloVersionedContract, SlasherUtil {
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (2, 0, 0, 0);

--- a/packages/protocol/contracts/governance/DowntimeSlasher.sol
+++ b/packages/protocol/contracts/governance/DowntimeSlasher.sol
@@ -33,10 +33,10 @@ contract DowntimeSlasher is ICeloVersionedContract, SlasherUtil {
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (2, 0, 0, 0);

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -133,7 +133,10 @@ contract Election is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 1);
@@ -188,7 +191,8 @@ contract Election is
 
   /**
    * @notice Returns the minimum and maximum number of validators that can be elected.
-   * @return The minimum and maximum number of validators that can be elected.
+   * @return minimum The minimum number of validators that can be elected.
+   * @return maximum The maximum number of validators that can be elected.
    */
   function getElectableValidators() external view returns (uint256, uint256) {
     return (electableValidators.min, electableValidators.max);
@@ -929,7 +933,8 @@ contract Election is
 
   /**
    * @notice Returns lists of all validator groups and the number of votes they've received.
-   * @return Lists of all validator groups and the number of votes they've received.
+   * @return lists Lists of all validator groups
+   * @return number Number of votes each validator group received.
    */
   function getTotalVotesForEligibleValidatorGroups()
     external

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -133,10 +133,10 @@ contract Election is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 1);
@@ -191,8 +191,8 @@ contract Election is
 
   /**
    * @notice Returns the minimum and maximum number of validators that can be elected.
-   * @return minimum The minimum number of validators that can be elected.
-   * @return maximum The maximum number of validators that can be elected.
+   * @return The minimum number of validators that can be elected.
+   * @return The maximum number of validators that can be elected.
    */
   function getElectableValidators() external view returns (uint256, uint256) {
     return (electableValidators.min, electableValidators.max);

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -932,9 +932,9 @@ contract Election is
   }
 
   /**
-   * @notice Returns lists of all validator groups and the number of votes they've received.
-   * @return lists Lists of all validator groups
-   * @return number Number of votes each validator group received.
+   * @notice Returns list of all validator groups and the number of votes they've received.
+   * @return List of all validator groups
+   * @return Number of votes each validator group received.
    */
   function getTotalVotesForEligibleValidatorGroups()
     external

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -86,10 +86,10 @@ contract EpochRewards is
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return storage Storage version of the contract.
-  * @return major Major version of the contract.
-  * @return minor Minor version of the contract.
-  * @return patch Patch version of the contract.
+  * @return Storage version of the contract.
+  * @return Major version of the contract.
+  * @return Minor version of the contract.
+  * @return Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);
@@ -151,9 +151,9 @@ contract EpochRewards is
 
   /**
    * @notice Returns the target voting yield parameters.
-   * @return target The target factor for target voting yield.
-   * @return max The max factor for target voting yield.
-   * @return adjustment The adjustment factor for target voting yield.
+   * @return The target factor for target voting yield.
+   * @return The max factor for target voting yield.
+   * @return The adjustment factor for target voting yield.
    */
   function getTargetVotingYieldParameters() external view returns (uint256, uint256, uint256) {
     TargetVotingYieldParameters storage params = targetVotingYieldParams;

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -86,7 +86,10 @@ contract EpochRewards is
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return The storage, major, minor, and patch version of the contract.
+  * @return storage Storage version of the contract.
+  * @return major Major version of the contract.
+  * @return minor Minor version of the contract.
+  * @return patch Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);
@@ -148,7 +151,9 @@ contract EpochRewards is
 
   /**
    * @notice Returns the target voting yield parameters.
-   * @return The target, max, and adjustment factor for target voting yield.
+   * @return target The target factor for target voting yield.
+   * @return max The max factor for target voting yield.
+   * @return adjustment The adjustment factor for target voting yield.
    */
   function getTargetVotingYieldParameters() external view returns (uint256, uint256, uint256) {
     TargetVotingYieldParameters storage params = targetVotingYieldParams;
@@ -157,7 +162,9 @@ contract EpochRewards is
 
   /**
    * @notice Returns the rewards multiplier parameters.
-   * @return The max multiplier and under/over spend adjustment factors.
+   * @return max The max multiplier.
+   * @return under The under spend adjustment factors.
+   * @return over The over spend adjustment factors.
    */
   function getRewardsMultiplierParameters() external view returns (uint256, uint256, uint256) {
     RewardsMultiplierParameters storage params = rewardsMultiplierParams;
@@ -514,8 +521,10 @@ contract EpochRewards is
 
   /**
    * @notice Calculates the per validator epoch payment and the total rewards to voters.
-   * @return The per validator epoch reward, the total rewards to voters, the total community
-   * reward, and the total carbon offsetting partner reward.
+   * @return epochReward The per validator epoch reward.
+   * @return voterReward The total rewards to voters
+   * @return comunityReward The total community reward
+   * @return partnerReward The total carbon offsetting partner reward.
    */
   function calculateTargetEpochRewards()
     external

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -162,9 +162,9 @@ contract EpochRewards is
 
   /**
    * @notice Returns the rewards multiplier parameters.
-   * @return max The max multiplier.
-   * @return under The under spend adjustment factors.
-   * @return over The over spend adjustment factors.
+   * @return The max multiplier.
+   * @return The under spend adjustment factors.
+   * @return The over spend adjustment factors.
    */
   function getRewardsMultiplierParameters() external view returns (uint256, uint256, uint256) {
     RewardsMultiplierParameters storage params = rewardsMultiplierParams;
@@ -521,10 +521,10 @@ contract EpochRewards is
 
   /**
    * @notice Calculates the per validator epoch payment and the total rewards to voters.
-   * @return epochReward The per validator epoch reward.
-   * @return voterReward The total rewards to voters
-   * @return comunityReward The total community reward
-   * @return partnerReward The total carbon offsetting partner reward.
+   * @return The per validator epoch reward.
+   * @return The total rewards to voters
+   * @return The total community reward
+   * @return The total carbon offsetting partner reward.
    */
   function calculateTargetEpochRewards()
     external

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -163,8 +163,8 @@ contract EpochRewards is
   /**
    * @notice Returns the rewards multiplier parameters.
    * @return The max multiplier.
-   * @return The under spend adjustment factors.
-   * @return The over spend adjustment factors.
+   * @return The underspend adjustment factors.
+   * @return The overspend adjustment factors.
    */
   function getRewardsMultiplierParameters() external view returns (uint256, uint256, uint256) {
     RewardsMultiplierParameters storage params = rewardsMultiplierParams;
@@ -522,8 +522,8 @@ contract EpochRewards is
   /**
    * @notice Calculates the per validator epoch payment and the total rewards to voters.
    * @return The per validator epoch reward.
-   * @return The total rewards to voters
-   * @return The total community reward
+   * @return The total rewards to voters.
+   * @return The total community reward.
    * @return The total carbon offsetting partner reward.
    */
   function calculateTargetEpochRewards()

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -197,7 +197,10 @@ contract Governance is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 1, 1);
@@ -491,7 +494,8 @@ contract Governance is
   /**
    * @notice Requires a proposal is dequeued and removes it if expired.
    * @param proposalId The ID of the proposal.
-   * @return The proposal storage struct and stage corresponding to `proposalId`.
+   * @return storage The proposal storage struct corresponding to `proposalId`.
+   * @return stage The proposal stage corresponding to `proposalId`.
    */
   function requireDequeuedAndDeleteExpired(uint256 proposalId, uint256 index)
     private
@@ -861,7 +865,10 @@ contract Governance is
 
   /**
    * @notice Returns the participation parameters.
-   * @return The participation parameters.
+   * @return baseline The participation baseline parameter.
+   * @return baselineFloor The participation baseline floor parameter.
+   * @return baselineUpdateFactor The participation baseline update factor parameter.
+   * @return baselineQuorumFactor The participation baseline quorum factor parameter.
    */
   function getParticipationParameters() external view returns (uint256, uint256, uint256, uint256) {
     return (
@@ -884,7 +891,11 @@ contract Governance is
   /**
    * @notice Returns an unpacked proposal struct with its transaction count.
    * @param proposalId The ID of the proposal to unpack.
-   * @return The unpacked proposal with its transaction count.
+   * @return proposer
+   * @return deposit
+   * @return timestamp
+   * @return transaction Transaction count.
+   * @return description Description url.
    */
   function getProposal(uint256 proposalId)
     external
@@ -898,7 +909,9 @@ contract Governance is
    * @notice Returns a specified transaction in a proposal.
    * @param proposalId The ID of the proposal to query.
    * @param index The index of the specified transaction in the proposal's transaction list.
-   * @return The specified transaction.
+   * @return value Transaction value.
+   * @return destination Transaction destination.
+   * @return data Transaction data.
    */
   function getProposalTransaction(uint256 proposalId, uint256 index)
     external
@@ -920,7 +933,9 @@ contract Governance is
   /**
    * @notice Returns the referendum vote totals for a proposal.
    * @param proposalId The ID of the proposal.
-   * @return The yes, no, and abstain vote totals.
+   * @return yes The yes vote totals.
+   * @return no The no vote totals.
+   * @return abstain The abstain vote totals.
    */
   function getVoteTotals(uint256 proposalId) external view returns (uint256, uint256, uint256) {
     return proposals[proposalId].getVoteTotals();
@@ -931,6 +946,8 @@ contract Governance is
    * @param account The address of the account to get the record for.
    * @param index The index in `dequeued`.
    * @return The corresponding proposal ID, vote value, and weight.
+   * @return vote The corresponding vote value.
+   * @return weight The corresponding weight.
    */
   function getVoteRecord(address account, uint256 index)
     external
@@ -961,7 +978,8 @@ contract Governance is
 
   /**
    * @notice Returns the proposal ID and upvote total for all queued proposals.
-   * @return The proposal ID and upvote total for all queued proposals.
+   * @return proposalID The proposal ID for all queued proposals.
+   * @return total The upvote total for all queued proposals.
    * @dev Note that this includes expired proposals that have yet to be removed from the queue.
    */
   function getQueue() external view returns (uint256[] memory, uint256[] memory) {
@@ -980,7 +998,8 @@ contract Governance is
   /**
    * @notice Returns the ID of the proposal upvoted by `account` and the weight of that upvote.
    * @param account The address of the account.
-   * @return The ID of the proposal upvoted by `account` and the weight of that upvote.
+   * @return proposalID The ID of the proposal upvoted by `account`.
+   * @return weight The weight of that upvote.
    */
   function getUpvoteRecord(address account) external view returns (uint256, uint256) {
     UpvoteRecord memory upvoteRecord = voters[account].upvote;
@@ -1030,7 +1049,9 @@ contract Governance is
   /**
    * @notice Gets information about a hotfix.
    * @param hash The abi encoded keccak256 hash of the hotfix transaction.
-   * @return Hotfix tuple of (approved, executed, preparedEpoch)
+   * @return approved Hotfix approved.
+   * @return executed Hotfix executed.
+   * @return preparedEpoch Hotfix preparedEpoch.
    */
   function getHotfixRecord(bytes32 hash) public view returns (bool, bool, uint256) {
     return (hotfixes[hash].approved, hotfixes[hash].executed, hotfixes[hash].preparedEpoch);

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -197,10 +197,10 @@ contract Governance is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 1, 1);
@@ -494,8 +494,8 @@ contract Governance is
   /**
    * @notice Requires a proposal is dequeued and removes it if expired.
    * @param proposalId The ID of the proposal.
-   * @return storage The proposal storage struct corresponding to `proposalId`.
-   * @return stage The proposal stage corresponding to `proposalId`.
+   * @return The proposal storage struct corresponding to `proposalId`.
+   * @return The proposal stage corresponding to `proposalId`.
    */
   function requireDequeuedAndDeleteExpired(uint256 proposalId, uint256 index)
     private
@@ -946,8 +946,8 @@ contract Governance is
    * @param account The address of the account to get the record for.
    * @param index The index in `dequeued`.
    * @return The corresponding proposal ID, vote value, and weight.
-   * @return vote The corresponding vote value.
-   * @return weight The corresponding weight.
+   * @return The corresponding vote value.
+   * @return The corresponding weight.
    */
   function getVoteRecord(address account, uint256 index)
     external
@@ -998,8 +998,8 @@ contract Governance is
   /**
    * @notice Returns the ID of the proposal upvoted by `account` and the weight of that upvote.
    * @param account The address of the account.
-   * @return proposalID The ID of the proposal upvoted by `account`.
-   * @return weight The weight of that upvote.
+   * @return The ID of the proposal upvoted by `account`.
+   * @return The weight of that upvote.
    */
   function getUpvoteRecord(address account) external view returns (uint256, uint256) {
     UpvoteRecord memory upvoteRecord = voters[account].upvote;
@@ -1049,9 +1049,9 @@ contract Governance is
   /**
    * @notice Gets information about a hotfix.
    * @param hash The abi encoded keccak256 hash of the hotfix transaction.
-   * @return approved Hotfix approved.
-   * @return executed Hotfix executed.
-   * @return preparedEpoch Hotfix preparedEpoch.
+   * @return Hotfix approved.
+   * @return Hotfix executed.
+   * @return Hotfix preparedEpoch.
    */
   function getHotfixRecord(bytes32 hash) public view returns (bool, bool, uint256) {
     return (hotfixes[hash].approved, hotfixes[hash].executed, hotfixes[hash].preparedEpoch);

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -78,7 +78,10 @@ contract LockedGold is
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return The storage, major, minor, and patch version of the contract.
+  * @return storage Storage version of the contract.
+  * @return major Major version of the contract.
+  * @return minor Minor version of the contract.
+  * @return patch Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 0);
@@ -265,7 +268,8 @@ contract LockedGold is
   /**
    * @notice Returns the pending withdrawals from unlocked gold for an account.
    * @param account The address of the account.
-   * @return The value and timestamp for each pending withdrawal.
+   * @return value The value for each pending withdrawal.
+   * @return timestamp The timestamp for each pending withdrawal.
    */
   function getPendingWithdrawals(address account)
     external
@@ -289,7 +293,7 @@ contract LockedGold is
    * @param account The address of the account.
    * @param index The index of the pending withdrawal.
    * @return The value of the pending withdrawal.
-   * @return The timestamp of the pending withdrawal.
+   * @return The timestamp of the pending withdrawal.   
    */
   function getPendingWithdrawal(address account, uint256 index)
     external

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -293,7 +293,7 @@ contract LockedGold is
    * @param account The address of the account.
    * @param index The index of the pending withdrawal.
    * @return The value of the pending withdrawal.
-   * @return The timestamp of the pending withdrawal.   
+   * @return The timestamp of the pending withdrawal.
    */
   function getPendingWithdrawal(address account, uint256 index)
     external

--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -78,10 +78,10 @@ contract LockedGold is
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return storage Storage version of the contract.
-  * @return major Major version of the contract.
-  * @return minor Minor version of the contract.
-  * @return patch Patch version of the contract.
+  * @return Storage version of the contract.
+  * @return Major version of the contract.
+  * @return Minor version of the contract.
+  * @return Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 0);
@@ -268,8 +268,8 @@ contract LockedGold is
   /**
    * @notice Returns the pending withdrawals from unlocked gold for an account.
    * @param account The address of the account.
-   * @return value The value for each pending withdrawal.
-   * @return timestamp The timestamp for each pending withdrawal.
+   * @return The value for each pending withdrawal.
+   * @return The timestamp for each pending withdrawal.
    */
   function getPendingWithdrawals(address account)
     external

--- a/packages/protocol/contracts/governance/Proposals.sol
+++ b/packages/protocol/contracts/governance/Proposals.sol
@@ -281,7 +281,9 @@ library Proposals {
    * @notice Returns a specified transaction in a proposal.
    * @param proposal The proposal struct.
    * @param index The index of the specified transaction in the proposal's transaction list.
-   * @return The specified transaction.
+   * @return value Transaction value.
+   * @return destination Transaction destination.
+   * @return data Transaction data.
    */
   function getTransaction(Proposal storage proposal, uint256 index)
     public
@@ -296,7 +298,11 @@ library Proposals {
   /**
    * @notice Returns an unpacked proposal struct with its transaction count.
    * @param proposal The proposal struct.
-   * @return The unpacked proposal with its transaction count.
+   * @return proposer
+   * @return deposit
+   * @return timestamp
+   * @return transaction Transaction count.
+   * @return description Description url.
    */
   function unpack(Proposal storage proposal)
     internal
@@ -315,7 +321,9 @@ library Proposals {
   /**
    * @notice Returns the referendum vote totals for a proposal.
    * @param proposal The proposal struct.
-   * @return The yes, no, and abstain vote totals.
+   * @return yes The yes vote totals.
+   * @return no The no vote totals.
+   * @return abstrain The abstain vote totals.
    */
   function getVoteTotals(Proposal storage proposal)
     internal

--- a/packages/protocol/contracts/governance/Proposals.sol
+++ b/packages/protocol/contracts/governance/Proposals.sol
@@ -281,9 +281,9 @@ library Proposals {
    * @notice Returns a specified transaction in a proposal.
    * @param proposal The proposal struct.
    * @param index The index of the specified transaction in the proposal's transaction list.
-   * @return value Transaction value.
-   * @return destination Transaction destination.
-   * @return data Transaction data.
+   * @return Transaction value.
+   * @return Transaction destination.
+   * @return Transaction data.
    */
   function getTransaction(Proposal storage proposal, uint256 index)
     public
@@ -321,9 +321,9 @@ library Proposals {
   /**
    * @notice Returns the referendum vote totals for a proposal.
    * @param proposal The proposal struct.
-   * @return yes The yes vote totals.
-   * @return no The no vote totals.
-   * @return abstrain The abstain vote totals.
+   * @return The yes vote totals.
+   * @return The no vote totals.
+   * @return The abstain vote totals.
    */
   function getVoteTotals(Proposal storage proposal)
     internal

--- a/packages/protocol/contracts/governance/Validators.sol
+++ b/packages/protocol/contracts/governance/Validators.sol
@@ -377,8 +377,8 @@ contract Validators is
 
   /**
    * @notice Returns the parameters that govern how a validator's score is calculated.
-   * @return The exponent that goven how a validator's score is calculated.
-   * @return The adjustment speed goven how a validator's score is calculated.
+   * @return The exponent that governs how a validator's score is calculated.
+   * @return The adjustment speed that governs how a validator's score is calculated.
    */
   function getValidatorScoreParameters() external view returns (uint256, uint256) {
     return (validatorScoreParameters.exponent, validatorScoreParameters.adjustmentSpeed.unwrap());

--- a/packages/protocol/contracts/governance/Validators.sol
+++ b/packages/protocol/contracts/governance/Validators.sol
@@ -160,7 +160,10 @@ contract Validators is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 0, 3);
@@ -374,7 +377,8 @@ contract Validators is
 
   /**
    * @notice Returns the parameters that govern how a validator's score is calculated.
-   * @return The parameters that goven how a validator's score is calculated.
+   * @return exponent The exponent that goven how a validator's score is calculated.
+   * @return adjustment The adjustment speed goven how a validator's score is calculated.
    */
   function getValidatorScoreParameters() external view returns (uint256, uint256) {
     return (validatorScoreParameters.exponent, validatorScoreParameters.adjustmentSpeed.unwrap());
@@ -383,7 +387,10 @@ contract Validators is
   /**
    * @notice Returns the group membership history of a validator.
    * @param account The validator whose membership history to return.
-   * @return The group membership history of a validator.
+   * @return epochs The epochs of a validator.
+   * @return groups The membership groups of a validator.
+   * @return timestamp The last removed from group timestamp of a validator.
+   * @return tail The tail of a validator.
    */
   function getMembershipHistory(address account)
     external
@@ -989,7 +996,13 @@ contract Validators is
   /**
    * @notice Returns validator group information.
    * @param account The account that registered the validator group.
-   * @return The unpacked validator group struct.
+   * @return keys The Keys.
+   * @return commision The commision.
+   * @return nextCommision The next commision.
+   * @return nextCommisionBlock The next commision block.
+   * @return size The Size history.
+   * @return multiplier The multiplier.
+   * @return lastSlashed The last slashed.
    */
   function getValidatorGroup(address account)
     external
@@ -1065,7 +1078,8 @@ contract Validators is
 
   /**
    * @notice Returns the Locked Gold requirements for validators.
-   * @return The Locked Gold requirements for validators.
+   * @return value The Locked Gold value.
+   * @return duration The Locked Gold duration.
    */
   function getValidatorLockedGoldRequirements() external view returns (uint256, uint256) {
     return (validatorLockedGoldRequirements.value, validatorLockedGoldRequirements.duration);
@@ -1073,7 +1087,8 @@ contract Validators is
 
   /**
    * @notice Returns the Locked Gold requirements for validator groups.
-   * @return The Locked Gold requirements for validator groups.
+   * @return value The Locked Gold value.
+   * @return duration The Locked Gold duration.
    */
   function getGroupLockedGoldRequirements() external view returns (uint256, uint256) {
     return (groupLockedGoldRequirements.value, groupLockedGoldRequirements.duration);

--- a/packages/protocol/contracts/governance/Validators.sol
+++ b/packages/protocol/contracts/governance/Validators.sol
@@ -160,10 +160,10 @@ contract Validators is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 0, 3);
@@ -377,8 +377,8 @@ contract Validators is
 
   /**
    * @notice Returns the parameters that govern how a validator's score is calculated.
-   * @return exponent The exponent that goven how a validator's score is calculated.
-   * @return adjustment The adjustment speed goven how a validator's score is calculated.
+   * @return The exponent that goven how a validator's score is calculated.
+   * @return The adjustment speed goven how a validator's score is calculated.
    */
   function getValidatorScoreParameters() external view returns (uint256, uint256) {
     return (validatorScoreParameters.exponent, validatorScoreParameters.adjustmentSpeed.unwrap());
@@ -388,9 +388,9 @@ contract Validators is
    * @notice Returns the group membership history of a validator.
    * @param account The validator whose membership history to return.
    * @return epochs The epochs of a validator.
-   * @return groups The membership groups of a validator.
-   * @return timestamp The last removed from group timestamp of a validator.
-   * @return tail The tail of a validator.
+   * @return The membership groups of a validator.
+   * @return The last removed from group timestamp of a validator.
+   * @return The tail of a validator.
    */
   function getMembershipHistory(address account)
     external
@@ -1078,8 +1078,8 @@ contract Validators is
 
   /**
    * @notice Returns the Locked Gold requirements for validators.
-   * @return value The Locked Gold value.
-   * @return duration The Locked Gold duration.
+   * @return The Locked Gold value.
+   * @return The Locked Gold duration.
    */
   function getValidatorLockedGoldRequirements() external view returns (uint256, uint256) {
     return (validatorLockedGoldRequirements.value, validatorLockedGoldRequirements.duration);
@@ -1087,8 +1087,8 @@ contract Validators is
 
   /**
    * @notice Returns the Locked Gold requirements for validator groups.
-   * @return value The Locked Gold value.
-   * @return duration The Locked Gold duration.
+   * @return The Locked Gold value.
+   * @return The Locked Gold duration.
    */
   function getGroupLockedGoldRequirements() external view returns (uint256, uint256) {
     return (groupLockedGoldRequirements.value, groupLockedGoldRequirements.duration);

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -618,7 +618,7 @@ contract Attestations is
    * @notice Helper function for batchGetAttestationStats to calculate the
              total number of addresses that have >0 complete attestations for the identifiers.
    * @param identifiersToLookup Array of n identifiers.
-   * @return numbers Array of n numbers that indicate the number of matching addresses per identifier.
+   * @return numbers Array of numbers that indicate the number of matching addresses per identifier.
    * @return addresses Array of addresses preallocated for total number of matches.
    */
   function batchlookupAccountsForIdentifier(bytes32[] memory identifiersToLookup)

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -174,7 +174,10 @@ contract Attestations is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 2);
@@ -337,11 +340,9 @@ contract Attestations is
    * @notice Returns the unselected attestation request for an identifier/account pair, if any.
    * @param identifier Hash of the identifier.
    * @param account Address of the account.
-   * @return [
-   *           Block number at which was requested,
-   *           Number of unselected requests,
-   *           Address of the token with which this attestation request was paid for
-   *         ]
+   * @return block Block number at which was requested.
+   * @return number Number of unselected requests.
+   * @return address Address of the token with which this attestation request was paid for.
    */
   function getUnselectedRequest(bytes32 identifier, address account)
     external
@@ -373,7 +374,8 @@ contract Attestations is
    * @notice Returns attestation stats for a identifier/account pair.
    * @param identifier Hash of the identifier.
    * @param account Address of the account.
-   * @return [Number of completed attestations, Number of total requested attestations]
+   * @return completed Number of completed attestations.
+   * @return requested Number of total requested attestations.
    */
   function getAttestationStats(bytes32 identifier, address account)
     external
@@ -432,11 +434,9 @@ contract Attestations is
    * @param identifier Hash of the identifier.
    * @param account Address of the account.
    * @param issuer Address of the issuer.
-   * @return [
-   *           Status of the attestation,
-   *           Block number of request/completion the attestation,
-   *           Address of the token with which this attestation request was paid for
-   *         ]
+   * @return status Status of the attestation.
+   * @return block Block number of request/completion the attestation.
+   * @return address Address of the token with which this attestation request was paid for.
    */
   function getAttestationState(bytes32 identifier, address account, address issuer)
     external
@@ -457,11 +457,10 @@ contract Attestations is
     * @notice Returns the state of all attestations that are completable
     * @param identifier Hash of the identifier.
     * @param account Address of the account.
-    * @return ( blockNumbers[] - Block number of request/completion the attestation,
-    *           issuers[] - Address of the issuer,
-    *           stringLengths[] - The length of each metadataURL string for each issuer,
-    *           stringData - All strings concatenated
-    *         )
+    * @return blockNumbers[] Block number of request/completion the attestation.
+    * @return issuers[] Address of the issuer.
+    * @return stringLengths[] The length of each metadataURL string for each issuer.
+    * @return stringData All strings concatenated.
     */
   function getCompletableAttestations(bytes32 identifier, address account)
     external
@@ -619,8 +618,8 @@ contract Attestations is
    * @notice Helper function for batchGetAttestationStats to calculate the
              total number of addresses that have >0 complete attestations for the identifiers.
    * @param identifiersToLookup Array of n identifiers.
-   * @return Array of n numbers that indicate the number of matching addresses per identifier
-   *         and array of addresses preallocated for total number of matches.
+   * @return numbers Array of n numbers that indicate the number of matching addresses per identifier.
+   * @return addresses Array of addresses preallocated for total number of matches.
    */
   function batchlookupAccountsForIdentifier(bytes32[] memory identifiersToLookup)
     internal

--- a/packages/protocol/contracts/identity/Attestations.sol
+++ b/packages/protocol/contracts/identity/Attestations.sol
@@ -174,10 +174,10 @@ contract Attestations is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 2);
@@ -457,10 +457,10 @@ contract Attestations is
     * @notice Returns the state of all attestations that are completable
     * @param identifier Hash of the identifier.
     * @param account Address of the account.
-    * @return blockNumbers[] Block number of request/completion the attestation.
-    * @return issuers[] Address of the issuer.
-    * @return stringLengths[] The length of each metadataURL string for each issuer.
-    * @return stringData All strings concatenated.
+    * @return Block number of request/completion the attestation.
+    * @return Address of the issuer.
+    * @return The length of each metadataURL string for each issuer.
+    * @return All strings concatenated.
     */
   function getCompletableAttestations(bytes32 identifier, address account)
     external
@@ -618,8 +618,8 @@ contract Attestations is
    * @notice Helper function for batchGetAttestationStats to calculate the
              total number of addresses that have >0 complete attestations for the identifiers.
    * @param identifiersToLookup Array of n identifiers.
-   * @return numbers Array of numbers that indicate the number of matching addresses per identifier.
-   * @return addresses Array of addresses preallocated for total number of matches.
+   * @return Array of numbers that indicate the number of matching addresses per identifier.
+   * @return Array of addresses preallocated for total number of matches.
    */
   function batchlookupAccountsForIdentifier(bytes32[] memory identifiersToLookup)
     internal

--- a/packages/protocol/contracts/identity/Escrow.sol
+++ b/packages/protocol/contracts/identity/Escrow.sol
@@ -71,10 +71,10 @@ contract Escrow is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 2);

--- a/packages/protocol/contracts/identity/Escrow.sol
+++ b/packages/protocol/contracts/identity/Escrow.sol
@@ -71,7 +71,10 @@ contract Escrow is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 2);

--- a/packages/protocol/contracts/identity/Random.sol
+++ b/packages/protocol/contracts/identity/Random.sol
@@ -36,7 +36,10 @@ contract Random is
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-  * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);

--- a/packages/protocol/contracts/identity/Random.sol
+++ b/packages/protocol/contracts/identity/Random.sol
@@ -36,10 +36,10 @@ contract Random is
 
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 1, 0);

--- a/packages/protocol/contracts/stability/Exchange.sol
+++ b/packages/protocol/contracts/stability/Exchange.sol
@@ -69,10 +69,10 @@ contract Exchange is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 3, 0, 0);
@@ -497,9 +497,10 @@ contract Exchange is
     return FixidityLib.fixed1().subtract(spread).multiply(FixidityLib.newFixed(sellAmount));
   }
 
-  /*
+  /**
    * @notice Checks conditions required for bucket updates.
-   * @return Whether or not buckets should be updated.
+   * @return The Rate numerator - whether or not buckets should be updated.
+   * @return The rate denominator - whether or not buckets should be updated.
    */
   function shouldUpdateBuckets() private view returns (bool) {
     ISortedOracles sortedOracles = ISortedOracles(

--- a/packages/protocol/contracts/stability/Exchange.sol
+++ b/packages/protocol/contracts/stability/Exchange.sol
@@ -69,7 +69,10 @@ contract Exchange is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 3, 0, 0);
@@ -260,7 +263,8 @@ contract Exchange is
    * @notice Returns the buy token and sell token bucket sizes, in order. The ratio of
    * the two also represents the exchange rate between the two.
    * @param sellGold `true` if gold is the sell token.
-   * @return (buyTokenBucket, sellTokenBucket)
+   * @return buyTokenBucket
+   * @return sellTokenBucket
    */
   function getBuyAndSellBuckets(bool sellGold) public view returns (uint256, uint256) {
     uint256 currentGoldBucket = goldBucket;
@@ -363,7 +367,8 @@ contract Exchange is
    * @notice Returns the buy token and sell token bucket sizes, in order. The ratio of
    * the two also represents the exchange rate between the two.
    * @param sellGold `true` if gold is the sell token.
-   * @return (buyTokenBucket, sellTokenBucket)
+   * @return buyTokenBucket
+   * @return sellTokenBucket
    */
   function _getBuyAndSellBuckets(bool sellGold) private view returns (uint256, uint256) {
     if (sellGold) {
@@ -426,6 +431,10 @@ contract Exchange is
     return numerator.unwrap().div(denominator.unwrap());
   }
 
+  /**
+   * @return buyTokenBucket
+   * @return sellTokenBucket
+   */
   function getUpdatedBuckets() private view returns (uint256, uint256) {
     uint256 updatedGoldBucket = getUpdatedGoldBucket();
     uint256 exchangeRateNumerator;

--- a/packages/protocol/contracts/stability/ExchangeBRL.sol
+++ b/packages/protocol/contracts/stability/ExchangeBRL.sol
@@ -12,10 +12,10 @@ contract ExchangeBRL is Exchange {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @dev This function is overloaded to maintain a distinct version from Exchange.sol.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 3, 0, 0);

--- a/packages/protocol/contracts/stability/ExchangeBRL.sol
+++ b/packages/protocol/contracts/stability/ExchangeBRL.sol
@@ -12,7 +12,10 @@ contract ExchangeBRL is Exchange {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @dev This function is overloaded to maintain a distinct version from Exchange.sol.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 3, 0, 0);

--- a/packages/protocol/contracts/stability/ExchangeEUR.sol
+++ b/packages/protocol/contracts/stability/ExchangeEUR.sol
@@ -12,7 +12,10 @@ contract ExchangeEUR is Exchange {
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
   * @dev This function is overloaded to maintain a distinct version from Exchange.sol.
-  * @return The storage, major, minor, and patch version of the contract.
+  * @return storage Storage version of the contract.
+  * @return major Major version of the contract.
+  * @return minor Minor version of the contract.
+  * @return patch Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 3, 0, 0);

--- a/packages/protocol/contracts/stability/ExchangeEUR.sol
+++ b/packages/protocol/contracts/stability/ExchangeEUR.sol
@@ -12,10 +12,10 @@ contract ExchangeEUR is Exchange {
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
   * @dev This function is overloaded to maintain a distinct version from Exchange.sol.
-  * @return storage Storage version of the contract.
-  * @return major Major version of the contract.
-  * @return minor Minor version of the contract.
-  * @return patch Patch version of the contract.
+  * @return Storage version of the contract.
+  * @return Major version of the contract.
+  * @return Minor version of the contract.
+  * @return Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 3, 0, 0);

--- a/packages/protocol/contracts/stability/GrandaMento.sol
+++ b/packages/protocol/contracts/stability/GrandaMento.sol
@@ -164,7 +164,10 @@ contract GrandaMento is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 1);
@@ -394,7 +397,8 @@ contract GrandaMento is
    * @dev For stable token sell amounts that are stored as units, the value
    * is returned. Ensures sell amount is not greater than this contract's balance.
    * @param proposal The proposal to get the sell token and sell amount for.
-   * @return (the IERC20 sell token, the value sell amount).
+   * @return token The IERC20 sell token.
+   * @return amount The value sell amount.
    */
   function getSellTokenAndSellAmount(ExchangeProposal memory proposal)
     private
@@ -533,7 +537,8 @@ contract GrandaMento is
    * involved in a single exchange.
    * @dev Reverts if there is no explicit exchange limit for the stable token.
    * @param stableTokenRegistryId The string registry ID for the stable token.
-   * @return (minimum exchange amount, maximum exchange amount).
+   * @return minimum Minimum exchange amount.
+   * @return maximum Maximum exchange amount.
    */
   function getStableTokenExchangeLimits(string memory stableTokenRegistryId)
     public

--- a/packages/protocol/contracts/stability/GrandaMento.sol
+++ b/packages/protocol/contracts/stability/GrandaMento.sol
@@ -164,10 +164,10 @@ contract GrandaMento is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 1);
@@ -397,8 +397,8 @@ contract GrandaMento is
    * @dev For stable token sell amounts that are stored as units, the value
    * is returned. Ensures sell amount is not greater than this contract's balance.
    * @param proposal The proposal to get the sell token and sell amount for.
-   * @return token The IERC20 sell token.
-   * @return amount The value sell amount.
+   * @return The IERC20 sell token.
+   * @return The value sell amount.
    */
   function getSellTokenAndSellAmount(ExchangeProposal memory proposal)
     private
@@ -537,8 +537,8 @@ contract GrandaMento is
    * involved in a single exchange.
    * @dev Reverts if there is no explicit exchange limit for the stable token.
    * @param stableTokenRegistryId The string registry ID for the stable token.
-   * @return minimum Minimum exchange amount.
-   * @return maximum Maximum exchange amount.
+   * @return Minimum exchange amount.
+   * @return Maximum exchange amount.
    */
   function getStableTokenExchangeLimits(string memory stableTokenRegistryId)
     public

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -86,10 +86,10 @@ contract Reserve is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 2);
@@ -427,8 +427,8 @@ contract Reserve is
 
   /**
    * @notice Returns the tobin tax, recomputing it if it's stale.
-   * @return numerator Tobin tax amount as a fraction.
-   * @return denominator Tobin tax amount as a fraction.
+   * @return The numerator - tobin tax amount as a fraction.
+   * @return The denominator - tobin tax amount as a fraction.
    */
   function getOrComputeTobinTax() external nonReentrant returns (uint256, uint256) {
     // solhint-disable-next-line not-rely-on-time

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -86,7 +86,10 @@ contract Reserve is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 2);
@@ -424,7 +427,8 @@ contract Reserve is
 
   /**
    * @notice Returns the tobin tax, recomputing it if it's stale.
-   * @return The tobin tax amount as a fraction.
+   * @return numerator Tobin tax amount as a fraction.
+   * @return denominator Tobin tax amount as a fraction.
    */
   function getOrComputeTobinTax() external nonReentrant returns (uint256, uint256) {
     // solhint-disable-next-line not-rely-on-time

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -56,10 +56,10 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 1);
@@ -168,7 +168,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @notice Check if last report is expired.
    * @param token The address of the token for which the CELO exchange rate is being reported.
    * @return isExpired
-   * @return address The address of the last report.
+   * @return The address of the last report.
    */
   function isOldestReportExpired(address token) public view returns (bool, address) {
     require(token != address(0));
@@ -237,7 +237,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   /**
    * @notice Returns the median rate.
    * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return median The median exchange rate for `token`.
+   * @return The median exchange rate for `token`.
    * @return fixidity
    */
   function medianRate(address token) external view returns (uint256, uint256) {

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -56,7 +56,10 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 2, 1);
@@ -164,7 +167,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   /**
    * @notice Check if last report is expired.
    * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return bool isExpired and the address of the last report
+   * @return isExpired
+   * @return address The address of the last report.
    */
   function isOldestReportExpired(address token) public view returns (bool, address) {
     require(token != address(0));
@@ -233,7 +237,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   /**
    * @notice Returns the median rate.
    * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return The median exchange rate for `token`.
+   * @return median The median exchange rate for `token`.
+   * @return fixidity
    */
   function medianRate(address token) external view returns (uint256, uint256) {
     return (rates[token].getMedianValue(), numRates(token) == 0 ? 0 : FIXED1_UINT);
@@ -242,7 +247,9 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return An unpacked list of elements from largest to smallest.
+   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @return values Values of an unpacked list of elements from largest to smallest.
+   * @return relations Relations of an unpacked list of elements from largest to smallest.
    */
   function getRates(address token)
     external
@@ -273,7 +280,9 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   /**
    * @notice Gets all elements from the doubly linked list.
    * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return An unpacked list of elements from largest to smallest.
+   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @return values Values of an unpacked list of elements from largest to smallest.
+   * @return relations Relations of an unpacked list of elements from largest to smallest.
    */
   function getTimestamps(address token)
     external

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -93,7 +93,10 @@ contract StableToken is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 0, 1);

--- a/packages/protocol/contracts/stability/StableToken.sol
+++ b/packages/protocol/contracts/stability/StableToken.sol
@@ -93,10 +93,10 @@ contract StableToken is
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 0, 1);

--- a/packages/protocol/contracts/stability/StableTokenBRL.sol
+++ b/packages/protocol/contracts/stability/StableTokenBRL.sol
@@ -12,7 +12,10 @@ contract StableTokenBRL is StableToken {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @dev This function is overloaded to maintain a distinct version from StableToken.sol.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);

--- a/packages/protocol/contracts/stability/StableTokenBRL.sol
+++ b/packages/protocol/contracts/stability/StableTokenBRL.sol
@@ -12,10 +12,10 @@ contract StableTokenBRL is StableToken {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @dev This function is overloaded to maintain a distinct version from StableToken.sol.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);

--- a/packages/protocol/contracts/stability/StableTokenEUR.sol
+++ b/packages/protocol/contracts/stability/StableTokenEUR.sol
@@ -12,7 +12,10 @@ contract StableTokenEUR is StableToken {
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
   * @dev This function is overloaded to maintain a distinct version from StableToken.sol.
-  * @return The storage, major, minor, and patch version of the contract.
+  * @return storage Storage version of the contract.
+  * @return major Major version of the contract.
+  * @return minor Minor version of the contract.
+  * @return patch Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 1);

--- a/packages/protocol/contracts/stability/StableTokenEUR.sol
+++ b/packages/protocol/contracts/stability/StableTokenEUR.sol
@@ -12,10 +12,10 @@ contract StableTokenEUR is StableToken {
   /**
   * @notice Returns the storage, major, minor, and patch version of the contract.
   * @dev This function is overloaded to maintain a distinct version from StableToken.sol.
-  * @return storage Storage version of the contract.
-  * @return major Major version of the contract.
-  * @return minor Minor version of the contract.
-  * @return patch Patch version of the contract.
+  * @return Storage version of the contract.
+  * @return Major version of the contract.
+  * @return Minor version of the contract.
+  * @return Patch version of the contract.
   */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 1);

--- a/packages/protocol/contracts/stability/StableTokenRegistry.sol
+++ b/packages/protocol/contracts/stability/StableTokenRegistry.sol
@@ -14,10 +14,10 @@ contract StableTokenRegistry is Initializable, Ownable {
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return storage Storage version of the contract.
-   * @return major Major version of the contract.
-   * @return minor Minor version of the contract.
-   * @return patch Patch version of the contract.
+   * @return Storage version of the contract.
+   * @return Major version of the contract.
+   * @return Minor version of the contract.
+   * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);
@@ -49,8 +49,8 @@ contract StableTokenRegistry is Initializable, Ownable {
 
   /**
    * @notice Returns all the contract instances created.
-   * @return collection Collection of stable token contracts.
-   * @return lengths Lengths of stable token contracts.
+   * @return Collection of stable token contracts.
+   * @return Lengths of stable token contracts.
    */
   function getContractInstances() external view returns (bytes memory, uint256[] memory) {
     uint256 totalLength = 0;

--- a/packages/protocol/contracts/stability/StableTokenRegistry.sol
+++ b/packages/protocol/contracts/stability/StableTokenRegistry.sol
@@ -14,7 +14,10 @@ contract StableTokenRegistry is Initializable, Ownable {
 
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);
@@ -46,7 +49,8 @@ contract StableTokenRegistry is Initializable, Ownable {
 
   /**
    * @notice Returns all the contract instances created.
-   * @return collection of stable token contracts.
+   * @return collection Collection of stable token contracts.
+   * @return lengths Lengths of stable token contracts.
    */
   function getContractInstances() external view returns (bytes memory, uint256[] memory) {
     uint256 totalLength = 0;

--- a/packages/protocol/scripts/generate-stabletoken-files.ts
+++ b/packages/protocol/scripts/generate-stabletoken-files.ts
@@ -15,7 +15,10 @@ contract StableToken${ticker} is StableToken {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @dev This function is overloaded to maintain a distinct version from StableToken.sol.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);
@@ -39,7 +42,10 @@ contract Exchange${ticker} is Exchange {
   /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @dev This function is overloaded to maintain a distinct version from Exchange.sol.
-   * @return The storage, major, minor, and patch version of the contract.
+   * @return storage Storage version of the contract.
+   * @return major Major version of the contract.
+   * @return minor Minor version of the contract.
+   * @return patch Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 1, 0, 0);


### PR DESCRIPTION
### Description

Separate @return lines for each returned value

If your function returns multiple values, like (int quotient, int remainder) then use multiple @return statements in the same format as the @param statements.
