### PR TITLE
Tests forced to run locally

### DIFF
--- a/packages/cli/src/commands/account/authorize.test.ts
+++ b/packages/cli/src/commands/account/authorize.test.ts
@@ -1,6 +1,7 @@
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Lock from '../lockedgold/lock'
 import ValidatorRegister from '../validator/register'
 import Authorize from './authorize'
@@ -11,8 +12,8 @@ process.env.NO_SYNCCHECK = 'true'
 testWithGanache('account:authorize cmd', (web3: Web3) => {
   test('can authorize vote signer', async () => {
     const accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
-    await Authorize.run([
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Authorize, [
       '--from',
       accounts[0],
       '--role',
@@ -26,8 +27,8 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
 
   test('can authorize attestation signer', async () => {
     const accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
-    await Authorize.run([
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Authorize, [
       '--from',
       accounts[0],
       '--role',
@@ -41,8 +42,8 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
 
   test('can authorize validator signer before validator is registered', async () => {
     const accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
-    await Authorize.run([
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Authorize, [
       '--from',
       accounts[0],
       '--role',
@@ -59,9 +60,9 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
     const newBlsPublicKey = web3.utils.randomHex(96)
     const newBlsPoP = web3.utils.randomHex(48)
     const ecdsaPublicKey = await addressToPublicKey(accounts[0], web3.eth.sign)
-    await Register.run(['--from', accounts[0]])
-    await Lock.run(['--from', accounts[0], '--value', '10000000000000000000000'])
-    await ValidatorRegister.run([
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Lock, ['--from', accounts[0], '--value', '10000000000000000000000'])
+    await testLocally(ValidatorRegister, [
       '--from',
       accounts[0],
       '--ecdsaKey',
@@ -72,7 +73,7 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
       '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
       '--yes',
     ])
-    await Authorize.run([
+    await testLocally(Authorize, [
       '--from',
       accounts[0],
       '--role',
@@ -91,9 +92,9 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
   test('cannot authorize validator signer without BLS after validator is registered', async () => {
     const accounts = await web3.eth.getAccounts()
     const ecdsaPublicKey = await addressToPublicKey(accounts[0], web3.eth.sign)
-    await Register.run(['--from', accounts[0]])
-    await Lock.run(['--from', accounts[0], '--value', '10000000000000000000000'])
-    await ValidatorRegister.run([
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Lock, ['--from', accounts[0], '--value', '10000000000000000000000'])
+    await testLocally(ValidatorRegister, [
       '--from',
       accounts[0],
       '--ecdsaKey',
@@ -105,7 +106,7 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
       '--yes',
     ])
     await expect(
-      Authorize.run([
+      testLocally(Authorize, [
         '--from',
         accounts[0],
         '--role',
@@ -121,9 +122,9 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
   test('can force authorize validator signer without BLS after validator is registered', async () => {
     const accounts = await web3.eth.getAccounts()
     const ecdsaPublicKey = await addressToPublicKey(accounts[0], web3.eth.sign)
-    await Register.run(['--from', accounts[0]])
-    await Lock.run(['--from', accounts[0], '--value', '10000000000000000000000'])
-    await ValidatorRegister.run([
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Lock, ['--from', accounts[0], '--value', '10000000000000000000000'])
+    await testLocally(ValidatorRegister, [
       '--from',
       accounts[0],
       '--ecdsaKey',
@@ -134,7 +135,7 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
       '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
       '--yes',
     ])
-    await Authorize.run([
+    await testLocally(Authorize, [
       '--from',
       accounts[0],
       '--role',
@@ -150,7 +151,7 @@ testWithGanache('account:authorize cmd', (web3: Web3) => {
   test('fails if from is not an account', async () => {
     const accounts = await web3.eth.getAccounts()
     await expect(
-      Authorize.run([
+      testLocally(Authorize, [
         '--from',
         accounts[0],
         '--role',

--- a/packages/cli/src/commands/account/claims.test.ts
+++ b/packages/cli/src/commands/account/claims.test.ts
@@ -4,6 +4,7 @@ import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { readFileSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import ClaimAccount from './claim-account'
 import ClaimDomain from './claim-domain'
 import ClaimName from './claim-name'
@@ -34,7 +35,7 @@ testWithGanache('account metadata cmds', (web3: Web3) => {
 
     test('account:create-metadata cmd', async () => {
       const newFilePath = `${tmpdir()}/newfile.json`
-      await CreateMetadata.run(['--from', account, newFilePath])
+      await testLocally(CreateMetadata, ['--from', account, newFilePath])
       const res = JSON.parse(readFileSync(newFilePath).toString())
       expect(res.meta.address).toEqual(account)
     })
@@ -42,7 +43,7 @@ testWithGanache('account metadata cmds', (web3: Web3) => {
     test('account:claim-name cmd', async () => {
       generateEmptyMetadataFile()
       const name = 'myname'
-      await ClaimName.run(['--from', account, '--name', name, emptyFilePath])
+      await testLocally(ClaimName, ['--from', account, '--name', name, emptyFilePath])
       const metadata = await readFile()
       const claim = metadata.findClaim(ClaimTypes.NAME)
       expect(claim).toBeDefined()
@@ -52,7 +53,7 @@ testWithGanache('account metadata cmds', (web3: Web3) => {
     test('account:claim-domain cmd', async () => {
       generateEmptyMetadataFile()
       const domain = 'test.com'
-      await ClaimDomain.run(['--from', account, '--domain', domain, emptyFilePath])
+      await testLocally(ClaimDomain, ['--from', account, '--domain', domain, emptyFilePath])
       const metadata = await readFile()
       const claim = metadata.findClaim(ClaimTypes.DOMAIN)
       expect(claim).toBeDefined()
@@ -62,7 +63,7 @@ testWithGanache('account metadata cmds', (web3: Web3) => {
     test('account:claim-account cmd', async () => {
       generateEmptyMetadataFile()
       const otherAccount = accounts[1]
-      await ClaimAccount.run(['--from', account, '--address', otherAccount, emptyFilePath])
+      await testLocally(ClaimAccount, ['--from', account, '--address', otherAccount, emptyFilePath])
       const metadata = await readFile()
       const claim = metadata.findClaim(ClaimTypes.ACCOUNT)
       expect(claim).toBeDefined()
@@ -78,11 +79,17 @@ testWithGanache('account metadata cmds', (web3: Web3) => {
       })
 
       test('can register metadata', async () => {
-        await RegisterMetadata.run(['--force', '--from', account, '--url', 'https://test.com'])
+        await testLocally(RegisterMetadata, [
+          '--force',
+          '--from',
+          account,
+          '--url',
+          'https://test.com',
+        ])
       })
 
       test('fails if url is missing', async () => {
-        await expect(RegisterMetadata.run(['--force', '--from', account])).rejects.toThrow(
+        await expect(testLocally(RegisterMetadata, ['--force', '--from', account])).rejects.toThrow(
           'Missing required flag'
         )
       })
@@ -90,7 +97,7 @@ testWithGanache('account metadata cmds', (web3: Web3) => {
 
     it('cannot register metadata', async () => {
       await expect(
-        RegisterMetadata.run(['--force', '--from', account, '--url', 'https://test.com'])
+        testLocally(RegisterMetadata, ['--force', '--from', account, '--url', 'https://test.com'])
       ).rejects.toThrow("Some checks didn't pass!")
     })
   })

--- a/packages/cli/src/commands/account/deauthorize.test.ts
+++ b/packages/cli/src/commands/account/deauthorize.test.ts
@@ -1,5 +1,6 @@
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Authorize from './authorize'
 import Deauthorize from './deauthorize'
 import Register from './register'
@@ -9,8 +10,8 @@ process.env.NO_SYNCCHECK = 'true'
 testWithGanache('account:deauthorize cmd', (web3: Web3) => {
   test('can deauthorize attestation signer', async () => {
     const accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
-    await Authorize.run([
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Authorize, [
       '--from',
       accounts[0],
       '--role',
@@ -20,15 +21,29 @@ testWithGanache('account:deauthorize cmd', (web3: Web3) => {
       '--signature',
       '0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb',
     ])
-    await Deauthorize.run(['--from', accounts[0], '--role', 'attestation', '--signer', accounts[1]])
+    await testLocally(Deauthorize, [
+      '--from',
+      accounts[0],
+      '--role',
+      'attestation',
+      '--signer',
+      accounts[1],
+    ])
   })
 
   test('cannot deauthorize a non-authorized signer', async () => {
     const accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
+    await testLocally(Register, ['--from', accounts[0]])
 
     await expect(
-      Deauthorize.run(['--from', accounts[0], '--role', 'attestation', '--signer', accounts[1]])
+      testLocally(Deauthorize, [
+        '--from',
+        accounts[0],
+        '--role',
+        'attestation',
+        '--signer',
+        accounts[1],
+      ])
     ).rejects.toThrow()
   })
 })

--- a/packages/cli/src/commands/account/register.test.ts
+++ b/packages/cli/src/commands/account/register.test.ts
@@ -1,5 +1,6 @@
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Register from './register'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -8,12 +9,12 @@ testWithGanache('account:register cmd', (web3: Web3) => {
   test('can register account', async () => {
     const accounts = await web3.eth.getAccounts()
 
-    await Register.run(['--from', accounts[0], '--name', 'Chapulin Colorado'])
+    await testLocally(Register, ['--from', accounts[0], '--name', 'Chapulin Colorado'])
   })
 
   test('fails if from is missing', async () => {
     // const accounts = await web3.eth.getAccounts()
 
-    await expect(Register.run([])).rejects.toThrow('Missing required flag')
+    await expect(testLocally(Register, [])).rejects.toThrow('Missing required flag')
   })
 })

--- a/packages/cli/src/commands/account/set-name.test.ts
+++ b/packages/cli/src/commands/account/set-name.test.ts
@@ -1,5 +1,6 @@
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import SetName from './set-name'
 
@@ -8,25 +9,29 @@ process.env.NO_SYNCCHECK = 'true'
 testWithGanache('account:set-name cmd', (web3: Web3) => {
   test('can set the name of an account', async () => {
     const accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
-    await SetName.run(['--account', accounts[0], '--name', 'TestName'])
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(SetName, ['--account', accounts[0], '--name', 'TestName'])
   })
 
   test('fails if account is not registered', async () => {
     const accounts = await web3.eth.getAccounts()
 
-    await expect(SetName.run(['--account', accounts[0], '--name', 'TestName'])).rejects.toThrow(
-      "Some checks didn't pass!"
-    )
+    await expect(
+      testLocally(SetName, ['--account', accounts[0], '--name', 'TestName'])
+    ).rejects.toThrow("Some checks didn't pass!")
   })
 
   test('fails if account is not provided', async () => {
-    await expect(SetName.run(['--name', 'TestName'])).rejects.toThrow('Missing required flag')
+    await expect(testLocally(SetName, ['--name', 'TestName'])).rejects.toThrow(
+      'Missing required flag'
+    )
   })
 
   test('fails if name is not provided', async () => {
     const accounts = await web3.eth.getAccounts()
 
-    await expect(SetName.run(['--account', accounts[0]])).rejects.toThrow('Missing required flag')
+    await expect(testLocally(SetName, ['--account', accounts[0]])).rejects.toThrow(
+      'Missing required flag'
+    )
   })
 })

--- a/packages/cli/src/commands/governance/approve.test.ts
+++ b/packages/cli/src/commands/governance/approve.test.ts
@@ -3,6 +3,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
 import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Approve from './approve'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -27,12 +28,12 @@ testWithGanache('governance:approve cmd', (web3: Web3) => {
     await timeTravel(expConfig.dequeueFrequency, web3)
   })
   test('approve fails if approver not passed in', async () => {
-    await expect(Approve.run(['--from', accounts[0], '--proposalID', proposalID])).rejects.toThrow(
-      "Some checks didn't pass!"
-    )
+    await expect(
+      testLocally(Approve, ['--from', accounts[0], '--proposalID', proposalID])
+    ).rejects.toThrow("Some checks didn't pass!")
   })
   test('can approve with multisig option', async () => {
-    await Approve.run(['--from', accounts[0], '--proposalID', proposalID, '--useMultiSig'])
+    await testLocally(Approve, ['--from', accounts[0], '--proposalID', proposalID, '--useMultiSig'])
     expect(await governance.isApproved(proposalID)).toBeTruthy()
   })
 })

--- a/packages/cli/src/commands/governance/vote.test.ts
+++ b/packages/cli/src/commands/governance/vote.test.ts
@@ -4,6 +4,7 @@ import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
 import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedgold/lock'
 import Approve from './approve'
@@ -30,21 +31,21 @@ testWithGanache('governance:vote cmd', (web3: Web3) => {
       .propose([], 'URL')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
     await timeTravel(expConfig.dequeueFrequency, web3)
-    await Dequeue.run(['--from', accounts[0]])
-    await Approve.run([
+    await testLocally(Dequeue, ['--from', accounts[0]])
+    await testLocally(Approve, [
       '--from',
       accounts[0],
       '--proposalID',
       proposalID.toString(10),
       '--useMultiSig',
     ])
-    await Register.run(['--from', accounts[0]])
-    await Lock.run(['--from', accounts[0], '--value', '100'])
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(Lock, ['--from', accounts[0], '--value', '100'])
     await timeTravel(expConfig.approvalStageDuration, web3)
   })
 
   test('can vote yes', async () => {
-    await Vote.run([
+    await testLocally(Vote, [
       '--from',
       accounts[0],
       '--proposalID',

--- a/packages/cli/src/commands/governance/withdraw.test.ts
+++ b/packages/cli/src/commands/governance/withdraw.test.ts
@@ -5,6 +5,7 @@ import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/
 import { ProposalBuilder } from '@celo/governance'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Withdraw from './withdraw'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -38,7 +39,7 @@ testWithGanache('governance:withdraw', (web3: Web3) => {
     console.log(await governance.getProposalStage(1))
     const balanceBefore = await kit.connection.getBalance(accounts[0])
     console.log(accounts[0], await governance.getRefundedDeposits(accounts[0]))
-    console.log(await Withdraw.run(['--from', accounts[0]]))
+    console.log(await testLocally(Withdraw, ['--from', accounts[0]]))
     const balanceAfter = await kit.connection.getBalance(accounts[0])
     const difference = new BigNumber(balanceAfter).minus(balanceBefore)
     expect(difference.toFixed()).toEqual(minDeposit)

--- a/packages/cli/src/commands/grandamento/cancel.test.ts
+++ b/packages/cli/src/commands/grandamento/cancel.test.ts
@@ -5,6 +5,7 @@ import { GrandaMentoWrapper } from '@celo/contractkit/lib/wrappers/GrandaMento'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Cancel from './cancel'
 import Propose from './propose'
 
@@ -31,7 +32,7 @@ testWithGanache('grandamento:cancel cmd', (web3: Web3) => {
     await assumeOwnership(web3, accounts[0])
     await increaseLimits()
     // create mock proposal
-    await Propose.run([
+    await testLocally(Propose, [
       '--from',
       accounts[0],
       '--sellCelo',
@@ -45,7 +46,7 @@ testWithGanache('grandamento:cancel cmd', (web3: Web3) => {
 
   describe('cancel', () => {
     it('left no proposal', async () => {
-      await Cancel.run(['--from', accounts[0], '--proposalID', '1'])
+      await testLocally(Cancel, ['--from', accounts[0], '--proposalID', '1'])
       const activeProposals = await grandaMento.getActiveProposalIds()
       expect(activeProposals).toEqual([])
     })

--- a/packages/cli/src/commands/grandamento/execute.test.ts
+++ b/packages/cli/src/commands/grandamento/execute.test.ts
@@ -5,6 +5,7 @@ import { GrandaMentoWrapper } from '@celo/contractkit/lib/wrappers/GrandaMento'
 import { testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Execute from './execute'
 import Propose from './propose'
 
@@ -25,7 +26,7 @@ testWithGanache('grandamento:execute cmd', (web3: Web3) => {
 
   const createExchangeProposal = () => {
     // create mock proposal
-    return Propose.run([
+    return testLocally(Propose, [
       '--from',
       accounts[0],
       '--sellCelo',
@@ -73,7 +74,7 @@ testWithGanache('grandamento:execute cmd', (web3: Web3) => {
 
   describe('execute', () => {
     it('executes the proposal', async () => {
-      await Execute.run(['--from', accounts[0], '--proposalID', '1'])
+      await testLocally(Execute, ['--from', accounts[0], '--proposalID', '1'])
       const activeProposals = await grandaMento.getActiveProposalIds()
       expect(activeProposals).toEqual([])
     })
@@ -82,7 +83,9 @@ testWithGanache('grandamento:execute cmd', (web3: Web3) => {
       // Create a proposal with proposalID 2, but don't wait the veto period
       await createExchangeProposal()
       await approveExchangeProposal(2)
-      await expect(Execute.run(['--from', accounts[0], '--proposalID', '2'])).rejects.toThrow()
+      await expect(
+        testLocally(Execute, ['--from', accounts[0], '--proposalID', '2'])
+      ).rejects.toThrow()
     })
   })
 })

--- a/packages/cli/src/commands/grandamento/get-buy-amount.test.ts
+++ b/packages/cli/src/commands/grandamento/get-buy-amount.test.ts
@@ -3,6 +3,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { assumeOwnership } from '@celo/contractkit/lib/test-utils/transferownership'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import GetBuyAmount from './get-buy-amount'
 
 testWithGanache('grandamento:get-buy-amount cmd', (web3: Web3) => {
@@ -19,7 +20,7 @@ testWithGanache('grandamento:get-buy-amount cmd', (web3: Web3) => {
   })
 
   it('gets the buy amount', async () => {
-    await GetBuyAmount.run([
+    await testLocally(GetBuyAmount, [
       '--sellCelo',
       'true',
       '--stableToken',

--- a/packages/cli/src/commands/grandamento/list.test.ts
+++ b/packages/cli/src/commands/grandamento/list.test.ts
@@ -7,6 +7,7 @@ import { GrandaMentoWrapper } from '@celo/contractkit/lib/wrappers/GrandaMento'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import { setGrandaMentoLimits } from '../../test-utils/grandaMento'
 import List from './list'
 
@@ -30,7 +31,7 @@ testWithGanache('grandamento:list cmd', (web3: Web3) => {
   })
 
   it('shows an empty list of proposals', async () => {
-    await List.run([])
+    await testLocally(List, [])
   })
 
   it('shows proposals', async () => {
@@ -45,6 +46,6 @@ testWithGanache('grandamento:list cmd', (web3: Web3) => {
       )
     ).sendAndWaitForReceipt()
 
-    await List.run([])
+    await testLocally(List, [])
   })
 })

--- a/packages/cli/src/commands/grandamento/propose.test.ts
+++ b/packages/cli/src/commands/grandamento/propose.test.ts
@@ -8,6 +8,7 @@ import {
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import { setGrandaMentoLimits } from '../../test-utils/grandaMento'
 import Propose from './propose'
 
@@ -29,7 +30,7 @@ testWithGanache('grandamento:propose cmd', (web3: Web3) => {
 
   describe('proposes', () => {
     it('can sell Celo', async () => {
-      await Propose.run([
+      await testLocally(Propose, [
         '--from',
         accounts[0],
         '--sellCelo',
@@ -54,7 +55,7 @@ testWithGanache('grandamento:propose cmd', (web3: Web3) => {
     })
 
     it('can buy Celo', async () => {
-      await Propose.run([
+      await testLocally(Propose, [
         '--from',
         accounts[0],
         '--sellCelo',
@@ -81,7 +82,7 @@ testWithGanache('grandamento:propose cmd', (web3: Web3) => {
       let activeProposals
 
       await expect(
-        Propose.run([
+        testLocally(Propose, [
           '--from',
           accounts[0],
           '--sellCelo',
@@ -96,7 +97,7 @@ testWithGanache('grandamento:propose cmd', (web3: Web3) => {
       expect(activeProposals).toEqual([])
 
       await expect(
-        Propose.run([
+        testLocally(Propose, [
           '--from',
           accounts[0],
           '--sellCelo',

--- a/packages/cli/src/commands/grandamento/show.test.ts
+++ b/packages/cli/src/commands/grandamento/show.test.ts
@@ -7,6 +7,7 @@ import { GrandaMentoWrapper } from '@celo/contractkit/lib/wrappers/GrandaMento'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import { setGrandaMentoLimits } from '../../test-utils/grandaMento'
 import Show from './show'
 
@@ -42,6 +43,6 @@ testWithGanache('grandamento:show cmd', (web3: Web3) => {
       )
     ).sendAndWaitForReceipt()
 
-    await Show.run(['--proposalID', '1'])
+    await testLocally(Show, ['--proposalID', '1'])
   })
 })

--- a/packages/cli/src/commands/identity/get-attestations.test.ts
+++ b/packages/cli/src/commands/identity/get-attestations.test.ts
@@ -1,3 +1,4 @@
+import { testLocally } from '../../test-utils/cliUtils'
 import GetAttestations from './get-attestations'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -9,20 +10,25 @@ describe('identity:get-attetstations', () => {
     beforeEach(() => (console.error = mockedError))
 
     it('Fails when neither from, pepper, nor identifier are specified', async () => {
-      await expect(GetAttestations.run(['--phoneNumber', '+15555555555'])).rejects.toThrow(
+      await expect(testLocally(GetAttestations, ['--phoneNumber', '+15555555555'])).rejects.toThrow(
         'Must specify either --from or --pepper or --identifier'
       )
     })
 
     it('Fails when neither phone number nor identifier are specified', async () => {
       await expect(
-        GetAttestations.run(['--from', '0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95'])
+        testLocally(GetAttestations, ['--from', '0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95'])
       ).rejects.toThrow('Must specify phoneNumber if identifier not provided')
     })
 
     it('Successfully prints identifier when given pepper and number', async () => {
       console.log = jest.fn()
-      await GetAttestations.run(['--phoneNumber', '+15555555555', '--pepper', 'XQke2bjvN7mPt'])
+      await testLocally(GetAttestations, [
+        '--phoneNumber',
+        '+15555555555',
+        '--pepper',
+        'XQke2bjvN7mPt',
+      ])
       expect(console.log).toHaveBeenCalledWith(
         'Identifier: 0xd9460ae529b2889716c8f1ccebb5efec945adc46fe1e9cd16f6242463e81f37c'
       )

--- a/packages/cli/src/commands/lockedgold/lock.test.ts
+++ b/packages/cli/src/commands/lockedgold/lock.test.ts
@@ -1,6 +1,7 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from './lock'
 import Unlock from './unlock'
@@ -13,12 +14,12 @@ testWithGanache('lockedgold:lock cmd', (web3: Web3) => {
     const account = accounts[0]
     const kit = newKitFromWeb3(web3)
     const lockedGold = await kit.contracts.getLockedGold()
-    await Register.run(['--from', account])
-    await Lock.run(['--from', account, '--value', '100'])
-    await Unlock.run(['--from', account, '--value', '50'])
-    await Lock.run(['--from', account, '--value', '75'])
-    await Unlock.run(['--from', account, '--value', '50'])
-    await Lock.run(['--from', account, '--value', '50'])
+    await testLocally(Register, ['--from', account])
+    await testLocally(Lock, ['--from', account, '--value', '100'])
+    await testLocally(Unlock, ['--from', account, '--value', '50'])
+    await testLocally(Lock, ['--from', account, '--value', '75'])
+    await testLocally(Unlock, ['--from', account, '--value', '50'])
+    await testLocally(Lock, ['--from', account, '--value', '50'])
     const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
     expect(pendingWithdrawalsTotalValue.toFixed()).toBe('0')
   })

--- a/packages/cli/src/commands/lockedgold/unlock.test.ts
+++ b/packages/cli/src/commands/lockedgold/unlock.test.ts
@@ -2,6 +2,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Vote from '../election/vote'
 import ValidatorAffiliate from '../validator/affiliate'
@@ -20,13 +21,13 @@ testWithGanache('lockedgold:unlock cmd', (web3: Web3) => {
     const validator = accounts[1]
     const kit = newKitFromWeb3(web3)
     const lockedGold = await kit.contracts.getLockedGold()
-    await Register.run(['--from', account])
-    await Lock.run(['--from', account, '--value', '20000000000000000000000'])
-    await ValidatorGroupRegister.run(['--from', account, '--commission', '0', '--yes'])
-    await Register.run(['--from', validator])
-    await Lock.run(['--from', validator, '--value', '20000000000000000000000'])
+    await testLocally(Register, ['--from', account])
+    await testLocally(Lock, ['--from', account, '--value', '20000000000000000000000'])
+    await testLocally(ValidatorGroupRegister, ['--from', account, '--commission', '0', '--yes'])
+    await testLocally(Register, ['--from', validator])
+    await testLocally(Lock, ['--from', validator, '--value', '20000000000000000000000'])
     const ecdsaPublicKey = await addressToPublicKey(validator, web3.eth.sign)
-    await ValidatorRegister.run([
+    await testLocally(ValidatorRegister, [
       '--from',
       validator,
       '--ecdsaKey',
@@ -37,10 +38,17 @@ testWithGanache('lockedgold:unlock cmd', (web3: Web3) => {
       '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
       '--yes',
     ])
-    await ValidatorAffiliate.run(['--yes', '--from', validator, account])
-    await ValidatorGroupMember.run(['--yes', '--from', account, '--accept', validator])
-    await Vote.run(['--from', account, '--for', account, '--value', '10000000000000000000000'])
-    await Unlock.run(['--from', account, '--value', '10000000000000000000000'])
+    await testLocally(ValidatorAffiliate, ['--yes', '--from', validator, account])
+    await testLocally(ValidatorGroupMember, ['--yes', '--from', account, '--accept', validator])
+    await testLocally(Vote, [
+      '--from',
+      account,
+      '--for',
+      account,
+      '--value',
+      '10000000000000000000000',
+    ])
+    await testLocally(Unlock, ['--from', account, '--value', '10000000000000000000000'])
     const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
     expect(pendingWithdrawalsTotalValue.toFixed()).toBe('10000000000000000000000')
   })

--- a/packages/cli/src/commands/releasegold/authorize.test.ts
+++ b/packages/cli/src/commands/releasegold/authorize.test.ts
@@ -2,6 +2,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { getContractFromEvent, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey, serializeSignature } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import ValidatorRegister from '../validator/register'
 import Authorize from './authorize'
 import CreateAccount from './create-account'
@@ -19,7 +20,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       web3
     )
     kit = newKitFromWeb3(web3)
-    await CreateAccount.run(['--contract', contractAddress])
+    await testLocally(CreateAccount, ['--contract', contractAddress])
   })
 
   describe('can authorize account signers', () => {
@@ -33,7 +34,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
     })
 
     test('can authorize account vote signer ', async () => {
-      await Authorize.run([
+      await testLocally(Authorize, [
         '--contract',
         contractAddress,
         '--role',
@@ -46,7 +47,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
     })
 
     test('can authorize account validator signer', async () => {
-      await Authorize.run([
+      await testLocally(Authorize, [
         '--contract',
         contractAddress,
         '--role',
@@ -59,7 +60,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
     })
 
     test('can authorize account attestation signer', async () => {
-      await Authorize.run([
+      await testLocally(Authorize, [
         '--contract',
         contractAddress,
         '--role',
@@ -78,7 +79,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
     const signer = accounts[1]
     const pop = await accountsWrapper.generateProofOfKeyPossession(contractAddress, signer)
     const ecdsaPublicKey = await addressToPublicKey(signer, web3.eth.sign)
-    await LockedGold.run([
+    await testLocally(LockedGold, [
       '--contract',
       contractAddress,
       '--action',
@@ -87,7 +88,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '10000000000000000000000',
       '--yes',
     ])
-    await Authorize.run([
+    await testLocally(Authorize, [
       '--contract',
       contractAddress,
       '--role',
@@ -97,7 +98,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '--signature',
       serializeSignature(pop),
     ])
-    await ValidatorRegister.run([
+    await testLocally(ValidatorRegister, [
       '--from',
       signer,
       '--ecdsaKey',
@@ -122,7 +123,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
     const newBlsPublicKey = web3.utils.randomHex(96)
     const newBlsPoP = web3.utils.randomHex(48)
 
-    await LockedGold.run([
+    await testLocally(LockedGold, [
       '--contract',
       contractAddress,
       '--action',
@@ -131,7 +132,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '10000000000000000000000',
       '--yes',
     ])
-    await Authorize.run([
+    await testLocally(Authorize, [
       '--contract',
       contractAddress,
       '--role',
@@ -141,7 +142,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '--signature',
       serializeSignature(pop),
     ])
-    await ValidatorRegister.run([
+    await testLocally(ValidatorRegister, [
       '--from',
       signer,
       '--ecdsaKey',
@@ -152,7 +153,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
       '--yes',
     ])
-    await Authorize.run([
+    await testLocally(Authorize, [
       '--contract',
       contractAddress,
       '--role',
@@ -178,7 +179,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
     const signerNew = accounts[2]
     const popNew = await accountsWrapper.generateProofOfKeyPossession(contractAddress, signerNew)
 
-    await LockedGold.run([
+    await testLocally(LockedGold, [
       '--contract',
       contractAddress,
       '--action',
@@ -187,7 +188,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '10000000000000000000000',
       '--yes',
     ])
-    await Authorize.run([
+    await testLocally(Authorize, [
       '--contract',
       contractAddress,
       '--role',
@@ -197,7 +198,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '--signature',
       serializeSignature(pop),
     ])
-    await ValidatorRegister.run([
+    await testLocally(ValidatorRegister, [
       '--from',
       signer,
       '--ecdsaKey',
@@ -209,7 +210,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
       '--yes',
     ])
     await expect(
-      Authorize.run([
+      testLocally(Authorize, [
         '--contract',
         contractAddress,
         '--role',
@@ -225,7 +226,7 @@ testWithGanache('releasegold:authorize cmd', (web3: Web3) => {
   test('fails if contract is not registered as an account', async () => {
     const accounts = await web3.eth.getAccounts()
     await expect(
-      Authorize.run([
+      testLocally(Authorize, [
         '--contract',
         contractAddress,
         '--role',

--- a/packages/cli/src/commands/releasegold/locked-gold.test.ts
+++ b/packages/cli/src/commands/releasegold/locked-gold.test.ts
@@ -1,6 +1,7 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { getContractFromEvent, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import CreateAccount from './create-account'
 import LockedGold from './locked-gold'
 
@@ -16,15 +17,43 @@ testWithGanache('releasegold:locked-gold cmd', (web3: Web3) => {
       web3
     )
     kit = newKitFromWeb3(web3)
-    await CreateAccount.run(['--contract', contractAddress])
+    await testLocally(CreateAccount, ['--contract', contractAddress])
   })
 
   test('can lock gold with pending withdrawals', async () => {
     const lockedGold = await kit.contracts.getLockedGold()
-    await LockedGold.run(['--contract', contractAddress, '--action', 'lock', '--value', '100'])
-    await LockedGold.run(['--contract', contractAddress, '--action', 'unlock', '--value', '50'])
-    await LockedGold.run(['--contract', contractAddress, '--action', 'lock', '--value', '75'])
-    await LockedGold.run(['--contract', contractAddress, '--action', 'unlock', '--value', '50'])
+    await testLocally(LockedGold, [
+      '--contract',
+      contractAddress,
+      '--action',
+      'lock',
+      '--value',
+      '100',
+    ])
+    await testLocally(LockedGold, [
+      '--contract',
+      contractAddress,
+      '--action',
+      'unlock',
+      '--value',
+      '50',
+    ])
+    await testLocally(LockedGold, [
+      '--contract',
+      contractAddress,
+      '--action',
+      'lock',
+      '--value',
+      '75',
+    ])
+    await testLocally(LockedGold, [
+      '--contract',
+      contractAddress,
+      '--action',
+      'unlock',
+      '--value',
+      '50',
+    ])
     const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(
       contractAddress
     )

--- a/packages/cli/src/commands/releasegold/refund-and-finalize.test.ts
+++ b/packages/cli/src/commands/releasegold/refund-and-finalize.test.ts
@@ -3,6 +3,7 @@ import { newReleaseGold } from '@celo/contractkit/lib/generated/ReleaseGold'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { getContractFromEvent, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import RefundAndFinalize from './refund-and-finalize'
 import Revoke from './revoke'
 import Show from './show'
@@ -23,7 +24,7 @@ testWithGanache('releasegold:refund-and-finalize cmd', (web3: Web3) => {
   })
 
   test('can refund gold', async () => {
-    await Revoke.run(['--contract', contractAddress, '--yesreally'])
+    await testLocally(Revoke, ['--contract', contractAddress, '--yesreally'])
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
       newReleaseGold(web3, contractAddress),
@@ -31,14 +32,14 @@ testWithGanache('releasegold:refund-and-finalize cmd', (web3: Web3) => {
     )
     const refundAddress = await releaseGoldWrapper.getRefundAddress()
     const balanceBefore = await kit.getTotalBalance(refundAddress)
-    await RefundAndFinalize.run(['--contract', contractAddress])
+    await testLocally(RefundAndFinalize, ['--contract', contractAddress])
     const balanceAfter = await kit.getTotalBalance(refundAddress)
     expect(balanceBefore.CELO!.toNumber()).toBeLessThan(balanceAfter.CELO!.toNumber())
   })
 
   test('can finalize the contract', async () => {
-    await Revoke.run(['--contract', contractAddress, '--yesreally'])
-    await RefundAndFinalize.run(['--contract', contractAddress])
-    await expect(Show.run(['--contract', contractAddress])).rejects.toThrow()
+    await testLocally(Revoke, ['--contract', contractAddress, '--yesreally'])
+    await testLocally(RefundAndFinalize, ['--contract', contractAddress])
+    await expect(testLocally(Show, ['--contract', contractAddress])).rejects.toThrow()
   })
 })

--- a/packages/cli/src/commands/releasegold/set-beneficiary.test.ts
+++ b/packages/cli/src/commands/releasegold/set-beneficiary.test.ts
@@ -3,6 +3,7 @@ import { newReleaseGold } from '@celo/contractkit/lib/generated/ReleaseGold'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { getContractFromEvent, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import SetBeneficiary from './set-beneficiary'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -40,7 +41,7 @@ testWithGanache('releasegold:set-beneficiary cmd', (web3: Web3) => {
 
   test('can change beneficiary', async () => {
     // First submit the tx from the release owner (accounts[0])
-    await SetBeneficiary.run([
+    await testLocally(SetBeneficiary, [
       '--contract',
       contractAddress,
       '--from',
@@ -51,7 +52,7 @@ testWithGanache('releasegold:set-beneficiary cmd', (web3: Web3) => {
     ])
     // The multisig tx should not confirm until both parties submit
     expect(await releaseGoldWrapper.getBeneficiary()).toEqual(beneficiary)
-    await SetBeneficiary.run([
+    await testLocally(SetBeneficiary, [
       '--contract',
       contractAddress,
       '--from',
@@ -67,7 +68,7 @@ testWithGanache('releasegold:set-beneficiary cmd', (web3: Web3) => {
 
   test('if called by a different account, it should fail', async () => {
     await expect(
-      SetBeneficiary.run([
+      testLocally(SetBeneficiary, [
         '--contract',
         contractAddress,
         '--from',
@@ -82,7 +83,7 @@ testWithGanache('releasegold:set-beneficiary cmd', (web3: Web3) => {
   test('if the owners submit different txs, nothing on the ReleaseGold contract should change', async () => {
     // ReleaseOwner tries to change the beneficiary to `newBeneficiary` while the beneficiary
     // tries to change to `otherAccount`. Nothing should change on the RG contract.
-    await SetBeneficiary.run([
+    await testLocally(SetBeneficiary, [
       '--contract',
       contractAddress,
       '--from',
@@ -91,7 +92,7 @@ testWithGanache('releasegold:set-beneficiary cmd', (web3: Web3) => {
       newBeneficiary,
       '--yesreally',
     ])
-    await SetBeneficiary.run([
+    await testLocally(SetBeneficiary, [
       '--contract',
       contractAddress,
       '--from',

--- a/packages/cli/src/commands/releasegold/transfer-dollars.test.ts
+++ b/packages/cli/src/commands/releasegold/transfer-dollars.test.ts
@@ -1,6 +1,7 @@
 import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { getContractFromEvent, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import TransferDollars from '../transfer/dollars'
 import CreateAccount from './create-account'
@@ -24,15 +25,15 @@ testWithGanache('releasegold:transfer-dollars cmd', (web3: Web3) => {
     )
     kit = newKitFromWeb3(web3)
     accounts = await web3.eth.getAccounts()
-    await Register.run(['--from', accounts[0]])
-    await CreateAccount.run(['--contract', contractAddress])
+    await testLocally(Register, ['--from', accounts[0]])
+    await testLocally(CreateAccount, ['--contract', contractAddress])
   })
 
   test('can transfer dollars out of the ReleaseGold contract', async () => {
     const balanceBefore = await kit.getTotalBalance(accounts[0])
     const cUSDToTransfer = '500000000000000000000'
     // Send cUSD to RG contract
-    await TransferDollars.run([
+    await testLocally(TransferDollars, [
       '--from',
       accounts[0],
       '--to',
@@ -44,7 +45,7 @@ testWithGanache('releasegold:transfer-dollars cmd', (web3: Web3) => {
     const contractBalance = await kit.getTotalBalance(contractAddress)
     expect(contractBalance.cUSD!.toFixed()).toEqual(cUSDToTransfer)
     // Attempt to send cUSD back
-    await RGTransferDollars.run([
+    await testLocally(RGTransferDollars, [
       '--contract',
       contractAddress,
       '--to',
@@ -58,7 +59,14 @@ testWithGanache('releasegold:transfer-dollars cmd', (web3: Web3) => {
 
   test('should fail if contract has no celo dollars', async () => {
     await expect(
-      RGTransferDollars.run(['--contract', contractAddress, '--to', accounts[0], '--value', '1'])
+      testLocally(RGTransferDollars, [
+        '--contract',
+        contractAddress,
+        '--to',
+        accounts[0],
+        '--value',
+        '1',
+      ])
     ).rejects.toThrow()
   })
 })

--- a/packages/cli/src/commands/reserve/transfergold.test.ts
+++ b/packages/cli/src/commands/reserve/transfergold.test.ts
@@ -4,6 +4,7 @@ import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrappe
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import TransferGold from './transfergold'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -21,7 +22,7 @@ testWithGanache('reserve:transfergold cmd', (web3: Web3) => {
   })
   test('transferGold fails if spender not passed in', async () => {
     await expect(
-      TransferGold.run([
+      testLocally(TransferGold, [
         '--from',
         accounts[0],
         '--value',
@@ -33,7 +34,7 @@ testWithGanache('reserve:transfergold cmd', (web3: Web3) => {
   })
   test('can transferGold with multisig option', async () => {
     const initialBalance = await goldToken.balanceOf(accounts[9])
-    await TransferGold.run([
+    await testLocally(TransferGold, [
       '--from',
       accounts[0],
       '--value',
@@ -42,7 +43,7 @@ testWithGanache('reserve:transfergold cmd', (web3: Web3) => {
       accounts[9],
       '--useMultiSig',
     ])
-    await TransferGold.run([
+    await testLocally(TransferGold, [
       '--from',
       accounts[7],
       '--value',

--- a/packages/cli/src/commands/validator/register.test.ts
+++ b/packages/cli/src/commands/validator/register.test.ts
@@ -1,6 +1,7 @@
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedgold/lock'
 import ValidatorRegister from './register'
@@ -15,12 +16,12 @@ testWithGanache('validator:register', (web3: Web3) => {
     const accounts = await web3.eth.getAccounts()
     account = accounts[0]
     ecdsaPublicKey = await addressToPublicKey(account, web3.eth.sign)
-    await Register.run(['--from', account])
-    await Lock.run(['--from', account, '--value', '10000000000000000000000'])
+    await testLocally(Register, ['--from', account])
+    await testLocally(Lock, ['--from', account, '--value', '10000000000000000000000'])
   })
 
   test('can register validator with 0x prefix', async () => {
-    await ValidatorRegister.run([
+    await testLocally(ValidatorRegister, [
       '--from',
       account,
       '--ecdsaKey',
@@ -34,7 +35,7 @@ testWithGanache('validator:register', (web3: Web3) => {
   })
 
   test('can register validator without 0x prefix', async () => {
-    await ValidatorRegister.run([
+    await testLocally(ValidatorRegister, [
       '--from',
       account,
       '--ecdsaKey',
@@ -48,7 +49,7 @@ testWithGanache('validator:register', (web3: Web3) => {
   })
 
   test('fails if validator already registered', async () => {
-    await ValidatorRegister.run([
+    await testLocally(ValidatorRegister, [
       '--from',
       account,
       '--ecdsaKey',
@@ -60,7 +61,7 @@ testWithGanache('validator:register', (web3: Web3) => {
       '--yes',
     ])
     await expect(
-      ValidatorRegister.run([
+      testLocally(ValidatorRegister, [
         '--from',
         account,
         '--ecdsaKey',

--- a/packages/cli/src/commands/validatorgroup/commission.test.ts
+++ b/packages/cli/src/commands/validatorgroup/commission.test.ts
@@ -1,5 +1,6 @@
 import { mineBlocks, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
 import AccountRegister from '../account/register'
 import Lock from '../lockedgold/lock'
 import Commission from './commission'
@@ -11,21 +12,27 @@ testWithGanache('validatorgroup:comission cmd', (web3: Web3) => {
   async function registerValidatorGroup() {
     const accounts = await web3.eth.getAccounts()
 
-    await AccountRegister.run(['--from', accounts[0]])
-    await Lock.run(['--from', accounts[0], '--value', '10000000000000000000000'])
-    await ValidatorGroupRegister.run(['--from', accounts[0], '--commission', '0.1', '--yes'])
+    await testLocally(AccountRegister, ['--from', accounts[0]])
+    await testLocally(Lock, ['--from', accounts[0], '--value', '10000000000000000000000'])
+    await testLocally(ValidatorGroupRegister, [
+      '--from',
+      accounts[0],
+      '--commission',
+      '0.1',
+      '--yes',
+    ])
   }
 
   test('can queue update', async () => {
     const accounts = await web3.eth.getAccounts()
     await registerValidatorGroup()
-    await Commission.run(['--from', accounts[0], '--queue-update', '0.2'])
+    await testLocally(Commission, ['--from', accounts[0], '--queue-update', '0.2'])
   })
   test('can apply update', async () => {
     const accounts = await web3.eth.getAccounts()
     await registerValidatorGroup()
-    await Commission.run(['--from', accounts[0], '--queue-update', '0.2'])
+    await testLocally(Commission, ['--from', accounts[0], '--queue-update', '0.2'])
     await mineBlocks(3, web3)
-    await Commission.run(['--from', accounts[0], '--apply'])
+    await testLocally(Commission, ['--from', accounts[0], '--apply'])
   })
 })

--- a/packages/cli/src/test-utils/cliUtils.ts
+++ b/packages/cli/src/test-utils/cliUtils.ts
@@ -1,0 +1,11 @@
+import { LoadOptions } from '@oclif/config'
+import { BaseCommand } from '../base'
+
+export async function testLocally(
+  command: typeof BaseCommand,
+  argv: string[],
+  config?: LoadOptions
+) {
+  const extendedArgv = [...argv, '--node', 'local']
+  return command.run(extendedArgv, config)
+}


### PR DESCRIPTION
### Description

Regardless of the settings of the cli in the local machine, the tests should always run using http://localhost:8545/ (or more precisely, the local port where the testchain is set up)

### Other changes

No other changes

### Tested

Unit tests are testing this

### Related issues

- Fixes #[8520](https://github.com/celo-org/celo-monorepo/issues/8520)

### Backwards compatibility

Fully backward compatible

### Documentation

No docs changes