### PR TITLE
DEK authentication tests

### DIFF
--- a/packages/phone-number-privacy/combiner/src/config.ts
+++ b/packages/phone-number-privacy/combiner/src/config.ts
@@ -25,7 +25,7 @@ export interface DatabaseConfig {
 export interface OdisConfig {
   serviceName: string
   enabled: boolean
-  authShouldFailOpen: boolean // TODO(2.0.0) consider refactoring config, this isn't relevant to domains endpoints
+  authShouldFailOpen: boolean // TODO(2.0.0) (https://github.com/celo-org/celo-monorepo/issues/9862) consider refactoring config, this isn't relevant to domains endpoints
   odisServices: {
     signers: string
     timeoutMilliSeconds: number

--- a/packages/phone-number-privacy/combiner/src/config.ts
+++ b/packages/phone-number-privacy/combiner/src/config.ts
@@ -25,6 +25,7 @@ export interface DatabaseConfig {
 export interface OdisConfig {
   serviceName: string
   enabled: boolean
+  authShouldFailOpen: boolean // TODO(2.0.0) consider refactoring config, this isn't relevant to domains endpoints
   odisServices: {
     signers: string
     timeoutMilliSeconds: number
@@ -71,6 +72,7 @@ if (DEV_MODE) {
     phoneNumberPrivacy: {
       serviceName: defaultServiceName,
       enabled: true,
+      authShouldFailOpen: true,
       odisServices: {
         signers:
           '[{"url": "http://localhost:3001", "fallbackUrl": "http://localhost:3001/fallback"}, {"url": "http://localhost:3002", "fallbackUrl": "http://localhost:3002/fallback"}, {"url": "http://localhost:3003", "fallbackUrl": "http://localhost:3003/fallback"}]',
@@ -86,6 +88,7 @@ if (DEV_MODE) {
     domains: {
       serviceName: defaultServiceName,
       enabled: true,
+      authShouldFailOpen: false,
       odisServices: {
         signers:
           '[{"url": "http://localhost:3001", "fallbackUrl": "http://localhost:3001/fallback"}, {"url": "http://localhost:3002", "fallbackUrl": "http://localhost:3002/fallback"}, {"url": "http://localhost:3003", "fallbackUrl": "http://localhost:3003/fallback"}]',
@@ -120,6 +123,7 @@ if (DEV_MODE) {
     phoneNumberPrivacy: {
       serviceName: functionConfig.phoneNumberPrivacy.service_name ?? defaultServiceName,
       enabled: toBool(functionConfig.phoneNumberPrivacy.enabled, false),
+      authShouldFailOpen: toBool(functionConfig.phoneNumberPrivacy.authShouldFailOpen, true),
       odisServices: {
         signers: functionConfig.phoneNumberPrivacy.odisservices.signers,
         timeoutMilliSeconds:
@@ -135,6 +139,7 @@ if (DEV_MODE) {
     domains: {
       serviceName: functionConfig.domains.service_name ?? defaultServiceName,
       enabled: toBool(functionConfig.domains.enabled, false),
+      authShouldFailOpen: toBool(functionConfig.domains.authShouldFailOpen, true),
       odisServices: {
         signers: functionConfig.domains.odisservices.signers,
         timeoutMilliSeconds: functionConfig.domains.odisservices.timeoutMilliSeconds ?? 5 * 1000,

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/io.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/io.ts
@@ -64,7 +64,7 @@ export class PnpQuotaIO extends IO<PnpQuotaRequest> {
   }
 
   async authenticate(request: Request<{}, {}, PnpQuotaRequest>, logger: Logger): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger)
+    return authenticateUser(request, this.kit, logger, this.config.authShouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
@@ -78,7 +78,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger)
+    return authenticateUser(request, this.kit, logger, this.config.authShouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
@@ -80,7 +80,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger)
+    return authenticateUser(request, this.kit, logger, this.config.authShouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -67,6 +67,7 @@ const signerConfig: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: false,
+      authShouldFailOpen: true,
     },
   },
   attestations: {

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -248,7 +248,7 @@ describe('domainService', () => {
         .post(CombinerEndpoint.DISABLE_DOMAIN)
         .send(await disableRequest())
       expect(res.status).toBe(200)
-      expect(res.body).toMatchObject<DisableDomainResponse>({
+      expect(res.body).toStrictEqual<DisableDomainResponse>({
         success: true,
         version: res.body.version,
       })
@@ -380,7 +380,7 @@ describe('domainService', () => {
         .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
         .send(await quotaRequest())
       expect(res.status).toBe(200)
-      expect(res.body).toMatchObject<DomainQuotaStatusResponse>({
+      expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
         success: true,
         version: res.body.version,
         status: { disabled: false, counter: 0, timer: 0, now: res.body.status.now },
@@ -521,7 +521,7 @@ describe('domainService', () => {
       const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
 
       expect(res.status).toBe(200)
-      expect(res.body).toMatchObject<DomainRestrictedSignatureResponse>({
+      expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
         success: true,
         version: res.body.version,
         signature: res.body.signature,

--- a/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
@@ -477,7 +477,7 @@ describe('legacyPnpService', () => {
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(401)
-        expect(res.body).toMatchObject<SignMessageResponseFailure>({
+        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
           success: false,
           version: expectedVersion,
           error: WarningMessage.UNAUTHENTICATED_USER,

--- a/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
@@ -80,6 +80,7 @@ const signerConfig: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: true,
+      authShouldFailOpen: true,
     },
   },
   attestations: {

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -141,9 +141,15 @@ const signerConfig: SignerConfig = {
 const testBlockNumber = 1000000
 
 const mockOdisPaymentsTotalPaidCUSD = jest.fn<BigNumber, []>()
+const mockGetWalletAddress = jest.fn<string, []>()
+const mockGetDataEncryptionKey = jest.fn<string, []>()
+
 const mockContractKit = createMockContractKit(
   {
-    [ContractRetrieval.getAccounts]: createMockAccounts(mockAccount, DEK_PUBLIC_KEY),
+    [ContractRetrieval.getAccounts]: createMockAccounts(
+      mockGetWalletAddress,
+      mockGetDataEncryptionKey
+    ),
     [ContractRetrieval.getOdisPayments]: createMockOdisPayments(mockOdisPaymentsTotalPaidCUSD),
   },
   createMockWeb3(5, testBlockNumber)
@@ -205,6 +211,9 @@ describe('pnpService', () => {
     }
 
     blindedMsgResult = threshold_bls.blind(message, userSeed)
+
+    mockGetDataEncryptionKey.mockReset().mockReturnValue(DEK_PUBLIC_KEY)
+    mockGetWalletAddress.mockReset().mockReturnValue(mockAccount)
   })
 
   afterEach(async () => {
@@ -442,9 +451,24 @@ describe('pnpService', () => {
         })
       })
 
-      it('Should respond with 401 on failed auth', async () => {
+      it('Should respond with 401 on failed WALLET_KEY auth', async () => {
         req.account = mockAccount
         const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+        const res = await sendPnpSignRequest(req, authorization, app)
+
+        expect(res.status).toBe(401)
+        expect(res.body).toMatchObject<SignMessageResponseFailure>({
+          success: false,
+          version: expectedVersion,
+          error: WarningMessage.UNAUTHENTICATED_USER,
+        })
+      })
+
+      it('Should respond with 401 on failed DEK auth', async () => {
+        req.account = mockAccount
+        req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
+        const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+        const authorization = getPnpRequestAuthorization(req, differentPk)
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(401)
@@ -481,6 +505,35 @@ describe('pnpService', () => {
           success: false,
           version: expectedVersion,
           error: WarningMessage.API_UNAVAILABLE,
+        })
+      })
+
+      describe('functionality in case of errors', () => {
+        it('Should return 200 on failure to fetch DEK', async () => {
+          mockGetDataEncryptionKey.mockImplementation(() => {
+            throw new Error()
+          })
+
+          req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
+          // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
+          const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+          const authorization = getPnpRequestAuthorization(req, differentPk)
+          const res = await sendPnpSignRequest(req, authorization, app)
+
+          expect(res.status).toBe(200)
+          expect(res.body).toMatchObject<SignMessageResponseSuccess>({
+            success: true,
+            version: expectedVersion,
+            signature: expectedSig,
+            performedQueryCount: 1,
+            totalQuota: expectedTotalQuota,
+            blockNumber: testBlockNumber,
+          })
+          const unblindedSig = threshold_bls.unblind(
+            Buffer.from(res.body.signature, 'base64'),
+            blindedMsgResult.blindingFactor
+          )
+          expect(Buffer.from(unblindedSig).toString('base64')).toEqual(expectedUnblindedMsg)
         })
       })
     })
@@ -631,6 +684,22 @@ describe('pnpService', () => {
       })
     })
 
+    it('Should respond with 200 on valid request', async () => {
+      const req = {
+        account: ACCOUNT_ADDRESS1,
+      }
+      const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+      const res = await getCombinerQuotaResponse(req, authorization)
+      expect(res.status).toBe(200)
+      expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+        success: true,
+        version: expectedVersion,
+        performedQueryCount: 0,
+        totalQuota,
+        blockNumber: testBlockNumber,
+      })
+    })
+
     it('Should respond with 200 on repeated valid requests', async () => {
       const req = {
         account: ACCOUNT_ADDRESS1,
@@ -716,10 +785,26 @@ describe('pnpService', () => {
       })
     })
 
-    it('Should respond with 401 on failed auth', async () => {
+    it('Should respond with 401 on failed WALLET_KEY auth', async () => {
       // Request from one account, signed by another account
       const req = {
         account: ACCOUNT_ADDRESS2,
+      }
+      const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+      const res = await getCombinerQuotaResponse(req, authorization)
+
+      expect(res.status).toBe(401)
+      expect(res.body).toMatchObject<PnpQuotaResponseFailure>({
+        success: false,
+        version: expectedVersion,
+        error: WarningMessage.UNAUTHENTICATED_USER,
+      })
+    })
+
+    it('Should respond with 401 on failed DEK auth', async () => {
+      const req = {
+        account: ACCOUNT_ADDRESS2,
+        AuthenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
       }
       const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
       const res = await getCombinerQuotaResponse(req, authorization)
@@ -769,6 +854,32 @@ describe('pnpService', () => {
         success: false,
         version: expectedVersion,
         error: WarningMessage.API_UNAVAILABLE,
+      })
+    })
+
+    describe('functionality in case of errors', () => {
+      it('Should respond with 200 on failure to fetch DEK', async () => {
+        mockGetDataEncryptionKey.mockReset().mockImplementation(() => {
+          throw new Error()
+        })
+
+        const req = {
+          account: ACCOUNT_ADDRESS1,
+          authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
+        }
+
+        // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
+        const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+        const authorization = getPnpRequestAuthorization(req, differentPk)
+        const res = await getCombinerQuotaResponse(req, authorization)
+        expect(res.status).toBe(200)
+        expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+          success: true,
+          version: expectedVersion,
+          performedQueryCount: 0,
+          totalQuota,
+          blockNumber: testBlockNumber,
+        })
       })
     })
   })

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -457,7 +457,7 @@ describe('pnpService', () => {
         const res = await sendPnpSignRequest(req, authorization, app)
 
         expect(res.status).toBe(401)
-        expect(res.body).toMatchObject<SignMessageResponseFailure>({
+        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
           success: false,
           version: expectedVersion,
           error: WarningMessage.UNAUTHENTICATED_USER,
@@ -778,7 +778,7 @@ describe('pnpService', () => {
       const res = await getCombinerQuotaResponse(req, authorization)
 
       expect(res.status).toBe(400)
-      expect(res.body).toMatchObject<PnpQuotaResponseFailure>({
+      expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
         success: false,
         version: expectedVersion,
         error: WarningMessage.INVALID_INPUT,
@@ -794,7 +794,7 @@ describe('pnpService', () => {
       const res = await getCombinerQuotaResponse(req, authorization)
 
       expect(res.status).toBe(401)
-      expect(res.body).toMatchObject<PnpQuotaResponseFailure>({
+      expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
         success: false,
         version: expectedVersion,
         error: WarningMessage.UNAUTHENTICATED_USER,
@@ -873,7 +873,7 @@ describe('pnpService', () => {
         const authorization = getPnpRequestAuthorization(req, differentPk)
         const res = await getCombinerQuotaResponse(req, authorization)
         expect(res.status).toBe(200)
-        expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+        expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
           success: true,
           version: expectedVersion,
           performedQueryCount: 0,

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -85,6 +85,7 @@ const signerConfig: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: true,
+      authShouldFailOpen: true,
     },
   },
   attestations: {

--- a/packages/phone-number-privacy/common/src/interfaces/errors.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/errors.ts
@@ -26,6 +26,7 @@ export enum ErrorMessage {
   FAILURE_TO_GET_PERFORMED_QUERY_COUNT = `CELO_ODIS_ERR_24 DB_ERR Failed to read performedQueryCount from signer db`,
   FAILURE_TO_GET_TOTAL_QUOTA = `CELO_ODIS_ERR_25 NODE_ERR Failed to read on-chain state to calculate total quota`,
   FAILURE_TO_GET_BLOCK_NUMBER = `CELO_ODIS_ERR_26 NODE_ERR Failed to read block number from full node`,
+  FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_26 NODE_ERR Failed to read user's DEK from full-node`,
 }
 
 export enum WarningMessage {

--- a/packages/phone-number-privacy/common/src/interfaces/errors.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/errors.ts
@@ -26,7 +26,8 @@ export enum ErrorMessage {
   FAILURE_TO_GET_PERFORMED_QUERY_COUNT = `CELO_ODIS_ERR_24 DB_ERR Failed to read performedQueryCount from signer db`,
   FAILURE_TO_GET_TOTAL_QUOTA = `CELO_ODIS_ERR_25 NODE_ERR Failed to read on-chain state to calculate total quota`,
   FAILURE_TO_GET_BLOCK_NUMBER = `CELO_ODIS_ERR_26 NODE_ERR Failed to read block number from full node`,
-  FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_26 NODE_ERR Failed to read user's DEK from full-node`,
+  FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_26 NODE_ERR Failed to read user's DEK from full-node, failing closed`,
+  OPEN_FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_27 NODE_ERR Failed to read user's DEK from full-node, failing open`,
 }
 
 export enum WarningMessage {

--- a/packages/phone-number-privacy/common/src/interfaces/responses.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/responses.ts
@@ -35,6 +35,8 @@ export interface SignMessageResponseSuccess extends PnpQuotaStatus {
   version: string
   signature: string
   warnings?: string[]
+  // TODO(2.0.0) audit req/res types - https://github.com/celo-org/celo-monorepo/issues/9804
+  // - warnings not provided in 1.1.11
 }
 
 export interface SignMessageResponseFailure {
@@ -44,6 +46,8 @@ export interface SignMessageResponseFailure {
   performedQueryCount?: number
   totalQuota?: number
   blockNumber?: number
+  // TODO(2.0.0) audit req/res types - https://github.com/celo-org/celo-monorepo/issues/9804
+  // - signature was previously optionally provided on failure, check sdk for backwards compatibility
 }
 
 export type SignMessageResponse = SignMessageResponseSuccess | SignMessageResponseFailure

--- a/packages/phone-number-privacy/common/src/test/utils.ts
+++ b/packages/phone-number-privacy/common/src/test/utils.ts
@@ -28,10 +28,13 @@ export function createMockToken(balanceOf: jest.Mock<BigNumber, []>) {
   }
 }
 
-export function createMockAccounts(walletAddress: string, dekPubKey?: string) {
+export function createMockAccounts(
+  getWalletAddress: jest.Mock<string, []>,
+  getDataEncryptionKey: jest.Mock<string, []>
+) {
   return {
-    getWalletAddress: jest.fn(() => walletAddress),
-    getDataEncryptionKey: jest.fn(() => dekPubKey),
+    getWalletAddress,
+    getDataEncryptionKey,
   }
 }
 
@@ -125,9 +128,14 @@ export async function registerWalletAddress(
     .sendAndWaitForReceipt({ from: accountAddress } as any)
 }
 
-export function getPnpQuotaRequest(account: string, hashedPhoneNumber?: string): PnpQuotaRequest {
+export function getPnpQuotaRequest(
+  account: string,
+  authenticationMethod?: string,
+  hashedPhoneNumber?: string
+): PnpQuotaRequest {
   return {
     account,
+    authenticationMethod,
     hashedPhoneNumber,
     sessionID: genSessionID(),
   }

--- a/packages/phone-number-privacy/common/src/utils/authentication.ts
+++ b/packages/phone-number-privacy/common/src/utils/authentication.ts
@@ -41,7 +41,7 @@ export async function authenticateUser(
       // getDataEncryptionKey should only throw if there is a full-node connection issue.
       // That is, it does not throw if the DEK is undefined or invalid
       if (shouldFailOpen) {
-        // TODO(2.0.0, optional) consider putting all fail-open logic behind an ENV var, or a request header
+        // TODO(2.0.0, optional) (https://github.com/celo-org/celo-monorepo/issues/9863) Put all fail-open logic (not just auth) behind an ENV var
         // TODO(2.0.0, release) add monitoring / alerting for these
         logger.error({ err }, ErrorMessage.OPEN_FAILURE_TO_GET_DEK)
         return true

--- a/packages/phone-number-privacy/common/src/utils/authentication.ts
+++ b/packages/phone-number-privacy/common/src/utils/authentication.ts
@@ -37,7 +37,7 @@ export async function authenticateUser(
     try {
       registeredEncryptionKey = await getDataEncryptionKey(signer, contractKit, logger)
     } catch (error) {
-      logger.warn('Assuming request is authenticated')
+      logger.error(ErrorMessage.FAILURE_TO_GET_DEK) // TODO(2.0.0) add monitoring / alerting for this
       return true
     }
     if (!registeredEncryptionKey) {
@@ -57,9 +57,11 @@ export async function authenticateUser(
 
   // Fallback to previous signing pattern
   logger.info(
-    { account: signer },
+    { account: signer, message, messageSignature },
     'Message was not authenticated with DEK, attempting to authenticate using wallet key'
   )
+  // TODO(2.0.0) This uses signature utils, why doesn't DEK authentication?
+  // (https://github.com/celo-org/celo-monorepo/issues/9803)
   return verifySignature(message, messageSignature, signer)
 }
 

--- a/packages/phone-number-privacy/signer/src/common/controller.ts
+++ b/packages/phone-number-privacy/signer/src/common/controller.ts
@@ -19,7 +19,7 @@ export class Controller<R extends OdisRequest> {
       }
     } catch (err) {
       response.locals.logger.error(
-        { error: err },
+        { err },
         `Unknown error in handler for ${this.action.io.endpoint}`
       )
       this.action.io.sendFailure(ErrorMessage.UNKNOWN_ERROR, 500, response)

--- a/packages/phone-number-privacy/signer/src/config.ts
+++ b/packages/phone-number-privacy/signer/src/config.ts
@@ -44,6 +44,7 @@ export interface SignerConfig {
     }
     phoneNumberPrivacy: {
       enabled: boolean
+      authShouldFailOpen: boolean
     }
   }
   attestations: {
@@ -121,6 +122,7 @@ export const config: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: toBool(env.PHONE_NUMBER_PRIVACY_API_ENABLED, false),
+      authShouldFailOpen: toBool(env.PHONE_NUMBER_PRIVACY_AUTH_SHOULD_FAIL_OPEN, true),
     },
   },
   attestations: {

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/io.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/io.ts
@@ -25,7 +25,11 @@ import { PnpSession } from '../../session'
 export class PnpQuotaIO extends IO<PnpQuotaRequest> {
   readonly endpoint = SignerEndpoint.PNP_QUOTA
 
-  constructor(enabled: boolean, readonly kit: ContractKit) {
+  constructor(
+    readonly enabled: boolean,
+    readonly authShouldFailOpen: boolean,
+    readonly kit: ContractKit
+  ) {
     super(enabled)
   }
 
@@ -53,7 +57,7 @@ export class PnpQuotaIO extends IO<PnpQuotaRequest> {
   }
 
   async authenticate(request: Request<{}, {}, PnpQuotaRequest>, logger: Logger): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger)
+    return authenticateUser(request, this.kit, logger, this.authShouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
@@ -27,7 +27,11 @@ import { PnpSession } from '../../session'
 export class LegacyPnpSignIO extends IO<SignMessageRequest> {
   readonly endpoint = SignerEndpoint.LEGACY_PNP_SIGN
 
-  constructor(enabled: boolean, readonly kit: ContractKit) {
+  constructor(
+    readonly enabled: boolean,
+    readonly authShouldFailOpen: boolean,
+    readonly kit: ContractKit
+  ) {
     super(enabled)
   }
 
@@ -64,7 +68,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger)
+    return authenticateUser(request, this.kit, logger, this.authShouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
@@ -27,7 +27,11 @@ import { PnpSession } from '../../session'
 export class PnpSignIO extends IO<SignMessageRequest> {
   readonly endpoint = SignerEndpoint.PNP_SIGN
 
-  constructor(enabled: boolean, readonly kit: ContractKit) {
+  constructor(
+    readonly enabled: boolean,
+    readonly authShouldFailOpen: boolean,
+    readonly kit: ContractKit
+  ) {
     super(enabled)
   }
 
@@ -64,7 +68,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger)
+    return authenticateUser(request, this.kit, logger, this.authShouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -92,7 +92,11 @@ export function startSigner(
     new PnpQuotaAction(
       config,
       pnpQuotaService,
-      new PnpQuotaIO(config.api.phoneNumberPrivacy.enabled, kit)
+      new PnpQuotaIO(
+        config.api.phoneNumberPrivacy.enabled,
+        config.api.phoneNumberPrivacy.authShouldFailOpen, // TODO(2.0.0) consider refactoring config to make the code cleaner
+        kit
+      )
     )
   )
   const pnpSign = new Controller(
@@ -101,7 +105,11 @@ export function startSigner(
       config,
       pnpQuotaService,
       keyProvider,
-      new PnpSignIO(config.api.phoneNumberPrivacy.enabled, kit)
+      new PnpSignIO(
+        config.api.phoneNumberPrivacy.enabled,
+        config.api.phoneNumberPrivacy.authShouldFailOpen,
+        kit
+      )
     )
   )
   const legacyPnpSign = new Controller(
@@ -110,14 +118,22 @@ export function startSigner(
       config,
       legacyPnpQuotaService,
       keyProvider,
-      new PnpSignIO(config.api.phoneNumberPrivacy.enabled, kit)
+      new PnpSignIO(
+        config.api.phoneNumberPrivacy.enabled,
+        config.api.phoneNumberPrivacy.authShouldFailOpen,
+        kit
+      )
     )
   )
   const legacyPnpQuota = new Controller(
     new PnpQuotaAction(
       config,
       legacyPnpQuotaService,
-      new PnpQuotaIO(config.api.phoneNumberPrivacy.enabled, kit)
+      new PnpQuotaIO(
+        config.api.phoneNumberPrivacy.enabled,
+        config.api.phoneNumberPrivacy.authShouldFailOpen,
+        kit
+      )
     )
   )
   const domainQuota = new Controller(

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -94,7 +94,7 @@ export function startSigner(
       pnpQuotaService,
       new PnpQuotaIO(
         config.api.phoneNumberPrivacy.enabled,
-        config.api.phoneNumberPrivacy.authShouldFailOpen, // TODO(2.0.0) consider refactoring config to make the code cleaner
+        config.api.phoneNumberPrivacy.authShouldFailOpen, // TODO(2.0.0) (https://github.com/celo-org/celo-monorepo/issues/9862) consider refactoring config to make the code cleaner
         kit
       )
     )

--- a/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
@@ -511,7 +511,7 @@ describe('legacyPNP', () => {
         const res = await sendRequest(badRequest, authorization, SignerEndpoint.LEGACY_PNP_QUOTA)
 
         expect(res.status).toBe(401)
-        expect(res.body).toMatchObject<PnpQuotaResponseFailure>({
+        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
           success: false,
           version: expectedVersion,
           error: WarningMessage.UNAUTHENTICATED_USER,
@@ -575,7 +575,7 @@ describe('legacyPNP', () => {
           const res = await sendRequest(req, authorization, SignerEndpoint.LEGACY_PNP_QUOTA)
 
           expect(res.status).toBe(200)
-          expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+          expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
             success: true,
             version: res.body.version,
             performedQueryCount: performedQueryCount,
@@ -916,7 +916,7 @@ describe('legacyPNP', () => {
         const authorization = getPnpRequestAuthorization(badRequest, differentPk)
         const res = await sendRequest(badRequest, authorization, SignerEndpoint.LEGACY_PNP_SIGN)
         expect(res.status).toBe(401)
-        expect(res.body).toMatchObject<SignMessageResponseFailure>({
+        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
           success: false,
           version: res.body.version,
           error: WarningMessage.UNAUTHENTICATED_USER,

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -193,7 +193,7 @@ describe('pnp', () => {
 
         const res = await sendRequest(req, authorization, SignerEndpoint.PNP_QUOTA)
         expect(res.status).toBe(200)
-        expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+        expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
           success: true,
           version: res.body.version,
           performedQueryCount: 0,
@@ -228,7 +228,7 @@ describe('pnp', () => {
 
         const res = await sendRequest(req, authorization, SignerEndpoint.PNP_QUOTA)
         expect(res.status).toBe(200)
-        expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+        expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
           success: true,
           version: res.body.version,
           performedQueryCount: 0,
@@ -298,7 +298,7 @@ describe('pnp', () => {
         const res = await sendRequest(badRequest, authorization, SignerEndpoint.PNP_QUOTA)
 
         expect(res.status).toBe(401)
-        expect(res.body).toMatchObject<PnpQuotaResponseFailure>({
+        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
           success: false,
           version: res.body.version,
           error: WarningMessage.UNAUTHENTICATED_USER,
@@ -367,7 +367,7 @@ describe('pnp', () => {
           const res = await sendRequest(req, authorization, SignerEndpoint.PNP_QUOTA)
 
           expect(res.status).toBe(200)
-          expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+          expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
             success: true,
             version: res.body.version,
             performedQueryCount: 0,
@@ -485,7 +485,7 @@ describe('pnp', () => {
         const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
         const res = await sendRequest(req, authorization, SignerEndpoint.PNP_SIGN)
         expect(res.status).toBe(200)
-        expect(res.body).toMatchObject<SignMessageResponseSuccess>({
+        expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
           success: true,
           version: res.body.version,
           signature: expectedSignature,
@@ -509,7 +509,7 @@ describe('pnp', () => {
         const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
         const res = await sendRequest(req, authorization, SignerEndpoint.PNP_SIGN)
         expect(res.status).toBe(200)
-        expect(res.body).toMatchObject<SignMessageResponseSuccess>({
+        expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
           success: true,
           version: res.body.version,
           signature: expectedSignature,
@@ -690,7 +690,7 @@ describe('pnp', () => {
         const authorization = getPnpRequestAuthorization(badRequest, differentPk)
         const res = await sendRequest(badRequest, authorization, SignerEndpoint.PNP_SIGN)
         expect(res.status).toBe(401)
-        expect(res.body).toMatchObject<SignMessageResponseFailure>({
+        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
           success: false,
           version: res.body.version,
           error: WarningMessage.UNAUTHENTICATED_USER,

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -32,19 +32,33 @@ import { startSigner } from '../../src/server'
 const {
   ContractRetrieval,
   createMockContractKit,
+  createMockAccounts,
   createMockOdisPayments,
   createMockWeb3,
   getPnpQuotaRequest,
   getPnpRequestAuthorization,
 } = TestUtils.Utils
-const { PRIVATE_KEY1, ACCOUNT_ADDRESS1, mockAccount } = TestUtils.Values
+const {
+  PRIVATE_KEY1,
+  ACCOUNT_ADDRESS1,
+  mockAccount,
+  DEK_PRIVATE_KEY,
+  DEK_PUBLIC_KEY,
+} = TestUtils.Values
 
 const testBlockNumber = 1000000
 const zeroBalance = new BigNumber(0)
 
 const mockOdisPaymentsTotalPaidCUSD = jest.fn<BigNumber, []>()
+const mockGetWalletAddress = jest.fn<string, []>()
+const mockGetDataEncryptionKey = jest.fn<string, []>()
+
 const mockContractKit = createMockContractKit(
   {
+    [ContractRetrieval.getAccounts]: createMockAccounts(
+      mockGetWalletAddress,
+      mockGetDataEncryptionKey
+    ),
     [ContractRetrieval.getOdisPayments]: createMockOdisPayments(mockOdisPaymentsTotalPaidCUSD),
   },
   createMockWeb3(5, testBlockNumber)
@@ -80,13 +94,14 @@ describe('pnp', () => {
     db = await initDatabase(_config)
     app = startSigner(_config, db, keyProvider, newKit('dummyKit'))
     mockOdisPaymentsTotalPaidCUSD.mockReset()
+    mockGetDataEncryptionKey.mockReset().mockReturnValue(DEK_PUBLIC_KEY)
+    mockGetWalletAddress.mockReset().mockReturnValue(mockAccount)
   })
 
   afterEach(async () => {
     // Close and destroy the in-memory database.
     // Note: If tests start to be too slow, this could be replaced with more complicated logic to
     // reset the database state without destroying and recreting it for each test.
-
     await db?.destroy()
   })
 
@@ -172,6 +187,22 @@ describe('pnp', () => {
         mockOdisPaymentsTotalPaidCUSD.mockReturnValue(onChainBalance)
       })
 
+      it('Should respond with 200 on valid request', async () => {
+        const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
+        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+
+        const res = await sendRequest(req, authorization, SignerEndpoint.PNP_QUOTA)
+        expect(res.status).toBe(200)
+        expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+          success: true,
+          version: res.body.version,
+          performedQueryCount: 0,
+          totalQuota: expectedQuota,
+          blockNumber: testBlockNumber,
+          warnings: [],
+        })
+      })
+
       it('Should respond with 200 on repeated valid requests', async () => {
         const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1)
         const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
@@ -189,6 +220,22 @@ describe('pnp', () => {
         const res2 = await sendRequest(req, authorization, SignerEndpoint.PNP_QUOTA)
         expect(res2.status).toBe(200)
         expect(res2.body).toMatchObject<PnpQuotaResponseSuccess>(res1.body)
+      })
+
+      it('Should respond with 200 on valid request when authenticated with DEK', async () => {
+        const req = getPnpQuotaRequest(ACCOUNT_ADDRESS1, AuthenticationMethod.ENCRYPTION_KEY)
+        const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
+
+        const res = await sendRequest(req, authorization, SignerEndpoint.PNP_QUOTA)
+        expect(res.status).toBe(200)
+        expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+          success: true,
+          version: res.body.version,
+          performedQueryCount: 0,
+          totalQuota: expectedQuota,
+          blockNumber: testBlockNumber,
+          warnings: [],
+        })
       })
 
       it('Should respond with 200 on extra request fields', async () => {
@@ -244,9 +291,9 @@ describe('pnp', () => {
         })
       })
 
-      it('Should respond with 401 on failed auth', async () => {
+      it('Should respond with 401 on failed WALLET_KEY auth', async () => {
         // Request from one account, signed by another account
-        const badRequest = getPnpQuotaRequest(mockAccount)
+        const badRequest = getPnpQuotaRequest(mockAccount, AuthenticationMethod.WALLET_KEY)
         const authorization = getPnpRequestAuthorization(badRequest, PRIVATE_KEY1)
         const res = await sendRequest(badRequest, authorization, SignerEndpoint.PNP_QUOTA)
 
@@ -254,6 +301,24 @@ describe('pnp', () => {
         expect(res.body).toMatchObject<PnpQuotaResponseFailure>({
           success: false,
           version: res.body.version,
+          error: WarningMessage.UNAUTHENTICATED_USER,
+        })
+      })
+
+      it('Should respond with 401 on failed DEK auth', async () => {
+        const badRequest = getPnpQuotaRequest(
+          ACCOUNT_ADDRESS1,
+          AuthenticationMethod.ENCRYPTION_KEY,
+          IDENTIFIER
+        )
+        const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+        const authorization = getPnpRequestAuthorization(badRequest, differentPk)
+        const res = await sendRequest(badRequest, authorization, SignerEndpoint.PNP_QUOTA)
+
+        expect(res.status).toBe(401)
+        expect(res.body).toMatchObject<PnpQuotaResponseFailure>({
+          success: false,
+          version: expectedVersion,
           error: WarningMessage.UNAUTHENTICATED_USER,
         })
       })
@@ -285,6 +350,33 @@ describe('pnp', () => {
       })
 
       describe('functionality in case of errors', () => {
+        it('Should respond with 200 on failure to fetch DEK', async () => {
+          mockGetDataEncryptionKey.mockImplementation(() => {
+            throw new Error()
+          })
+
+          const req = getPnpQuotaRequest(
+            ACCOUNT_ADDRESS1,
+            AuthenticationMethod.ENCRYPTION_KEY,
+            IDENTIFIER
+          )
+
+          // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
+          const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+          const authorization = getPnpRequestAuthorization(req, differentPk)
+          const res = await sendRequest(req, authorization, SignerEndpoint.PNP_QUOTA)
+
+          expect(res.status).toBe(200)
+          expect(res.body).toMatchObject<PnpQuotaResponseSuccess>({
+            success: true,
+            version: res.body.version,
+            performedQueryCount: 0,
+            totalQuota: expectedQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          })
+        })
+
         it('Should respond with 500 on DB performedQueryCount query failure', async () => {
           const spy = jest
             .spyOn(
@@ -405,6 +497,27 @@ describe('pnp', () => {
         expect(res.get(KEY_VERSION_HEADER)).toEqual(
           _config.keystore.keys.phoneNumberPrivacy.latest.toString()
         )
+      })
+
+      it('Should respond with 200 on valid request when authenticated with DEK', async () => {
+        const req = getPnpSignRequest(
+          ACCOUNT_ADDRESS1,
+          BLINDED_PHONE_NUMBER,
+          AuthenticationMethod.ENCRYPTION_KEY,
+          IDENTIFIER
+        )
+        const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
+        const res = await sendRequest(req, authorization, SignerEndpoint.PNP_SIGN)
+        expect(res.status).toBe(200)
+        expect(res.body).toMatchObject<SignMessageResponseSuccess>({
+          success: true,
+          version: res.body.version,
+          signature: expectedSignature,
+          performedQueryCount: performedQueryCount + 1,
+          totalQuota: expectedQuota,
+          blockNumber: testBlockNumber,
+          warnings: [],
+        })
       })
 
       it('Should respond with 200 on valid request with key version header', async () => {
@@ -566,11 +679,29 @@ describe('pnp', () => {
         })
       })
 
-      it('Should respond with 401 on failed auth', async () => {
+      it('Should respond with 401 on failed WALLET_KEY auth', async () => {
         const badRequest = getPnpSignRequest(
           ACCOUNT_ADDRESS1,
           BLINDED_PHONE_NUMBER,
           AuthenticationMethod.WALLET_KEY,
+          IDENTIFIER
+        )
+        const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+        const authorization = getPnpRequestAuthorization(badRequest, differentPk)
+        const res = await sendRequest(badRequest, authorization, SignerEndpoint.PNP_SIGN)
+        expect(res.status).toBe(401)
+        expect(res.body).toMatchObject<SignMessageResponseFailure>({
+          success: false,
+          version: res.body.version,
+          error: WarningMessage.UNAUTHENTICATED_USER,
+        })
+      })
+
+      it('Should respond with 401 on failed DEK auth', async () => {
+        const badRequest = getPnpSignRequest(
+          ACCOUNT_ADDRESS1,
+          BLINDED_PHONE_NUMBER,
+          AuthenticationMethod.ENCRYPTION_KEY,
           IDENTIFIER
         )
         const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
@@ -868,6 +999,34 @@ describe('pnp', () => {
           expect(await getRequestExists(db, req, rootLogger(config.serviceName))).toBe(false)
         })
 
+        it('Should return 200 on failure to fetch DEK', async () => {
+          mockGetDataEncryptionKey.mockImplementation(() => {
+            throw new Error()
+          })
+
+          const req = getPnpSignRequest(
+            ACCOUNT_ADDRESS1,
+            BLINDED_PHONE_NUMBER,
+            AuthenticationMethod.ENCRYPTION_KEY,
+            IDENTIFIER
+          )
+
+          // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
+          const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+          const authorization = getPnpRequestAuthorization(req, differentPk)
+          const res = await sendRequest(req, authorization, SignerEndpoint.PNP_SIGN)
+          expect(res.status).toBe(200)
+          expect(res.body).toMatchObject<SignMessageResponseSuccess>({
+            success: true,
+            version: res.body.version,
+            signature: expectedSignature,
+            performedQueryCount: performedQueryCount + 1,
+            totalQuota: expectedQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          })
+        })
+
         it('Should return 500 on bls signing error', async () => {
           const spy = jest
             .spyOn(jest.requireActual('blind-threshold-bls'), 'partialSignBlindedMessage')
@@ -885,7 +1044,6 @@ describe('pnp', () => {
           const res = await sendRequest(req, authorization, SignerEndpoint.PNP_SIGN)
 
           expect(res.status).toBe(500)
-          // TODO(2.0.0)(Alec): investigate whether we have the intended behavior here
           expect(res.body).toMatchObject<SignMessageResponseFailure>({
             success: false,
             version: res.body.version,


### PR DESCRIPTION
### Description

Adds several test cases to the combiner and signer related to DEK authentication

### Other changes

Adds a new error message that can be used to monitor "fail-open" DEK authentication
Puts "fail-open" DEK authentication behind an env var 

### Tested

Integration tests added

### Related issues

- Fixes #9837 

### Backwards compatibility

Yes

### Documentation

None