### PR TITLE
Add codecov to ODIS pkgs 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -793,13 +793,13 @@ jobs:
             ./scripts/ci_check_if_test_should_run_v2.sh @celo/phone-number-privacy-signer,@celo/phone-number-privacy-combiner,@celo/phone-number-privacy-common
       - run:
           name: Run Tests for common package
-          command: yarn --cwd=packages/phone-number-privacy/common test
+          command: yarn --cwd=packages/phone-number-privacy/common test:coverage
       - run:
           name: Run Tests for combiner
-          command: yarn --cwd=packages/phone-number-privacy/combiner test
+          command: yarn --cwd=packages/phone-number-privacy/combiner test:coverage
       - run:
           name: Run Tests for signer
-          command: yarn --cwd=packages/phone-number-privacy/signer test
+          command: yarn --cwd=packages/phone-number-privacy/signer test:coverage
 
   certora-test:
     working_directory: ~/app

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,7 +13,8 @@
     "pkief.material-icon-theme",
     "davidanson.vscode-markdownlint",
     "mikestead.dotenv",
-    "coenraads.bracket-pair-colorizer-2"
+    "coenraads.bracket-pair-colorizer-2",
+    "markis.code-coverage"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/packages/phone-number-privacy/combiner/jest.config.js
+++ b/packages/phone-number-privacy/combiner/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   preset: 'ts-jest',
   ...nodeFlakeTracking,
   setupFilesAfterEnv: ['<rootDir>/jest_setup.ts', ...nodeFlakeTracking.setupFilesAfterEnv],
+  coverageReporters: [['lcov', { projectRoot: '../../../' }], 'text'],
 }

--- a/packages/phone-number-privacy/combiner/jest.config.js
+++ b/packages/phone-number-privacy/combiner/jest.config.js
@@ -5,4 +5,10 @@ module.exports = {
   ...nodeFlakeTracking,
   setupFilesAfterEnv: ['<rootDir>/jest_setup.ts', ...nodeFlakeTracking.setupFilesAfterEnv],
   coverageReporters: [['lcov', { projectRoot: '../../../' }], 'text'],
+  collectCoverageFrom: ['./src/**'],
+  coverageThreshold: {
+    global: {
+      lines: 59, // TODO(2.0.0) make this higher in testing audit ticket (https://github.com/celo-org/celo-monorepo/issues/9811)
+    },
+  },
 }

--- a/packages/phone-number-privacy/combiner/package.json
+++ b/packages/phone-number-privacy/combiner/package.json
@@ -20,6 +20,7 @@
     "build": "tsc -b .",
     "lint": "tslint --project .",
     "test": "jest --runInBand --testPathIgnorePatterns test/end-to-end",
+    "test:coverage": "yarn test --coverage",
     "test:integration": "jest --runInBand test/integration",
     "test:e2e": "jest test/end-to-end --verbose",
     "test:e2e:staging": "ODIS_COMBINER_SERVICE_URL=https://us-central1-celo-phone-number-privacy-stg.cloudfunctions.net yarn test:e2e",

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -917,6 +917,7 @@ describe('pnpService', () => {
           performedQueryCount: 0,
           totalQuota,
           blockNumber: testBlockNumber,
+          warnings: [],
         })
       })
     })

--- a/packages/phone-number-privacy/common/jest.config.js
+++ b/packages/phone-number-privacy/common/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
+  coverageReporters: [['lcov', { projectRoot: '../../../' }], 'text'],
 }

--- a/packages/phone-number-privacy/common/jest.config.js
+++ b/packages/phone-number-privacy/common/jest.config.js
@@ -1,4 +1,10 @@
 module.exports = {
   preset: 'ts-jest',
   coverageReporters: [['lcov', { projectRoot: '../../../' }], 'text'],
+  collectCoverageFrom: ['./src/**'],
+  coverageThreshold: {
+    global: {
+      lines: 78, // TODO(2.0.0) make this higher in testing audit ticket (https://github.com/celo-org/celo-monorepo/issues/9811)
+    },
+  },
 }

--- a/packages/phone-number-privacy/common/package.json
+++ b/packages/phone-number-privacy/common/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -b .",
     "clean": "tsc -b . --clean",
     "test": "jest --testPathIgnorePatterns test/end-to-end",
-    "test:coverage": "jest --testPathIgnorePatterns test/end-to-end --coverage",
+    "test:coverage": "yarn test --coverage",
     "lint": "tslint -c tslint.json --project ."
   },
   "files": [

--- a/packages/phone-number-privacy/common/test/domains.test.ts
+++ b/packages/phone-number-privacy/common/test/domains.test.ts
@@ -6,9 +6,9 @@ import {
   noNumber,
   noString,
 } from '@celo/utils/lib/sign-typed-data-utils'
-import { DomainIdentifiers } from './constants'
-import { Domain, domainEIP712, DomainOptions } from './domains'
-import { SequentialDelayDomain } from './sequential-delay'
+import { DomainIdentifiers } from '../src/domains/constants'
+import { Domain, domainEIP712, DomainOptions } from '../src/domains/domains'
+import { SequentialDelayDomain } from '../src/domains/sequential-delay'
 
 // Compile-time check that Domain can be cast to type EIP712Object
 export const TEST_DOMAIN_IS_EIP712: EIP712Object = ({} as unknown) as Domain

--- a/packages/phone-number-privacy/signer/jest.config.js
+++ b/packages/phone-number-privacy/signer/jest.config.js
@@ -5,4 +5,10 @@ module.exports = {
   ...nodeFlakeTracking,
   setupFiles: ['dotenv/config'],
   coverageReporters: [['lcov', { projectRoot: '../../../' }], 'text'],
+  collectCoverageFrom: ['./src/**'],
+  coverageThreshold: {
+    global: {
+      lines: 79, // TODO(2.0.0) make this higher in testing audit ticket (https://github.com/celo-org/celo-monorepo/issues/9811)
+    },
+  },
 }

--- a/packages/phone-number-privacy/signer/jest.config.js
+++ b/packages/phone-number-privacy/signer/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   preset: 'ts-jest',
   ...nodeFlakeTracking,
   setupFiles: ['dotenv/config'],
+  coverageReporters: [['lcov', { projectRoot: '../../../' }], 'text'],
 }

--- a/packages/phone-number-privacy/signer/package.json
+++ b/packages/phone-number-privacy/signer/package.json
@@ -14,6 +14,7 @@
     "test": "jest --testPathIgnorePatterns test/end-to-end",
     "test:debughandles": "jest --watch --runInBand --detectOpenHandles --testPathIgnorePatterns test/end-to-end",
     "test:debug": "node --inspect ../../../node_modules/.bin/jest --runInBand",
+    "test:coverage": "yarn test --coverage",
     "test:integration": "jest --runInBand test/integration",
     "test:e2e": "jest --runInBand test/end-to-end",
     "test:e2e:staging:0": "ODIS_SIGNER_SERVICE_URL=https://staging-pgpnp-signer0.azurefd.net yarn test:e2e",


### PR DESCRIPTION
### Description

Adds test:coverage commands to signer and combiner 
Adds coverage configs to odis packages 
Adds coverage inspector to vs code extensions recommendations
Adds coverage thresholds to odis packages -- build will fail if thresholds aren't met
Decided NOT to upload coverage results to CodeCov due to blockers, and the realization that local coverage testing should be sufficient

### Other changes

Moves a test file that was in a different place than the others 

### Tested

In CI

### Related issues

- Fixes #9805 

### Backwards compatibility

Yes

### Documentation

NA