### PR TITLE
Added support for network suffixes

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -106,6 +106,14 @@ spec:
           value: {{ .Values.blockscout.web.sourcify.repoUrl | quote }}
         - name: CHAIN_ID
           value: {{ .Values.blockscout.chain.networkID | quote }}
+        {{- if .Values.blockscout.api.suffix.enabled }}
+        - name: NETWORK_PATH
+          value: /{{ .Values.blockscout.api.suffix.path }}
+        - name: API_PATH
+          value: /{{ .Values.blockscout.api.suffix.path }}
+        - name: API_URL
+          value: /{{ .Values.blockscout.api.suffix.path }}
+        {{- end }}
 {{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.api.db }}
 {{ include "celo.blockscout.env-vars" $data | indent 8 }}
 {{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -142,6 +142,14 @@ spec:
           value: {{ .Values.blockscout.secrets.recaptcha.apiKey }}
         - name: SEGMENT_KEY
           value: {{ .Values.blockscout.secrets.segmentKey }}
+        {{- if .Values.blockscout.web.suffix.enabled }}
+        - name: NETWORK_PATH
+          value: /{{ .Values.blockscout.web.suffix.path }}
+        - name: API_PATH
+          value: /{{ .Values.blockscout.web.suffix.path }}
+        - name: API_URL
+          value: /{{ .Values.blockscout.web.suffix.path }}
+        {{- end }}
 {{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.web.db }}
 {{ include "celo.blockscout.env-vars" $data | indent 8 }}
 {{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.ingress.yaml
@@ -9,7 +9,15 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    {{- if .Values.blockscout.web.suffix.enabled }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{- if .Values.blockscout.web.suffix.enabled }}
+      location ~ ^/(?!({{ .Values.blockscout.web.suffix.path }})) {
+        return 307 /{{ .Values.blockscout.web.suffix.path }}$request_uri;
+      }
+      {{- end }}
       location ~ /admin/.* {
         deny all;
       }
@@ -32,21 +40,36 @@ spec:
   - host: {{ .Release.Name }}.{{ .Values.blockscout.domainName }}
     http:
       paths:
-      - path: /api/v1/(decompiled_smart_contract|verified_smart_contracts)
+      -
+        {{- if .Values.blockscout.web.suffix.enabled }}
+        path: /({{ .Values.blockscout.web.suffix.path }})/(api/v1/(decompiled_smart_contract|verified_smart_contracts))
+        {{ else }}
+        path: /api/v1/(decompiled_smart_contract|verified_smart_contracts)
+        {{- end }}
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}-web
             port: 
               number: 4000
-      - path: /(graphql|graphiql|api)
+      -
+        {{- if .Values.blockscout.web.suffix.enabled }}
+        path: /({{ .Values.blockscout.web.suffix.path }})/((graphql|graphiql|api).*)
+        {{ else }}
+        path: /(graphql|graphiql|api)
+        {{- end }}
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}-api
             port: 
               number: 4000
-      - path: /
+      -
+        {{- if .Values.blockscout.web.suffix.enabled }}
+        path: /{{ .Values.blockscout.web.suffix.path }}(/|$)(.*)
+        {{ else }}
+        path: /
+        {{- end }}
         pathType: Prefix
         backend:
           service:

--- a/packages/helm-charts/blockscout/values-rc1-blockscout1.yaml
+++ b/packages/helm-charts/blockscout/values-rc1-blockscout1.yaml
@@ -13,6 +13,9 @@ blockscout:
         memory: 12Gi
         cpu: 5
   api:
+    suffix:
+      enabled: true
+      path: "mainnet"
     autoscaling:
         maxReplicas: 5
         minReplicas: 2
@@ -32,6 +35,9 @@ blockscout:
         cpu: 1500m
   web:
     host: explorer.celo.org
+    suffix:
+      enabled: true
+      path: "mainnet"
     autoscaling:
       maxReplicas: 5
       minReplicas: 2

--- a/packages/helm-charts/blockscout/values-rc1-blockscout3.yaml
+++ b/packages/helm-charts/blockscout/values-rc1-blockscout3.yaml
@@ -13,6 +13,9 @@ blockscout:
         memory: 12Gi
         cpu: 5
   api:
+    suffix:
+      enabled: true
+      path: "mainnet"
     autoscaling:
         maxReplicas: 5
         minReplicas: 2
@@ -32,6 +35,9 @@ blockscout:
         cpu: 1500m
   web:
     host: explorer.celo.org
+    suffix:
+      enabled: true
+      path: "mainnet"
     autoscaling:
       maxReplicas: 5
       minReplicas: 2

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -56,6 +56,9 @@ blockscout:
         memory: 1000Mi
         cpu: 2
   api:
+    suffix:
+      enabled: false
+      path: ""
     port: 4000
     strategy:
       rollingUpdate:
@@ -116,6 +119,10 @@ blockscout:
         memory: 500Mi
         cpu: 500m
   web:
+    host: ""
+    suffix:
+      enabled: false
+      path: ""
     port: 4000
     strategy:
       rollingUpdate:


### PR DESCRIPTION
### Description

Blockscout helm charts update to support network suffixes for the migration to a single domain.
Rolled out to mainnet to support https://explorer.celo.org -> https://explorer.celo.org/mainnet migration.

Related to https://github.com/celo-org/data-services/issues/440

### Other changes

No.

### Tested

Tested on staging, rolled out to production.

### Backwards compatibility

Can be disabled by changing the `enabled` parameter to `false` for the given environment.