### PR TITLE
Refactor DEK signing and use this in pnp tests

### DIFF
--- a/dependency-graph.json
+++ b/dependency-graph.json
@@ -130,7 +130,6 @@
       "@celo/base",
       "@celo/contractkit",
       "@celo/flake-tracker",
-      "@celo/identity",
       "@celo/phone-number-privacy-common",
       "@celo/utils",
       "@celo/wallet-hsm-azure",

--- a/packages/phone-number-privacy/combiner/package.json
+++ b/packages/phone-number-privacy/combiner/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@celo/contractkit": "2.0.1-dev",
-    "@celo/identity": "2.0.1-dev",
     "@celo/phone-number-privacy-common": "1.0.42-dev",
     "@celo/poprf": "^0.1.9",
     "@celo/utils": "2.0.1-dev",
@@ -46,8 +45,9 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@types/btoa": "^1.2.3",
+    "@celo/identity": "2.0.1-dev",
     "@celo/phone-number-privacy-signer": "2.0.0-dev",
+    "@types/btoa": "^1.2.3",
     "@types/express": "^4.17.6",
     "@types/uuid": "^7.0.3",
     "dotenv": "^8.2.0",

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
@@ -1,8 +1,8 @@
-import { SignMessageRequest } from '@celo/identity/lib/odis/query'
 import {
   ErrorMessage,
   ErrorType,
   MAX_BLOCK_DISCREPANCY_THRESHOLD,
+  SignMessageRequest,
   WarningMessage,
 } from '@celo/phone-number-privacy-common'
 import { CryptoSession } from '../../../common/crypto-session'

--- a/packages/phone-number-privacy/combiner/test/end-to-end/get-blinded-sig.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/get-blinded-sig.test.ts
@@ -1,4 +1,5 @@
 import { OdisUtils } from '@celo/identity/lib/odis'
+// TODO(2.0.0) revisit these imports from the identity package (vs. directly from common)
 import {
   AuthenticationMethod,
   ErrorMessages,

--- a/packages/phone-number-privacy/combiner/test/end-to-end/get-blinded-sig.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/get-blinded-sig.test.ts
@@ -1,5 +1,5 @@
 import { OdisUtils } from '@celo/identity/lib/odis'
-// TODO(2.0.0) revisit these imports from the identity package (vs. directly from common)
+// TODO(2.0.0, imports) revisit these imports from the identity package (vs. directly from common)
 import {
   AuthenticationMethod,
   ErrorMessages,

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -264,7 +264,7 @@ describe('pnpService', () => {
       })
 
       it('Should respond with 200 on valid request', async () => {
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(200)
@@ -282,7 +282,7 @@ describe('pnpService', () => {
       })
 
       it('Should respond with 200 on valid request with key version header', async () => {
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app, '1')
 
         expect(res.status).toBe(200)
@@ -294,7 +294,7 @@ describe('pnpService', () => {
       })
 
       it('Should respond with 200 on repeated valid requests', async () => {
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res1 = await sendPnpSignRequest(req, authorization, app)
 
         expect(res1.status).toBe(200)
@@ -312,7 +312,7 @@ describe('pnpService', () => {
       it('Should respond with 200 on extra request fields', async () => {
         // @ts-ignore Intentionally adding an extra field to the request type
         req.extraField = 'dummyString'
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(200)
@@ -325,7 +325,7 @@ describe('pnpService', () => {
 
       it('Should respond with 200 when authenticated with DEK', async () => {
         req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
-        const authorization = getPnpRequestAuthorization(req, '', DEK_PRIVATE_KEY)
+        const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(200)
@@ -337,7 +337,7 @@ describe('pnpService', () => {
       })
 
       it('Should get the same unblinded signatures from the same message (different seed)', async () => {
-        const authorization1 = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization1 = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res1 = await sendPnpSignRequest(req, authorization1, app)
 
         expect(res1.status).toBe(200)
@@ -357,7 +357,7 @@ describe('pnpService', () => {
         // Sanity check
         expect(req2.blindedQueryPhoneNumber).not.toEqual(req.blindedQueryPhoneNumber)
 
-        const authorization2 = getPnpRequestAuthorization(req2, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization2 = getPnpRequestAuthorization(req2, PRIVATE_KEY1)
         const res2 = await sendPnpSignRequest(req2, authorization2, app)
         expect(res2.status).toBe(200)
         const unblindedSig1 = threshold_bls.unblind(
@@ -375,7 +375,7 @@ describe('pnpService', () => {
       it('Should respond with 400 on missing request fields', async () => {
         // @ts-ignore Intentionally deleting required field
         delete req.account
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(400)
@@ -387,7 +387,7 @@ describe('pnpService', () => {
       })
 
       it('Should respond with 400 on invalid key version', async () => {
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app, 'a')
         expect(res.status).toBe(400)
         expect(res.body).toMatchObject<SignMessageResponseFailure>({
@@ -399,7 +399,7 @@ describe('pnpService', () => {
 
       it('Should respond with 401 on failed auth', async () => {
         req.account = mockAccount
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(401)
@@ -412,7 +412,7 @@ describe('pnpService', () => {
 
       it('Should respond with 403 on out of quota', async () => {
         mockOdisPaymentsTotalPaidCUSD.mockReturnValue(new BigNumber(0))
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(403)
@@ -428,7 +428,7 @@ describe('pnpService', () => {
         configWithApiDisabled.phoneNumberPrivacy.enabled = false
         const appWithApiDisabled = startCombiner(configWithApiDisabled)
 
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, appWithApiDisabled)
 
         expect(res.status).toBe(503)
@@ -463,7 +463,7 @@ describe('pnpService', () => {
       })
 
       it('Should respond with 200 on valid request', async () => {
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(200)
@@ -504,7 +504,7 @@ describe('pnpService', () => {
       })
 
       it('Should respond with 500 even if request is valid', async () => {
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(500)

--- a/packages/phone-number-privacy/common/package.json
+++ b/packages/phone-number-privacy/common/package.json
@@ -33,6 +33,7 @@
     "is-base64": "^1.1.0"
   },
   "devDependencies": {
+    "@celo/identity": "2.0.1-dev",
     "@celo/poprf": "^0.1.9",
     "@celo/wallet-local": "2.0.1-dev",
     "@types/btoa": "^1.2.3",

--- a/packages/phone-number-privacy/common/package.json
+++ b/packages/phone-number-privacy/common/package.json
@@ -33,7 +33,6 @@
     "is-base64": "^1.1.0"
   },
   "devDependencies": {
-    "@celo/identity": "2.0.1-dev",
     "@celo/poprf": "^0.1.9",
     "@celo/wallet-local": "2.0.1-dev",
     "@types/btoa": "^1.2.3",

--- a/packages/phone-number-privacy/common/src/test/utils.ts
+++ b/packages/phone-number-privacy/common/src/test/utils.ts
@@ -1,4 +1,5 @@
 import { EncryptionKeySigner, signWithDEK } from '@celo/identity/lib/odis/query'
+import { privateKeyToAddress } from '@celo/utils/lib/address'
 import { serializeSignature, Signature, signMessage } from '@celo/utils/lib/signatureUtils'
 import BigNumber from 'bignumber.js'
 import * as threshold from 'blind-threshold-bls'
@@ -124,11 +125,7 @@ export function getPnpQuotaRequest(account: string, hashedPhoneNumber?: string):
   }
 }
 
-export function getPnpRequestAuthorization(
-  req: PhoneNumberPrivacyRequest,
-  account: string,
-  pk: string
-) {
+export function getPnpRequestAuthorization(req: PhoneNumberPrivacyRequest, pk: string) {
   const msg = JSON.stringify(req)
   if (req.authenticationMethod === AuthenticationMethod.ENCRYPTION_KEY) {
     const dekSigner: EncryptionKeySigner = {
@@ -137,6 +134,6 @@ export function getPnpRequestAuthorization(
     }
     return signWithDEK(JSON.stringify(req), dekSigner)
   }
-  // const account = privateKeyToAddress(pk)
+  const account = privateKeyToAddress(pk)
   return serializeSignature(signMessage(msg, pk, account))
 }

--- a/packages/phone-number-privacy/common/src/test/utils.ts
+++ b/packages/phone-number-privacy/common/src/test/utils.ts
@@ -5,7 +5,7 @@ import * as threshold from 'blind-threshold-bls'
 import btoa from 'btoa'
 import Web3 from 'web3'
 import { AuthenticationMethod, PhoneNumberPrivacyRequest, PnpQuotaRequest } from '../interfaces'
-import { signWithRawDEK } from '../utils/authentication'
+import { signWithRawKey } from '../utils/authentication'
 import { genSessionID } from '../utils/logger'
 
 export function createMockAttestation(completed: number, total: number) {
@@ -20,10 +20,10 @@ export function createMockToken(balanceOf: jest.Mock<BigNumber, []>) {
   }
 }
 
-export function createMockAccounts(walletAddress: string, dataEncryptionKey?: string) {
+export function createMockAccounts(walletAddress: string, dekPubKey?: string) {
   return {
     getWalletAddress: jest.fn(() => walletAddress),
-    getDataEncryptionKey: jest.fn(() => dataEncryptionKey),
+    getDataEncryptionKey: jest.fn(() => dekPubKey),
   }
 }
 
@@ -128,7 +128,7 @@ export function getPnpQuotaRequest(account: string, hashedPhoneNumber?: string):
 export function getPnpRequestAuthorization(req: PhoneNumberPrivacyRequest, pk: string) {
   const msg = JSON.stringify(req)
   if (req.authenticationMethod === AuthenticationMethod.ENCRYPTION_KEY) {
-    return signWithRawDEK(JSON.stringify(req), pk)
+    return signWithRawKey(JSON.stringify(req), pk)
   }
   const account = privateKeyToAddress(pk)
   return serializeSignature(signMessage(msg, pk, account))

--- a/packages/phone-number-privacy/common/src/test/utils.ts
+++ b/packages/phone-number-privacy/common/src/test/utils.ts
@@ -1,4 +1,3 @@
-import { EncryptionKeySigner, signWithDEK } from '@celo/identity/lib/odis/query'
 import { privateKeyToAddress } from '@celo/utils/lib/address'
 import { serializeSignature, Signature, signMessage } from '@celo/utils/lib/signatureUtils'
 import BigNumber from 'bignumber.js'
@@ -6,6 +5,7 @@ import * as threshold from 'blind-threshold-bls'
 import btoa from 'btoa'
 import Web3 from 'web3'
 import { AuthenticationMethod, PhoneNumberPrivacyRequest, PnpQuotaRequest } from '../interfaces'
+import { signWithRawDEK } from '../utils/authentication'
 import { genSessionID } from '../utils/logger'
 
 export function createMockAttestation(completed: number, total: number) {
@@ -128,11 +128,7 @@ export function getPnpQuotaRequest(account: string, hashedPhoneNumber?: string):
 export function getPnpRequestAuthorization(req: PhoneNumberPrivacyRequest, pk: string) {
   const msg = JSON.stringify(req)
   if (req.authenticationMethod === AuthenticationMethod.ENCRYPTION_KEY) {
-    const dekSigner: EncryptionKeySigner = {
-      authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
-      rawKey: pk,
-    }
-    return signWithDEK(JSON.stringify(req), dekSigner)
+    return signWithRawDEK(JSON.stringify(req), pk)
   }
   const account = privateKeyToAddress(pk)
   return serializeSignature(signMessage(msg, pk, account))

--- a/packages/phone-number-privacy/common/src/test/values.ts
+++ b/packages/phone-number-privacy/common/src/test/values.ts
@@ -16,6 +16,8 @@ export const PHONE_NUMBER = '+15555555555'
 export const IDENTIFIER = PhoneNumberUtils.getPhoneHash(PHONE_NUMBER)
 export const BLINDING_FACTOR = Buffer.from('0IsBvRfkBrkKCIW6HV0/T1zrzjQSe8wRyU3PKojCnww=', 'base64')
 export const BLINDED_PHONE_NUMBER = getBlindedPhoneNumber(PHONE_NUMBER, BLINDING_FACTOR)
+export const DEK_PUBLIC_KEY = '0x026063780c81991c032fb4fa7485c6607b7542e048ef85d08516fe5c4482360e4b'
+export const DEK_PRIVATE_KEY = '0xc2bbdabb440141efed205497a41d5fb6114e0435fd541e368dc628a8e086bfee'
 
 // Public keys are expected to be in base64
 export const PNP_DEV_ODIS_PUBLIC_KEY =

--- a/packages/phone-number-privacy/common/src/utils/authentication.ts
+++ b/packages/phone-number-privacy/common/src/utils/authentication.ts
@@ -69,7 +69,9 @@ export function getMessageDigest(message: string) {
   return crypto.createHash('sha256').update(JSON.stringify(message)).digest('hex')
 }
 
-export function signWithRawDEK(msg: string, rawKey: string) {
+// Used primarily for signing requests with a DEK, counterpart of verifyDEKSignature
+// For general signing, use SignatureUtils in @celo/utils
+export function signWithRawKey(msg: string, rawKey: string) {
   // NOTE: elliptic is disabled elsewhere in this library to prevent
   // accidental signing of truncated messages.
   // tslint:disable-next-line:import-blacklist

--- a/packages/phone-number-privacy/common/test/utils/authentication.test.ts
+++ b/packages/phone-number-privacy/common/test/utils/authentication.test.ts
@@ -109,7 +109,7 @@ describe('Authentication test suite', () => {
         account: '0xc1912fee45d61c87cc5ea59dae31190fffff232d',
         authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
       }
-      const sig = auth.signWithRawDEK(JSON.stringify(body), rawKey)
+      const sig = auth.signWithRawKey(JSON.stringify(body), rawKey)
       const sampleRequest: Request = {
         get: (name: string) => (name === 'Authorization' ? sig : ''),
         body,
@@ -151,7 +151,7 @@ describe('Authentication test suite', () => {
           message.slice(0, i) +
           String.fromCharCode(message.charCodeAt(i) + 1) +
           message.slice(i + 1)
-        const sig = auth.signWithRawDEK(modified, rawKey)
+        const sig = auth.signWithRawKey(modified, rawKey)
         const sampleRequest: Request = {
           get: (name: string) => (name === 'Authorization' ? sig : ''),
           body,
@@ -186,7 +186,7 @@ describe('Authentication test suite', () => {
         account: '0xc1912fee45d61c87cc5ea59dae31190fffff232d',
         authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
       }
-      const sig = auth.signWithRawDEK(JSON.stringify(body), rawKey)
+      const sig = auth.signWithRawKey(JSON.stringify(body), rawKey)
       const sampleRequest: Request = {
         get: (name: string) => (name === 'Authorization' ? sig : ''),
         body,
@@ -223,7 +223,7 @@ describe('Authentication test suite', () => {
         authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
       }
       // Manipulate the signature.
-      const sig = auth.signWithRawDEK(JSON.stringify(body), rawKey)
+      const sig = auth.signWithRawKey(JSON.stringify(body), rawKey)
       const modified = JSON.stringify([0] + JSON.parse(sig))
       const sampleRequest: Request = {
         get: (name: string) => (name === 'Authorization' ? modified : ''),

--- a/packages/phone-number-privacy/common/test/utils/authentication.test.ts
+++ b/packages/phone-number-privacy/common/test/utils/authentication.test.ts
@@ -2,7 +2,6 @@ import { hexToBuffer } from '@celo/base'
 import { ContractKit } from '@celo/contractkit'
 import Logger from 'bunyan'
 import { Request } from 'express'
-import { signWithRawKey } from '../../../../sdk/identity/src/odis/query'
 import { AuthenticationMethod } from '../../src/interfaces/requests'
 import * as auth from '../../src/utils/authentication'
 
@@ -110,7 +109,7 @@ describe('Authentication test suite', () => {
         account: '0xc1912fee45d61c87cc5ea59dae31190fffff232d',
         authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
       }
-      const sig = signWithRawKey(JSON.stringify(body), rawKey)
+      const sig = auth.signWithRawDEK(JSON.stringify(body), rawKey)
       const sampleRequest: Request = {
         get: (name: string) => (name === 'Authorization' ? sig : ''),
         body,
@@ -152,7 +151,7 @@ describe('Authentication test suite', () => {
           message.slice(0, i) +
           String.fromCharCode(message.charCodeAt(i) + 1) +
           message.slice(i + 1)
-        const sig = signWithRawKey(modified, rawKey)
+        const sig = auth.signWithRawDEK(modified, rawKey)
         const sampleRequest: Request = {
           get: (name: string) => (name === 'Authorization' ? sig : ''),
           body,
@@ -187,7 +186,7 @@ describe('Authentication test suite', () => {
         account: '0xc1912fee45d61c87cc5ea59dae31190fffff232d',
         authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
       }
-      const sig = signWithRawKey(JSON.stringify(body), rawKey)
+      const sig = auth.signWithRawDEK(JSON.stringify(body), rawKey)
       const sampleRequest: Request = {
         get: (name: string) => (name === 'Authorization' ? sig : ''),
         body,
@@ -224,7 +223,7 @@ describe('Authentication test suite', () => {
         authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
       }
       // Manipulate the signature.
-      const sig = signWithRawKey(JSON.stringify(body), rawKey)
+      const sig = auth.signWithRawDEK(JSON.stringify(body), rawKey)
       const modified = JSON.stringify([0] + JSON.parse(sig))
       const sampleRequest: Request = {
         get: (name: string) => (name === 'Authorization' ? modified : ''),

--- a/packages/phone-number-privacy/signer/package.json
+++ b/packages/phone-number-privacy/signer/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@celo/base": "2.0.1-dev",
     "@celo/contractkit": "2.0.1-dev",
-    "@celo/identity": "2.0.1-dev",
     "@celo/phone-number-privacy-common": "1.0.42-dev",
     "@celo/poprf": "^0.1.9",
     "@celo/utils": "2.0.1-dev",

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
@@ -1,5 +1,4 @@
-import { SignMessageRequest } from '@celo/identity/lib/odis/query'
-import { WarningMessage } from '@celo/phone-number-privacy-common'
+import { SignMessageRequest, WarningMessage } from '@celo/phone-number-privacy-common'
 import { Knex } from 'knex'
 import { Action, Session } from '../../../common/action'
 import { computeBlindedSignature } from '../../../common/bls/bls-cryptography-client'

--- a/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
@@ -8,7 +8,6 @@ import {
   TestUtils,
   WarningMessage,
 } from '@celo/phone-number-privacy-common'
-import { privateKeyToAddress } from '@celo/utils/lib/address'
 import BigNumber from 'bignumber.js'
 import { Knex } from 'knex'
 import request from 'supertest'
@@ -175,7 +174,7 @@ describe('legacyPNP', () => {
         )
 
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1, identifier)
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(req, authorization)
 
         expect(res.status).toBe(200)
@@ -327,7 +326,7 @@ describe('legacyPNP', () => {
 
       it('Should respond with 200 on repeated valid requests', async () => {
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1, IDENTIFIER)
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
 
         const res1 = await sendPnpQuotaRequest(req, authorization)
         expect(res1.status).toBe(200)
@@ -348,7 +347,7 @@ describe('legacyPNP', () => {
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1, IDENTIFIER)
         // @ts-ignore Intentionally adding an extra field to the request type
         req.extraField = 'dummyString'
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(req, authorization)
         expect(res.status).toBe(200)
         expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
@@ -365,7 +364,7 @@ describe('legacyPNP', () => {
         const badRequest = getPnpQuotaRequest(ACCOUNT_ADDRESS1, IDENTIFIER)
         // @ts-ignore Intentionally deleting required field
         delete badRequest.account
-        const authorization = getPnpRequestAuthorization(badRequest, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(badRequest, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(badRequest, authorization)
 
         expect(res.status).toBe(400)
@@ -380,11 +379,7 @@ describe('legacyPNP', () => {
         // Request from one account, signed by another account
         const badRequest = getPnpQuotaRequest(ACCOUNT_ADDRESS1, IDENTIFIER)
         const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
-        const authorization = getPnpRequestAuthorization(
-          badRequest,
-          privateKeyToAddress(differentPk),
-          differentPk
-        )
+        const authorization = getPnpRequestAuthorization(badRequest, differentPk)
         const res = await sendPnpQuotaRequest(badRequest, authorization)
 
         expect(res.status).toBe(401)
@@ -399,7 +394,7 @@ describe('legacyPNP', () => {
         _config.api.phoneNumberPrivacy.enabled = false
         const appWithApiDisabled = startSigner(_config, db, keyProvider, newKit('dummyKit'))
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1, IDENTIFIER)
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(req, authorization, appWithApiDisabled)
         expect.assertions(2)
         expect(res.status).toBe(503)

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -108,7 +108,7 @@ describe('pnp', () => {
         it(`Should get totalQuota=${expectedTotalQuota} for ${cusdWei.toString()} cUSD (wei)`, async () => {
           mockOdisPaymentsTotalPaidCUSD.mockReturnValue(cusdWei)
           const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
-          const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
           const res = await sendPnpQuotaRequest(req, authorization)
 
           expect(res.status).toBe(200)
@@ -128,7 +128,7 @@ describe('pnp', () => {
           throw new Error('dummy error')
         })
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(req, authorization)
 
         expect(res.status).toBe(200)
@@ -151,7 +151,7 @@ describe('pnp', () => {
 
       it('Should respond with 200 on repeated valid requests', async () => {
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
 
         const res1 = await sendPnpQuotaRequest(req, authorization)
         expect(res1.status).toBe(200)
@@ -172,7 +172,7 @@ describe('pnp', () => {
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
         // @ts-ignore Intentionally adding an extra field to the request type
         req.extraField = 'dummyString'
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(req, authorization)
         expect(res.status).toBe(200)
         expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
@@ -189,7 +189,7 @@ describe('pnp', () => {
         const badRequest = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
         // @ts-ignore Intentionally deleting required field
         delete badRequest.account
-        const authorization = getPnpRequestAuthorization(badRequest, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(badRequest, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(badRequest, authorization)
 
         expect(res.status).toBe(400)
@@ -203,7 +203,7 @@ describe('pnp', () => {
       it('Should respond with 401 on failed auth', async () => {
         // Request from one account, signed by another account
         const badRequest = getPnpQuotaRequest(mockAccount)
-        const authorization = getPnpRequestAuthorization(badRequest, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(badRequest, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(badRequest, authorization)
 
         expect(res.status).toBe(401)
@@ -224,7 +224,7 @@ describe('pnp', () => {
           newKit('dummyKit')
         )
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
-        const authorization = getPnpRequestAuthorization(req, ACCOUNT_ADDRESS1, PRIVATE_KEY1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendPnpQuotaRequest(req, authorization, appWithApiDisabled)
         expect(res.status).toBe(503)
         expect(res.body).toMatchObject<PnpQuotaResponseFailure>({

--- a/packages/sdk/identity/src/odis/query.ts
+++ b/packages/sdk/identity/src/odis/query.ts
@@ -1,4 +1,3 @@
-import { hexToBuffer } from '@celo/base/lib/address'
 import { selectiveRetryAsyncWithBackOff } from '@celo/base/lib/async'
 import { ContractKit } from '@celo/contractkit'
 import {
@@ -12,9 +11,9 @@ import {
   GetContactMatchesRequest,
   GetContactMatchesResponse,
   PhoneNumberPrivacyRequest,
+  signWithRawDEK,
 } from '@celo/phone-number-privacy-common'
 import fetch from 'cross-fetch'
-import crypto from 'crypto'
 import debugFactory from 'debug'
 import { isLeft } from 'fp-ts/lib/Either'
 import * as t from 'io-ts'
@@ -98,19 +97,8 @@ export function signWithDEK(msg: string, signer: EncryptionKeySigner) {
 }
 
 export function signWithRawKey(msg: string, rawKey: string) {
-  // NOTE: Elliptic will truncate the raw msg to 64 bytes before signing,
-  // so make sure to always pass the hex encoded msgDigest instead.
-  const msgDigest = crypto.createHash('sha256').update(JSON.stringify(msg)).digest('hex')
-
-  // NOTE: elliptic is disabled elsewhere in this library to prevent
-  // accidental signing of truncated messages.
-  // tslint:disable-next-line:import-blacklist
-  const EC = require('elliptic').ec
-  const ec = new EC('secp256k1')
-
-  // Sign
-  const key = ec.keyFromPrivate(hexToBuffer(rawKey))
-  return JSON.stringify(key.sign(msgDigest).toDER())
+  // For backwards compatibility
+  return signWithRawDEK(msg, rawKey)
 }
 
 /**

--- a/packages/sdk/identity/src/odis/query.ts
+++ b/packages/sdk/identity/src/odis/query.ts
@@ -11,7 +11,7 @@ import {
   GetContactMatchesRequest,
   GetContactMatchesResponse,
   PhoneNumberPrivacyRequest,
-  signWithRawDEK,
+  signWithRawKey,
 } from '@celo/phone-number-privacy-common'
 import fetch from 'cross-fetch'
 import debugFactory from 'debug'
@@ -34,7 +34,7 @@ export interface EncryptionKeySigner {
 export type AuthSigner = WalletKeySigner | EncryptionKeySigner
 
 // Re-export types and aliases to maintain backwards compatibility.
-export { AuthenticationMethod, PhoneNumberPrivacyRequest }
+export { AuthenticationMethod, PhoneNumberPrivacyRequest, signWithRawKey }
 export type SignMessageRequest = GetBlindedMessageSigRequest
 export type MatchmakingRequest = GetContactMatchesRequest
 export type MatchmakingResponse = GetContactMatchesResponse
@@ -94,11 +94,6 @@ export function getServiceContext(contextName = 'mainnet') {
 
 export function signWithDEK(msg: string, signer: EncryptionKeySigner) {
   return signWithRawKey(msg, signer.rawKey)
-}
-
-export function signWithRawKey(msg: string, rawKey: string) {
-  // For backwards compatibility
-  return signWithRawDEK(msg, rawKey)
 }
 
 /**


### PR DESCRIPTION
### Description

- adds a test case for authorizing via a DEK signer (in combiner PNP sign tests) and adds some helpers to make it easy to do this for legacy/pnp test cases in the combiner/signer
- factors out some common code in sdk/identity & phone-number-privacy-common
  - moves the "core" DEK signing code -> phone-number-privacy-common (since sdk/identity depends on this, so we can't import from sdk/identity without running into build issues)
  - fixes a sketchy import in the authentication tests (in phone-number-privacy-common)