### PR TITLE
Add PairManager contract

### DIFF
--- a/packages/protocol/contracts/stability/PairManager.sol
+++ b/packages/protocol/contracts/stability/PairManager.sol
@@ -2,6 +2,9 @@ pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import { IPairManager } from "./interfaces/IPairManager.sol";
+import { IReserve } from "./interfaces/IReserve.sol";
+
+import { StableToken } from "./StableToken.sol";
 
 import { UsingRegistry } from "../common/UsingRegistry.sol";
 import { Initializable } from "../common/Initializable.sol";
@@ -16,9 +19,19 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
 
   /* ==================== State Variables ==================== */
 
-  // Maps a pair id to the corresponding pair.
+  // Maps a pair id to the corresponding pair struct.
   // pairId is in the format "stableSymbol:collateralSymbol:exchangeName"
   mapping(bytes32 => Pair) public pairs;
+  // Tracks whether or not a pair with the given pairId exists.
+  mapping(bytes32 => bool) public isPair;
+
+  // Tracks the total fraction of reserve collateral
+  // that has been allocated to existing virtual pairs.
+  mapping(address => FixidityLib.Fraction) public allocatedCollateralFractions;
+
+  // TODO: Confirm total allocations with Nadiem
+  // Tracks the total fraction of reserve stable that has been allocated to existing virtual pairs.
+  mapping(address => FixidityLib.Fraction) public allocatedStableFractions;
 
   /* ==================== Constructor ==================== */
 
@@ -37,11 +50,103 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
 
   /* ==================== Restricted Functions ==================== */
 
-  // TODO: Create function overload with minimal parms
+  /**
+   * @notice Creates a new pair using the given parameters.
+   * @param pairInfo The information required to create the pair.
+   * @return pairId The id of the newly created pair.
+   */
+  function createPair(Pair calldata pairInfo) external onlyOwner returns (bytes32 pairId) {
+    validatePairInfo(pairInfo);
+
+    // TODO: Erc20 does not have definition for symbol
+    // TODO: Need IMentoExchange.name()
+    pairId = keccak256(abi.encodePacked(StableToken(pairInfo.stableAsset).symbol(), ":"));
+    require(!isPair[pairId], "A pair with the specified assets and exchange exists");
+
+    // Initilize buckets
+    // TODO: Add call to
+    // IMentoExchange.getUpdatedBuckets()
+    // (uint256 newStableBucket, uint256 newCollateralBucket) = IMentoExchange(pairInfo.mentoExchange).getUpdatedBuckets(...);
+    // pairInfo.stableBucket = newStableBucket;
+    // pairInfo.collateralBucket = newCollateralBucket;
+
+    pairs[pairId] = pairInfo;
+    isPair[pairId] = true;
+    emit PairCreated(pairInfo.stableAsset, pairInfo.collateralAsset, pairInfo.mentoExchange);
+  }
 
   /**
-   * @notice Creates a new virtual pair using the given parameters.
-   * @param pairInfo The info
+   * @notice Valitates a virtual pair with the given information.
+   * @param pairInfo The information on the virtual pair to be validated.
+   * @return isValid A bool indicating whether or not the pair information provided is valid.
    */
-  function createPair(Pair calldata pairInfo) external onlyOwner returns (bytes32 pairId) {}
+  function validatePairInfo(Pair memory pairInfo) private returns (bool isValid) {
+    IReserve reserve = IReserve(registry.getAddressForOrDie(RESERVE_REGISTRY_ID));
+
+    require(
+      reserve.isStableAsset(pairInfo.stableAsset),
+      "Stable asset specified is not registered with reserve"
+    );
+    require(
+      reserve.isCollateralAsset(pairInfo.collateralAsset),
+      "Collateral asset specified is not registered with reserve"
+    );
+    require(
+      pairInfo.collateralBucketFraction.lt(FixidityLib.fixed1()),
+      "Collateral asset fraction must be smaller than 1"
+    );
+    require(
+      pairInfo.collateralBucketFraction.lt(
+        getAvailableCollateralFraction(pairInfo.collateralAsset)
+      ),
+      "Collateral asset fraction must be less than available collateral fraction"
+    );
+    require(pairInfo.mentoExchange != address(0), "Mento exchange must be set");
+
+    require(
+      pairInfo.stableBucketMaxFraction.unwrap() > 0,
+      "Stable bucket fraction must be greater than 0"
+    );
+
+    require(
+      pairInfo.stableBucketMaxFraction.lt(FixidityLib.fixed1()),
+      "Stable bucket fraction must be smaller than 1"
+    );
+
+    require(
+      FixidityLib.lte(pairInfo.spread, FixidityLib.fixed1()),
+      "Spread must be less than or equal to 1"
+    );
+
+    // TODO: Stable bucket max fraction should not exceed available stable bucket fraction.
+    // TODO: minSupplyForStableBucketCap gt 0 & is there an aggregated value that needs to be checked
+
+    isValid = true; //TODO: Necessary?
+  }
+
+  /* ==================== Private Functions ==================== */
+
+  /**
+   * @notice Retrieve the availble fraction of the reserve collateral that can be allocated to a virtual pair.
+   * @param collateralAsset The address of the collateral asset.
+   * @return availableFraction The available fraction that can be allocated to a pair with the specified collateral asset.
+   */
+  function getAvailableCollateralFraction(address collateralAsset)
+    private
+    returns (FixidityLib.Fraction memory availableFraction)
+  {
+    return FixidityLib.fixed1().subtract(allocatedCollateralFractions[collateralAsset]);
+  }
+
+  /**
+   * @notice Retrieve the availble fraction of the reserve stable assets that can be allocated to a virtual pair.
+   * @param stableAsset The address of the stable asset.
+   * @return availableFraction The available fraction that can be allocated to a pair with the specified collateral asset.
+   */
+  function getAvailableStableFraction(address stableAsset)
+    private
+    returns (FixidityLib.Fraction memory availableFraction)
+  {
+    return FixidityLib.fixed1().subtract(allocatedStableFractions[stableAsset]);
+  }
 }

--- a/packages/protocol/contracts/stability/PairManager.sol
+++ b/packages/protocol/contracts/stability/PairManager.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { IPairManager } from "./interfaces/IPairManager.sol";
+
+import { UsingRegistry } from "../common/UsingRegistry.sol";
+import { Initializable } from "../common/Initializable.sol";
+import { FixidityLib } from "../common/FixidityLib.sol";
+
+/**
+ * @title PairManager
+ * @notice The pair manager allows the creation of virtual pairs that are tradeable via Mento.
+ */
+contract PairManager is IPairManager, Initializable, UsingRegistry {
+  using FixidityLib for FixidityLib.Fraction;
+
+  /* ==================== State Variables ==================== */
+
+  // Maps a pair id to the corresponding pair.
+  // pairId is in the format "stableSymbol:collateralSymbol:exchangeName"
+  mapping(bytes32 => Pair) public pairs;
+
+  /* ==================== Constructor ==================== */
+
+  /**
+   * @notice Sets initialized == true on implementation contracts.
+   * @param test Set to true to skip implementation initialization.
+   */
+  constructor(bool test) public Initializable(test) {}
+
+  /**
+   * @notice Allows the contract to be upgradable via the proxy.
+   */
+  function initilize() external initializer {
+    _transferOwnership(msg.sender);
+  }
+
+  /* ==================== Restricted Functions ==================== */
+
+  // TODO: Create function overload with minimal parms
+
+  /**
+   * @notice Creates a new virtual pair using the given parameters.
+   * @param pairInfo The info
+   */
+  function createPair(Pair calldata pairInfo) external onlyOwner returns (bytes32 pairId) {}
+}

--- a/packages/protocol/contracts/stability/PairManager.sol
+++ b/packages/protocol/contracts/stability/PairManager.sol
@@ -38,7 +38,7 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
   // that has been allocated to existing virtual pairs.
   mapping(address => FixidityLib.Fraction) public allocatedCollateralFractions;
 
-  // TODO: Confirm total allocations with Nadiem
+  // TODO: https://github.com/mento-protocol/mento-general/issues/60
   // Tracks the total fraction of reserve stable that has been allocated to existing virtual pairs.
   mapping(address => FixidityLib.Fraction) public allocatedStableFractions;
 
@@ -93,6 +93,10 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
    * @return pairId The id of the newly created pair.
    */
   function createPair(Pair calldata pair) external onlyOwner returns (bytes32 pairId) {
+    require(address(pair.mentoExchange) != address(0), "Mento exchange must be set");
+    require(address(pair.stableAsset) != address(0), "Stable asset must be set");
+    require(address(pair.collateralAsset) != address(0), "Collateral asset must be set");
+
     Pair memory pairInfo = pair;
 
     pairId = keccak256(
@@ -119,14 +123,15 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
     pairInfo.stableBucket = tokenInBucket;
     pairInfo.collateralBucket = tokenOutBucket;
 
+    // TODO: https://github.com/mento-protocol/mento-general/issues/60
     // Update allocated collateral fraction
-    allocatedCollateralFractions[pairInfo.collateralAsset] = allocatedCollateralFractions[pairInfo
-      .collateralAsset]
-      .add(pairInfo.collateralBucketFraction);
+    // allocatedCollateralFractions[pairInfo.collateralAsset] = allocatedCollateralFractions[
+    //   pairInfo.collateralAsset
+    // ].add(pairInfo.collateralBucketFraction);
 
-    // Update allocated stable bucket fraction
-    allocatedStableFractions[pairInfo.stableAsset] = allocatedStableFractions[pairInfo.stableAsset]
-      .add(pairInfo.stableBucketMaxFraction);
+    // // Update allocated stable bucket fraction
+    // allocatedStableFractions[pairInfo.stableAsset] = allocatedStableFractions[pairInfo.stableAsset]
+    //   .add(pairInfo.stableBucketMaxFraction);
 
     pairs[pairId] = pairInfo;
     isPair[pairId] = true;
@@ -164,14 +169,15 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
 
     Pair memory pair = pairs[pairId];
 
+    // TODO: https://github.com/mento-protocol/mento-general/issues/60
     // Update allocated collateral fraction
-    allocatedCollateralFractions[pair.collateralAsset] = allocatedCollateralFractions[pair
-      .collateralAsset]
-      .subtract(pair.collateralBucketFraction);
+    // allocatedCollateralFractions[pair.collateralAsset] = allocatedCollateralFractions[
+    //   pair.collateralAsset
+    // ].subtract(pair.collateralBucketFraction);
 
-    // Update allocated stable bucket fraction
-    allocatedStableFractions[pair.stableAsset] = allocatedStableFractions[pair.stableAsset]
-      .subtract(pair.stableBucketMaxFraction);
+    // // Update allocated stable bucket fraction
+    // allocatedStableFractions[pair.stableAsset] = allocatedStableFractions[pair.stableAsset]
+    //   .subtract(pair.stableBucketMaxFraction);
 
     isPair[pairId] = false;
     delete pairs[pairId];
@@ -225,13 +231,14 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
       pairInfo.collateralBucketFraction.lt(FixidityLib.fixed1()),
       "Collateral asset fraction must be smaller than 1"
     );
-    require(
-      pairInfo.collateralBucketFraction.lt(
-        getAvailableCollateralFraction(pairInfo.collateralAsset)
-      ),
-      "Collateral asset fraction must be less than available collateral fraction"
-    );
-    require(address(pairInfo.mentoExchange) != address(0), "Mento exchange must be set");
+
+    // TODO: https://github.com/mento-protocol/mento-general/issues/60
+    // require(
+    //   pairInfo.collateralBucketFraction.lt(
+    //     getAvailableCollateralFraction(pairInfo.collateralAsset)
+    //   ),
+    //   "Collateral asset fraction must be less than available collateral fraction"
+    // );
 
     require(
       pairInfo.stableBucketMaxFraction.unwrap() > 0,

--- a/packages/protocol/contracts/stability/PairManager.sol
+++ b/packages/protocol/contracts/stability/PairManager.sol
@@ -34,6 +34,8 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
   // Tracks whether or not a pair with the given pairId exists.
   mapping(bytes32 => bool) public isPair;
 
+  // TODO: Implement getPairs that takes in asset addresses & not exchange
+
   // Tracks the total fraction of reserve collateral
   // that has been allocated to existing virtual pairs.
   mapping(address => FixidityLib.Fraction) public allocatedCollateralFractions;
@@ -70,7 +72,7 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
 
   /* ==================== View Functions ==================== */
 
-  function getPair(bytes32 pairId) external view returns (Pair memory pair) {
+  function getPair(bytes32 pairId) public view returns (Pair memory pair) {
     require(isPair[pairId], "A pair with the specified id does not exist");
     pair = pairs[pairId];
   }
@@ -157,6 +159,7 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
   {
     require(stableAsset != address(0), "Stable asset address must be specified");
     require(collateralAsset != address(0), "Collateral asset address must be specified");
+    require(address(mentoExchange) != address(0), "Mento exchange must be set");
 
     bytes32 pairId = keccak256(
       abi.encodePacked(
@@ -197,9 +200,7 @@ contract PairManager is IPairManager, Initializable, UsingRegistry {
     external
     onlyBroker
   {
-    require(isPair[pairId], "A pair with the specified id does not exist");
-
-    Pair memory pair = pairs[pairId];
+    Pair memory pair = getPair(pairId);
     pair.collateralBucket = collateralBucket;
     pair.stableBucket = stableBucket;
 

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -574,4 +574,12 @@ contract Reserve is
       return FixidityLib.wrap(tobinTax);
     }
   }
+
+  function isStableAsset(address) external view returns (bool) {
+    return true;
+  }
+
+  function isCollateralAsset(address) external view returns (bool) {
+    return true;
+  }
 }

--- a/packages/protocol/contracts/stability/interfaces/IMentoExchange.sol
+++ b/packages/protocol/contracts/stability/interfaces/IMentoExchange.sol
@@ -39,4 +39,10 @@ interface IMentoExchange {
     uint256 amountOut,
     bytes32 pairId
   ) external view returns (uint256 tokenInBucketSize, uint256 tokenOutBucketSize);
+
+  /**
+   * @notice Retrieve the name of this exchange.
+   * @return exchangeName The name of the exchange.
+   */
+  function name() external pure returns (string memory exchangeName);
 }

--- a/packages/protocol/contracts/stability/interfaces/IMentoExchange.sol
+++ b/packages/protocol/contracts/stability/interfaces/IMentoExchange.sol
@@ -44,5 +44,5 @@ interface IMentoExchange {
    * @notice Retrieve the name of this exchange.
    * @return exchangeName The name of the exchange.
    */
-  function name() external pure returns (string memory exchangeName);
+  function name() external view returns (string memory exchangeName);
 }

--- a/packages/protocol/contracts/stability/interfaces/IPairManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IPairManager.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { FixidityLib } from "../../common/FixidityLib.sol";
+
+/**
+ * @title Pair Manager Interface
+ * @notice The pair manager is responsible for managing the state of all Mento virtual pairs.
+ */
+interface IPairManager {
+  struct Pair {
+    address stableAsset;
+    address collateralAsset;
+    address mentoExchange; // TODO: Switch to IMentoExchange after merge
+    uint256 stableBucket;
+    uint256 collateralBucket;
+    uint256 bucketUpdateFrequency;
+    uint256 lastBucketUpdate;
+    FixidityLib.Fraction reserveCollateralFraction;
+    FixidityLib.Fraction spread;
+    FixidityLib.Fraction stableBucketMaxFraction;
+    uint256 minimumReports;
+    uint256 minSupplyForStableBucketCap;
+    bytes32 stableTokenRegistryId;
+  }
+
+  /**
+   * @notice Retrieves the pair with the specified pairId.
+   * @param pairId The id of the pair to be retrieved.
+   * @return found A boolean indicating whether a pair with the given pairId was found.
+   * @return pair The pair information.
+   */
+  function getPair(bytes32 pairId) external view returns (bool found, Pair memory pair);
+}

--- a/packages/protocol/contracts/stability/interfaces/IPairManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IPairManager.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
+import { IMentoExchange } from "./IMentoExchange.sol";
+
 import { FixidityLib } from "../../common/FixidityLib.sol";
 
 /**
@@ -11,7 +13,7 @@ interface IPairManager {
   struct Pair {
     address stableAsset;
     address collateralAsset;
-    address mentoExchange;
+    IMentoExchange mentoExchange;
     uint256 stableBucket;
     uint256 collateralBucket;
     uint256 bucketUpdateFrequency;
@@ -49,10 +51,24 @@ interface IPairManager {
   );
 
   /**
+   * @notice Emitted when the broker address is updated.
+   * @param newBroker The address of the new broker.
+   */
+  event BrokerUpdated(address indexed newBroker);
+
+  /**
+   * @notice Emitted when the buckets for a specified pair are updated.
+   * @param pairId The id of the pair.
+   * @param colalteralBucket The new collateral bucket size.
+   * @param stableBucket The new stable bucket size.
+   */
+  event BucketsUpdated(bytes32 pairId, uint256 colalteralBucket, uint256 stableBucket);
+
+  /**
    * @notice Retrieves the pair with the specified pairId.
    * @param pairId The id of the pair to be retrieved.
    * @return found A boolean indicating whether a pair with the given pairId was found.
    * @return pair The pair information.
    */
-  function getPair(bytes32 pairId) external view returns (bool found, Pair memory pair);
+  function getPair(bytes32 pairId) external view returns (Pair memory pair);
 }

--- a/packages/protocol/contracts/stability/interfaces/IPairManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IPairManager.sol
@@ -11,18 +11,42 @@ interface IPairManager {
   struct Pair {
     address stableAsset;
     address collateralAsset;
-    address mentoExchange; // TODO: Switch to IMentoExchange after merge
+    address mentoExchange;
     uint256 stableBucket;
     uint256 collateralBucket;
     uint256 bucketUpdateFrequency;
     uint256 lastBucketUpdate;
-    FixidityLib.Fraction reserveCollateralFraction;
-    FixidityLib.Fraction spread;
+    FixidityLib.Fraction collateralBucketFraction;
     FixidityLib.Fraction stableBucketMaxFraction;
+    FixidityLib.Fraction spread;
     uint256 minimumReports;
     uint256 minSupplyForStableBucketCap;
     bytes32 stableTokenRegistryId;
   }
+
+  /**
+   * @notice Emitted when a new virtual pair has been created.
+   * @param stableAsset The address of the stable asset.
+   * @param collateralAsset The address of the collateral asset.
+   * @param mentoExchange The address of the Mento exchange.
+   */
+  event PairCreated(
+    address indexed stableAsset,
+    address indexed collateralAsset,
+    address indexed mentoExchange
+  );
+
+  /**
+   * @notice Emitted when a virtual pair has been destroyed.
+   * @param stableAsset The address of the stable asset.
+   * @param collateralAsset The address of the collateral asset.
+   * @param mentoExchange The address of the Mento exchange.
+   */
+  event PairDestroyed(
+    address indexed stableAsset,
+    address indexed collateralAsset,
+    address indexed mentoExchange
+  );
 
   /**
    * @notice Retrieves the pair with the specified pairId.

--- a/packages/protocol/contracts/stability/interfaces/IPairManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IPairManager.sol
@@ -23,7 +23,6 @@ interface IPairManager {
     FixidityLib.Fraction spread;
     uint256 minimumReports;
     uint256 minSupplyForStableBucketCap;
-    bytes32 stableTokenRegistryId;
   }
 
   /**

--- a/packages/protocol/contracts/stability/interfaces/IPairManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IPairManager.sol
@@ -58,10 +58,10 @@ interface IPairManager {
   /**
    * @notice Emitted when the buckets for a specified pair are updated.
    * @param pairId The id of the pair.
-   * @param colalteralBucket The new collateral bucket size.
+   * @param collateralBucket The new collateral bucket size.
    * @param stableBucket The new stable bucket size.
    */
-  event BucketsUpdated(bytes32 pairId, uint256 colalteralBucket, uint256 stableBucket);
+  event BucketsUpdated(bytes32 pairId, uint256 collateralBucket, uint256 stableBucket);
 
   /**
    * @notice Retrieves the pair with the specified pairId.

--- a/packages/protocol/contracts/stability/interfaces/IPairManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IPairManager.sol
@@ -30,11 +30,13 @@ interface IPairManager {
    * @param stableAsset The address of the stable asset.
    * @param collateralAsset The address of the collateral asset.
    * @param mentoExchange The address of the Mento exchange.
+   * @param pairId The id of the newly created pair.
    */
   event PairCreated(
     address indexed stableAsset,
     address indexed collateralAsset,
-    address indexed mentoExchange
+    address indexed mentoExchange,
+    bytes32 pairId
   );
 
   /**
@@ -54,6 +56,12 @@ interface IPairManager {
    * @param newBroker The address of the new broker.
    */
   event BrokerUpdated(address indexed newBroker);
+
+  /**
+   * @notice Emitted when the reserve address is updated.
+   * @param newReserve The address of the new reserve.
+   */
+  event ReserveUpdated(address indexed newReserve);
 
   /**
    * @notice Emitted when the buckets for a specified pair are updated.

--- a/packages/protocol/contracts/stability/interfaces/IReserve.sol
+++ b/packages/protocol/contracts/stability/interfaces/IReserve.sol
@@ -15,4 +15,6 @@ interface IReserve {
   function removeExchangeSpender(address, uint256) external;
   function addSpender(address) external;
   function removeSpender(address) external;
+  function isStableAsset(address) external view returns (bool);
+  function isCollateralAsset(address) external view returns (bool);
 }

--- a/packages/protocol/contracts/stability/test/MockERC20.sol
+++ b/packages/protocol/contracts/stability/test/MockERC20.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.13;
+
+contract MockERC20 {
+  string private _name;
+  string private _symbol;
+
+  constructor(string memory name_, string memory symbol_) public {
+    _name = name_;
+    _symbol = symbol_;
+  }
+
+  function name() public view returns (string memory) {
+    return _name;
+  }
+
+  function symbol() public view returns (string memory) {
+    return _symbol;
+  }
+}

--- a/packages/protocol/contracts/stability/test/MockMentoExchange.sol
+++ b/packages/protocol/contracts/stability/test/MockMentoExchange.sol
@@ -1,3 +1,31 @@
 pragma solidity ^0.5.13;
 
-contract MockMentoExchange {}
+import { IMentoExchange } from "../interfaces/IMentoExchange.sol";
+
+contract MockMentoExchange is IMentoExchange {
+  string private _name;
+
+  constructor(string memory name_) public {
+    _name = name_;
+  }
+
+  function name() external view returns (string memory) {
+    return _name;
+  }
+
+  function getAmountOut(address, address, uint256, uint256, uint256)
+    external
+    view
+    returns (uint256)
+  {
+    return 0;
+  }
+
+  function getUpdatedBuckets(address, address, uint256, uint256, bytes32)
+    external
+    view
+    returns (uint256, uint256)
+  {
+    return (0, 0);
+  }
+}

--- a/packages/protocol/contracts/stability/test/MockMentoExchange.sol
+++ b/packages/protocol/contracts/stability/test/MockMentoExchange.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.13;
+
+contract MockMentoExchange {}

--- a/packages/protocol/contracts/stability/test/MockReserve.sol
+++ b/packages/protocol/contracts/stability/test/MockReserve.sol
@@ -40,4 +40,12 @@ contract MockReserve {
   function getUnfrozenReserveGoldBalance() external view returns (uint256) {
     return address(this).balance;
   }
+
+  function isStableAsset(address) external view returns (bool) {
+    return false;
+  }
+
+  function isCollateralAsset(address) external view returns (bool) {
+    return false;
+  }
 }

--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'contracts'
 out = 'out'
 test = 'test-sol'
@@ -15,5 +15,12 @@ remappings = [
 ]
 
 no_match_contract = "RandomTest"
+verbosity = 3
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+[profile.integration]
+
+no_match_contract = "RandomTest"
+match_contract = "Integration"
+
+[rpc_endpoints]
+celo_mainnet="https://forno.celo.org"

--- a/packages/protocol/test-sol/stability/PairManager.t.sol
+++ b/packages/protocol/test-sol/stability/PairManager.t.sol
@@ -7,59 +7,95 @@ import { Test } from "celo-foundry/Test.sol";
 import { IMentoExchange } from "contracts/stability/interfaces/IMentoExchange.sol";
 import { PairManager } from "contracts/stability/PairManager.sol";
 import { WithRegistry } from "../utils/WithRegistry.sol";
+
 import { MockReserve } from "contracts/stability/test/MockReserve.sol";
+import { MockERC20 } from "contracts/stability/test/MockERC20.sol";
+import { MockMentoExchange } from "contracts/stability/test/MockMentoExchange.sol";
+
 import { FixidityLib } from "contracts/common/FixidityLib.sol";
 
 // forge test --match-contract PairManager -vvv
 contract PairManagerTest is Test, WithRegistry {
+  struct UpdatedBuckets {
+    uint256 stableBucket;
+    uint256 collateralBucket;
+  }
+
   address deployer;
   address notDeployer;
   address broker;
 
-  address testStableAsset;
-  address testCollateralAsset;
-  address fakeMentoExchange;
+  MockERC20 testStableAsset;
+  MockERC20 anotherTestStableAsset;
+  MockERC20 testCollateralAsset;
+  MockMentoExchange testMentoExchange;
 
   MockReserve mockReserve;
   PairManager testee;
 
   event BrokerUpdated(address indexed newBroker);
+  event PairCreated(
+    address indexed stableAsset,
+    address indexed collateralAsset,
+    address indexed mentoExchange
+  );
 
   function setUp() public {
     deployer = actor("deployer");
     notDeployer = actor("notDeployer");
     broker = actor("broker");
-    testStableAsset = actor("testStableAsset");
-    testCollateralAsset = actor("testCollateralAsset");
-    fakeMentoExchange = actor("fakeMentoExchange");
 
-    changePrank(deployer);
+    testStableAsset = new MockERC20("Test Stable Asset", "TSA");
+    anotherTestStableAsset = new MockERC20("Another Test Stable Asset", "ATSA");
+    testCollateralAsset = new MockERC20("Test Collateral Asset", "TCA");
+    testMentoExchange = new MockMentoExchange("TestExchange");
 
     mockReserve = new MockReserve();
     testee = new PairManager(true);
 
+    UpdatedBuckets memory testBuckets = UpdatedBuckets(250000000000, 250000000000);
+
+    vm.mockCall(
+      address(testMentoExchange),
+      abi.encodeWithSelector(testMentoExchange.getUpdatedBuckets.selector),
+      abi.encode(testBuckets)
+    );
+
+    vm.mockCall(
+      address(mockReserve),
+      abi.encodeWithSelector(mockReserve.isStableAsset.selector, address(anotherTestStableAsset)),
+      abi.encode(true)
+    );
+
+    changePrank(deployer);
+
     registry.setAddressFor("Reserve", address(mockReserve));
 
     testee.initilize(broker, address(registry));
+
+    initPairs();
   }
 
   function initPairs() public {
-    // Mock reserve is stable asset & isCollateral asset
-    // vm.mockCall(
-    //     address(mockReserve),
-    //     abi.encodeWithSelector(mockReserve.isStableAsset.selector)
-    //     abi.encode(true)
-    // );
+    vm.mockCall(
+      address(mockReserve),
+      abi.encodeWithSelector(mockReserve.isStableAsset.selector, address(testStableAsset)),
+      abi.encode(true)
+    );
+
+    vm.mockCall(
+      address(mockReserve),
+      abi.encodeWithSelector(mockReserve.isCollateralAsset.selector, address(testCollateralAsset)),
+      abi.encode(true)
+    );
 
     PairManager.Pair memory newPair;
-    newPair.stableAsset = testStableAsset;
-    newPair.collateralAsset = testCollateralAsset;
-    newPair.mentoExchange = IMentoExchange(fakeMentoExchange);
+    newPair.stableAsset = address(testStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(address(testMentoExchange));
     newPair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
     newPair.stableBucketMaxFraction = FixidityLib.wrap(0.1 * 10**24);
     newPair.spread = FixidityLib.wrap(0.1 * 10**24);
-
-    vm.expectEmit(true, false, false, false);
 
     testee.createPair(newPair);
   }
@@ -101,7 +137,160 @@ contract PairManagerTest_initilizerAndSetters is PairManagerTest {
 }
 
 contract PairManagerTest_createPair is PairManagerTest {
+  function test_createPair_whenNotCalledByOwner_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    changePrank(notDeployer);
+
+    vm.expectRevert("Ownable: caller is not the owner");
+    testee.createPair(newPair);
+  }
+
   function test_createPair_whenPairWithIdExists_shouldRevert() public {
     vm.expectRevert("A pair with the specified assets and exchange exists");
+
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(testStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(address(testMentoExchange));
+    newPair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.stableBucketMaxFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.spread = FixidityLib.wrap(0.1 * 10**24);
+
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenStableAssetIsNotRegistered_shouldRevert() public {
+    MockERC20 nonReserveStable = new MockERC20("Non Reserve Stable Asset", "NRSA");
+
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(nonReserveStable);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(address(testMentoExchange));
+
+    vm.expectRevert("Stable asset specified is not registered with reserve");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenCollateralAssetIsNotRegistered_shouldRevert() public {
+    MockERC20 nonReserveCollateral = new MockERC20("Non Reserve Collateral Asset", "NRCA");
+
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(testStableAsset);
+    newPair.collateralAsset = address(nonReserveCollateral);
+    newPair.mentoExchange = IMentoExchange(address(testMentoExchange));
+
+    vm.expectRevert("Collateral asset specified is not registered with reserve");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenCollateralBucketFractionIsOne_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(anotherTestStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(address(testMentoExchange));
+    newPair.collateralBucketFraction = FixidityLib.fixed1();
+
+    vm.expectRevert("Collateral asset fraction must be smaller than 1");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenMentoExchangeIsNotSet_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(testStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(address(0));
+    newPair.collateralBucketFraction = FixidityLib.fixed1();
+
+    vm.expectRevert("Mento exchange must be set");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenStableAssetIsNotSet_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(0);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(testMentoExchange);
+    newPair.collateralBucketFraction = FixidityLib.fixed1();
+
+    vm.expectRevert("Stable asset must be set");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenCollateralAssetIsNotSet_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(testStableAsset);
+    newPair.collateralAsset = address(0);
+    newPair.mentoExchange = IMentoExchange(testMentoExchange);
+    newPair.collateralBucketFraction = FixidityLib.fixed1();
+
+    vm.expectRevert("Collateral asset must be set");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenStableBucketFractionNotGTZero_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(anotherTestStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(testMentoExchange);
+    newPair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.stableBucketMaxFraction = FixidityLib.wrap(0);
+
+    vm.expectRevert("Stable bucket fraction must be greater than 0");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenStableBucketFractionNotLTOne_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(anotherTestStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(testMentoExchange);
+    newPair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.stableBucketMaxFraction = FixidityLib.fixed1();
+
+    vm.expectRevert("Stable bucket fraction must be smaller than 1");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenSpreadNotLTEOne_shouldRevert() public {
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(anotherTestStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(testMentoExchange);
+    newPair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.stableBucketMaxFraction = FixidityLib.wrap(0.123 * 10**24);
+    newPair.spread = FixidityLib.wrap(2 * 10**24);
+
+    vm.expectRevert("Spread must be less than or equal to 1");
+    testee.createPair(newPair);
+  }
+
+  function test_createPair_whenInfoIsValid_shouldUpdateMappingAndEmit() public {
+    bytes32 pairId = keccak256(
+      abi.encodePacked(
+        anotherTestStableAsset.symbol(),
+        testCollateralAsset.symbol(),
+        testMentoExchange.name()
+      )
+    );
+
+    // Create pair
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = address(anotherTestStableAsset);
+    newPair.collateralAsset = address(testCollateralAsset);
+    newPair.mentoExchange = IMentoExchange(testMentoExchange);
+    newPair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.stableBucketMaxFraction = FixidityLib.wrap(0.123 * 10**24);
+    newPair.spread = FixidityLib.wrap(0.4 * 10**24);
+
+    vm.expectEmit(true, true, true, false);
+    emit PairCreated(
+      address(anotherTestStableAsset),
+      address(testCollateralAsset),
+      address(testMentoExchange)
+    );
+    testee.createPair(newPair);
+
+    // Verify pair exists
+
   }
 }

--- a/packages/protocol/test-sol/stability/PairManager.t.sol
+++ b/packages/protocol/test-sol/stability/PairManager.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test } from "celo-foundry/Test.sol";
+
+import { IMentoExchange } from "contracts/stability/interfaces/IMentoExchange.sol";
+import { PairManager } from "contracts/stability/PairManager.sol";
+import { WithRegistry } from "../utils/WithRegistry.sol";
+import { MockReserve } from "contracts/stability/test/MockReserve.sol";
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+// forge test --match-contract PairManager -vvv
+contract PairManagerTest is Test, WithRegistry {
+  address deployer;
+  address notDeployer;
+  address broker;
+
+  address testStableAsset;
+  address testCollateralAsset;
+  address fakeMentoExchange;
+
+  MockReserve mockReserve;
+  PairManager testee;
+
+  event BrokerUpdated(address indexed newBroker);
+
+  function setUp() public {
+    deployer = actor("deployer");
+    notDeployer = actor("notDeployer");
+    broker = actor("broker");
+    testStableAsset = actor("testStableAsset");
+    testCollateralAsset = actor("testCollateralAsset");
+    fakeMentoExchange = actor("fakeMentoExchange");
+
+    changePrank(deployer);
+
+    mockReserve = new MockReserve();
+    testee = new PairManager(true);
+
+    registry.setAddressFor("Reserve", address(mockReserve));
+
+    testee.initilize(broker, address(registry));
+  }
+
+  function initPairs() public {
+    // Mock reserve is stable asset & isCollateral asset
+    // vm.mockCall(
+    //     address(mockReserve),
+    //     abi.encodeWithSelector(mockReserve.isStableAsset.selector)
+    //     abi.encode(true)
+    // );
+
+    PairManager.Pair memory newPair;
+    newPair.stableAsset = testStableAsset;
+    newPair.collateralAsset = testCollateralAsset;
+    newPair.mentoExchange = IMentoExchange(fakeMentoExchange);
+    newPair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.stableBucketMaxFraction = FixidityLib.wrap(0.1 * 10**24);
+    newPair.spread = FixidityLib.wrap(0.1 * 10**24);
+
+    vm.expectEmit(true, false, false, false);
+
+    testee.createPair(newPair);
+  }
+}
+
+contract PairManagerTest_initilizerAndSetters is PairManagerTest {
+  /* ---------- Initilizer ---------- */
+
+  function test_initilize_shouldSetOwner() public view {
+    assert(testee.owner() == deployer);
+  }
+
+  function test_initilize_shouldSetBroker() public view {
+    assert(testee.broker() == broker);
+  }
+
+  /* ---------- Setters ---------- */
+
+  function test_setBroker_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    testee.setBroker(address(0));
+  }
+
+  function test_setBroker_whenAddressIsZero_shouldRevert() public {
+    vm.expectRevert("Broker address must be set");
+    testee.setBroker(address(0));
+  }
+
+  function test_setBroker_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    address newBroker = actor("newBroker");
+    vm.expectEmit(true, false, false, false);
+    emit BrokerUpdated(newBroker);
+
+    testee.setBroker(newBroker);
+
+    assert(testee.broker() == newBroker);
+  }
+}
+
+contract PairManagerTest_createPair is PairManagerTest {
+  function test_createPair_whenPairWithIdExists_shouldRevert() public {
+    vm.expectRevert("A pair with the specified assets and exchange exists");
+  }
+}


### PR DESCRIPTION
### Description

Adds the pair manager contract with functionality described in [the issue](https://github.com/mento-protocol/mento-general/issues/49) & [current design](https://www.notion.so/McMint-GeneralMento-XXX-7fe7c45d83fc4521a1659ff79d7e7147).

The purpose of this PR is to consolidate the separate components in the main feature branch to allow the broker work to continue.

### Other changes

- Added dummy implementation of `isStableAsset` & `isCollateralAsset` to Reserve.sol until @ninocomputer changes are merged

### Tested

Unit tests have been started but are not complete

### Related issues

- Mento Issue: https://github.com/mento-protocol/mento-general/issues/49

### Backwards compatibility

N/A

### Documentation

N/A