### PR TITLE
PoC: Move Generated Typescript Web3 Core Contracts to their own package

### DIFF
--- a/packages/typescript-contracts/package.json
+++ b/packages/typescript-contracts/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@celo/web3-contracts",
+  "version": "0.1.0",
+  "description": "Generated Typescript for Celo Core Contracts",
+  "author": "cLabs",
+  "license": "Apache-2.0",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "scripts": {
+    "build:web3": "BUILD_DIR=./build/$RELEASE_TAG yarn --cwd ../protocol ts-node ./scripts/build.ts --web3Types ../typescript-contracts/src",
+    "build:ts": "tsc -b .",
+    "build": "yarn build:web3 && yarn build:ts",
+    "clean": "tsc -b . --clean"
+  },
+  "devDependencies": {
+    "ts-node": "8.3.0"
+  },
+  "files": [
+    "lib/*.js",
+    "lib/*.d.ts"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/celo-org/celo-monorepo.git"
+  },
+  "keywords": [
+    "celo",
+    "contracts"
+  ],
+  "bugs": {
+    "url": "https://github.com/celo-org/celo-monorepo/issues"
+  },
+  "homepage": "https://github.com/celo-org/celo-monorepo#readme"
+}

--- a/packages/typescript-contracts/tsconfig.json
+++ b/packages/typescript-contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@celo/typescript/tsconfig.library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "downlevelIteration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/", "src/**/*.json"],
+  "exclude": ["**/*.test.ts"]
+}


### PR DESCRIPTION
### Description

Currently the typescript files for the core contracts are generated in the contractkit package using a script in the protocol package (as well as using .sol files). This creates a bind between protocol package and  the contractkit package. 

In order to to achieve separation I propose creating a third package which would consist solely of the generated js and type files for the contracts.  
* @celo/contractkit could use as an external dependency. 
* contract owners can release versions and keep package version that makes sense to them 
* Owner would be the primatives team  (or whoever owns contracts)

### Other changes

n/a

### Tested

not yet, testing would just be confirming it fits our needs

### Related issues

- Fixes monorepo breakup 

### compatibility

we could add re exports to contract kit to make this not breaking if we want

### Documentation
