### PR TITLE
Change quote interfaces

### DIFF
--- a/packages/protocol/contracts/stability/interfaces/IBroker.sol
+++ b/packages/protocol/contracts/stability/interfaces/IBroker.sol
@@ -65,7 +65,7 @@ interface IBroker {
   ) external returns (uint256 amountIn);
 
   /**
-   * @notice Quote a token swap with fixed amountIn
+   * @notice Calculate amountOut of tokenOut received for a given amountIn of tokenIn
    * @param exchangeManager the address of the exchange manager for the pair
    * @param exchangeId The id of the exchange to use
    * @param tokenIn The token to be sold
@@ -73,7 +73,7 @@ interface IBroker {
    * @param amountIn The amount of tokenIn to be sold
    * @return amountOut The amount of tokenOut to be bought
    */
-  function quoteIn(
+  function getAmountOut(
     address exchangeManager,
     bytes32 exchangeId,
     address tokenIn,
@@ -82,7 +82,7 @@ interface IBroker {
   ) external returns (uint256 amountOut);
 
   /**
-   * @notice Quote a token swap with fixed amountOut
+   * @notice Calculate amountIn of tokenIn needed for a given amountOut of tokenOut
    * @param exchangeManager the address of the exchange manager for the pair
    * @param exchangeId The id of the exchange to use
    * @param tokenIn The token to be sold
@@ -90,7 +90,7 @@ interface IBroker {
    * @param amountOut The amount of tokenOut to be bought
    * @return amountIn The amount of tokenIn to be sold
    */
-  function quoteOut(
+  function getAmountIn(
     address exchangeManager,
     bytes32 exchangeId,
     address tokenIn,

--- a/packages/protocol/contracts/stability/interfaces/IExchangeManager.sol
+++ b/packages/protocol/contracts/stability/interfaces/IExchangeManager.sol
@@ -41,26 +41,26 @@ interface IExchangeManager {
   ) external returns (uint256 amountIn);
 
   /**
-   * @notice Quote a token swap with fixed amountIn
+   * @notice Calculate amountOut of tokenOut for a given amountIn of tokenIn
    * @param exchangeId The id of the exchange to use
    * @param tokenIn The token to be sold
    * @param tokenOut The token to be bought 
    * @param amountIn The amount of tokenIn to be sold
    * @return amountOut The amount of tokenOut to be bought
    */
-  function quoteIn(bytes32 exchangeId, address tokenIn, address tokenOut, uint256 amountIn)
+  function getAmountOut(bytes32 exchangeId, address tokenIn, address tokenOut, uint256 amountIn)
     external
     returns (uint256 amountOut);
 
   /**
-   * @notice Quote a token swap with fixed amountOut
+   * @notice Calculate amountIn of tokenIn for a given amountIn of tokenIn
    * @param exchangeId The id of the exchange to use
    * @param tokenIn The token to be sold
    * @param tokenOut The token to be bought 
    * @param amountOut The amount of tokenOut to be bought
    * @return amountIn The amount of tokenIn to be sold
    */
-  function quoteOut(bytes32 exchangeId, address tokenIn, address tokenOut, uint256 amountOut)
+  function getAmountIn(bytes32 exchangeId, address tokenIn, address tokenOut, uint256 amountOut)
     external
     returns (uint256 amountIn);
 }


### PR DESCRIPTION
### Description

Changes `quoteIn` to `getAmountOut` and `quoteOut` to `getAmountIn` to fix some naming inconsistencies.
See [discussion on discord](https://discord.com/channels/966739027782955068/1014839438637015080/1017425952902488104)

### Other changes

-

### Tested

-

### Related issues

-

### Backwards compatibility

-

### Documentation

-