### PR TITLE
Reenable write api + master db access for blockscout web.

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -130,7 +130,7 @@ spec:
         - name: DISPLAY_REWARDS
           value: "{{.Values.blockscout.epoch_rewards.enabled}}"
         - name: DISABLE_WRITE_API
-          value: "true"
+          value: "false"
         - name: RE_CAPTCHA_PROJECT_ID
           valueFrom:
             secretKeyRef:
@@ -147,7 +147,7 @@ spec:
               name:  {{ .Values.blockscout.web.recaptchaSecretName | quote }}
               key: api_key
 {{ include "celo.blockscout-env-vars" . | indent 8 }}
-{{- $data := dict "Values" .Values "DbSuffix" "-replica" "Database" .Values.blockscout.web.db }}
+{{- $data := dict "Values" .Values "Database" .Values.blockscout.web.db }}
 {{ include "celo.blockscout-db-sidecar" $data | indent 6 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
### Description

A few more operations requiring write access have been added to the web pod recently and we can't currently handle directing them all to replica operations. This PR reverts some changes and sets the web pod back to using the master db. :(

### Notes

* relevant error logs - https://cloudlogging.app.goo.gl/kX9u3BFkiPCyTXZr9