### PR TITLE
McMint MVP Broker 

### DIFF
--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly-7e9e6a5d6b30ad3f543857198234edcdbceb724a
+          version: nightly
 
       - name: Install forge dependencies
         run: forge install

--- a/packages/protocol/contracts/stability/Broker.sol
+++ b/packages/protocol/contracts/stability/Broker.sol
@@ -1,0 +1,111 @@
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+import { IPairManager } from "./interfaces/IPairManager.sol";
+import { IBroker } from "./interfaces/IBroker.sol";
+import { IReserve } from "./interfaces/IReserve.sol";
+import { IMentoExchange } from "./interfaces/IMentoExchange.sol";
+
+import { StableToken } from "./StableToken.sol";
+
+import { UsingRegistry } from "../common/UsingRegistry.sol";
+import { Initializable } from "../common/Initializable.sol";
+import { FixidityLib } from "../common/FixidityLib.sol";
+
+// TODO: Remove when migrating to mento-core. Newer versions of OZ-contracts have this interface
+interface IERC20Metadata {
+  function symbol() external view returns (string memory);
+}
+
+/**
+ * @title Broker
+ * @notice The broker executes swaps and keeps track of spending limits per pair
+ */
+contract Broker is IBroker, Initializable, Ownable {
+  using FixidityLib for FixidityLib.Fraction;
+
+  /* ==================== State Variables ==================== */
+
+  // Address of the broker contract.
+  IPairManager public pairManager;
+
+  // Address of the reserve.
+  IReserve public reserve;
+
+  /* ==================== Constructor ==================== */
+
+  /**
+   * @notice Sets initialized == true on implementation contracts.
+   * @param test Set to true to skip implementation initialization.
+   */
+  constructor(bool test) public Initializable(test) {}
+
+  /**
+   * @notice Allows the contract to be upgradable via the proxy.
+   * @param _broker The address of the broker contract.
+   * @param registryAddress The address of the Celo registry.
+   */
+  function initilize(address _pairManager, address _registry) external initializer {
+    _transferOwnership(msg.sender);
+    setPairManager(registryAddress);
+    setRegistry(_broker);
+  }
+
+  /* ==================== View Functions ==================== */
+
+  function quote(bytes32 pairId, address tokenIn, uint256 amountIn)
+    external
+    view
+    returns (address tokenOut, uint256 amountOut)
+  {
+    Pair memory pair = pairManager.getPair(pairId);
+
+    require(
+      tokenIn == pair.stableAsset || tokenIn == pair.collateralAsset,
+      "tokenIn is not in the pair"
+    );
+
+    if (pair.stableAsset == tokenIn) {
+      tokenOut = pair.collateralAsset;
+      amountOut = pair.exchange.getAmountOut(
+        tokenIn,
+        tokenOut,
+        pair.stableBucket,
+        pair.collateralBucket,
+        amountIn
+      );
+    } else {
+      tokenOut = pair.stableAsset;
+      amountOut = pair.exchange.getAmountOut(
+        tokenIn,
+        tokenOut,
+        pair.collateralBucket,
+        pair.stableBucket,
+        amountIn
+      );
+    }
+  }
+
+  /* ==================== Mutative Functions ==================== */
+
+  function swap(bytes32 pairId, address tokenIn, uint256 amountIn, uint256 amountOutMin)
+    external
+    view
+    returns (address tokenOut, uint256 amountOut)
+  {
+    (address tokenOut, uint256 amountOut) = quote(pairId, tokenIn, amountIn);
+    require(amountOut < amountOutMin, "slippage to low");
+
+    // TODO: adjust bucket
+    if (tokenIn == pair.stableAsset) {
+      IERC20(tokenIn).transferFrom(msg.sender, amountIn, address(this));
+      IERC20(tokenIn).burn(amountIn);
+      reserve.transferToken(tokenOut, msg.sender, amountOut);
+    } else {
+      IERC20(tokenIn).transferFrom(msg.sender, amountIn, address(reserve));
+      IERC20(tokenOut).mint(msg.sender, amountOut);
+    }
+  }
+}

--- a/packages/protocol/contracts/stability/Broker.sol
+++ b/packages/protocol/contracts/stability/Broker.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
-import { console2 as console } from "forge-std/console2.sol";
-
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/protocol/contracts/stability/Reserve.sol
+++ b/packages/protocol/contracts/stability/Reserve.sol
@@ -772,11 +772,7 @@ contract Reserve is
     }
   }
 
-  function isStableAsset(address) external view returns (bool) {
-    return true;
-  }
-
-  function isCollateralAsset(address) external view returns (bool) {
-    return true;
+  function isStableAsset(address token) external view returns (bool) {
+    return isToken[token];
   }
 }

--- a/packages/protocol/contracts/stability/interfaces/IBroker.sol
+++ b/packages/protocol/contracts/stability/interfaces/IBroker.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+
+/*
+ * @title Broker Interface
+ * @notice The broker is responsible for executing swaps and keeping track of trading limits
+ */
+interface IBroker {
+  /**
+   * @notice Emitted when a swap occurs
+   * @param pairId The id of the pair where the swap occured
+   * @param trader The user that initiated the swap
+   * @param tokenIn The address of the token that was sold
+   * @param tokenOut The address of the token that was bought
+   * @param amountIn The amount of token sold 
+   * @param amountOut The amount of token bought
+   */
+  event Swap(
+    bytes32 indexed pairId,
+    address indexed trader,
+    address indexed tokenIn,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOut
+  );
+
+  /**
+   * @notice Execute a token swap
+   * @param pairId The id of the pair to be swapped
+   * @param tokenIn The address of the token to be sold
+   * @param amountIn The amount of tokenIn to be sold
+   * @param amountOutMin Minimum amountOut to be received - controls slippage
+   * @return tokenOut The token to be bought 
+   * @return amountOut The amount of tokenOut to be bought
+   */
+  function swap(bytes32 pairId, address tokenIn, uint256 amountIn, uint256 amountOutMin)
+    external
+    view
+    returns (address tokenOut, uint256 amountOut);
+
+  /**
+   * @notice Calculates the quote for a swap
+   * @param pairId The id of the pair
+   * @param tokenIn The address of the token to be sold
+   * @param amountIn The amount of tokenIn to be sold
+   * @return tokenOut The token to be bought 
+   * @return amountOut The amount of tokenOut to be bought
+   */
+  function quote(bytes32 pairId, address tokenIn, uint256 amountIn)
+    external
+    view
+    returns (address tokenOut, uint256 amountOut);
+
+}

--- a/packages/protocol/contracts/stability/interfaces/IBroker.sol
+++ b/packages/protocol/contracts/stability/interfaces/IBroker.sol
@@ -25,6 +25,20 @@ interface IBroker {
   );
 
   /**
+   * @notice Emitted the PairManager is updated
+   * @param newAddress the new address
+   * @param prevAddress the previous address
+   */
+  event PairManagerUpdated(address indexed newAddress, address indexed prevAddress);
+
+  /**
+   * @notice Emitted the Reserve is updated
+   * @param newAddress the new address
+   * @param prevAddress the previous address
+   */
+  event ReserveUpdated(address indexed newAddress, address indexed prevAddress);
+
+  /**
    * @notice Execute a token swap
    * @param pairId The id of the pair to be swapped
    * @param tokenIn The address of the token to be sold
@@ -50,5 +64,4 @@ interface IBroker {
     external
     view
     returns (address tokenOut, uint256 amountOut);
-
 }

--- a/packages/protocol/contracts/stability/interfaces/IBroker.sol
+++ b/packages/protocol/contracts/stability/interfaces/IBroker.sol
@@ -49,7 +49,6 @@ interface IBroker {
    */
   function swap(bytes32 pairId, address tokenIn, uint256 amountIn, uint256 amountOutMin)
     external
-    view
     returns (address tokenOut, uint256 amountOut);
 
   /**

--- a/packages/protocol/contracts/stability/interfaces/IMentoExchange.sol
+++ b/packages/protocol/contracts/stability/interfaces/IMentoExchange.sol
@@ -6,13 +6,15 @@ pragma solidity ^0.5.13;
  */
 interface IMentoExchange {
   /**
-   * @notice Returns the output amount for a given input amount.
+   * @notice Returns the output amount and new bucket sizes for a given input amount.
    * @param tokenIn Address of the token being used to pay for another one.
    * @param tokenOut Address of the token being exchanged for.
    * @param tokenInBucketSize Size of the tokenIn bucket.
    * @param tokenOutBucketSize Size of the tokenOut bucket.
    * @param amountIn Amount of tokenIn being paid in.
    * @return amountOut Amount of tokenOut that will be paid out.
+   * @return newtokenInBucketSize Size of the tokenIn bucket after the swap.
+   * @return newtokenOutBucketSize Size of the tokenOut bucket after the swap.
    */
   function getAmountOut(
     address tokenIn,
@@ -20,7 +22,10 @@ interface IMentoExchange {
     uint256 tokenInBucketSize,
     uint256 tokenOutBucketSize,
     uint256 amountIn
-  ) external view returns (uint256 amountOut);
+  )
+    external
+    view
+    returns (uint256 amountOut, uint256 newTokenInBucketSize, uint256 newTokenOutBucketSize);
 
   /**
    * @notice Returns the size of a pair's buckets after an exchange.

--- a/packages/protocol/contracts/stability/interfaces/IPairManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IPairManager.sol
@@ -78,4 +78,12 @@ interface IPairManager {
    * @return pair The pair information.
    */
   function getPair(bytes32 pairId) external view returns (Pair memory pair);
+
+  /**
+   * @notice Updates the bucket sizes for the virtual pair with the specified pairId.
+   * @param pairId The id of the pair to be updated.
+   * @param stableBucket The new stable bucket size.
+   * @param collateralBucket The new collateral bucket size.
+   */
+  function updateBuckets(bytes32 pairId, uint256 stableBucket, uint256 collateralBucket) external;
 }

--- a/packages/protocol/contracts/stability/interfaces/IReserve.sol
+++ b/packages/protocol/contracts/stability/interfaces/IReserve.sol
@@ -6,6 +6,9 @@ interface IReserve {
   function removeToken(address, uint256) external returns (bool);
   function transferGold(address payable, uint256) external returns (bool);
   function transferExchangeGold(address payable, uint256) external returns (bool);
+  function transferCollateralAsset(address collateralAsset, address payable to, uint256 value)
+    external
+    returns (bool);
   function getReserveGoldBalance() external view returns (uint256);
   function getUnfrozenReserveGoldBalance() external view returns (uint256);
   function getOrComputeTobinTax() external returns (uint256, uint256);

--- a/packages/protocol/contracts/stability/test/MockMentoExchange.sol
+++ b/packages/protocol/contracts/stability/test/MockMentoExchange.sol
@@ -16,9 +16,9 @@ contract MockMentoExchange is IMentoExchange {
   function getAmountOut(address, address, uint256, uint256, uint256)
     external
     view
-    returns (uint256)
+    returns (uint256, uint256, uint256)
   {
-    return 0;
+    return (0, 0, 0);
   }
 
   function getUpdatedBuckets(address, address, uint256, uint256, bytes32)

--- a/packages/protocol/test-sol/stability/Broker.t.sol
+++ b/packages/protocol/test-sol/stability/Broker.t.sol
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test } from "celo-foundry/Test.sol";
+import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+import { Broker } from "contracts/stability/Broker.sol";
+import { IMentoExchange } from "contracts/stability/interfaces/IMentoExchange.sol";
+import { IPairManager } from "contracts/stability/interfaces/IPairManager.sol";
+import { IReserve } from "contracts/stability/interfaces/IReserve.sol";
+import { IStableToken } from "contracts/stability/interfaces/IStableToken.sol";
+
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+// forge test --match-contract Broker -vvv
+contract BrokerTest is Test {
+  event Swap(
+    bytes32 indexed pairId,
+    address indexed trader,
+    address indexed tokenIn,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOut
+  );
+  event PairManagerUpdated(address indexed newAddress, address indexed prevAddress);
+  event ReserveUpdated(address indexed newAddress, address indexed prevAddress);
+
+  address deployer;
+  address notDeployer;
+  address trader;
+
+  IStableToken stableAsset;
+  IERC20 collateralAsset;
+  address testRandomAsset;
+  IMentoExchange exchange;
+
+  uint256 constant initialStableBucket = 1e24;
+  uint256 constant initialCollateralBucket = 2e24;
+
+  IReserve reserve;
+  IPairManager pairManager;
+
+  Broker broker;
+
+  function setUp() public {
+    /* Dependencies and actors */
+    deployer = actor("deployer");
+    notDeployer = actor("notDeployer");
+    reserve = IReserve(actor("reserve"));
+    pairManager = IPairManager(actor("pairManager"));
+    stableAsset = IStableToken(actor("stableAsset"));
+    collateralAsset = IERC20(actor("collateralAsset"));
+    testRandomAsset = actor("testRandomAsset");
+    exchange = IMentoExchange(actor("exchange"));
+    trader = actor("trader");
+
+    /* Mocks for dependent contracts */
+    vm.mockCall(
+      address(stableAsset),
+      abi.encodePacked(IERC20(address(stableAsset)).transferFrom.selector),
+      abi.encode(0x0)
+    );
+
+    vm.mockCall(address(stableAsset), abi.encodePacked(stableAsset.burn.selector), abi.encode(0x0));
+
+    vm.mockCall(address(stableAsset), abi.encodePacked(stableAsset.mint.selector), abi.encode(0x0));
+
+    vm.mockCall(
+      address(reserve),
+      abi.encodePacked(reserve.transferCollateralAsset.selector),
+      abi.encode(0x0)
+    );
+
+    vm.mockCall(
+      address(collateralAsset),
+      abi.encodePacked(collateralAsset.transferFrom.selector),
+      abi.encode(0x0)
+    );
+
+    changePrank(deployer);
+    broker = new Broker(true);
+    broker.initilize(address(pairManager), address(reserve));
+    changePrank(trader);
+  }
+
+  function createPair() internal view returns (bytes32 pairId, IPairManager.Pair memory pair) {
+    pair.stableAsset = address(stableAsset);
+    pair.collateralAsset = address(collateralAsset);
+    pair.mentoExchange = IMentoExchange(exchange);
+    pair.collateralBucketFraction = FixidityLib.wrap(0.1 * 10**24);
+    pair.stableBucketMaxFraction = FixidityLib.wrap(0.1 * 10**24);
+    pair.stableBucket = initialStableBucket;
+    pair.collateralBucket = initialCollateralBucket;
+    pair.spread = FixidityLib.wrap(0.1 * 10**24);
+    pairId = keccak256(abi.encode(pair));
+  }
+
+  function mockGetPair() internal returns (bytes32 pairId) {
+    IPairManager.Pair memory pair;
+    (pairId, pair) = createPair();
+    vm.mockCall(
+      address(pairManager),
+      abi.encodeWithSelector(pairManager.getPair.selector, pairId),
+      abi.encode(pair)
+    );
+  }
+}
+
+contract BrokerTest_initilizerAndSetters is BrokerTest {
+  /* ---------- Initilizer ---------- */
+
+  function test_initilize_shouldSetOwner() public {
+    assertEq(broker.owner(), deployer);
+  }
+
+  function test_initilize_shouldSetPairManager() public {
+    assertEq(address(broker.pairManager()), address(pairManager));
+  }
+
+  function test_initilize_shouldSetReserve() public {
+    assertEq(address(broker.reserve()), address(reserve));
+  }
+
+  /* ---------- Setters ---------- */
+
+  function test_setPairManager_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    broker.setPairManager(address(0));
+  }
+
+  function test_setPairManager_whenAddressIsZero_shouldRevert() public {
+    changePrank(deployer);
+    vm.expectRevert("PairManager address must be set");
+    broker.setPairManager(address(0));
+  }
+
+  function test_setPairManager_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    changePrank(deployer);
+    address newPairManager = actor("newPairManager");
+    vm.expectEmit(true, false, false, false);
+    emit PairManagerUpdated(newPairManager, address(pairManager));
+
+    broker.setPairManager(newPairManager);
+    assertEq(address(broker.pairManager()), newPairManager);
+  }
+
+  function test_setReserve_whenSenderIsNotOwner_shouldRevert() public {
+    changePrank(notDeployer);
+    vm.expectRevert("Ownable: caller is not the owner");
+    broker.setReserve(address(0));
+  }
+
+  function test_setReserve_whenAddressIsZero_shouldRevert() public {
+    changePrank(deployer);
+    vm.expectRevert("Reserve address must be set");
+    broker.setReserve(address(0));
+  }
+
+  function test_setReserve_whenSenderIsOwner_shouldUpdateAndEmit() public {
+    changePrank(deployer);
+    address newReserve = actor("newReserve");
+    vm.expectEmit(true, false, false, false);
+    emit ReserveUpdated(newReserve, address(reserve));
+
+    broker.setReserve(newReserve);
+    assertEq(address(broker.reserve()), newReserve);
+  }
+}
+
+contract BrokerTest_quote is BrokerTest {
+  function test_tokenInStableAsset() public {
+    bytes32 pairId = mockGetPair();
+    uint256 amountIn = 1e18;
+
+    vm.mockCall(
+      address(exchange),
+      abi.encodeWithSelector(
+        exchange.getAmountOut.selector,
+        stableAsset,
+        collateralAsset,
+        initialStableBucket,
+        initialCollateralBucket,
+        amountIn
+      ),
+      abi.encode(2e18, 1e24, 2e24)
+    );
+
+    (address tokenOut, uint256 amountOut) = broker.quote(pairId, address(stableAsset), amountIn);
+    assertEq(tokenOut, address(collateralAsset));
+    assertEq(amountOut, 2e18);
+  }
+
+  function test_tokenInCollateralAsset() public {
+    bytes32 pairId = mockGetPair();
+    uint256 amountIn = 1e18;
+
+    vm.mockCall(
+      address(exchange),
+      abi.encodeWithSelector(
+        exchange.getAmountOut.selector,
+        collateralAsset,
+        stableAsset,
+        initialCollateralBucket,
+        initialStableBucket,
+        amountIn
+      ),
+      abi.encode(2e18, 10e18, 20e18)
+    );
+
+    (address tokenOut, uint256 amountOut) = broker.quote(pairId, address(collateralAsset), 1e18);
+    assertEq(tokenOut, address(stableAsset));
+    assertEq(amountOut, 2e18);
+  }
+
+  function test_tokenInRandomAsset() public {
+    bytes32 pairId = mockGetPair();
+    vm.expectRevert("tokenIn is not in the pair");
+    broker.quote(pairId, testRandomAsset, 1e18);
+  }
+}
+
+contract BrokerTest_swap is BrokerTest {
+  function test_tokenInStableAsset() public {
+    bytes32 pairId = mockGetPair();
+    uint256 amountIn = 1e18;
+    uint256 mockAmountOut = 2e18;
+    uint256 nextStableBucket = initialStableBucket + amountIn;
+    uint256 nextCollateralBucket = initialCollateralBucket - mockAmountOut;
+
+    vm.mockCall(
+      address(exchange),
+      abi.encodeWithSelector(
+        exchange.getAmountOut.selector,
+        stableAsset,
+        collateralAsset,
+        initialStableBucket,
+        initialCollateralBucket,
+        amountIn
+      ),
+      abi.encode(mockAmountOut, nextStableBucket, nextCollateralBucket)
+    );
+
+    vm.expectCall(
+      address(stableAsset),
+      abi.encodeWithSelector(
+        IERC20(address(stableAsset)).transferFrom.selector,
+        trader,
+        address(broker),
+        amountIn
+      )
+    );
+
+    vm.expectCall(
+      address(stableAsset),
+      abi.encodeWithSelector(stableAsset.burn.selector, amountIn)
+    );
+
+    vm.expectCall(
+      address(reserve),
+      abi.encodeWithSelector(
+        reserve.transferCollateralAsset.selector,
+        address(collateralAsset),
+        trader,
+        mockAmountOut
+      )
+    );
+
+    vm.expectCall(
+      address(pairManager),
+      abi.encodeWithSelector(
+        pairManager.updateBuckets.selector,
+        pairId,
+        nextStableBucket,
+        nextCollateralBucket
+      )
+    );
+
+    vm.expectEmit(true, true, true, true, address(broker));
+    emit Swap(
+      pairId,
+      trader,
+      address(stableAsset),
+      address(collateralAsset),
+      amountIn,
+      mockAmountOut
+    );
+    (address tokenOut, uint256 amountOut) = broker.swap(pairId, address(stableAsset), amountIn, 0);
+    assertEq(tokenOut, address(collateralAsset));
+    assertEq(amountOut, mockAmountOut);
+  }
+
+  function test_tokenInCollateralAsset() public {
+    bytes32 pairId = mockGetPair();
+    uint256 amountIn = 2e18;
+    uint256 mockAmountOut = 1e18;
+    uint256 nextStableBucket = initialStableBucket - mockAmountOut;
+    uint256 nextCollateralBucket = initialCollateralBucket + amountIn;
+
+    vm.mockCall(
+      address(exchange),
+      abi.encodeWithSelector(
+        exchange.getAmountOut.selector,
+        collateralAsset,
+        stableAsset,
+        initialCollateralBucket,
+        initialStableBucket,
+        amountIn
+      ),
+      abi.encode(mockAmountOut, nextCollateralBucket, nextStableBucket)
+    );
+
+    vm.expectCall(
+      address(collateralAsset),
+      abi.encodeWithSelector(
+        collateralAsset.transferFrom.selector,
+        trader,
+        address(reserve),
+        amountIn
+      )
+    );
+
+    vm.expectCall(
+      address(stableAsset),
+      abi.encodeWithSelector(stableAsset.mint.selector, trader, mockAmountOut)
+    );
+
+    vm.expectCall(
+      address(pairManager),
+      abi.encodeWithSelector(
+        pairManager.updateBuckets.selector,
+        pairId,
+        nextStableBucket,
+        nextCollateralBucket
+      )
+    );
+
+    vm.expectEmit(true, true, true, true, address(broker));
+    emit Swap(
+      pairId,
+      trader,
+      address(collateralAsset),
+      address(stableAsset),
+      amountIn,
+      mockAmountOut
+    );
+    (address tokenOut, uint256 amountOut) = broker.swap(
+      pairId,
+      address(collateralAsset),
+      amountIn,
+      0
+    );
+    assertEq(tokenOut, address(stableAsset));
+    assertEq(amountOut, mockAmountOut);
+  }
+
+  function test_minAmountNotMet() public {
+    bytes32 pairId = mockGetPair();
+    uint256 amountIn = 1e18;
+    uint256 mockAmountOut = 2e18;
+    uint256 nextStableBucket = initialStableBucket + amountIn;
+    uint256 nextCollateralBucket = initialCollateralBucket - mockAmountOut;
+
+    vm.mockCall(
+      address(exchange),
+      abi.encodeWithSelector(
+        exchange.getAmountOut.selector,
+        stableAsset,
+        collateralAsset,
+        initialStableBucket,
+        initialCollateralBucket,
+        amountIn
+      ),
+      abi.encode(mockAmountOut, nextStableBucket, nextCollateralBucket)
+    );
+
+    vm.expectRevert("amountOutMin not met");
+    broker.swap(pairId, address(stableAsset), amountIn, mockAmountOut + 1);
+  }
+}

--- a/packages/protocol/test-sol/stability/Broker.t.sol
+++ b/packages/protocol/test-sol/stability/Broker.t.sol
@@ -170,7 +170,7 @@ contract BrokerTest_initilizerAndSetters is BrokerTest {
 }
 
 contract BrokerTest_quote is BrokerTest {
-  function test_tokenInStableAsset() public {
+  function test_quote_tokenInStableAsset_shouldReturnQuote() public {
     bytes32 pairId = mockGetPair();
     uint256 amountIn = 1e18;
 
@@ -192,7 +192,7 @@ contract BrokerTest_quote is BrokerTest {
     assertEq(amountOut, 2e18);
   }
 
-  function test_tokenInCollateralAsset() public {
+  function test_quote_tokenInCollateralAsset_shouldReturnQuote() public {
     bytes32 pairId = mockGetPair();
     uint256 amountIn = 1e18;
 
@@ -214,7 +214,7 @@ contract BrokerTest_quote is BrokerTest {
     assertEq(amountOut, 2e18);
   }
 
-  function test_tokenInNotInPair() public {
+  function test_quote_tokenInNotInPair_shouldRevert() public {
     bytes32 pairId = mockGetPair();
     vm.expectRevert("tokenIn is not in the pair");
     broker.quote(pairId, randomAsset, 1e18);
@@ -222,7 +222,7 @@ contract BrokerTest_quote is BrokerTest {
 }
 
 contract BrokerTest_swap is BrokerTest {
-  function test_tokenInStableAsset() public {
+  function test_swap_tokenInStableAsset_shouldExecuteSwap() public {
     bytes32 pairId = mockGetPair();
     uint256 amountIn = 1e18;
     uint256 mockAmountOut = 2e18;
@@ -291,7 +291,7 @@ contract BrokerTest_swap is BrokerTest {
     assertEq(amountOut, mockAmountOut);
   }
 
-  function test_tokenInCollateralAsset() public {
+  function test_swap_tokenInCollateralAsset_shouldExecuteSwap() public {
     bytes32 pairId = mockGetPair();
     uint256 amountIn = 2e18;
     uint256 mockAmountOut = 1e18;
@@ -355,7 +355,7 @@ contract BrokerTest_swap is BrokerTest {
     assertEq(amountOut, mockAmountOut);
   }
 
-  function test_minAmountNotMet() public {
+  function test_swap_minAmountNotMet_shouldRevert() public {
     bytes32 pairId = mockGetPair();
     uint256 amountIn = 1e18;
     uint256 mockAmountOut = 2e18;
@@ -379,7 +379,7 @@ contract BrokerTest_swap is BrokerTest {
     broker.swap(pairId, address(stableAsset), amountIn, mockAmountOut + 1);
   }
 
-  function test_assetNotInPair() public {
+  function test_swap_assetNotInPair_shouldRevert() public {
     bytes32 pairId = mockGetPair();
     vm.expectRevert("tokenIn is not in the pair");
     broker.swap(pairId, randomAsset, 1e18, 0);

--- a/packages/protocol/test-sol/stability/Broker.t.sol
+++ b/packages/protocol/test-sol/stability/Broker.t.sol
@@ -32,7 +32,7 @@ contract BrokerTest is Test {
 
   IStableToken stableAsset;
   IERC20 collateralAsset;
-  address testRandomAsset;
+  address randomAsset;
   IMentoExchange exchange;
 
   uint256 constant initialStableBucket = 1e24;
@@ -51,7 +51,7 @@ contract BrokerTest is Test {
     pairManager = IPairManager(actor("pairManager"));
     stableAsset = IStableToken(actor("stableAsset"));
     collateralAsset = IERC20(actor("collateralAsset"));
-    testRandomAsset = actor("testRandomAsset");
+    randomAsset = actor("randomAsset");
     exchange = IMentoExchange(actor("exchange"));
     trader = actor("trader");
 
@@ -214,10 +214,10 @@ contract BrokerTest_quote is BrokerTest {
     assertEq(amountOut, 2e18);
   }
 
-  function test_tokenInRandomAsset() public {
+  function test_tokenInNotInPair() public {
     bytes32 pairId = mockGetPair();
     vm.expectRevert("tokenIn is not in the pair");
-    broker.quote(pairId, testRandomAsset, 1e18);
+    broker.quote(pairId, randomAsset, 1e18);
   }
 }
 
@@ -377,5 +377,11 @@ contract BrokerTest_swap is BrokerTest {
 
     vm.expectRevert("amountOutMin not met");
     broker.swap(pairId, address(stableAsset), amountIn, mockAmountOut + 1);
+  }
+
+  function test_assetNotInPair() public {
+    bytes32 pairId = mockGetPair();
+    vm.expectRevert("tokenIn is not in the pair");
+    broker.swap(pairId, randomAsset, 1e18, 0);
   }
 }


### PR DESCRIPTION
### Description

Add implementation for the Broker which executes a swap by interacting with the PairManager, the Reserve, and the IMentoExchange implementation of the pair.

This contract currently handles unlimited swaps, but a later version should implement trading limits.

⚠️ This PR contains the work in #9697 and #9786 so it should be rebased after those get merged.

### Other changes

- Made some changes to the IMentoExchange interface to remove the need for two separate calls to the exchange, but this can be discussed.
- Also touched the Reserve a bit to fix a compilation error.

### Tested

Unit tests for Broker implementation added which mock all dependencies.
Integration test will be added in a later PR.

### Related issues

- https://github.com/mento-protocol/mento-general/issues/32
- https://github.com/mento-protocol/mento-general/issues/37

### Backwards compatibility

New implementation

### Documentation

_The set of community facing docs that have been added/modified because of this change_