### PR TITLE
Put fail-open logic behind an ENV var

### DIFF
--- a/packages/phone-number-privacy/combiner/src/config.ts
+++ b/packages/phone-number-privacy/combiner/src/config.ts
@@ -29,7 +29,7 @@ export interface DatabaseConfig {
 export interface OdisConfig {
   serviceName: string
   enabled: boolean
-  authShouldFailOpen: boolean // TODO(2.0.0) (https://github.com/celo-org/celo-monorepo/issues/9862) consider refactoring config, this isn't relevant to domains endpoints
+  shouldFailOpen: boolean // TODO(2.0.0) (https://github.com/celo-org/celo-monorepo/issues/9862) consider refactoring config, this isn't relevant to domains endpoints
   odisServices: {
     signers: string
     timeoutMilliSeconds: number
@@ -76,7 +76,7 @@ if (DEV_MODE) {
     phoneNumberPrivacy: {
       serviceName: defaultServiceName,
       enabled: true,
-      authShouldFailOpen: true,
+      shouldFailOpen: true,
       odisServices: {
         signers:
           '[{"url": "http://localhost:3001", "fallbackUrl": "http://localhost:3001/fallback"}, {"url": "http://localhost:3002", "fallbackUrl": "http://localhost:3002/fallback"}, {"url": "http://localhost:3003", "fallbackUrl": "http://localhost:3003/fallback"}]',
@@ -92,7 +92,7 @@ if (DEV_MODE) {
     domains: {
       serviceName: defaultServiceName,
       enabled: true,
-      authShouldFailOpen: false,
+      shouldFailOpen: false,
       odisServices: {
         signers:
           '[{"url": "http://localhost:3001", "fallbackUrl": "http://localhost:3001/fallback"}, {"url": "http://localhost:3002", "fallbackUrl": "http://localhost:3002/fallback"}, {"url": "http://localhost:3003", "fallbackUrl": "http://localhost:3003/fallback"}]',
@@ -127,7 +127,7 @@ if (DEV_MODE) {
     phoneNumberPrivacy: {
       serviceName: functionConfig.phoneNumberPrivacy.service_name ?? defaultServiceName,
       enabled: toBool(functionConfig.phoneNumberPrivacy.enabled, false),
-      authShouldFailOpen: toBool(functionConfig.phoneNumberPrivacy.authShouldFailOpen, true),
+      shouldFailOpen: toBool(functionConfig.phoneNumberPrivacy.shouldFailOpen, true),
       odisServices: {
         signers: functionConfig.phoneNumberPrivacy.odisservices.signers,
         timeoutMilliSeconds:
@@ -143,7 +143,7 @@ if (DEV_MODE) {
     domains: {
       serviceName: functionConfig.domains.service_name ?? defaultServiceName,
       enabled: toBool(functionConfig.domains.enabled, false),
-      authShouldFailOpen: toBool(functionConfig.domains.authShouldFailOpen, true),
+      shouldFailOpen: toBool(functionConfig.domains.authShouldFailOpen, true),
       odisServices: {
         signers: functionConfig.domains.odisservices.signers,
         timeoutMilliSeconds: functionConfig.domains.odisservices.timeoutMilliSeconds ?? 5 * 1000,

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/io.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/io.ts
@@ -64,7 +64,7 @@ export class PnpQuotaIO extends IO<PnpQuotaRequest> {
   }
 
   async authenticate(request: Request<{}, {}, PnpQuotaRequest>, logger: Logger): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger, this.config.authShouldFailOpen)
+    return authenticateUser(request, this.kit, logger, this.config.shouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.legacy.ts
@@ -78,7 +78,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger, this.config.authShouldFailOpen)
+    return authenticateUser(request, this.kit, logger, this.config.shouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/io.ts
@@ -80,7 +80,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger, this.config.authShouldFailOpen)
+    return authenticateUser(request, this.kit, logger, this.config.shouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -67,7 +67,7 @@ const signerConfig: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: false,
-      authShouldFailOpen: true,
+      shouldFailOpen: true,
     },
   },
   attestations: {

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -36,10 +36,12 @@ import { Server as HttpsServer } from 'https'
 import { Knex } from 'knex'
 import { Server } from 'net'
 import request from 'supertest'
-import config, { CombinerConfig } from '../../src/config'
+import config from '../../src/config'
 import { startCombiner } from '../../src/server'
 
-const combinerConfig: CombinerConfig = { ...config }
+// create deep copy of config
+const combinerConfig: typeof config = JSON.parse(JSON.stringify(config))
+combinerConfig.domains.enabled = true
 
 const signerConfig: SignerConfig = {
   serviceName: 'odis-signer',
@@ -223,12 +225,9 @@ describe('domainService', () => {
   })
 
   beforeEach(async () => {
-    config.domains.enabled = true
-
     signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
     signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
     signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
-
     signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
     signer2 = startSigner(signerConfig, signerDB2, keyProvider2).listen(3002)
     signer3 = startSigner(signerConfig, signerDB3, keyProvider3).listen(3003)
@@ -358,7 +357,9 @@ describe('domainService', () => {
     // TODO(2.0.0, testing) test this with signers disabled too
     // https://github.com/celo-org/celo-monorepo/issues/9811
     it('Should respond with 503 on disabled api', async () => {
-      const configWithApiDisabled = combinerConfig
+      const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+        JSON.stringify(combinerConfig)
+      )
       configWithApiDisabled.domains.enabled = false
       const appWithApiDisabled = startCombiner(configWithApiDisabled)
 
@@ -495,7 +496,9 @@ describe('domainService', () => {
     })
 
     it('Should respond with 503 on disabled api', async () => {
-      const configWithApiDisabled = combinerConfig
+      const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+        JSON.stringify(combinerConfig)
+      )
       configWithApiDisabled.domains.enabled = false
       const appWithApiDisabled = startCombiner(configWithApiDisabled)
 
@@ -805,34 +808,24 @@ describe('domainService', () => {
       })
     })
 
-    // it('Should respond with 503 on disabled api', async () => {
-    //   const configWithApiDisabled = { ...config }
-    //   configWithApiDisabled.api.domains.enabled = false
-    //   const appWithApiDisabled = createServer(configWithApiDisabled)
+    it('Should respond with 503 on disabled api', async () => {
+      const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+        JSON.stringify(combinerConfig)
+      )
+      configWithApiDisabled.domains.enabled = false
+      const appWithApiDisabled = startCombiner(configWithApiDisabled)
 
-    //   const [req, _] = await signatureRequest()
+      const [req, _] = await signatureRequest()
 
-    //   const res = await request(appWithApiDisabled).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+      const res = await request(appWithApiDisabled).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
 
-    //   expect(res.status).toBe(503)
-    //   // @ts-ignore res.body.status is expected to be undefined
-    //   expect(res.body).toMatchObject<DomainRestrictedSignatureResponse>({
-    //     success: false,
-    //     version: res.body.version,
-    //     error: WarningMessage.API_UNAVAILABLE,
-    //   })
-    // })
+      expect(res.status).toBe(503)
+      // @ts-ignore res.body.status is expected to be undefined
+      expect(res.body).toMatchObject<DomainRestrictedSignatureResponse>({
+        success: false,
+        version: res.body.version,
+        error: WarningMessage.API_UNAVAILABLE,
+      })
+    })
   })
-
-  /*
-[ ] Bad signature (combiner + signer)
-[ ] Bad encoding (combiner + signer)
-[ ] Undefined domain (combiner + signer)
-[ ] Extra fields? -> should reject / use t.strict (combiner + signer)
-[ ] Valid key versions (combiner + signer)
-[ ] Invalid key versions (combiner + signer)
-[ ] Out of quota (combiner + signer)
-[ ] Bad nonce (combiner + signer)
-[ ] Request too early for rate limiting (both)
-  */
 })

--- a/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
@@ -80,7 +80,7 @@ const signerConfig: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: true,
-      authShouldFailOpen: true,
+      shouldFailOpen: true,
     },
   },
   attestations: {

--- a/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/legacypnp.test.ts
@@ -29,7 +29,7 @@ import { Server as HttpsServer } from 'https'
 import { Knex } from 'knex'
 import { Server } from 'net'
 import request from 'supertest'
-import config, { CombinerConfig } from '../../src/config'
+import config from '../../src/config'
 import { startCombiner } from '../../src/server'
 
 const {
@@ -52,7 +52,9 @@ const {
   BLS_THRESHOLD_DEV_PK_SHARE_3,
 } = TestUtils.Values
 
-const combinerConfig: CombinerConfig = { ...config }
+// create deep copy
+const combinerConfig: typeof config = JSON.parse(JSON.stringify(config))
+combinerConfig.phoneNumberPrivacy.enabled = true
 
 const signerConfig: SignerConfig = {
   serviceName: 'odis-signer',
@@ -197,8 +199,6 @@ describe('legacyPnpService', () => {
   })
 
   beforeEach(async () => {
-    config.phoneNumberPrivacy.enabled = true
-
     signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
     signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
     signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
@@ -514,7 +514,9 @@ describe('legacyPnpService', () => {
       })
 
       it('Should respond with 503 on disabled api', async () => {
-        const configWithApiDisabled = { ...combinerConfig }
+        const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+          JSON.stringify(combinerConfig)
+        )
         configWithApiDisabled.phoneNumberPrivacy.enabled = false
         const appWithApiDisabled = startCombiner(configWithApiDisabled)
 

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -35,7 +35,7 @@ import { Server as HttpsServer } from 'https'
 import { Knex } from 'knex'
 import { Server } from 'net'
 import request from 'supertest'
-import config, { CombinerConfig } from '../../src/config'
+import config from '../../src/config'
 import { startCombiner } from '../../src/server'
 
 const {
@@ -57,7 +57,9 @@ const {
   BLS_THRESHOLD_DEV_PK_SHARE_3,
 } = TestUtils.Values
 
-const combinerConfig: CombinerConfig = { ...config }
+// create deep copy of config
+const combinerConfig: typeof config = JSON.parse(JSON.stringify(config))
+combinerConfig.phoneNumberPrivacy.enabled = true
 
 const signerConfig: SignerConfig = {
   serviceName: 'odis-signer',
@@ -200,8 +202,6 @@ describe('pnpService', () => {
   })
 
   beforeEach(async () => {
-    config.phoneNumberPrivacy.enabled = true
-
     signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
     signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
     signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
@@ -494,7 +494,9 @@ describe('pnpService', () => {
       })
 
       it('Should respond with 503 on disabled api', async () => {
-        const configWithApiDisabled = { ...combinerConfig }
+        const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+          JSON.stringify(combinerConfig)
+        )
         configWithApiDisabled.phoneNumberPrivacy.enabled = false
         const appWithApiDisabled = startCombiner(configWithApiDisabled)
 
@@ -876,7 +878,9 @@ describe('pnpService', () => {
     })
 
     it('Should respond with 503 on disabled api', async () => {
-      const configWithApiDisabled = { ...combinerConfig }
+      const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+        JSON.stringify(combinerConfig)
+      )
       configWithApiDisabled.phoneNumberPrivacy.enabled = false
       const appWithApiDisabled = startCombiner(configWithApiDisabled)
       const req = {

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -85,7 +85,7 @@ const signerConfig: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: true,
-      authShouldFailOpen: true,
+      shouldFailOpen: true,
     },
   },
   attestations: {
@@ -917,6 +917,7 @@ describe('pnpService', () => {
           performedQueryCount: 0,
           totalQuota,
           blockNumber: testBlockNumber,
+          warnings: [],
         })
       })
     })

--- a/packages/phone-number-privacy/common/src/interfaces/errors.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/errors.ts
@@ -26,8 +26,9 @@ export enum ErrorMessage {
   FAILURE_TO_GET_PERFORMED_QUERY_COUNT = `CELO_ODIS_ERR_24 DB_ERR Failed to read performedQueryCount from signer db`,
   FAILURE_TO_GET_TOTAL_QUOTA = `CELO_ODIS_ERR_25 NODE_ERR Failed to read on-chain state to calculate total quota`,
   FAILURE_TO_GET_BLOCK_NUMBER = `CELO_ODIS_ERR_26 NODE_ERR Failed to read block number from full node`,
-  FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_26 NODE_ERR Failed to read user's DEK from full-node, failing closed`,
-  OPEN_FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_27 NODE_ERR Failed to read user's DEK from full-node, failing open`,
+  FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_26 NODE_ERR Failed to read user's DEK from full-node`,
+  FAILING_OPEN = `CELO_ODIS_ERR_27 NODE_ERR Failing open on full-node error`,
+  FAILING_CLOSED = `CELO_ODIS_ERR_28 NODE_ERR Failing closed on full-node error`,
 }
 
 export enum WarningMessage {

--- a/packages/phone-number-privacy/common/src/utils/authentication.ts
+++ b/packages/phone-number-privacy/common/src/utils/authentication.ts
@@ -40,13 +40,13 @@ export async function authenticateUser(
     } catch (err) {
       // getDataEncryptionKey should only throw if there is a full-node connection issue.
       // That is, it does not throw if the DEK is undefined or invalid
+      logger.error({ err, shouldFailOpen }, ErrorMessage.FAILURE_TO_GET_DEK)
       if (shouldFailOpen) {
-        // TODO(2.0.0, optional) (https://github.com/celo-org/celo-monorepo/issues/9863) Put all fail-open logic (not just auth) behind an ENV var
         // TODO(2.0.0, release) add monitoring / alerting for these
-        logger.error({ err }, ErrorMessage.OPEN_FAILURE_TO_GET_DEK)
+        logger.error(ErrorMessage.FAILING_OPEN)
         return true
       } else {
-        logger.error({ err }, ErrorMessage.FAILURE_TO_GET_DEK)
+        logger.error(ErrorMessage.FAILING_CLOSED)
         return false
       }
     }

--- a/packages/phone-number-privacy/common/test/utils/authentication.test.ts
+++ b/packages/phone-number-privacy/common/test/utils/authentication.test.ts
@@ -38,7 +38,7 @@ describe('Authentication test suite', () => {
       expect(result).toBe(false)
     })
 
-    it('Should succeed authentication with error in getDataEncryptionKey', async () => {
+    it('Should succeed authentication with error in getDataEncryptionKey when shouldFailOpen is true', async () => {
       const sampleRequest: Request = {
         get: (name: string) => (name === 'Authorization' ? 'Test' : ''),
         body: {
@@ -48,9 +48,24 @@ describe('Authentication test suite', () => {
       } as Request
       const mockContractKit = {} as ContractKit
 
-      const result = await auth.authenticateUser(sampleRequest, mockContractKit, logger)
+      const result = await auth.authenticateUser(sampleRequest, mockContractKit, logger, true)
 
       expect(result).toBe(true)
+    })
+
+    it('Should fail authentication with error in getDataEncryptionKey when shouldFailOpen is false', async () => {
+      const sampleRequest: Request = {
+        get: (name: string) => (name === 'Authorization' ? 'Test' : ''),
+        body: {
+          account: '0xc1912fee45d61c87cc5ea59dae31190fffff232d',
+          authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
+        },
+      } as Request
+      const mockContractKit = {} as ContractKit
+
+      const result = await auth.authenticateUser(sampleRequest, mockContractKit, logger, false)
+
+      expect(result).toBe(false)
     })
 
     it('Should fail authentication when key is not registered', async () => {

--- a/packages/phone-number-privacy/signer/src/common/metrics.ts
+++ b/packages/phone-number-privacy/signer/src/common/metrics.ts
@@ -63,7 +63,12 @@ export const Counters = {
   requestsFailingOpen: new Counter({
     name: 'requests_failing_open',
     help:
-      'Counter for the number of requests bypassing quota due to blockchain or db connection failures',
+      'Counter for the number of requests bypassing quota or authentication checks due to full-node errors',
+  }),
+  requestsFailingClosed: new Counter({
+    name: 'requests_failing_closed',
+    help:
+      'Counter for the number of requests failing quota or authentication checks due to full-node errors',
   }),
 }
 const buckets = [

--- a/packages/phone-number-privacy/signer/src/config.ts
+++ b/packages/phone-number-privacy/signer/src/config.ts
@@ -44,7 +44,7 @@ export interface SignerConfig {
     }
     phoneNumberPrivacy: {
       enabled: boolean
-      authShouldFailOpen: boolean
+      shouldFailOpen: boolean
     }
   }
   attestations: {
@@ -122,7 +122,7 @@ export const config: SignerConfig = {
     },
     phoneNumberPrivacy: {
       enabled: toBool(env.PHONE_NUMBER_PRIVACY_API_ENABLED, false),
-      authShouldFailOpen: toBool(env.PHONE_NUMBER_PRIVACY_AUTH_SHOULD_FAIL_OPEN, true),
+      shouldFailOpen: toBool(env.FULL_NODE_ERRORS_SHOULD_FAIL_OPEN, true),
     },
   },
   attestations: {

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/io.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/io.ts
@@ -27,7 +27,7 @@ export class PnpQuotaIO extends IO<PnpQuotaRequest> {
 
   constructor(
     readonly enabled: boolean,
-    readonly authShouldFailOpen: boolean,
+    readonly shouldFailOpen: boolean,
     readonly kit: ContractKit
   ) {
     super(enabled)
@@ -57,7 +57,7 @@ export class PnpQuotaIO extends IO<PnpQuotaRequest> {
   }
 
   async authenticate(request: Request<{}, {}, PnpQuotaRequest>, logger: Logger): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger, this.authShouldFailOpen)
+    return authenticateUser(request, this.kit, logger, this.shouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.legacy.ts
@@ -29,7 +29,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
 
   constructor(
     readonly enabled: boolean,
-    readonly authShouldFailOpen: boolean,
+    readonly shouldFailOpen: boolean,
     readonly kit: ContractKit
   ) {
     super(enabled)
@@ -68,7 +68,7 @@ export class LegacyPnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger, this.authShouldFailOpen)
+    return authenticateUser(request, this.kit, logger, this.shouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
@@ -29,7 +29,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
 
   constructor(
     readonly enabled: boolean,
-    readonly authShouldFailOpen: boolean,
+    readonly shouldFailOpen: boolean,
     readonly kit: ContractKit
   ) {
     super(enabled)
@@ -68,7 +68,7 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     request: Request<{}, {}, SignMessageRequest>,
     logger: Logger
   ): Promise<boolean> {
-    return authenticateUser(request, this.kit, logger, this.authShouldFailOpen)
+    return authenticateUser(request, this.kit, logger, this.shouldFailOpen)
   }
 
   sendSuccess(

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -94,7 +94,7 @@ export function startSigner(
       pnpQuotaService,
       new PnpQuotaIO(
         config.api.phoneNumberPrivacy.enabled,
-        config.api.phoneNumberPrivacy.authShouldFailOpen, // TODO(2.0.0) (https://github.com/celo-org/celo-monorepo/issues/9862) consider refactoring config to make the code cleaner
+        config.api.phoneNumberPrivacy.shouldFailOpen, // TODO(2.0.0) (https://github.com/celo-org/celo-monorepo/issues/9862) consider refactoring config to make the code cleaner
         kit
       )
     )
@@ -107,7 +107,7 @@ export function startSigner(
       keyProvider,
       new PnpSignIO(
         config.api.phoneNumberPrivacy.enabled,
-        config.api.phoneNumberPrivacy.authShouldFailOpen,
+        config.api.phoneNumberPrivacy.shouldFailOpen,
         kit
       )
     )
@@ -120,7 +120,7 @@ export function startSigner(
       keyProvider,
       new PnpSignIO(
         config.api.phoneNumberPrivacy.enabled,
-        config.api.phoneNumberPrivacy.authShouldFailOpen,
+        config.api.phoneNumberPrivacy.shouldFailOpen,
         kit
       )
     )
@@ -131,7 +131,7 @@ export function startSigner(
       legacyPnpQuotaService,
       new PnpQuotaIO(
         config.api.phoneNumberPrivacy.enabled,
-        config.api.phoneNumberPrivacy.authShouldFailOpen,
+        config.api.phoneNumberPrivacy.shouldFailOpen,
         kit
       )
     )

--- a/packages/phone-number-privacy/signer/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/domain.test.ts
@@ -114,17 +114,18 @@ describe('domain', () => {
   let app: any
   let db: Knex
 
-  const _config = config
+  // create deep copy
+  const _config: typeof config = JSON.parse(JSON.stringify(config))
+  _config.db.type = SupportedDatabase.Sqlite
+  _config.keystore.type = SupportedKeystore.MOCK_SECRET_MANAGER
+  _config.api.domains.enabled = true
 
   beforeAll(async () => {
-    _config.db.type = SupportedDatabase.Sqlite
-    _config.keystore.type = SupportedKeystore.MOCK_SECRET_MANAGER
     keyProvider = await initKeyProvider(_config)
   })
 
   beforeEach(async () => {
     // Create a new in-memory database for each test.
-    _config.api.domains.enabled = true
     db = await initDatabase(_config)
     app = startSigner(_config, db, keyProvider)
   })
@@ -259,8 +260,9 @@ describe('domain', () => {
     })
 
     it('Should respond with 503 on disabled api', async () => {
-      _config.api.domains.enabled = false
-      const appWithApiDisabled = startSigner(_config, db, keyProvider)
+      const configWithApiDisabled: typeof _config = JSON.parse(JSON.stringify(_config))
+      configWithApiDisabled.api.domains.enabled = false
+      const appWithApiDisabled = startSigner(configWithApiDisabled, db, keyProvider)
 
       const req = await disableRequest()
 
@@ -399,8 +401,9 @@ describe('domain', () => {
     })
 
     it('Should respond with 503 on disabled api', async () => {
-      _config.api.domains.enabled = false
-      const appWithApiDisabled = startSigner(_config, db, keyProvider)
+      const configWithApiDisabled: typeof _config = JSON.parse(JSON.stringify(_config))
+      configWithApiDisabled.api.domains.enabled = false
+      const appWithApiDisabled = startSigner(configWithApiDisabled, db, keyProvider)
 
       const req = await quotaRequest()
 
@@ -719,7 +722,7 @@ describe('domain', () => {
     })
 
     it('Should respond with 503 on disabled api', async () => {
-      const configWithApiDisabled = { ...config }
+      const configWithApiDisabled: typeof _config = JSON.parse(JSON.stringify(_config))
       configWithApiDisabled.api.domains.enabled = false
       const appWithApiDisabled = startSigner(configWithApiDisabled, db, keyProvider)
 

--- a/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
@@ -1056,7 +1056,7 @@ describe('legacyPNP', () => {
       })
 
       describe('functionality in case of errors', () => {
-        it('Should return 200 w/ warning on DB performedQueryCount query failure', async () => {
+        it('Should return 500 on DB performedQueryCount query failure', async () => {
           // deplete user's quota
           const remainingQuota = expectedQuota - performedQueryCount
           await db.transaction(async (trx) => {
@@ -1085,27 +1085,17 @@ describe('legacyPNP', () => {
           const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
           const res = await sendRequest(req, authorization, SignerEndpoint.LEGACY_PNP_SIGN)
 
-          expect(res.status).toBe(200)
-          expect(res.body).toMatchObject<SignMessageResponseSuccess>({
-            success: true,
+          expect(res.status).toBe(500)
+          expect(res.body).toMatchObject<SignMessageResponseFailure>({
+            success: false,
             version: res.body.version,
-            signature: expectedSignature,
-            performedQueryCount: 1,
+            performedQueryCount: -1,
             totalQuota: expectedQuota,
             blockNumber: testBlockNumber,
-            warnings: [
-              ErrorMessage.DATABASE_GET_FAILURE,
-              ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT,
-            ],
+            error: ErrorMessage.DATABASE_GET_FAILURE,
           })
 
           spy.mockRestore()
-
-          // check DB state: performedQueryCount was still incremented and request was stored
-          expect(
-            await getPerformedQueryCount(db, ACCOUNT_ADDRESS1, rootLogger(config.serviceName))
-          ).toBe(expectedQuota + 1)
-          expect(await getRequestExists(db, req, rootLogger(config.serviceName))).toBe(true)
         })
 
         it('Should return 200 w/ warning on blockchain totalQuota query failure', async () => {

--- a/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
@@ -1099,6 +1099,7 @@ describe('legacyPNP', () => {
         })
 
         it('Should return 200 w/ warning on blockchain totalQuota query failure when shouldFailOpen is true', async () => {
+          expect(_config.api.phoneNumberPrivacy.shouldFailOpen).toBe(true)
           // deplete user's quota
           const remainingQuota = expectedQuota - performedQueryCount
           await db.transaction(async (trx) => {

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -872,6 +872,7 @@ describe('pnp', () => {
         })
 
         it('Should return 200 w/ warning on blockchain totalQuota query failure when shouldFailOpen is true', async () => {
+          expect(_config.api.phoneNumberPrivacy.shouldFailOpen).toBe(true)
           // deplete user's quota
           const remainingQuota = expectedQuota - performedQueryCount
           await db.transaction(async (trx) => {


### PR DESCRIPTION
### Description

makes fail open logic related to full-node errors configurable by env var (or firebase function config in the case of the combiner)

removes fail open logic for performedQueryCount db query failures

### Other changes

Replaces { ...obj } copying method used to safely copy the config in the tests to a deep copy. (i.e const obj = JSON.parse(JSON.stringify(obj)) as typeof obj) 

### Tested

Updates tests 

### Related issues

- Fixes #9863 

### Backwards compatibility

yes

### Documentation

NA