### PR TITLE
removed reference to secrets.GITHUB_TOKEN since that doesn't exist in…

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
     - uses: actions/stale@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale and will be closed in 30 days without activity'
         stale-pr-message: 'This PR is stale and will be closed in 30 days without activity'
         stale-issue-label: 'stale'


### PR DESCRIPTION
… the repository anyways

Removing reference to secret in stale.yaml workflow, because the secret doesn't exist in this repository anyways


### Tested

going to test the workflow with a pull request


### Backwards compatibility

should be backwards compatible, because this secret doesn't even exist in the action secrets
