### PR TITLE
Fix foundry config.

### DIFF
--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'contracts'
 out = 'out'
 test = 'test-sol'


### PR DESCRIPTION
By running 'forge config --fix', to remove a warning.