### PR TITLE
Keep more Prometheus metrics

### DIFF
--- a/packages/helm-charts/prometheus-stackdriver/values.yaml
+++ b/packages/helm-charts/prometheus-stackdriver/values.yaml
@@ -121,7 +121,7 @@ remote_write:
               |container_cpu_user_seconds_total\
               |container_file_.+\
               |container_fs_.+\
-              |container_memory_[^w].*\
+              |container_memory_[^wu].*\
               |container_last_.+\
               |container_network_.+\
               |container_processes\

--- a/packages/helm-charts/prometheus-stackdriver/values.yaml
+++ b/packages/helm-charts/prometheus-stackdriver/values.yaml
@@ -167,7 +167,6 @@ remote_write:
               |kube_pod_status_ready\
               |kube_pod_status_scheduled\
               |kube_pod_status_scheduled_time\
-              |kube_pod_status_phase\
               |kube_pod_container_[^r].+\
               |kube_pod_container_status_last_terminated_reason\
               |kube_pod_container_status_terminated_reason\

--- a/packages/helm-charts/prometheus-stackdriver/values.yaml
+++ b/packages/helm-charts/prometheus-stackdriver/values.yaml
@@ -168,6 +168,7 @@ remote_write:
               |kube_pod_status_scheduled\
               |kube_pod_status_scheduled_time\
               |kube_pod_container_[^rs].+\
+              |kube_pod_container_state.+\
               |kube_pod_container_status_last_terminated_reason\
               |kube_pod_container_status_ready\
               |kube_pod_container_status_running\

--- a/packages/helm-charts/prometheus-stackdriver/values.yaml
+++ b/packages/helm-charts/prometheus-stackdriver/values.yaml
@@ -167,9 +167,13 @@ remote_write:
               |kube_pod_status_ready\
               |kube_pod_status_scheduled\
               |kube_pod_status_scheduled_time\
-              |kube_pod_container_[^r].+\
+              |kube_pod_container_[^rs].+\
               |kube_pod_container_status_last_terminated_reason\
+              |kube_pod_container_status_ready\
+              |kube_pod_container_status_running\
+              |kube_pod_container_status_terminated\
               |kube_pod_container_status_terminated_reason\
+              |kube_pod_container_status_waiting\
               |kube_pod_container_status_waiting_reason\
               |kube_replicaset.*\
               |kube_resourcequota.*\


### PR DESCRIPTION
### Description

Send a few more Prometheus metrics to the `remote_write` destination, namely
- `container_memory_usage_bytes`
- `kube_pod_container_status_restarts_total`
- `kube_pod_status_phase`

These are needed for dashboards and alerting.

[Expected additional metrics volume: in mainnet, ~3k metrics.](https://mainnet-grafana.celo-testnet.org/goto/3MpNMNZVk?orgId=1)
[Available volume: ~30k metrics. ](https://clabs.grafana.net/goto/iKqNMHZVk?orgId=1)

### Other changes

N/A

### Tested

No.

### Related issues

https://github.com/celo-org/data-services/issues/372

### Backwards compatibility

Backwards compatible with existing features.

### Documentation

N/A