### PR TITLE
Make governance tooling work with arbitrary transactions

### DIFF
--- a/packages/sdk/connect/src/utils/abi-utils.ts
+++ b/packages/sdk/connect/src/utils/abi-utils.ts
@@ -1,5 +1,5 @@
 import { ensureLeading0x } from '@celo/base/lib/address'
-import { AbiCoder, AbiItem, DecodedParamsObject } from '../abi-types'
+import { AbiCoder, ABIDefinition, AbiItem, DecodedParamsObject } from '../abi-types'
 
 /** @internal */
 export const getAbiByName = (abi: AbiItem[], methodName: string) =>
@@ -19,6 +19,36 @@ export const parseDecodedParams = (params: DecodedParamsObject) => {
     }
   })
   return { args, params }
+}
+
+/** @internal */
+export const signatureToAbiDefinition = (fnSignature: string): ABIDefinition => {
+  const matches = /(?<method>[^\(]+)\((?<args>.*)\)/.exec(fnSignature)
+  if (matches == null) {
+    throw new Error(`${fnSignature} is malformed`)
+  }
+  const method = matches.groups!['method']
+  const args = matches.groups!['args'].split(',')
+
+  return {
+    name: method,
+    signature: fnSignature,
+    type: 'function',
+    inputs: args.map((type, index) => {
+      const parts = type
+        .trim()
+        .split(' ')
+        .map((p) => p.trim())
+      if (parts.length > 2) {
+        throw new Error(`${fnSignature} is malformed`)
+      }
+
+      return {
+        name: parts.length > 1 ? parts[1] : `a${index}`,
+        type: parts[0],
+      }
+    }),
+  }
 }
 
 /** @internal */

--- a/packages/sdk/connect/src/utils/abi-utils.ts
+++ b/packages/sdk/connect/src/utils/abi-utils.ts
@@ -27,8 +27,8 @@ export const signatureToAbiDefinition = (fnSignature: string): ABIDefinition => 
   if (matches == null) {
     throw new Error(`${fnSignature} is malformed`)
   }
-  const method = matches.groups!['method']
-  const args = matches.groups!['args'].split(',')
+  const method = matches.groups!.method
+  const args = matches.groups!.args.split(',')
 
   return {
     name: method,

--- a/packages/sdk/explorer/src/block-explorer.ts
+++ b/packages/sdk/explorer/src/block-explorer.ts
@@ -60,7 +60,9 @@ export class BlockExplorer {
 
   constructor(private kit: ContractKit, readonly contractDetails: ContractDetails[]) {
     this.addressMapping = mapFromPairs(
-      contractDetails.map((cd) => [cd.address, getContractMappingFromDetails(cd)])
+      contractDetails
+        .filter((cd) => /Proxy/.exec(cd.name) == null)
+        .map((cd) => [cd.address, getContractMappingFromDetails(cd)])
     )
   }
 
@@ -191,8 +193,6 @@ export class BlockExplorer {
     if (callDetails == null) {
       callDetails = this.tryParseAsExternalContractCall(address, input)
     }
-    console.log(input)
-    console.log(callDetails)
     return callDetails
   }
 }

--- a/packages/sdk/explorer/src/block-explorer.ts
+++ b/packages/sdk/explorer/src/block-explorer.ts
@@ -1,4 +1,11 @@
-import { ABIDefinition, Address, Block, CeloTxPending, parseDecodedParams } from '@celo/connect'
+import {
+  ABIDefinition,
+  Address,
+  Block,
+  CeloTxPending,
+  parseDecodedParams,
+  signatureToAbiDefinition,
+} from '@celo/connect'
 import { CeloContract, ContractKit } from '@celo/contractkit'
 import { PROXY_ABI } from '@celo/contractkit/lib/proxy'
 import { fromFixed } from '@celo/utils/lib/fixidity'
@@ -114,23 +121,28 @@ export class BlockExplorer {
     }
   }
 
-  async tryParseTxInput(address: string, input: string): Promise<null | CallDetails> {
-    const callSignature = input.slice(0, 10)
-    const { contract: contractName, abi: matchedAbi } = this.getContractMethodAbi(
-      address,
-      callSignature
-    )
-    if (!contractName || !matchedAbi) {
-      return null
+  getKnownFunction(selector: string): ABIDefinition | undefined {
+    // TODO(bogdan): This could be replaced with a call to 4byte.directory
+    // or a local database of common functions.
+    const knownFunctions: { [k: string]: string } = {
+      '0x095ea7b3': 'approve(address to, uint256 value)',
+      '0x4d49e87d': 'addLiquidity(uint256[] amounts, uint256 minLPToMint, uint256 deadline)',
     }
+    const signature = knownFunctions[selector]
+    if (signature) {
+      return signatureToAbiDefinition(signature)
+    }
+    return undefined
+  }
 
+  buildCallDetails(contract: string, abi: ABIDefinition, input: string): CallDetails {
     const encodedParameters = input.slice(10)
     const { args, params } = parseDecodedParams(
-      this.kit.connection.getAbiCoder().decodeParameters(matchedAbi.inputs!, encodedParameters)
+      this.kit.connection.getAbiCoder().decodeParameters(abi.inputs!, encodedParameters)
     )
 
     // transform numbers to big numbers in params
-    matchedAbi.inputs!.forEach((abiInput, idx) => {
+    abi.inputs!.forEach((abiInput, idx) => {
       if (abiInput.type === 'uint256') {
         debug('transforming number param')
         params[abiInput.name] = new BigNumber(args[idx])
@@ -146,10 +158,41 @@ export class BlockExplorer {
       })
 
     return {
-      contract: contractName,
-      function: matchedAbi.name!,
+      contract,
+      function: abi.name!,
       paramMap: params,
       argList: args,
     }
+  }
+
+  tryParseAsCoreContractCall(address: string, input: string): CallDetails | null {
+    const selector = input.slice(0, 10)
+    const { contract: contractName, abi: matchedAbi } = this.getContractMethodAbi(address, selector)
+
+    if (matchedAbi == undefined || contractName == undefined) {
+      return null
+    }
+
+    return this.buildCallDetails(contractName, matchedAbi, input)
+  }
+
+  tryParseAsExternalContractCall(address: string, input: string): CallDetails | null {
+    const selector = input.slice(0, 10)
+    const matchedAbi = this.getKnownFunction(selector)
+    if (matchedAbi == undefined) {
+      return null
+    }
+
+    return this.buildCallDetails(address, matchedAbi, input)
+  }
+
+  async tryParseTxInput(address: string, input: string): Promise<CallDetails | null> {
+    let callDetails = this.tryParseAsCoreContractCall(address, input)
+    if (callDetails == null) {
+      callDetails = this.tryParseAsExternalContractCall(address, input)
+    }
+    console.log(input)
+    console.log(callDetails)
+    return callDetails
   }
 }

--- a/packages/sdk/explorer/src/block-explorer.ts
+++ b/packages/sdk/explorer/src/block-explorer.ts
@@ -61,7 +61,7 @@ export class BlockExplorer {
   constructor(private kit: ContractKit, readonly contractDetails: ContractDetails[]) {
     this.addressMapping = mapFromPairs(
       contractDetails
-        .filter((cd) => /Proxy/.exec(cd.name) == null)
+        .filter((cd) => /Proxy$/.exec(cd.name) == null)
         .map((cd) => [cd.address, getContractMappingFromDetails(cd)])
     )
   }

--- a/packages/sdk/explorer/src/block-explorer.ts
+++ b/packages/sdk/explorer/src/block-explorer.ts
@@ -171,7 +171,7 @@ export class BlockExplorer {
     const selector = input.slice(0, 10)
     const { contract: contractName, abi: matchedAbi } = this.getContractMethodAbi(address, selector)
 
-    if (matchedAbi == undefined || contractName == undefined) {
+    if (matchedAbi === undefined || contractName === undefined) {
       return null
     }
 
@@ -181,7 +181,7 @@ export class BlockExplorer {
   tryParseAsExternalContractCall(address: string, input: string): CallDetails | null {
     const selector = input.slice(0, 10)
     const matchedAbi = this.getKnownFunction(selector)
-    if (matchedAbi == undefined) {
+    if (matchedAbi === undefined) {
       return null
     }
 

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -133,6 +133,8 @@ export const proposalToJSON = async (
     await blockExplorer.updateContractDetailsMapping(stripProxy(name), address)
   }
 
+  console.log(proposal)
+
   if (registryAdditions) {
     // Update the registry mapping with registry additions prior to processing the proposal.
     for (const nameStr of Object.keys(registryAdditions)) {
@@ -332,14 +334,6 @@ export class ProposalBuilder {
     const contract = await this.kit._web3Contracts.getContract(tx.contract, address)
     const methodName = tx.function
     let method = (contract.methods as Contract['methods'])[methodName]
-    if (!method && /Proxy/.exec(tx.contract) == null) {
-      const proxy = await this.kit._web3Contracts.getContract(
-        `${tx.contract}Proxy` as CeloContract,
-        address
-      )
-      method = (proxy.methods as Contract['methods'])[methodName]
-    }
-
     if (!method) {
       throw new Error(`Method ${methodName} not found on ${tx.contract}`)
     }

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -133,8 +133,6 @@ export const proposalToJSON = async (
     await blockExplorer.updateContractDetailsMapping(stripProxy(name), address)
   }
 
-  console.log(proposal)
-
   if (registryAdditions) {
     // Update the registry mapping with registry additions prior to processing the proposal.
     for (const nameStr of Object.keys(registryAdditions)) {

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -153,7 +153,7 @@ export const proposalToJSON = async (
     }
 
     debug(`decoding tx ${JSON.stringify(tx)}`)
-    let parsedTx = await blockExplorer.tryParseTx(tx as CeloTxPending)
+    const parsedTx = await blockExplorer.tryParseTx(tx as CeloTxPending)
     if (parsedTx == null) {
       throw new Error(`Unable to parse ${JSON.stringify(tx)} with block explorer`)
     }
@@ -331,7 +331,7 @@ export class ProposalBuilder {
 
     const contract = await this.kit._web3Contracts.getContract(tx.contract, address)
     const methodName = tx.function
-    let method = (contract.methods as Contract['methods'])[methodName]
+    const method = (contract.methods as Contract['methods'])[methodName]
     if (!method) {
       throw new Error(`Method ${methodName} not found on ${tx.contract}`)
     }


### PR DESCRIPTION
### Description

This PR tackles two related issues with the current governance tooling:

1. A bug that prevents transactions in a proposal on both a contract and its proxy
2. A limitation of the tooling that doesn't allow function calls on external contracts

These two issues arose while working on [CGP60](https://forum.celo.org/t/discussion-cgp-60-governance-owned-cusd-usdc-liquidity/4036). The intended structure of the proposal can be seen [here](https://github.com/celo-org/governance/pull/158/files).

#### (1) The proxy related bug

In this proposal, we want to point `StableToken` to an alternative implementation which allows `Governance` to call `mint`, then `mint` cUSD to `Governance`, then repoint `StableToken` back to its existing implementation.

That part of the proposal looks like:
```json
[
  {
    "contract": "StableTokenProxy",
    "function": "_setImplementation",
    "args": [
      "0x41a2887d4C4D96C9E1a3505CF4553Fd0b1380F13"
    ],
    "value": "0"
  },
  {
    "contract": "StableToken",
    "function": "mint",
    "args": [
      "0xd533ca259b330c7a88f74e000a3faea2d63b7972",
      "5000000000000000000000000"
    ],
    "value": "0"
  },
  {
    "contract": "StableTokenProxy",
    "function": "_setImplementation",
    "args": [
      "0x18e6bfdc909063f7445e410a5495264619495bcb"
    ],
    "value": "0"
  }
```

The tooling relies on two translation processes:
(a) `json->raw`, which takes in the human readable json and outputs the raw transactions submitted on-chain
(b) `raw->json`, which reads the transactions submitted on-chain and attempts to reconstruct the human readable json.

With the example above step (b) fails because during step (a) `StableTokenProxy` is referenced and this causes the contract to be loaded in ContractKit's cache, and this introduces a subtle bug [here](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/explorer/src/block-explorer.ts#L62), because the logic here keeps a mapping from address to ContractDetails, and `StableToken` and `StableTokenProxy` have the same address and the mapping ends holding a reference to `StableTokenProxy` and the tooling is unable to find the `mint` function at this address.
The tooling usually gets around this by adding the `Proxy` ABI to all contracts [here](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/explorer/src/block-explorer.ts#L45-L47), therefore we should ignore `Proxy` contracts when building this mapping.

#### (2) The external contract call limitation

During this proposal, we need to make two external calls from `Governance`, one to `USDC` to set approval, and one to a `StableSwap Pool` to deposit liquidity. As it currently stands the tooling doesn't support this, but this PR aims to set the foundations for the work needed to allow this sort of interaction, with a focus on an immediate solution because of the urgency around this particular CGP. 

The transactions in the proposal look like:

```json
[
  {
    "contract": "0x37f750B7cC259A2f741AF45294f6a16572CF5cAd",
    "function": "approve(address,uint256)",
    "args": [
      "0x37f750B7cC259A2f741AF45294f6a16572CF5cAd",
      "5000000000000"
    ],
    "value": "0"
  },
  {
    "contract": "0x37f750B7cC259A2f741AF45294f6a16572CF5cAd",
    "function": "addLiquidity(uint256[],uint256,uint256)",
    "args": [
      [
        "5000000000000000000000000",
        "5000000000000"
      ],
      0,
      1661419596
    ],
    "value": "0"
  }
]
```

As stated in the previous section, the tooling has two processes that we're interested in:
(a) `json->raw`, which takes in the human readable json and outputs the raw transactions submitted on-chain
(b) `raw->json`, which reads the transactions submitted on-chain and attempts to reconstruct the human readable json

This feature is __trivial__ to implement in (a) because we can include the function signature in the CGP and use that to encode the transaction, but (b) is non-trivial because we would need to reconstruct the function call in a human-readable form, without access to the ABI. There are a couple of different approaches we can take:

1. Use an external source like [4byte.directory](4byte.directory) to get function signatures and parse the transactions
2. Have a local database of __well known__  `function selector => function signature`  used to parse the transactions
3. Support transactions that can't be parsed

(1) is an ideal but I've had problems with `4byte.directory` being down in the past so the system shouldn't fully rely on it, so (1) can't exist without (3) otherwise the governance flow can suffer. (2) can also act as a backup for (1), in a layered approach.

But for this PR I only went with (2) in the interest of time and added the signatures for the functions that are included in this proposal.

### Other changes

None

### Tested

Tested locally but none of the packages have tests so I didn't add them now.

### Backwards compatibility

All changes are backward compatible

### Documentation

No doc changes needed, but we might want to extend the CLI proposal creation process to allow for external contract calls in the proposal.