### PR TITLE
Improve signer and combiner domain.test.ts

### DIFF
--- a/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
@@ -1,8 +1,11 @@
 import {
   CombinerEndpoint,
   DomainRestrictedSignatureRequest,
+  ErrorMessage,
+  ErrorType,
   getSignerEndpoint,
   SignerEndpoint,
+  WarningMessage,
 } from '@celo/phone-number-privacy-common'
 import { CryptoSession } from '../../../common/crypto-session'
 import { IO } from '../../../common/io'
@@ -56,5 +59,18 @@ export class DomainSignAction extends SignAction<DomainRestrictedSignatureReques
   ): void {
     // TODO
     throw new Error('Method not implemented.')
+  }
+
+  protected errorCodeToError(errorCode: number): ErrorType {
+    switch (errorCode) {
+      case 403:
+      case 429:
+        return WarningMessage.EXCEEDED_QUOTA
+      case 401:
+        // Authentication is checked in the combiner, but invalid nonces are passed through
+        return WarningMessage.INVALID_NONCE
+      default:
+        return ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES
+    }
   }
 }

--- a/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/io.ts
@@ -84,7 +84,7 @@ export class DomainSignIO extends IO<DomainRestrictedSignatureRequest> {
     error: ErrorType,
     status: number,
     response: Response<DomainRestrictedSignatureResponseFailure>,
-    domainState?: DomainState
+    domainState?: DomainState // TODO: is status ever provided on failure?
   ) {
     send(
       response,

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/io.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/io.ts
@@ -49,8 +49,7 @@ export class PnpQuotaIO extends IO<PnpQuotaRequest> {
       this.sendFailure(WarningMessage.UNAUTHENTICATED_USER, 401, response)
       return null
     }
-    // TODO: refactor so crypto client doesn't need to be passed here
-    return new Session(request, response, undefined)
+    return new Session(request, response)
   }
 
   validateClientRequest(

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
@@ -1,5 +1,10 @@
 import { SignMessageRequest } from '@celo/identity/lib/odis/query'
-import { MAX_BLOCK_DISCREPANCY_THRESHOLD, WarningMessage } from '@celo/phone-number-privacy-common'
+import {
+  ErrorMessage,
+  ErrorType,
+  MAX_BLOCK_DISCREPANCY_THRESHOLD,
+  WarningMessage,
+} from '@celo/phone-number-privacy-common'
 import { CryptoSession } from '../../../common/crypto-session'
 import { IO } from '../../../common/io'
 import { SignAction } from '../../../common/sign'
@@ -85,6 +90,16 @@ export class PnpSignAction extends SignAction<SignMessageRequest> {
       if (discrepancyFound) {
         return
       }
+    }
+  }
+
+  protected errorCodeToError(errorCode: number): ErrorType {
+    switch (errorCode) {
+      case 403:
+      case 429:
+        return WarningMessage.EXCEEDED_QUOTA
+      default:
+        return ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES
     }
   }
 }

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -561,7 +561,7 @@ describe('domainService', () => {
     })
 
     it('Should respond with 200 if nonce > domainState', async () => {
-      const [req, poprfClient] = await signatureRequest(undefined, 1)
+      const [req, poprfClient] = await signatureRequest(undefined, 2)
 
       const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
 
@@ -572,7 +572,7 @@ describe('domainService', () => {
         signature: res.body.signature,
         status: {
           disabled: false,
-          counter: 1,
+          counter: 1, // counter gets incremented, not set to nonce value
           timer: res.body.status.timer,
           now: res.body.status.now,
         },

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -390,16 +390,20 @@ describe('domainService', () => {
     it('Should respond with 200 on repeated valid requests', async () => {
       const req = await quotaRequest()
       const res1 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
-      expect(res1.status).toBe(200)
-      expect(res1.body).toMatchObject<DomainQuotaStatusResponse>({
+      const expectedResponse: DomainQuotaStatusResponse = {
         success: true,
         version: res1.body.version,
         status: { disabled: false, counter: 0, timer: 0, now: res1.body.status.now },
-      })
+      }
+
+      expect(res1.status).toBe(200)
+      expect(res1.body).toMatchObject<DomainQuotaStatusResponse>(expectedResponse)
 
       const res2 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
       expect(res2.status).toBe(200)
-      expect(res2.body).toMatchObject<DomainQuotaStatusResponse>(res1.body)
+      // Prevent flakiness due to slight timing inconsistencies
+      expectedResponse.status.now = res2.body.status.now
+      expect(res2.body).toMatchObject<DomainQuotaStatusResponse>(expectedResponse)
     })
 
     it('Should respond with 200 on extra request fields', async () => {

--- a/packages/phone-number-privacy/common/src/interfaces/endpoints.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/endpoints.ts
@@ -37,6 +37,8 @@ export function getSignerEndpoint(endpoint: CombinerEndpoint): SignerEndpoint {
       return SignerEndpoint.DOMAIN_QUOTA_STATUS
     case CombinerEndpoint.DOMAIN_SIGN:
       return SignerEndpoint.DOMAIN_SIGN
+    case CombinerEndpoint.PNP_QUOTA:
+      return SignerEndpoint.PNP_QUOTA
     case CombinerEndpoint.PNP_SIGN:
       return SignerEndpoint.PNP_SIGN
     case CombinerEndpoint.LEGACY_PNP_SIGN:
@@ -54,6 +56,8 @@ export function getCombinerEndpoint(endpoint: SignerEndpoint): CombinerEndpoint 
       return CombinerEndpoint.DOMAIN_QUOTA_STATUS
     case SignerEndpoint.DOMAIN_SIGN:
       return CombinerEndpoint.DOMAIN_SIGN
+    case SignerEndpoint.PNP_QUOTA:
+      return CombinerEndpoint.PNP_QUOTA
     case SignerEndpoint.PNP_SIGN:
       return CombinerEndpoint.PNP_SIGN
     case SignerEndpoint.LEGACY_PNP_SIGN:

--- a/packages/phone-number-privacy/common/src/interfaces/responses.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/responses.ts
@@ -137,7 +137,7 @@ export interface DomainRestrictedSignatureResponseFailure<D extends Domain = Dom
   success: false
   version: string
   error: string
-  status: DomainState<D> | undefined
+  status?: DomainState<D>
 }
 
 export type DomainRestrictedSignatureResponse<D extends Domain = Domain> =
@@ -196,7 +196,12 @@ export function domainRestrictedSignatureResponseSchema<D extends Domain>(
       success: t.literal(false),
       version: t.string,
       error: t.string,
-      status: t.union([state, t.undefined]),
+      status: state,
+    }),
+    t.type({
+      success: t.literal(false),
+      version: t.string,
+      error: t.string,
     }),
   ])
 }

--- a/packages/phone-number-privacy/signer/src/domain/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/signer/src/domain/endpoints/sign/io.ts
@@ -77,7 +77,7 @@ export class DomainSignIO extends IO<DomainRestrictedSignatureRequest> {
     error: ErrorType,
     status: number,
     response: Response<DomainRestrictedSignatureResponseFailure>,
-    domainState?: DomainState
+    domainState?: DomainState // TODO: is status ever provided on failure?
   ) {
     send(
       response,

--- a/packages/phone-number-privacy/signer/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/domain.test.ts
@@ -521,7 +521,7 @@ describe('domainService', () => {
     })
 
     it('Should respond with 200 if nonce > domainState', async () => {
-      const [req, thresholdPoprfClient] = await signatureRequest(undefined, 1)
+      const [req, thresholdPoprfClient] = await signatureRequest(undefined, 2)
       const res = await request(app).post(SignerEndpoint.DOMAIN_SIGN).send(req)
       expect(res.status).toBe(200)
       expect(res.body).toMatchObject<DomainRestrictedSignatureResponse>({
@@ -530,7 +530,7 @@ describe('domainService', () => {
         signature: res.body.signature,
         status: {
           disabled: false,
-          counter: 1,
+          counter: 1, // counter gets incremented, not set to nonce value
           timer: res.body.status.timer,
           now: res.body.status.now,
         },

--- a/packages/phone-number-privacy/signer/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/domain.test.ts
@@ -467,12 +467,12 @@ describe('domainService', () => {
     })
 
     it('Should respond with 200 on repeated valid requests with nonce updated', async () => {
-      const [req1, thresholdPoprfClient] = await signatureRequest()
+      const [req, thresholdPoprfClient] = await signatureRequest()
 
       const res1 = await request(app)
         .post(SignerEndpoint.DOMAIN_SIGN)
         .set('keyVersion', '1')
-        .send(req1)
+        .send(req)
 
       expect(res1.status).toBe(200)
       expect(res1.body).toMatchObject<DomainRestrictedSignatureResponse>({
@@ -492,15 +492,16 @@ describe('domainService', () => {
       expect(eval1.toString('base64')).toEqual(expectedEval)
 
       // submit identical request with nonce set to 1
-      req1.options.nonce = defined(1)
-      req1.options.signature = noString
-      req1.options.signature = defined(
-        await wallet.signTypedData(walletAddress, domainRestrictedSignatureRequestEIP712(req1))
+      req.options.nonce = defined(1)
+      // This is how
+      req.options.signature = noString
+      req.options.signature = defined(
+        await wallet.signTypedData(walletAddress, domainRestrictedSignatureRequestEIP712(req))
       )
       const res2 = await request(app)
         .post(SignerEndpoint.DOMAIN_SIGN)
         .set('keyVersion', '1')
-        .send(req1)
+        .send(req)
       expect(res2.status).toBe(200)
       expect(res2.body).toMatchObject<DomainRestrictedSignatureResponse>({
         success: true,


### PR DESCRIPTION
### Description
- uses `ThresholdPoprfClient` to evaluate partial signatures returned by `DOMAIN_SIGN` signer endpoints
  - ⚠️❓ currently just checks against a hard-coded evaluation result, not sure if there's a better way of doing this
- fix test cases with nonces (previously was failing due to incorrect authorization, not nonce being invalid) (in both signer and combiner tests)
  - add case with nonce >0 being valid (this is allowed by the current domain signer logic -- if we don't want this to be the case, we need to update the logic)
  - fix case with repeated request + nonce being incremented (valid) -- keeps the request the same except for the nonce (including blinded message, sessionID being the same -- wasn't the case before)
  - fix nonce failure case -- requires repeat request + nonce not being updated
- modifY `DomainRestrictedSignatureResponse` slightly (allows status field to not be present), moved TODO from tests -> `sendFailure`
- passthrough 401 errors from the signer as nonce errors in the combiner (since auth is already checked on the combiner side, it seems more likely that 401s are caused by nonce issues and it's pretty confusing to only get the missing signatures error) -- happy to change this back though!


Will merge after the POPRF changes are approved since this is based off of those changes!