### PR TITLE
[ODISv2] Bump @celo/poprf and fix poprf.test.ts

### DIFF
--- a/packages/phone-number-privacy/common/package.json
+++ b/packages/phone-number-privacy/common/package.json
@@ -33,7 +33,7 @@
     "is-base64": "^1.1.0"
   },
   "devDependencies": {
-    "@celo/poprf": "^0.1.8",
+    "@celo/poprf": "^0.1.9",
     "@celo/wallet-local": "2.0.1-dev",
     "@types/btoa": "^1.2.3",
     "@types/bunyan": "1.8.4",

--- a/packages/phone-number-privacy/common/test/poprf.test.ts
+++ b/packages/phone-number-privacy/common/test/poprf.test.ts
@@ -92,7 +92,11 @@ describe('end-to-end', () => {
       (i) => new ThresholdPoprfServer(TEST_THRESHOLD_POPRF_KEYS.getShare(i))
     )
     const combiner = new PoprfCombiner(TEST_THRESHOLD_T)
-    const client = new PoprfClient(TEST_POPRF_KEYPAIR.publicKey, TEST_TAG_A, TEST_MESSAGE_A)
+    const client = new PoprfClient(
+      TEST_THRESHOLD_POPRF_KEYS.thresholdPublicKey,
+      TEST_TAG_A,
+      TEST_MESSAGE_A
+    )
 
     const blindedPartials = servers.map((s) =>
       s.blindPartialEval(client.tag, client.blindedMessage)
@@ -106,7 +110,7 @@ describe('end-to-end', () => {
 
     // POPRF hashed outputs should be 32 bytes.
     expect(evaluation.length).toEqual(32)
-    expect(evaluation.toString('base64')).toEqual('5xHueBbMK1wfm7VyrPYJJAhOrV8X0rP0hz7gRxTLEcA=')
+    expect(evaluation.toString('base64')).toEqual('C1jKGStMWC3lNpYDV61D+3waetY0bHlD4ElYzV+Isqc=')
   })
 
   it('successfully completes client-server exchange with threshold client and server', () => {
@@ -139,6 +143,6 @@ describe('end-to-end', () => {
 
     // POPRF hashed outputs should be 32 bytes.
     expect(evaluation.length).toEqual(32)
-    expect(evaluation.toString('base64')).toEqual('5xHueBbMK1wfm7VyrPYJJAhOrV8X0rP0hz7gRxTLEcA=')
+    expect(evaluation.toString('base64')).toEqual('C1jKGStMWC3lNpYDV61D+3waetY0bHlD4ElYzV+Isqc=')
   })
 })

--- a/packages/phone-number-privacy/signer/package.json
+++ b/packages/phone-number-privacy/signer/package.json
@@ -35,7 +35,7 @@
     "@celo/contractkit": "2.0.1-dev",
     "@celo/identity": "2.0.1-dev",
     "@celo/phone-number-privacy-common": "1.0.42-dev",
-    "@celo/poprf": "^0.1.8",
+    "@celo/poprf": "^0.1.9",
     "@celo/utils": "2.0.1-dev",
     "@celo/wallet-hsm-azure": "2.0.1-dev",
     "@google-cloud/secret-manager": "3.0.0",

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -47,10 +47,9 @@ export function startSigner(config: SignerConfig, db: Knex, keyProvider: KeyProv
   // TODO: Clean this up / maybe roll into to Controller class
   const addMeteredSignerEndpoint = (
     endpoint: SignerEndpoint,
-    handler: (req: Request, res: Response) => Promise<void>,
-    method: 'post' | 'get' = 'post'
+    handler: (req: Request, res: Response) => Promise<void>
   ) =>
-    app[method](endpoint, async (req, res) => {
+    app.post(endpoint, async (req, res) => {
       await callAndMeterLatency(endpoint, handler, req, res)
     })
 
@@ -128,20 +127,15 @@ export function startSigner(config: SignerConfig, db: Knex, keyProvider: KeyProv
   )
 
   addMeteredSignerEndpoint(SignerEndpoint.PNP_SIGN, pnpSign.handle.bind(pnpSign))
-  addMeteredSignerEndpoint(SignerEndpoint.PNP_QUOTA, pnpQuota.handle.bind(pnpQuota), 'get')
-  addMeteredSignerEndpoint(
-    SignerEndpoint.DOMAIN_QUOTA_STATUS,
-    domainQuota.handle.bind(domainQuota),
-    'get'
-  )
+  addMeteredSignerEndpoint(SignerEndpoint.PNP_QUOTA, pnpQuota.handle.bind(pnpQuota))
+  addMeteredSignerEndpoint(SignerEndpoint.DOMAIN_QUOTA_STATUS, domainQuota.handle.bind(domainQuota))
   addMeteredSignerEndpoint(SignerEndpoint.DOMAIN_SIGN, domainSign.handle.bind(domainSign))
   addMeteredSignerEndpoint(SignerEndpoint.DISABLE_DOMAIN, domainDisable.handle.bind(domainDisable))
 
   addMeteredSignerEndpoint(SignerEndpoint.LEGACY_PNP_SIGN, legacyPnpSign.handle.bind(legacyPnpSign))
   addMeteredSignerEndpoint(
     SignerEndpoint.LEGACY_PNP_QUOTA,
-    legacyPnpQuota.handle.bind(legacyPnpQuota),
-    'get'
+    legacyPnpQuota.handle.bind(legacyPnpQuota)
   )
 
   const sslOptions = getSslOptions(config)

--- a/packages/phone-number-privacy/signer/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/domain.test.ts
@@ -273,7 +273,7 @@ describe('domainService', () => {
   describe(`${SignerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
     it('Should respond with 200 on valid request', async () => {
       const res = await request(app)
-        .get(SignerEndpoint.DOMAIN_QUOTA_STATUS)
+        .post(SignerEndpoint.DOMAIN_QUOTA_STATUS)
         .send(await quotaRequest())
 
       expect(res.status).toBe(200)
@@ -286,7 +286,7 @@ describe('domainService', () => {
 
     it('Should respond with 200 on repeated valid requests', async () => {
       const res1 = await request(app)
-        .get(SignerEndpoint.DOMAIN_QUOTA_STATUS)
+        .post(SignerEndpoint.DOMAIN_QUOTA_STATUS)
         .send(await quotaRequest())
       expect(res1.status).toBe(200)
       expect(res1.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -296,7 +296,7 @@ describe('domainService', () => {
       })
 
       const res2 = await request(app)
-        .get(SignerEndpoint.DOMAIN_QUOTA_STATUS)
+        .post(SignerEndpoint.DOMAIN_QUOTA_STATUS)
         .send(await quotaRequest())
       expect(res2.status).toBe(200)
       expect(res2.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -311,7 +311,7 @@ describe('domainService', () => {
       // @ts-ignore Intentionally adding an extra field to the request type
       req.options.extraField = noString
 
-      const res = await request(app).get(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
+      const res = await request(app).post(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
 
       expect(res.status).toBe(200)
       expect(res.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -326,7 +326,7 @@ describe('domainService', () => {
       // @ts-ignore Intentionally deleting required field
       delete badRequest.domain.version
 
-      const res = await request(app).get(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
+      const res = await request(app).post(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
 
       expect(res.status).toBe(400)
       expect(res.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -342,7 +342,7 @@ describe('domainService', () => {
       // @ts-ignore UnknownDomain is (intentionally) not a valid domain identifier.
       unknownRequest.domain.name = 'UnknownDomain'
 
-      const res = await request(app).get(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(unknownRequest)
+      const res = await request(app).post(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(unknownRequest)
 
       expect(res.status).toBe(400)
       expect(res.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -357,7 +357,7 @@ describe('domainService', () => {
       // @ts-ignore Intentionally not JSON
       badRequest1.domain = 'Freddy'
 
-      const res1 = await request(app).get(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest1)
+      const res1 = await request(app).post(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest1)
 
       expect(res1.status).toBe(400)
       expect(res1.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -368,7 +368,7 @@ describe('domainService', () => {
 
       const badRequest2 = ''
 
-      const res2 = await request(app).get(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest2)
+      const res2 = await request(app).post(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest2)
 
       expect(res2.status).toBe(400)
       expect(res2.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -383,7 +383,7 @@ describe('domainService', () => {
       const badRequest = await quotaRequest()
       badRequest.domain.salt = defined('badSalt')
 
-      const res = await request(app).get(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
+      const res = await request(app).post(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
 
       expect(res.status).toBe(401)
       expect(res.body).toMatchObject<DomainQuotaStatusResponse>({
@@ -400,7 +400,7 @@ describe('domainService', () => {
       const req = await quotaRequest()
 
       const res = await request(appWithApiDisabled)
-        .get(SignerEndpoint.DOMAIN_QUOTA_STATUS)
+        .post(SignerEndpoint.DOMAIN_QUOTA_STATUS)
         .send(req)
 
       expect(res.status).toBe(503)

--- a/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
@@ -117,7 +117,7 @@ describe('legacyPNP', () => {
     signerApp: any = app
   ) => {
     return request(signerApp)
-      .get(SignerEndpoint.LEGACY_PNP_QUOTA)
+      .post(SignerEndpoint.LEGACY_PNP_QUOTA)
       .set('Authorization', authorization)
       .send(req)
   }

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -87,7 +87,7 @@ describe('pnp', () => {
     signerApp: any = app
   ) => {
     return request(signerApp)
-      .get(SignerEndpoint.PNP_QUOTA)
+      .post(SignerEndpoint.PNP_QUOTA)
       .set('Authorization', authorization)
       .send(req)
   }

--- a/packages/sdk/encrypted-backup/package.json
+++ b/packages/sdk/encrypted-backup/package.json
@@ -28,7 +28,7 @@
     "@celo/base": "2.0.1-dev",
     "@celo/identity": "2.0.1-dev",
     "@celo/phone-number-privacy-common": "1.0.39",
-    "@celo/poprf": "^0.1.8",
+    "@celo/poprf": "^0.1.9",
     "@celo/utils": "2.0.1-dev",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,6 +1486,11 @@
   resolved "https://registry.yarnpkg.com/@celo/poprf/-/poprf-0.1.8.tgz#00d38aeb20993dae1c50d23f3293afe7a8abebc2"
   integrity sha512-gWyl37lqLXwo44tTBJIVVyOD/Qec02T0ndKKpr1ms073frcLMBvcdNOfXgQ0/ROEhl9ewOALx5hxMm+RHy5XNw==
 
+"@celo/poprf@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@celo/poprf/-/poprf-0.1.9.tgz#38c514ce0f572b80edeb9dc280b6cf5e9d7c2a75"
+  integrity sha512-+993EA/W+TBCZyY5G0B2EVdXnPX6t2AldgRAIMaT9WIqTwZKi/TcdJDUQl8mj7HEHMPHlpgCBOVgaHkUcwo/5A==
+
 "@celo/typechain-target-web3-v1-celo@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@celo/typechain-target-web3-v1-celo/-/typechain-target-web3-v1-celo-0.2.0.tgz#2560b470e348d2628debe899885724ce5b218bc3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,11 +1481,6 @@
     elliptic "^6.5.4"
     is-base64 "^1.1.0"
 
-"@celo/poprf@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@celo/poprf/-/poprf-0.1.8.tgz#00d38aeb20993dae1c50d23f3293afe7a8abebc2"
-  integrity sha512-gWyl37lqLXwo44tTBJIVVyOD/Qec02T0ndKKpr1ms073frcLMBvcdNOfXgQ0/ROEhl9ewOALx5hxMm+RHy5XNw==
-
 "@celo/poprf@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@celo/poprf/-/poprf-0.1.9.tgz#38c514ce0f572b80edeb9dc280b6cf5e9d7c2a75"


### PR DESCRIPTION
### Description

This PR addresses the failing test in @celo/phone-number-privacy-common, poprf.test.ts.
It makes a few changes:

* Use a newly published version of @celo/poprf 0.1.9. This does not actually effect the results in
    the test, but contains an important change to the check that received elements of G_T are in the
    correct subgroup before operating on them.
* Fix the usage of the wrong public key in the test that involves the combiner.
* Update the final result values to reflect a [change to the final hashing
    step.](https://github.com/celo-org/celo-poprf-rs/commit/469d343b85a52662f2d63a78c3a58c8d5db05339#diff-33fe835991eaaf936afe751a2ded677560466271c87c68ff7d7bd5fc3379de6aR31)
