### PR TITLE
Add threshold state values to pnp sign responses in combiner

### DIFF
--- a/packages/phone-number-privacy/combiner/src/common/sign.ts
+++ b/packages/phone-number-privacy/combiner/src/common/sign.ts
@@ -15,7 +15,7 @@ import { IO } from './io'
 
 // prettier-ignore
 export type OdisSignatureRequest = SignMessageRequest | DomainRestrictedSignatureRequest
-export type ThresholdStateService<R> = R extends SignMessageRequest
+export type ThresholdStateService<R extends OdisSignatureRequest> = R extends SignMessageRequest
   ? PnpThresholdStateService<R>
   : never | R extends DomainRestrictedSignatureRequest
   ? DomainThresholdStateService<R>

--- a/packages/phone-number-privacy/combiner/src/common/sign.ts
+++ b/packages/phone-number-privacy/combiner/src/common/sign.ts
@@ -8,7 +8,7 @@ import {
 import { Response as FetchResponse } from 'node-fetch'
 import { OdisConfig } from '../config'
 import { DomainThresholdStateService } from '../domain/services/thresholdState'
-import { CombinerThresholdStateService } from '../pnp/services/thresholdState'
+import { PnpThresholdStateService } from '../pnp/services/thresholdState'
 import { CombineAction } from './combine'
 import { CryptoSession } from './crypto-session'
 import { IO } from './io'
@@ -16,7 +16,7 @@ import { IO } from './io'
 // prettier-ignore
 export type OdisSignatureRequest = SignMessageRequest | DomainRestrictedSignatureRequest
 export type ThresholdStateService<R> = R extends SignMessageRequest
-  ? CombinerThresholdStateService<R>
+  ? PnpThresholdStateService<R>
   : never | R extends DomainRestrictedSignatureRequest
   ? DomainThresholdStateService<R>
   : never

--- a/packages/phone-number-privacy/combiner/src/common/sign.ts
+++ b/packages/phone-number-privacy/combiner/src/common/sign.ts
@@ -7,16 +7,27 @@ import {
 } from '@celo/phone-number-privacy-common'
 import { Response as FetchResponse } from 'node-fetch'
 import { OdisConfig } from '../config'
+import { DomainThresholdStateService } from '../domain/services/thresholdState'
+import { CombinerThresholdStateService } from '../pnp/services/thresholdState'
 import { CombineAction } from './combine'
 import { CryptoSession } from './crypto-session'
 import { IO } from './io'
 
 // prettier-ignore
 export type OdisSignatureRequest = SignMessageRequest | DomainRestrictedSignatureRequest
+export type ThresholdStateService<R> = R extends SignMessageRequest
+  ? CombinerThresholdStateService<R>
+  : never | R extends DomainRestrictedSignatureRequest
+  ? DomainThresholdStateService<R>
+  : never
 
 // tslint:disable-next-line: max-classes-per-file
 export abstract class SignAction<R extends OdisSignatureRequest> extends CombineAction<R> {
-  constructor(readonly config: OdisConfig, readonly io: IO<R>) {
+  constructor(
+    readonly config: OdisConfig,
+    readonly thresholdStateService: ThresholdStateService<R>,
+    readonly io: IO<R>
+  ) {
     super(config, io)
   }
 

--- a/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
@@ -8,22 +8,11 @@ import {
   WarningMessage,
 } from '@celo/phone-number-privacy-common'
 import { CryptoSession } from '../../../common/crypto-session'
-import { IO } from '../../../common/io'
 import { SignAction } from '../../../common/sign'
-import { OdisConfig } from '../../../config'
-import { DomainThresholdStateService } from '../../services/thresholdState'
 
 export class DomainSignAction extends SignAction<DomainRestrictedSignatureRequest> {
   readonly endpoint: CombinerEndpoint = CombinerEndpoint.DOMAIN_SIGN
   readonly signerEndpoint: SignerEndpoint = getSignerEndpoint(this.endpoint)
-
-  constructor(
-    readonly config: OdisConfig,
-    readonly thresholdStateService: DomainThresholdStateService<DomainRestrictedSignatureRequest>,
-    readonly io: IO<DomainRestrictedSignatureRequest>
-  ) {
-    super(config, io)
-  }
 
   combine(session: CryptoSession<DomainRestrictedSignatureRequest>): void {
     // this.logResponseDiscrepancies(session)

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/action.ts
@@ -3,12 +3,12 @@ import { CombineAction } from '../../../common/combine'
 import { IO } from '../../../common/io'
 import { Session } from '../../../common/session'
 import { OdisConfig } from '../../../config'
-import { CombinerThresholdStateService } from '../../services/thresholdState'
+import { PnpThresholdStateService } from '../../services/thresholdState'
 
 export class PnpQuotaAction extends CombineAction<PnpQuotaRequest> {
   constructor(
     readonly config: OdisConfig,
-    readonly thresholdStateService: CombinerThresholdStateService<PnpQuotaRequest>,
+    readonly thresholdStateService: PnpThresholdStateService<PnpQuotaRequest>,
     readonly io: IO<PnpQuotaRequest>
   ) {
     super(config, io)

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
@@ -19,14 +19,14 @@ export class PnpSignAction extends SignAction<SignMessageRequest> {
           session.logger
         )
 
-        const pnpState = this.thresholdStateService.findCombinerQuotaState(session)
+        const pnpQuotaStatus = this.thresholdStateService.findCombinerQuotaState(session)
         return this.io.sendSuccess(
           200,
           session.response,
           combinedSignature,
-          pnpState.performedQueryCount,
-          pnpState.totalQuota,
-          pnpState.blockNumber
+          pnpQuotaStatus.performedQueryCount,
+          pnpQuotaStatus.totalQuota,
+          pnpQuotaStatus.blockNumber
         )
       } catch (error) {
         // May fail upon combining signatures if too many sigs are invalid

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
@@ -6,20 +6,9 @@ import {
   WarningMessage,
 } from '@celo/phone-number-privacy-common'
 import { CryptoSession } from '../../../common/crypto-session'
-import { IO } from '../../../common/io'
 import { SignAction } from '../../../common/sign'
-import { OdisConfig } from '../../../config'
-import { CombinerThresholdStateService } from '../../services/thresholdState'
 
 export class PnpSignAction extends SignAction<SignMessageRequest> {
-  constructor(
-    readonly config: OdisConfig,
-    readonly thresholdStateService: CombinerThresholdStateService<SignMessageRequest>,
-    readonly io: IO<SignMessageRequest>
-  ) {
-    super(config, io)
-  }
-
   combine(session: CryptoSession<SignMessageRequest>): void {
     this.logResponseDiscrepancies(session)
 

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
@@ -110,7 +110,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     error: ErrorType,
     status: number,
     response: Response<SignMessageResponseFailure>,
-    queryCount?: number,
+    performedQueryCount?: number,
     totalQuota?: number,
     blockNumber?: number,
     signature?: string
@@ -121,7 +121,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
         success: false,
         version: VERSION,
         error,
-        performedQueryCount: queryCount,
+        performedQueryCount,
         totalQuota,
         blockNumber,
         signature,

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
@@ -85,8 +85,8 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     status: number,
     response: Response<SignMessageResponseSuccess>,
     signature: string,
-    performedQueryCount?: number,
-    totalQuota?: number,
+    performedQueryCount: number,
+    totalQuota: number,
     blockNumber?: number,
     warnings?: string[]
   ) {

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
@@ -87,8 +87,8 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     status: number,
     response: Response<SignMessageResponseSuccess>,
     signature: string,
-    performedQueryCount?: number,
-    totalQuota?: number,
+    performedQueryCount: number,
+    totalQuota: number,
     blockNumber?: number,
     warnings?: string[]
   ) {

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
@@ -112,7 +112,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     error: ErrorType,
     status: number,
     response: Response<SignMessageResponseFailure>,
-    queryCount?: number,
+    performedQueryCount?: number,
     totalQuota?: number,
     blockNumber?: number,
     signature?: string
@@ -123,7 +123,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
         success: false,
         version: VERSION,
         error,
-        performedQueryCount: queryCount,
+        performedQueryCount,
         totalQuota,
         blockNumber,
         signature,

--- a/packages/phone-number-privacy/combiner/src/pnp/services/thresholdState.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/services/thresholdState.ts
@@ -1,6 +1,6 @@
 import {
   PnpQuotaRequest,
-  PnpState,
+  PnpQuotaStatus,
   SignMessageRequest,
   WarningMessage,
 } from '@celo/phone-number-privacy-common'
@@ -12,10 +12,10 @@ import { OdisConfig } from '../../config'
 export class PnpThresholdStateService<R extends PnpQuotaRequest | SignMessageRequest> {
   constructor(readonly config: OdisConfig) {}
 
-  findCombinerQuotaState(session: Session<R>): PnpState {
+  findCombinerQuotaState(session: Session<R>): PnpQuotaStatus {
     const signerResponses = session.responses
       .map((signerResponse) => signerResponse.res)
-      .filter((res) => res.success) as PnpState[]
+      .filter((res) => res.success) as PnpQuotaStatus[]
 
     const sortedResponses = signerResponses.sort(
       (a, b) => a.performedQueryCount - b.performedQueryCount

--- a/packages/phone-number-privacy/combiner/src/pnp/services/thresholdState.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/services/thresholdState.ts
@@ -1,6 +1,7 @@
 import {
   PnpQuotaRequest,
-  PnpQuotaResponseSuccess,
+  PnpState,
+  SignMessageRequest,
   WarningMessage,
 } from '@celo/phone-number-privacy-common'
 import { Session } from '../../common/session'
@@ -8,13 +9,13 @@ import { OdisConfig } from '../../config'
 
 // TODO(2.0.0, testing): add unit tests for this and domains equivalent
 // (https://github.com/celo-org/celo-monorepo/issues/9792)
-export class CombinerThresholdStateService<R extends PnpQuotaRequest> {
+export class CombinerThresholdStateService<R extends PnpQuotaRequest | SignMessageRequest> {
   constructor(readonly config: OdisConfig) {}
 
-  findCombinerQuotaState(session: Session<R>) {
+  findCombinerQuotaState(session: Session<R>): PnpState {
     const signerResponses = session.responses
       .map((signerResponse) => signerResponse.res)
-      .filter((res) => res.success) as PnpQuotaResponseSuccess[]
+      .filter((res) => res.success) as PnpState[]
 
     const sortedResponses = signerResponses.sort(
       (a, b) => a.performedQueryCount - b.performedQueryCount

--- a/packages/phone-number-privacy/combiner/src/pnp/services/thresholdState.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/services/thresholdState.ts
@@ -9,7 +9,7 @@ import { OdisConfig } from '../../config'
 
 // TODO(2.0.0, testing): add unit tests for this and domains equivalent
 // (https://github.com/celo-org/celo-monorepo/issues/9792)
-export class CombinerThresholdStateService<R extends PnpQuotaRequest | SignMessageRequest> {
+export class PnpThresholdStateService<R extends PnpQuotaRequest | SignMessageRequest> {
   constructor(readonly config: OdisConfig) {}
 
   findCombinerQuotaState(session: Session<R>): PnpState {

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -65,7 +65,7 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
       new PnpQuotaIO(config.phoneNumberPrivacy, kit)
     )
   )
-  app.get(CombinerEndpoint.PNP_QUOTA, (req, res) =>
+  app.post(CombinerEndpoint.PNP_QUOTA, (req, res) =>
     meterResponse(pnpQuota.handle.bind(pnpQuota), req, res, CombinerEndpoint.PNP_QUOTA, config)
   )
 

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -24,7 +24,7 @@ import { PnpQuotaIO } from './pnp/endpoints/quota/io'
 import { PnpSignAction } from './pnp/endpoints/sign/action'
 import { PnpSignIO } from './pnp/endpoints/sign/io'
 import { LegacyPnpSignIO } from './pnp/endpoints/sign/io.legacy'
-import { CombinerThresholdStateService } from './pnp/services/thresholdState'
+import { PnpThresholdStateService } from './pnp/services/thresholdState'
 
 require('events').EventEmitter.defaultMaxListeners = 15
 
@@ -39,12 +39,12 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
 
   kit = kit ?? getContractKit(config.blockchain)
 
-  const combinerThresholdStateService = new CombinerThresholdStateService(config.phoneNumberPrivacy)
+  const pnpThresholdStateService = new PnpThresholdStateService(config.phoneNumberPrivacy)
 
   const legacyPnpSign = new Controller(
     new PnpSignAction(
       config.phoneNumberPrivacy,
-      combinerThresholdStateService,
+      pnpThresholdStateService,
       new LegacyPnpSignIO(config.phoneNumberPrivacy, kit)
     )
   )
@@ -61,7 +61,7 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
   const pnpQuota = new Controller(
     new PnpQuotaAction(
       config.phoneNumberPrivacy,
-      combinerThresholdStateService,
+      pnpThresholdStateService,
       new PnpQuotaIO(config.phoneNumberPrivacy, kit)
     )
   )
@@ -72,7 +72,7 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
   const pnpSign = new Controller(
     new PnpSignAction(
       config.phoneNumberPrivacy,
-      combinerThresholdStateService,
+      pnpThresholdStateService,
       new PnpSignIO(config.phoneNumberPrivacy, kit)
     )
   )

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -176,6 +176,8 @@ describe('pnpService', () => {
   const expectedVersion = getVersion()
 
   const onChainPaymentsDefault = new BigNumber(1e18)
+  const expectedTotalQuota = 10
+
   const message = Buffer.from('test message', 'utf8')
   const expectedSig = 'xgFMQtcgAMHJAEX/m9B4VFopYtxqPFSw0024sWzRYvQDvnmFqhXOPdnRDfa8WCEA'
   const expectedUnblindedMsg = 'lOASnDJNbJBTMYfkbU4fMiK7FcNwSyqZo8iQSM95X8YK+/158be4S1A+jcQsCUYA'
@@ -262,6 +264,9 @@ describe('pnpService', () => {
           success: true,
           version: expectedVersion,
           signature: expectedSig,
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
         })
         const unblindedSig = threshold_bls.unblind(
           Buffer.from(res.body.signature, 'base64'),
@@ -280,23 +285,61 @@ describe('pnpService', () => {
           success: true,
           version: expectedVersion,
           signature: expectedSig,
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
         })
       })
 
       it('Should respond with 200 on repeated valid requests', async () => {
         const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res1 = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res1.status).toBe(200)
-        expect(res1.body).toMatchObject<SignMessageResponseSuccess>({
+        const expectedResponse: SignMessageResponseSuccess = {
           success: true,
           version: expectedVersion,
           signature: expectedSig,
-        })
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
+        }
+
+        expect(res1.status).toBe(200)
+        expect(res1.body).toMatchObject<SignMessageResponseSuccess>(expectedResponse)
 
         const res2 = await sendPnpSignRequest(req, authorization, app)
         expect(res2.status).toBe(200)
-        expect(res2.body).toMatchObject<SignMessageResponseSuccess>(res1.body)
+        // Do not expect performedQueryCount to increase since this is a duplicate request
+        expect(res2.body).toMatchObject<SignMessageResponseSuccess>(expectedResponse)
+      })
+
+      it('Should increment performedQueryCount on request from the same account with a new message', async () => {
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+        const res1 = await sendPnpSignRequest(req, authorization, app)
+        const expectedResponse: SignMessageResponseSuccess = {
+          success: true,
+          version: expectedVersion,
+          signature: expectedSig,
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
+        }
+
+        expect(res1.status).toBe(200)
+        expect(res1.body).toMatchObject<SignMessageResponseSuccess>(expectedResponse)
+
+        // Second request for the same account but with new message
+        const message2 = Buffer.from('second test message', 'utf8')
+        const blindedMsg2 = threshold_bls.blind(message2, userSeed)
+        const req2 = getSignRequest(blindedMsg2)
+        const authorization2 = getPnpRequestAuthorization(req2, PRIVATE_KEY1)
+
+        // Expect performedQueryCount to increase
+        expectedResponse.performedQueryCount++
+        expectedResponse.signature =
+          'PWvuSYIA249x1dx+qzgl6PKSkoulXXE/P4WHJvGmtw77pCRilEWTn3xSp+6JS9+A'
+        const res2 = await sendPnpSignRequest(req2, authorization2, app)
+        expect(res2.status).toBe(200)
+        expect(res2.body).toMatchObject<SignMessageResponseSuccess>(expectedResponse)
       })
 
       it('Should respond with 200 on extra request fields', async () => {
@@ -310,6 +353,9 @@ describe('pnpService', () => {
           success: true,
           version: expectedVersion,
           signature: expectedSig,
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
         })
       })
 
@@ -323,6 +369,9 @@ describe('pnpService', () => {
           success: true,
           version: expectedVersion,
           signature: expectedSig,
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
         })
       })
 
@@ -335,6 +384,9 @@ describe('pnpService', () => {
           success: true,
           version: expectedVersion,
           signature: expectedSig,
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
         })
 
         const secondUserSeed = new Uint8Array(userSeed)
@@ -461,6 +513,9 @@ describe('pnpService', () => {
           success: true,
           version: expectedVersion,
           signature: expectedSig,
+          performedQueryCount: 1,
+          totalQuota: expectedTotalQuota,
+          blockNumber: testBlockNumber,
         })
         const unblindedSig = threshold_bls.unblind(
           Buffer.from(res.body.signature, 'base64'),

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -563,8 +563,8 @@ describe('pnpService', () => {
   })
 
   describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
-    const useQuery = async (queryCount: number, signer: Server | HttpsServer) => {
-      for (let i = 0; i < queryCount; i++) {
+    const useQuery = async (performedQueryCount: number, signer: Server | HttpsServer) => {
+      for (let i = 0; i < performedQueryCount; i++) {
         const phoneNumber = '+1' + Math.floor(Math.random() * 10 ** 10)
         const blindedNumber = getBlindedPhoneNumber(phoneNumber, BLINDING_FACTOR)
         const req = {

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -581,7 +581,7 @@ describe('pnpService', () => {
 
     const getCombinerQuotaResponse = async (req: PnpQuotaRequest, authorization: string) => {
       const res = await request(app)
-        .get(CombinerEndpoint.PNP_QUOTA)
+        .post(CombinerEndpoint.PNP_QUOTA)
         .set('Authorization', authorization)
         .send(req)
       return res
@@ -758,7 +758,7 @@ describe('pnpService', () => {
       }
       const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
       const res = await request(appWithApiDisabled)
-        .get(CombinerEndpoint.PNP_QUOTA)
+        .post(CombinerEndpoint.PNP_QUOTA)
         .set('Authorization', authorization)
         .send(req)
       expect(res.status).toBe(503)

--- a/packages/phone-number-privacy/common/src/interfaces/responses.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/responses.ts
@@ -13,14 +13,14 @@ import {
 import { Domain, DomainState } from '../domains'
 
 // Phone Number Privacy
-export interface PnpState {
+export interface PnpQuotaStatus {
   performedQueryCount: number
   // all time total quota
   totalQuota: number
   blockNumber?: number
 }
 
-const PnpStateSchema: t.Type<PnpState> = t.intersection([
+const PnpQuotaStatusSchema: t.Type<PnpQuotaStatus> = t.intersection([
   t.type({
     performedQueryCount: t.number,
     totalQuota: t.number,
@@ -30,7 +30,7 @@ const PnpStateSchema: t.Type<PnpState> = t.intersection([
   }),
 ])
 
-export interface SignMessageResponseSuccess extends PnpState {
+export interface SignMessageResponseSuccess extends PnpQuotaStatus {
   success: true
   version: string
   signature: string
@@ -58,7 +58,7 @@ export const SignMessageResponseSchema: t.Type<SignMessageResponse> = t.union([
     t.partial({
       warnings: t.union([t.array(t.string), t.undefined]),
     }),
-    PnpStateSchema,
+    PnpQuotaStatusSchema,
   ]),
   t.intersection([
     t.type({
@@ -74,7 +74,7 @@ export const SignMessageResponseSchema: t.Type<SignMessageResponse> = t.union([
   ]),
 ])
 
-export interface PnpQuotaResponseSuccess extends PnpState {
+export interface PnpQuotaResponseSuccess extends PnpQuotaStatus {
   success: true
   version: string
   warnings?: string[]
@@ -97,7 +97,7 @@ export const PnpQuotaResponseSchema: t.Type<PnpQuotaResponse> = t.union([
     t.partial({
       warnings: t.union([t.array(t.string), t.undefined]),
     }),
-    PnpStateSchema,
+    PnpQuotaStatusSchema,
   ]),
   t.type({
     success: t.literal(false),

--- a/packages/phone-number-privacy/common/src/interfaces/responses.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/responses.ts
@@ -13,13 +13,27 @@ import {
 import { Domain, DomainState } from '../domains'
 
 // Phone Number Privacy
-export interface SignMessageResponseSuccess {
+export interface PnpState {
+  performedQueryCount: number
+  // all time total quota
+  totalQuota: number
+  blockNumber?: number
+}
+
+const PnpStateSchema: t.Type<PnpState> = t.intersection([
+  t.type({
+    performedQueryCount: t.number,
+    totalQuota: t.number,
+  }),
+  t.partial({
+    blockNumber: t.union([t.number, t.undefined]),
+  }),
+])
+
+export interface SignMessageResponseSuccess extends PnpState {
   success: true
   version: string
   signature: string
-  performedQueryCount?: number
-  totalQuota?: number
-  blockNumber?: number
   warnings?: string[]
 }
 
@@ -42,11 +56,9 @@ export const SignMessageResponseSchema: t.Type<SignMessageResponse> = t.union([
       signature: t.string,
     }),
     t.partial({
-      performedQueryCount: t.union([t.number, t.undefined]),
-      totalQuota: t.union([t.number, t.undefined]),
-      blockNumber: t.union([t.number, t.undefined]),
       warnings: t.union([t.array(t.string), t.undefined]),
     }),
+    PnpStateSchema,
   ]),
   t.intersection([
     t.type({
@@ -62,13 +74,9 @@ export const SignMessageResponseSchema: t.Type<SignMessageResponse> = t.union([
   ]),
 ])
 
-export interface PnpQuotaResponseSuccess {
+export interface PnpQuotaResponseSuccess extends PnpState {
   success: true
   version: string
-  performedQueryCount: number
-  // all time total quota
-  totalQuota: number
-  blockNumber?: number
   warnings?: string[]
 }
 
@@ -85,13 +93,11 @@ export const PnpQuotaResponseSchema: t.Type<PnpQuotaResponse> = t.union([
     t.type({
       success: t.literal(true),
       version: t.string,
-      performedQueryCount: t.number,
-      totalQuota: t.number,
     }),
     t.partial({
-      blockNumber: t.union([t.number, t.undefined]),
       warnings: t.union([t.array(t.string), t.undefined]),
     }),
+    PnpStateSchema,
   ]),
   t.type({
     success: t.literal(false),

--- a/packages/phone-number-privacy/signer/src/common/quota.ts
+++ b/packages/phone-number-privacy/signer/src/common/quota.ts
@@ -3,17 +3,21 @@ import {
   DomainRestrictedSignatureRequest,
   OdisRequest,
   PnpQuotaRequest,
+  PnpQuotaStatus,
   SignMessageRequest,
 } from '@celo/phone-number-privacy-common'
 import { Knex } from 'knex'
 import { DomainStateRecord } from '../common/database/models/domainState'
-import { PnpQuotaStatus } from '../pnp/services/quota'
 import { Session } from './action'
 
 // prettier-ignore
-export type OdisQuotaStatus<R extends OdisRequest> =
-  | R extends DomainQuotaStatusRequest | DomainRestrictedSignatureRequest ? DomainStateRecord : never
-  | R extends SignMessageRequest | PnpQuotaRequest ? PnpQuotaStatus : never
+export type OdisQuotaStatus<R extends OdisRequest> = R extends
+  | DomainQuotaStatusRequest
+  | DomainRestrictedSignatureRequest
+  ? DomainStateRecord
+  : never | R extends SignMessageRequest | PnpQuotaRequest
+  ? PnpQuotaStatus
+  : never
 
 export interface OdisQuotaStatusResult<R extends OdisRequest> {
   sufficient: boolean

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
@@ -13,7 +13,16 @@ export class PnpQuotaAction implements Action<PnpQuotaRequest> {
   ) {}
 
   public async perform(session: PnpSession<PnpQuotaRequest>): Promise<void> {
-    const { queryCount, totalQuota, blockNumber } = await this.quota.getQuotaStatus(session)
-    this.io.sendSuccess(200, session.response, queryCount, totalQuota, blockNumber, session.errors)
+    const { performedQueryCount, totalQuota, blockNumber } = await this.quota.getQuotaStatus(
+      session
+    )
+    this.io.sendSuccess(
+      200,
+      session.response,
+      performedQueryCount,
+      totalQuota,
+      blockNumber,
+      session.errors
+    )
   }
 }

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
@@ -23,7 +23,8 @@ export class PnpSignAction implements Action<SignMessageRequest> {
   public async perform(session: PnpSession<SignMessageRequest>): Promise<void> {
     await this.db.transaction(async (trx) => {
       const quotaStatus = await this.quota.getQuotaStatus(session, trx)
-      let { performedQueryCount, totalQuota, blockNumber } = quotaStatus
+      const { totalQuota, blockNumber } = quotaStatus
+      let { performedQueryCount } = quotaStatus
 
       if (await getRequestExists(this.db, session.request.body, session.logger, trx)) {
         Counters.duplicateRequests.inc()

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
@@ -23,7 +23,7 @@ export class PnpSignAction implements Action<SignMessageRequest> {
   public async perform(session: PnpSession<SignMessageRequest>): Promise<void> {
     await this.db.transaction(async (trx) => {
       const quotaStatus = await this.quota.getQuotaStatus(session, trx)
-      let { queryCount, totalQuota, blockNumber } = quotaStatus
+      let { performedQueryCount, totalQuota, blockNumber } = quotaStatus
 
       if (await getRequestExists(this.db, session.request.body, session.logger, trx)) {
         Counters.duplicateRequests.inc()
@@ -34,10 +34,10 @@ export class PnpSignAction implements Action<SignMessageRequest> {
       } else {
         // In the case of a blockchain connection failure, totalQuota and/or blockNumber
         // may be undefined.
-        // In the case of a database connection failure, queryCount
+        // In the case of a database connection failure, performedQueryCount
         // may be undefined.
-        // Note that queryCount or totalQuota can be 0 and that should not fail open.
-        if (queryCount !== undefined && totalQuota !== undefined) {
+        // Note that performedQueryCount or totalQuota can be 0 and that should not fail open.
+        if (performedQueryCount !== undefined && totalQuota !== undefined) {
           const { sufficient, state } = await this.quota.checkAndUpdateQuotaStatus(
             quotaStatus,
             session,
@@ -48,16 +48,16 @@ export class PnpSignAction implements Action<SignMessageRequest> {
               WarningMessage.EXCEEDED_QUOTA,
               403,
               session.response,
-              queryCount,
+              performedQueryCount,
               totalQuota,
               blockNumber
             )
             return
           }
-          queryCount = state.queryCount
+          performedQueryCount = state.performedQueryCount
         } else {
           // TODO(2.0.0, refactor) this logic is all wrong, revisit (https://github.com/celo-org/celo-monorepo/issues/9800)
-          // If queryCount or totalQuota are undefined,
+          // If performedQueryCount or totalQuota are undefined,
           // we fail open and service the request to not block the user.
           // Error messages are stored in the session and included along
           // with the signature in the response.
@@ -83,7 +83,7 @@ export class PnpSignAction implements Action<SignMessageRequest> {
         session.response,
         key,
         signature,
-        queryCount,
+        performedQueryCount,
         totalQuota,
         blockNumber,
         session.errors

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
@@ -98,7 +98,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     error: string,
     status: number,
     response: Response<SignMessageResponseFailure>,
-    queryCount?: number,
+    performedQueryCount?: number,
     totalQuota?: number,
     blockNumber?: number
   ) {
@@ -108,7 +108,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
         success: false,
         version: getVersion(),
         error,
-        performedQueryCount: queryCount,
+        performedQueryCount,
         totalQuota,
         blockNumber,
       },

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
@@ -71,8 +71,8 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     response: Response<SignMessageResponseSuccess>,
     key: Key,
     signature: string,
-    performedQueryCount?: number,
-    totalQuota?: number,
+    performedQueryCount: number,
+    totalQuota: number,
     blockNumber?: number,
     warnings?: string[]
   ) {

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
@@ -71,8 +71,8 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     response: Response<SignMessageResponseSuccess>,
     key: Key,
     signature: string,
-    performedQueryCount?: number,
-    totalQuota?: number,
+    performedQueryCount: number,
+    totalQuota: number,
     blockNumber?: number,
     warnings?: string[]
   ) {

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
@@ -98,7 +98,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     error: string,
     status: number,
     response: Response<SignMessageResponseFailure>,
-    queryCount?: number,
+    performedQueryCount?: number,
     totalQuota?: number,
     blockNumber?: number
   ) {
@@ -108,7 +108,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
         success: false,
         version: getVersion(),
         error,
-        performedQueryCount: queryCount,
+        performedQueryCount,
         totalQuota,
         blockNumber,
       },


### PR DESCRIPTION
### Description
- makes `performedQueryCount` & `totalQuota` non-optional fields in `SignMessageResponseSuccess`
- edit: moves `PnpQuotaStatus`  interface to common package (and makes blockNumber undefined -- possible values throughout should be audited, since return vals from the same functions were treated differently in different places) + introduces a corresponding type schema to clean up some type handling
  - also standardize var naming from `queryCount` -> `performedQueryCount`
- adds a test case each for the new & legacy PNP combiner integration tests to check that performedQueryCounts do increment on queries by the same account for different messages
- moves the `getQuotaStatus` query in `PnpSignAction` so this happens for all requests (including duplicates)
- changes combiner PNP_QUOTA from GET -> POST
- renames `CombinerThresholdStateService` -> `PnpThresholdStateService` for clarity

### Notes
- does not improve/audit logic in `PnpSignAction`; this should still be reconsidered and fixed!
- decided against explicitly checking undefined for `performedQueryCount` and `totalQuota` in the `CombinerThresholdStateService` (since this should in theory be true for the successful Sign & Quota responses), but we should double check that the response types are being enforced elsewhere
- didn't go as far as to create a separate interface for `ThresholdStateService`, but hopefully the new type is sufficient for now

Closes #9794
