### PR TITLE
Blockscout web readonly

### DIFF
--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -7,6 +7,9 @@ chart: blockscout
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
 {{- end -}}
+{{- define "celo.blockscout.elixir.labels" -}}
+erlang-cluster: {{ .Release.Name }}
+{{- end -}}
 
 {{- /*
 Defines common annotations across all blockscout components.

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Release.Name }}-api
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
-    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
     component: blockscout-api
   annotations:
     {{- include "celo.blockscout.annotations" . | nindent 4 }}
@@ -32,6 +31,7 @@ spec:
         app: blockscout
         release: {{ .Release.Name }}
         component: blockscout-api
+        {{- include "celo.blockscout.elixir.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-rbac
       initContainers:

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-api
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
+    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
     component: blockscout-api
   annotations:
     {{- include "celo.blockscout.annotations" . | nindent 4 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-epmd.service.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-epmd.service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-epmd-service
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
+    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
 spec:
   selector:
     app: blockscout

--- a/packages/helm-charts/blockscout/templates/blockscout-epmd.service.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-epmd.service.yaml
@@ -4,11 +4,11 @@ metadata:
   name: {{ .Release.Name }}-epmd-service
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
-    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
 spec:
   selector:
     app: blockscout
     release: {{ .Release.Name }}
+    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
   spec:
   clusterIP: None
   ports:

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Release.Name }}-indexer
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
-    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
     component: blockscout-indexer
   annotations:
     {{- include "celo.blockscout.annotations" . | nindent 4 }}
@@ -32,6 +31,7 @@ spec:
         app: blockscout
         release: {{ .Release.Name }}
         component: blockscout-indexer
+        {{- include "celo.blockscout.elixir.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-rbac
       terminationGracePeriodSeconds: {{ .Values.blockscout.indexer.terminationGracePeriodSeconds }}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-indexer
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
+    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
     component: blockscout-indexer
   annotations:
     {{- include "celo.blockscout.annotations" . | nindent 4 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -128,6 +128,8 @@ spec:
           value: {{ .Values.blockscout.web.appsMenu.learningList | quote }}
         - name: DISPLAY_REWARDS
           value: "{{.Values.blockscout.epoch_rewards.enabled}}"
+        - name: DISABLE_WRITE_API
+          value: "true"
         - name: RE_CAPTCHA_PROJECT_ID
           valueFrom:
             secretKeyRef:

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Release.Name }}-web
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
-    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
     component: blockscout-web
   annotations:
     {{- include "celo.blockscout.annotations" . | nindent 4 }}
@@ -32,6 +31,7 @@ spec:
         app: blockscout
         release: {{ .Release.Name }}
         component: blockscout-web
+        {{- include "celo.blockscout.elixir.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-rbac
       initContainers:

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -147,7 +147,7 @@ spec:
               name:  {{ .Values.blockscout.web.recaptchaSecretName | quote }}
               key: api_key
 {{ include "celo.blockscout-env-vars" . | indent 8 }}
-{{- $data := dict "Values" .Values "Database" .Values.blockscout.web.db }}
+{{- $data := dict "Values" .Values "DbSuffix" "-replica" "Database" .Values.blockscout.web.db }}
 {{ include "celo.blockscout-db-sidecar" $data | indent 6 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-web
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
+    {{- include "celo.blockscout.elixir.labels" . | nindent 4 }}
     component: blockscout-web
   annotations:
     {{- include "celo.blockscout.annotations" . | nindent 4 }}

--- a/packages/helm-charts/blockscout/values-rc1staging.yaml
+++ b/packages/helm-charts/blockscout/values-rc1staging.yaml
@@ -31,7 +31,7 @@ blockscout:
   web:
     host: rc1staging-blockscout.celo-testnet.org
     autoscaling:
-      maxReplicas: 2
+      maxReplicas: 1
       minReplicas: 1
       target:
         cpu: 70


### PR DESCRIPTION
### Description

Sets blockscout-web pods to disable write api + use replica db

> This will require changing k8s secrets across environments such that the web pod has the correct username and password for the replica db. This hasn't been performed on any environment other than rc1staging

### Other changes

* sets rc1staging web instances to max `1` replica because it's a pita to test with multiple instances
* modifies epmd service to apply only on an explicit `erlang-cluster` label
    *  previously `metadata-crawler` instances were getting picked up, these are node apps and erlang nodes were trying to connnect to them resulting in "unable to connect" errors continuously being logged

### Tested

* Deployed to rc1staging and checked behavior

### Related issues

- Fixes https://github.com/celo-org/data-services/issues/444
