### PR TITLE
Fix solhint warning.

### DIFF
--- a/packages/protocol/.solhint.json
+++ b/packages/protocol/.solhint.json
@@ -1,7 +1,7 @@
 {
   "extends": "solhint:default",
   "rules": {
-    "compiler-fixed": false,
+    "compiler-fixed": "off",
     "function-max-lines": 70,
     "indent": ["error", 2],
     "max-line-length": ["error", 100]


### PR DESCRIPTION
"[Solhint] Warning: Disabling rules with `false` or `0` is deprecated.
Please use `"off"` instead."