### PR TITLE
CeloCli Approval fix

### DIFF
--- a/packages/cli/src/commands/governance/approve.ts
+++ b/packages/cli/src/commands/governance/approve.ts
@@ -62,9 +62,11 @@ export default class Approve extends BaseCommand {
         await governance.dequeueProposalsIfReady().sendAndWaitForReceipt()
       }
 
+      const governanceVersion = await governance.version()
+
       await checkBuilder
         .proposalExists(id)
-        .proposalInStage(id, 'Referendum')
+        .proposalInStage(id, governanceVersion.major < 3 ? 'Approval' : 'Referendum')
         .addCheck(`${id} not already approved`, async () => !(await governance.isApproved(id)))
         .runChecks()
       governanceTx = await governance.approve(id)

--- a/packages/cli/src/commands/governance/approve.ts
+++ b/packages/cli/src/commands/governance/approve.ts
@@ -68,7 +68,7 @@ export default class Approve extends BaseCommand {
         .proposalExists(id)
         .proposalInStage(
           id,
-          governanceVersion.storage == 1 && governanceVersion.major < 3 ? 'Approval' : 'Referendum'
+          governanceVersion.storage === 1 && governanceVersion.major < 3 ? 'Approval' : 'Referendum'
         )
         .addCheck(`${id} not already approved`, async () => !(await governance.isApproved(id)))
         .runChecks()

--- a/packages/cli/src/commands/governance/approve.ts
+++ b/packages/cli/src/commands/governance/approve.ts
@@ -66,7 +66,10 @@ export default class Approve extends BaseCommand {
 
       await checkBuilder
         .proposalExists(id)
-        .proposalInStage(id, governanceVersion.major < 3 ? 'Approval' : 'Referendum')
+        .proposalInStage(
+          id,
+          governanceVersion.storage == 1 && governanceVersion.major < 3 ? 'Approval' : 'Referendum'
+        )
         .addCheck(`${id} not already approved`, async () => !(await governance.isApproved(id)))
         .runChecks()
       governanceTx = await governance.approve(id)


### PR DESCRIPTION
### Description

Current Celo cli cannot approve until 1.3.0.0 Governance.sol is deployed. Approve fails since it expects proposal in Referendum stage.

### Other changes

No other changes

### Tested

Tested manually

### Related issues

- Fixes #9924

### Backwards compatibility

This is fixing incompatible change

### Documentation

No documentation changes