### PR TITLE
Infra support for creating erlang cluster in blockscout pods

### DIFF
--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -125,6 +125,12 @@ blockscout components.
     secretKeyRef:
       name:  {{ .Values.blockscout.cookieSecretName }}
       key: ERLANG_COOKIE
+- name: POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: EPMD_SERVICE_NAME
+  value: {{ .Release.Name }}-epmd-service
 - name: NETWORK
   value: Celo
 - name: SUBNETWORK

--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -120,6 +120,11 @@ blockscout components.
     secretKeyRef:
       name:  {{ .Release.Name }}
       key: DATABASE_PASSWORD
+- name: ERLANG_COOKIE
+  valueFrom:
+    secretKeyRef:
+      name:  {{ .Values.blockscout.cookieSecretName }}
+      key: ERLANG_COOKIE
 - name: NETWORK
   value: Celo
 - name: SUBNETWORK

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app block_scout_web "iex  --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
+           exec mix cmd --app block_scout_web "iex --cookie $ERLANG_COOKIE  --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
         ports:
         - name: http
           containerPort: {{ .Values.blockscout.api.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app block_scout_web "iex --cookie $ERLANG_COOKIE  --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
+           exec mix cmd --app block_scout_web "iex --cookie $(ERLANG_COOKIE)  --name {{ .Values.blockscout.erlangNodeName}}@$(POD_IP) -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
         ports:
         - name: http
           containerPort: {{ .Values.blockscout.api.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app block_scout_web "iex  --name {{ .Values.blockscout.api.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
+           exec mix cmd --app block_scout_web "iex  --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
         ports:
         - name: http
           containerPort: {{ .Values.blockscout.api.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-epmd.service.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-epmd.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-epmd-service
+  labels:
+    {{- include "celo.blockscout.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: blockscout
+    release: {{ .Release.Name }}
+  spec:
+  clusterIP: None
+  ports:
+    - port: 4369
+      name: epmd

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app indexer "iex --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix run --no-compile"
+           exec mix cmd --app indexer "iex --cookie $ERLANG_COOKIE --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix run --no-compile"
         ports:
         - name: health
           containerPort: {{ .Values.blockscout.indexer.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app indexer "iex --name {{ .Values.blockscout.indexer.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix run --no-compile"
+           exec mix cmd --app indexer "iex --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix run --no-compile"
         ports:
         - name: health
           containerPort: {{ .Values.blockscout.indexer.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app indexer "iex --cookie $ERLANG_COOKIE --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix run --no-compile"
+           exec mix cmd --app indexer "iex --cookie $(ERLANG_COOKIE) --name {{ .Values.blockscout.erlangNodeName}}@$(POD_IP) -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix run --no-compile"
         ports:
         - name: health
           containerPort: {{ .Values.blockscout.indexer.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app block_scout_web "iex --name {{ .Values.blockscout.web.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
+           exec mix cmd --app block_scout_web "iex --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
         ports:
         - name: http
           containerPort: {{ .Values.blockscout.web.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app block_scout_web "iex --cookie ERLANG_COOKIE --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
+           exec mix cmd --app block_scout_web "iex --cookie $(ERLANG_COOKIE) --name {{ .Values.blockscout.erlangNodeName}}@$(POD_IP) -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
         ports:
         - name: http
           containerPort: {{ .Values.blockscout.web.port }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - -c
         args:
         - |
-           exec mix cmd --app block_scout_web "iex --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
+           exec mix cmd --app block_scout_web "iex --cookie ERLANG_COOKIE --name {{ .Values.blockscout.erlangNodeName}}@0.0.0.0 -e 'IEx.configure(default_prompt: \"\", alive_prompt: \"\")' -S mix do deps.loadpaths --no-deps-check, phx.server --no-compile"
         ports:
         - name: http
           containerPort: {{ .Values.blockscout.web.port }}

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -48,7 +48,7 @@ blockscout:
       requests:
         memory: 1000Mi
         cpu: 2
-    erlangNodeName: blockscout-indexer
+  erlangNodeName: blockscout
   api:
     port: 4000
     strategy:

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -48,7 +48,6 @@ blockscout:
       requests:
         memory: 1000Mi
         cpu: 2
-  erlangNodeName: blockscout
   api:
     port: 4000
     strategy:
@@ -100,7 +99,6 @@ blockscout:
       requests:
         memory: 500Mi
         cpu: 500m
-    erlangNodeName: blockscout-api
   web:
     port: 4000
     strategy:
@@ -156,7 +154,6 @@ blockscout:
       requests:
         memory: 250M
         cpu: 500m
-    erlangNodeName: blockscout-web
     appsMenu:
       enabled: true
       swapList: '[{"url":"https://ubeswap.org/", "title":"Ubeswap"}, {"url":"https://symmetric.finance/", "title":"Symmetric"}, {"url":"https://www.mobius.money/", "title":"Mobius"}, {"url":"https://mento.finance/", "title":"Mento-fi"}, {"url":"https://swap.bitssa.com/", "title":"Swap Bitssa"}]'
@@ -176,6 +173,8 @@ blockscout:
     repository: gcr.io/celo-testnet/blockscout
     tag: v2.0.4-beta-celo
   healthy_blocks_period: 300
+  erlangNodeName: blockscout
+  cookieSecretName: blockscout-erlang-cookie
   db:
     # ip: must be provided at runtime # IP address of the postgres DB
     # connection_name: must be provided at runtime # name of the cloud sql connection


### PR DESCRIPTION
### Description

Some changes necessary to allow blockscout pods to communicate with each other.

* A headless service (list of ips) which lists pods of type `app=blockscout` for each instance
* Adds some environment vars to each pod
    * Running pod ip (for erlang hostname)
    * Shared cookie (to permit communication between nodes)
    * Name of the above service (for discovery)
* Renames the running erlang node instances to have the same app name

### Tested

* Deployed to rc1staging and saw communication between instances

### Related issues

- Relates to https://github.com/celo-org/data-services/issues/442