### PR TITLE
Mini PR: Sets `RELEASE_TAG` to `core-contracts.v8.pre-audit` in `celo-monorepo/circleci/config.yml`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ defaults: &defaults
 contract-defaults: &contract-defaults
   <<: *defaults
   environment:
-    RELEASE_TAG: core-contracts.v7
+    RELEASE_TAG: core-contracts-v8.pre-audit
 
 e2e-defaults: &e2e-defaults
   <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,15 @@ defaults: &defaults
 contract-defaults: &contract-defaults
   <<: *defaults
   environment:
+    # This should be the tag of the latest cut release branch, so that version
+    # checking on master is done against either the currently released
+    # contracts, or the current pending release if there is one.
     RELEASE_TAG: core-contracts-v8.pre-audit
+    # This should be the number of the latest full release that's been deployed
+    # onchain. I.e. if the above tag is of a finalized release, it will
+    # correspond to the tag's version, if the above tag is a pre-release one, it
+    # should be one lower.
+    LAST_RELEASE: 7
 
 e2e-defaults: &e2e-defaults
   <<: *defaults

--- a/packages/protocol/scripts/bash/release-snapshots.sh
+++ b/packages/protocol/scripts/bash/release-snapshots.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-N=`echo -n $RELEASE_TAG | tail -c -1`
+N=$LAST_RELEASE
 
 for i in `eval echo {1..$N}`
 do


### PR DESCRIPTION


### Description

_(Double checked with @m-chrzan before making this PR against master)_

Sets `RELEASE_TAG` to [`core-contracts.v8.pre-audit`](https://github.com/celo-org/celo-monorepo/releases/tag/core-contracts.v8.pre-audit) on the master branch in [celo-monorepo](https://github.com/celo-org/celo-monorepo)/[.circleci](https://github.com/celo-org/celo-monorepo/tree/master/.circleci)/[config.yml](https://github.com/celo-org/celo-monorepo/blob/master/.circleci/config.yml) as described in [git release management](https://docs.celo.org/community/release-process/smart-contracts#when-a-new-release-branch-is-cut). This is a required step in the Core Contracts release process.

On the release branch ([release/core-contracts/8](https://github.com/celo-org/celo-monorepo/commits/release/core-contracts/8)), `RELEASE_TAG` (in [celo-monorepo](https://github.com/celo-org/celo-monorepo)/[.circleci](https://github.com/celo-org/celo-monorepo/tree/master/.circleci)/[config.yml](https://github.com/celo-org/celo-monorepo/blob/master/.circleci/config.yml)) should remain unchanged (currently `core-contracts.v7`).

### Tested

Doesn't need to be tested, this is a routine change during each Core Contract release.
(_Double checked with @m-chrzan before making this PR against master_)

### Related issues

- https://github.com/celo-org/celo-monorepo/issues/9711