### PR TITLE
Audit timeout and responses

### DIFF
--- a/packages/phone-number-privacy/combiner/src/common/combine.ts
+++ b/packages/phone-number-privacy/combiner/src/common/combine.ts
@@ -68,7 +68,9 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
           session.logger.info({ signer }, WarningMessage.CANCELLED_REQUEST_TO_SIGNER)
         }
       } else {
-        session.logger.error({ signer, err }, ErrorMessage.SIGNER_REQUEST_ERROR)
+        // Logging the err & message simultaneously fails to log the message in some cases
+        session.logger.error({ signer }, ErrorMessage.SIGNER_REQUEST_ERROR)
+        session.logger.error({ signer, err })
       }
     }
     return this.handleFetchResult(signer, session, signerFetchResult)

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -170,7 +170,8 @@ export async function meterResponse(
       logger.info({ res }, 'Response sent')
     })
     .catch((err) => {
-      logger.error({ err }, 'Caught error in outer endpoint handler')
+      logger.error(ErrorMessage.CAUGHT_ERROR_IN_ENDPOINT_HANDLER)
+      logger.error(err)
       if (!res.headersSent) {
         logger.info('Responding with error in outer endpoint handler')
         res.status(500).json({
@@ -178,7 +179,7 @@ export async function meterResponse(
           error: ErrorMessage.UNKNOWN_ERROR,
         })
       } else {
-        logger.error('Error in endpoint thrown after response was already sent')
+        logger.error(ErrorMessage.ERROR_AFTER_RESPONSE_SENT)
       }
     })
     .finally(() => {

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -171,7 +171,7 @@ export async function meterResponse(
     })
     .catch((err) => {
       logger.error({ err }, 'Caught error in outer endpoint handler')
-      if (!res.finished && !res.headersSent) {
+      if (!res.headersSent) {
         logger.info('Responding with error in outer endpoint handler')
         res.status(500).json({
           success: false,

--- a/packages/phone-number-privacy/combiner/test/unit/domain-response-logger.test.ts
+++ b/packages/phone-number-privacy/combiner/test/unit/domain-response-logger.test.ts
@@ -309,7 +309,6 @@ describe('domain response logger', () => {
   ]
   testCases.forEach((testCase) => {
     it(testCase.it, () => {
-      console.log(testCase.responses)
       const session = getSession(testCase.responses)
       const logSpys = {
         info: {

--- a/packages/phone-number-privacy/combiner/test/unit/pnp-response-logger.test.ts
+++ b/packages/phone-number-privacy/combiner/test/unit/pnp-response-logger.test.ts
@@ -664,7 +664,6 @@ describe('pnp response logger', () => {
   ]
   testCases.forEach((testCase) => {
     it(testCase.it, () => {
-      console.log(testCase.responses)
       const session = getSession(testCase.responses)
       const logSpys = {
         info: {

--- a/packages/phone-number-privacy/common/src/interfaces/errors.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/errors.ts
@@ -29,6 +29,8 @@ export enum ErrorMessage {
   FAILURE_TO_GET_DEK = `CELO_ODIS_ERR_26 NODE_ERR Failed to read user's DEK from full-node`,
   FAILING_OPEN = `CELO_ODIS_ERR_27 NODE_ERR Failing open on full-node error`,
   FAILING_CLOSED = `CELO_ODIS_ERR_28 NODE_ERR Failing closed on full-node error`,
+  CAUGHT_ERROR_IN_ENDPOINT_HANDLER = `CELO_ODIS_ERR_29 Caught error in outer endpoint handler`,
+  ERROR_AFTER_RESPONSE_SENT = `CELO_ODIS_ERR_30 Error in endpoint thrown after response was already sent`,
 }
 
 export enum WarningMessage {

--- a/packages/phone-number-privacy/common/src/utils/responses.utils.ts
+++ b/packages/phone-number-privacy/common/src/utils/responses.utils.ts
@@ -32,4 +32,5 @@ export function send<
     logger.info({ status, body }, 'Responding with success')
   }
   response.status(status).json(body)
+  logger.info('Completed send')
 }

--- a/packages/phone-number-privacy/signer/src/common/action.ts
+++ b/packages/phone-number-privacy/signer/src/common/action.ts
@@ -17,5 +17,5 @@ export type Session<R extends OdisRequest> = R extends DomainRequest
 export interface Action<R extends OdisRequest> {
   readonly config: SignerConfig
   readonly io: IO<R>
-  perform(session: Session<R>, timeoutError: Symbol): Promise<void>
+  perform(session: Session<R>, timeoutError: symbol): Promise<void>
 }

--- a/packages/phone-number-privacy/signer/src/common/action.ts
+++ b/packages/phone-number-privacy/signer/src/common/action.ts
@@ -17,5 +17,5 @@ export type Session<R extends OdisRequest> = R extends DomainRequest
 export interface Action<R extends OdisRequest> {
   readonly config: SignerConfig
   readonly io: IO<R>
-  perform(session: Session<R>): Promise<void>
+  perform(session: Session<R>, timeoutError: Symbol): Promise<void>
 }

--- a/packages/phone-number-privacy/signer/src/common/controller.ts
+++ b/packages/phone-number-privacy/signer/src/common/controller.ts
@@ -11,16 +11,25 @@ export class Controller<R extends OdisRequest> {
     response: Response<OdisResponse<R>>
   ): Promise<void> {
     Counters.requests.labels(this.action.io.endpoint).inc()
+    // Unique error to be thrown on timeout
+    const timeoutError = Symbol()
     await meter(
       async () => {
         const session = await this.action.io.init(request, response)
         // Init returns a response to the user internally.
         if (session) {
-          await this.action.perform(session)
+          await this.action.perform(session, timeoutError)
         }
       },
       [],
       (err: any) => {
+        // TODO EN: can reduce duplication here a bit more (i.e. just change error)
+        // TODO EN: can consider adding generic DB error handling here
+        if (err === timeoutError) {
+          Counters.timeouts.inc()
+          this.action.io.sendFailure(ErrorMessage.TIMEOUT_FROM_SIGNER, 500, response)
+          return
+        }
         response.locals.logger.error(
           { err },
           `Unknown error in handler for ${this.action.io.endpoint}`

--- a/packages/phone-number-privacy/signer/src/common/database/utils.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/utils.ts
@@ -30,7 +30,7 @@ export function countAndThrowDBError<T>(
 
   Counters.databaseErrors.labels(label).inc()
   logger.error({ err }, errorMsg)
-  throw err
+  throw errorMsg
 }
 
 export function tableWithLockForTrx(baseQuery: Knex.QueryBuilder, trx?: Knex.Transaction) {

--- a/packages/phone-number-privacy/signer/src/common/database/utils.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/utils.ts
@@ -30,7 +30,7 @@ export function countAndThrowDBError<T>(
 
   Counters.databaseErrors.labels(label).inc()
   logger.error({ err }, errorMsg)
-  throw errorMsg
+  throw new Error(errorMsg)
 }
 
 export function tableWithLockForTrx(baseQuery: Knex.QueryBuilder, trx?: Knex.Transaction) {

--- a/packages/phone-number-privacy/signer/src/common/database/wrappers/domain-state.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/wrappers/domain-state.ts
@@ -4,9 +4,9 @@ import Logger from 'bunyan'
 import { Knex } from 'knex'
 import { Histograms, meter } from '../../metrics'
 import {
-  DomainStateRecord,
   DOMAIN_STATE_COLUMNS,
   DOMAIN_STATE_TABLE,
+  DomainStateRecord,
   toDomainStateRecord,
 } from '../models/domain-state'
 import { countAndThrowDBError, tableWithLockForTrx } from '../utils'

--- a/packages/phone-number-privacy/signer/src/common/database/wrappers/domain-state.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/wrappers/domain-state.ts
@@ -4,9 +4,9 @@ import Logger from 'bunyan'
 import { Knex } from 'knex'
 import { Histograms, meter } from '../../metrics'
 import {
+  DomainStateRecord,
   DOMAIN_STATE_COLUMNS,
   DOMAIN_STATE_TABLE,
-  DomainStateRecord,
   toDomainStateRecord,
 } from '../models/domain-state'
 import { countAndThrowDBError, tableWithLockForTrx } from '../utils'

--- a/packages/phone-number-privacy/signer/src/common/metrics.ts
+++ b/packages/phone-number-privacy/signer/src/common/metrics.ts
@@ -70,6 +70,14 @@ export const Counters = {
     help:
       'Counter for the number of requests failing quota or authentication checks due to full-node errors',
   }),
+  errorsCaughtInEndpointHandler: new Counter({
+    name: 'errors_caught_in_endpoint_handler',
+    help: 'Counter for the number of errors thrown in the outermost endpoint handler',
+  }),
+  errorsThrownAfterResponseSent: new Counter({
+    name: 'errors_thrown_after_response_sent',
+    help: 'Counter for the number of errors thrown after a response was already sent',
+  }),
 }
 const buckets = [
   0.001,

--- a/packages/phone-number-privacy/signer/src/domain/endpoints/disable/action.ts
+++ b/packages/phone-number-privacy/signer/src/domain/endpoints/disable/action.ts
@@ -18,7 +18,7 @@ export class DomainDisableAction implements Action<DisableDomainRequest> {
 
   public async perform(
     session: DomainSession<DisableDomainRequest>,
-    timeoutError: Symbol
+    timeoutError: symbol
   ): Promise<void> {
     const domain = session.request.body.domain
     session.logger.info(
@@ -51,7 +51,7 @@ export class DomainDisableAction implements Action<DisableDomainRequest> {
         }
       }
       // Ensure timeouts roll back DB trx
-      return await timeout(disableDomainHandler, [], this.config.timeout, timeoutError)
+      return timeout(disableDomainHandler, [], this.config.timeout, timeoutError)
     })
 
     this.io.sendSuccess(

--- a/packages/phone-number-privacy/signer/src/domain/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/signer/src/domain/endpoints/quota/action.ts
@@ -16,7 +16,7 @@ export class DomainQuotaAction implements Action<DomainQuotaStatusRequest> {
 
   public async perform(
     session: DomainSession<DomainQuotaStatusRequest>,
-    timeoutError: Symbol
+    timeoutError: symbol
   ): Promise<void> {
     const domain = session.request.body.domain
     session.logger.info('Processing request to get domain quota status', {

--- a/packages/phone-number-privacy/signer/src/domain/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/signer/src/domain/endpoints/quota/action.ts
@@ -1,9 +1,5 @@
 import { timeout } from '@celo/base'
-import {
-  domainHash,
-  DomainQuotaStatusRequest,
-  ErrorMessage,
-} from '@celo/phone-number-privacy-common'
+import { domainHash, DomainQuotaStatusRequest } from '@celo/phone-number-privacy-common'
 import { Action } from '../../../common/action'
 import { toSequentialDelayDomainState } from '../../../common/database/models/domain-state'
 import { SignerConfig } from '../../../config'
@@ -28,21 +24,12 @@ export class DomainQuotaAction implements Action<DomainQuotaStatusRequest> {
       version: domain.version,
       hash: domainHash(domain).toString('hex'),
     })
-    try {
-      const domainStateRecord = await timeout(
-        () => this.quotaService.getQuotaStatus(session),
-        [],
-        this.config.timeout,
-        timeoutError
-      )
-      this.io.sendSuccess(200, session.response, toSequentialDelayDomainState(domainStateRecord))
-    } catch (error) {
-      // TODO EN: try to move this into outer controller class
-      if (error === timeoutError) {
-        throw error
-      }
-      session.logger.error(error, 'Error while getting domain status')
-      this.io.sendFailure(ErrorMessage.DATABASE_GET_FAILURE, 500, session.response)
-    }
+    const domainStateRecord = await timeout(
+      () => this.quotaService.getQuotaStatus(session),
+      [],
+      this.config.timeout,
+      timeoutError
+    )
+    this.io.sendSuccess(200, session.response, toSequentialDelayDomainState(domainStateRecord))
   }
 }

--- a/packages/phone-number-privacy/signer/src/domain/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/domain/endpoints/sign/action.ts
@@ -47,7 +47,7 @@ export class DomainSignAction implements Action<DomainRestrictedSignatureRequest
 
   public async perform(
     session: DomainSession<DomainRestrictedSignatureRequest>,
-    timeoutError: Symbol
+    timeoutError: symbol
   ): Promise<void> {
     const domain = session.request.body.domain
     session.logger.info(
@@ -121,7 +121,7 @@ export class DomainSignAction implements Action<DomainRestrictedSignatureRequest
         }
       }
       // Ensure timeouts roll back DB trx
-      return await timeout(domainSignHandler, [], this.config.timeout, timeoutError)
+      return timeout(domainSignHandler, [], this.config.timeout, timeoutError)
     })
 
     if (res.success) {

--- a/packages/phone-number-privacy/signer/src/domain/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/domain/endpoints/sign/action.ts
@@ -140,6 +140,7 @@ export class DomainSignAction implements Action<DomainRestrictedSignatureRequest
         )
       }
     } catch (error) {
+      // TODO EN: try to move this into outer controller class
       if (error === timeoutRes) {
         this.io.sendFailure(ErrorMessage.TIMEOUT_FROM_SIGNER, 500, session.response)
         return

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
@@ -1,7 +1,10 @@
+import { timeout } from '@celo/base'
 import {
   ErrorMessage,
+  ErrorType,
   LegacyPnpQuotaRequest,
   PnpQuotaRequest,
+  PnpQuotaStatus,
 } from '@celo/phone-number-privacy-common'
 import { Action } from '../../../common/action'
 import { SignerConfig } from '../../../config'
@@ -10,6 +13,18 @@ import { PnpSession } from '../../session'
 import { PnpQuotaIO } from './io'
 import { LegacyPnpQuotaIO } from './io.legacy'
 
+type PnpQuotaHandleResult =
+  | {
+      success: false
+      status: number
+      quotaStatus: PnpQuotaStatus
+      error: ErrorType
+    }
+  | {
+      success: true
+      status: number
+      quotaStatus: PnpQuotaStatus
+    }
 export class PnpQuotaAction implements Action<PnpQuotaRequest | LegacyPnpQuotaRequest> {
   constructor(
     readonly config: SignerConfig,
@@ -20,18 +35,65 @@ export class PnpQuotaAction implements Action<PnpQuotaRequest | LegacyPnpQuotaRe
   public async perform(
     session: PnpSession<PnpQuotaRequest | LegacyPnpQuotaRequest>
   ): Promise<void> {
-    const quotaStatus = await this.quota.getQuotaStatus(session)
+    // TODO EN: try to surround the quotaStatus result with the timeout logic  (not the entire function, to avoid sending failure within)
 
-    if (quotaStatus.performedQueryCount > -1 && quotaStatus.totalQuota > -1) {
-      this.io.sendSuccess(200, session.response, quotaStatus, session.errors)
-      return
+    const pnpQuotaHandler = async (): Promise<PnpQuotaHandleResult> => {
+      const quotaStatus = await this.quota.getQuotaStatus(session)
+
+      if (quotaStatus.performedQueryCount > -1 && quotaStatus.totalQuota > -1) {
+        return {
+          success: true,
+          status: 200,
+          quotaStatus,
+        }
+        // this.io.sendSuccess(200, session.response, quotaStatus, session.errors)
+        // return
+      }
+      return {
+        success: false,
+        status: 500,
+        quotaStatus,
+        error:
+          quotaStatus.performedQueryCount === -1
+            ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
+            : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
+      }
+      // this.io.sendFailure(
+      //   quotaStatus.performedQueryCount === -1
+      //     ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
+      //     : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
+      //   500,
+      //   session.response
+      // )
     }
-    this.io.sendFailure(
-      quotaStatus.performedQueryCount === -1
-        ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
-        : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
-      500,
-      session.response
-    )
+    const timeoutRes = Symbol()
+    try {
+      const res = await timeout(pnpQuotaHandler, [], this.config.timeout, timeoutRes)
+      if (res.success) {
+        this.io.sendSuccess(res.status, session.response, res.quotaStatus, session.errors)
+        return
+      }
+      this.io.sendFailure(res.error, res.status, session.response)
+    } catch (error) {
+      // TODO EN: move this try catch to the controller instead of the action class if possible
+      if (error === timeoutRes) {
+        this.io.sendFailure(ErrorMessage.TIMEOUT_FROM_SIGNER, 500, session.response)
+        return
+      }
+      // TODO EN TEMPORARY, move to controller
+      throw error
+    }
+
+    // if (quotaStatus.performedQueryCount > -1 && quotaStatus.totalQuota > -1) {
+    //   this.io.sendSuccess(200, session.response, quotaStatus, session.errors)
+    //   return
+    // }
+    // this.io.sendFailure(
+    //   quotaStatus.performedQueryCount === -1
+    //     ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
+    //     : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
+    //   500,
+    //   session.response
+    // )
   }
 }

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
@@ -1,10 +1,8 @@
 import { timeout } from '@celo/base'
 import {
   ErrorMessage,
-  ErrorType,
   LegacyPnpQuotaRequest,
   PnpQuotaRequest,
-  PnpQuotaStatus,
 } from '@celo/phone-number-privacy-common'
 import { Action } from '../../../common/action'
 import { SignerConfig } from '../../../config'
@@ -13,18 +11,6 @@ import { PnpSession } from '../../session'
 import { PnpQuotaIO } from './io'
 import { LegacyPnpQuotaIO } from './io.legacy'
 
-type PnpQuotaHandleResult =
-  | {
-      success: false
-      status: number
-      quotaStatus: PnpQuotaStatus
-      error: ErrorType
-    }
-  | {
-      success: true
-      status: number
-      quotaStatus: PnpQuotaStatus
-    }
 export class PnpQuotaAction implements Action<PnpQuotaRequest | LegacyPnpQuotaRequest> {
   constructor(
     readonly config: SignerConfig,
@@ -35,45 +21,25 @@ export class PnpQuotaAction implements Action<PnpQuotaRequest | LegacyPnpQuotaRe
   public async perform(
     session: PnpSession<PnpQuotaRequest | LegacyPnpQuotaRequest>
   ): Promise<void> {
-    // TODO EN: try to surround the quotaStatus result with the timeout logic  (not the entire function, to avoid sending failure within)
-
-    const pnpQuotaHandler = async (): Promise<PnpQuotaHandleResult> => {
-      const quotaStatus = await this.quota.getQuotaStatus(session)
-
-      if (quotaStatus.performedQueryCount > -1 && quotaStatus.totalQuota > -1) {
-        return {
-          success: true,
-          status: 200,
-          quotaStatus,
-        }
-        // this.io.sendSuccess(200, session.response, quotaStatus, session.errors)
-        // return
-      }
-      return {
-        success: false,
-        status: 500,
-        quotaStatus,
-        error:
-          quotaStatus.performedQueryCount === -1
-            ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
-            : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
-      }
-      // this.io.sendFailure(
-      //   quotaStatus.performedQueryCount === -1
-      //     ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
-      //     : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
-      //   500,
-      //   session.response
-      // )
-    }
     const timeoutRes = Symbol()
     try {
-      const res = await timeout(pnpQuotaHandler, [], this.config.timeout, timeoutRes)
-      if (res.success) {
-        this.io.sendSuccess(res.status, session.response, res.quotaStatus, session.errors)
+      const quotaStatus = await timeout(
+        () => this.quota.getQuotaStatus(session),
+        [],
+        this.config.timeout,
+        timeoutRes
+      )
+      if (quotaStatus.performedQueryCount > -1 && quotaStatus.totalQuota > -1) {
+        this.io.sendSuccess(200, session.response, quotaStatus, session.errors)
         return
       }
-      this.io.sendFailure(res.error, res.status, session.response)
+      this.io.sendFailure(
+        quotaStatus.performedQueryCount === -1
+          ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
+          : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
+        500,
+        session.response
+      )
     } catch (error) {
       // TODO EN: move this try catch to the controller instead of the action class if possible
       if (error === timeoutRes) {
@@ -83,17 +49,5 @@ export class PnpQuotaAction implements Action<PnpQuotaRequest | LegacyPnpQuotaRe
       // TODO EN TEMPORARY, move to controller
       throw error
     }
-
-    // if (quotaStatus.performedQueryCount > -1 && quotaStatus.totalQuota > -1) {
-    //   this.io.sendSuccess(200, session.response, quotaStatus, session.errors)
-    //   return
-    // }
-    // this.io.sendFailure(
-    //   quotaStatus.performedQueryCount === -1
-    //     ? ErrorMessage.FAILURE_TO_GET_PERFORMED_QUERY_COUNT
-    //     : ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
-    //   500,
-    //   session.response
-    // )
   }
 }

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/quota/action.ts
@@ -20,7 +20,7 @@ export class PnpQuotaAction implements Action<PnpQuotaRequest | LegacyPnpQuotaRe
 
   public async perform(
     session: PnpSession<PnpQuotaRequest | LegacyPnpQuotaRequest>,
-    timeoutError: Symbol
+    timeoutError: symbol
   ): Promise<void> {
     const quotaStatus = await timeout(
       () => this.quota.getQuotaStatus(session),

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
@@ -1,3 +1,4 @@
+import { timeout } from '@celo/base'
 import {
   ErrorMessage,
   LegacySignMessageRequest,
@@ -31,95 +32,117 @@ export abstract class PnpSignAction
 
   public async perform(
     session: PnpSession<SignMessageRequest | LegacySignMessageRequest>
+    // timeoutError: any,
   ): Promise<void> {
     // Compute quota lookup, update, and signing within transaction
     // so that these occur atomically and rollback on error.
     await this.db.transaction(async (trx) => {
-      const quotaStatus = await this.quota.getQuotaStatus(session, trx)
+      const pnpSignHandler = async () => {
+        const quotaStatus = await this.quota.getQuotaStatus(session, trx)
 
-      let isDuplicateRequest = false
-      try {
-        isDuplicateRequest = await getRequestExists(
-          this.db,
-          this.requestsTable,
-          session.request.body.account,
-          session.request.body.blindedQueryPhoneNumber,
-          session.logger,
-          trx
-        )
-      } catch (err) {
-        session.logger.error(err, 'Failed to check if request already exists in db')
-      }
-
-      if (isDuplicateRequest) {
-        Counters.duplicateRequests.inc()
-        session.logger.info(
-          'Request already exists in db. Will service request without charging quota.'
-        )
-        session.errors.push(WarningMessage.DUPLICATE_REQUEST_TO_GET_PARTIAL_SIG)
-      } else {
-        // In the case of a database connection failure, performedQueryCount will be -1
-        if (quotaStatus.performedQueryCount === -1) {
-          this.io.sendFailure(ErrorMessage.DATABASE_GET_FAILURE, 500, session.response, quotaStatus)
-          return
+        let isDuplicateRequest = false
+        try {
+          isDuplicateRequest = await getRequestExists(
+            this.db,
+            this.requestsTable,
+            session.request.body.account,
+            session.request.body.blindedQueryPhoneNumber,
+            session.logger,
+            trx
+          )
+        } catch (err) {
+          session.logger.error(err, 'Failed to check if request already exists in db')
         }
-        // In the case of a blockchain connection failure, totalQuota will be -1
-        if (quotaStatus.totalQuota === -1) {
-          if (this.config.api.phoneNumberPrivacy.shouldFailOpen) {
-            // We fail open and service requests on full-node errors to not block the user.
-            // Error messages are stored in the session and included along with the signature in the response.
-            quotaStatus.totalQuota = Number.MAX_SAFE_INTEGER
-            session.logger.error(ErrorMessage.FAILING_OPEN)
-            Counters.requestsFailingOpen.inc()
-            // TODO(2.0.0) Ensure we have monitoring in the combiner for this too,
-            // since we don't have visibility into prometheus metrics for partner signers. The combiner monitoring
-            // should be based intelligently off of the warning messages returned by signers
-            // (https://github.com/celo-org/celo-monorepo/issues/9836)
-          } else {
-            session.logger.error(ErrorMessage.FAILING_CLOSED)
-            Counters.requestsFailingClosed.inc()
-            this.io.sendFailure(ErrorMessage.FULL_NODE_ERROR, 500, session.response, quotaStatus)
+
+        if (isDuplicateRequest) {
+          Counters.duplicateRequests.inc()
+          session.logger.info(
+            'Request already exists in db. Will service request without charging quota.'
+          )
+          session.errors.push(WarningMessage.DUPLICATE_REQUEST_TO_GET_PARTIAL_SIG)
+        } else {
+          // In the case of a database connection failure, performedQueryCount will be -1
+          if (quotaStatus.performedQueryCount === -1) {
+            this.io.sendFailure(
+              ErrorMessage.DATABASE_GET_FAILURE,
+              500,
+              session.response,
+              quotaStatus
+            )
+            return
+          }
+          // In the case of a blockchain connection failure, totalQuota will be -1
+          if (quotaStatus.totalQuota === -1) {
+            if (this.config.api.phoneNumberPrivacy.shouldFailOpen) {
+              // We fail open and service requests on full-node errors to not block the user.
+              // Error messages are stored in the session and included along with the signature in the response.
+              quotaStatus.totalQuota = Number.MAX_SAFE_INTEGER
+              session.logger.error(ErrorMessage.FAILING_OPEN)
+              Counters.requestsFailingOpen.inc()
+              // TODO(2.0.0) Ensure we have monitoring in the combiner for this too,
+              // since we don't have visibility into prometheus metrics for partner signers. The combiner monitoring
+              // should be based intelligently off of the warning messages returned by signers
+              // (https://github.com/celo-org/celo-monorepo/issues/9836)
+            } else {
+              session.logger.error(ErrorMessage.FAILING_CLOSED)
+              Counters.requestsFailingClosed.inc()
+              this.io.sendFailure(ErrorMessage.FULL_NODE_ERROR, 500, session.response, quotaStatus)
+              return
+            }
+          }
+
+          // TODO(after 2.0.0) add more specific error messages on DB and key version
+          // https://github.com/celo-org/celo-monorepo/issues/9882
+          // quotaStatus is updated in place; throws on failure to update
+          const { sufficient } = await this.quota.checkAndUpdateQuotaStatus(
+            quotaStatus,
+            session,
+            trx
+          )
+          if (!sufficient) {
+            this.io.sendFailure(WarningMessage.EXCEEDED_QUOTA, 403, session.response, quotaStatus)
             return
           }
         }
 
-        // TODO(after 2.0.0) add more specific error messages on DB and key version
-        // https://github.com/celo-org/celo-monorepo/issues/9882
-        // quotaStatus is updated in place; throws on failure to update
-        const { sufficient } = await this.quota.checkAndUpdateQuotaStatus(quotaStatus, session, trx)
-        if (!sufficient) {
-          this.io.sendFailure(WarningMessage.EXCEEDED_QUOTA, 403, session.response, quotaStatus)
+        const key: Key = {
+          version:
+            this.io.getRequestKeyVersion(session.request, session.logger) ??
+            this.config.keystore.keys.phoneNumberPrivacy.latest,
+          name: DefaultKeyName.PHONE_NUMBER_PRIVACY,
+        }
+
+        try {
+          const signature = await this.sign(
+            session.request.body.blindedQueryPhoneNumber,
+            key,
+            session
+          )
+          this.io.sendSuccess(200, session.response, key, signature, quotaStatus, session.errors)
+          return
+        } catch (err) {
+          session.logger.error({ err })
+          quotaStatus.performedQueryCount--
+          this.io.sendFailure(
+            ErrorMessage.SIGNATURE_COMPUTATION_FAILURE,
+            500,
+            session.response,
+            quotaStatus
+          )
+          // Note that errors thrown after rollback will have no effect, hence doing this last
+          await trx.rollback()
           return
         }
       }
-
-      const key: Key = {
-        version:
-          this.io.getRequestKeyVersion(session.request, session.logger) ??
-          this.config.keystore.keys.phoneNumberPrivacy.latest,
-        name: DefaultKeyName.PHONE_NUMBER_PRIVACY,
-      }
-
+      const timeoutRes = Symbol()
       try {
-        const signature = await this.sign(
-          session.request.body.blindedQueryPhoneNumber,
-          key,
-          session
-        )
-        this.io.sendSuccess(200, session.response, key, signature, quotaStatus, session.errors)
-        return
-      } catch (err) {
-        session.logger.error({ err })
-        quotaStatus.performedQueryCount--
-        this.io.sendFailure(
-          ErrorMessage.SIGNATURE_COMPUTATION_FAILURE,
-          500,
-          session.response,
-          quotaStatus
-        )
-        // Note that errors thrown after rollback will have no effect, hence doing this last
-        await trx.rollback()
-        return
+        await timeout(pnpSignHandler, [], this.config.timeout, timeoutRes)
+      } catch (error) {
+        if (error === timeoutRes) {
+          this.io.sendFailure(ErrorMessage.TIMEOUT_FROM_SIGNER, 500, session.response)
+          return
+        }
+        throw error
       }
     })
   }

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
@@ -31,8 +31,8 @@ export abstract class PnpSignAction
   ) {}
 
   public async perform(
-    session: PnpSession<SignMessageRequest | LegacySignMessageRequest>
-    // timeoutError: any,
+    session: PnpSession<SignMessageRequest | LegacySignMessageRequest>,
+    timeoutError: Symbol
   ): Promise<void> {
     // Compute quota lookup, update, and signing within transaction
     // so that these occur atomically and rollback on error.
@@ -134,16 +134,7 @@ export abstract class PnpSignAction
           return
         }
       }
-      const timeoutRes = Symbol()
-      try {
-        await timeout(pnpSignHandler, [], this.config.timeout, timeoutRes)
-      } catch (error) {
-        if (error === timeoutRes) {
-          this.io.sendFailure(ErrorMessage.TIMEOUT_FROM_SIGNER, 500, session.response)
-          return
-        }
-        throw error
-      }
+      await timeout(pnpSignHandler, [], this.config.timeout, timeoutError)
     })
   }
 

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/action.ts
@@ -32,7 +32,7 @@ export abstract class PnpSignAction
 
   public async perform(
     session: PnpSession<SignMessageRequest | LegacySignMessageRequest>,
-    timeoutError: Symbol
+    timeoutError: symbol
   ): Promise<void> {
     // Compute quota lookup, update, and signing within transaction
     // so that these occur atomically and rollback on error.

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -1,4 +1,3 @@
-import { timeout } from '@celo/base'
 import { ContractKit } from '@celo/contractkit'
 import {
   ErrorMessage,
@@ -69,11 +68,14 @@ export function startSigner(
       const timeoutRes = Symbol()
       try {
         // TODO(2.0.0, timeout) https://github.com/celo-org/celo-monorepo/issues/9845
-        await timeout(handler, [req, res], config.timeout, timeoutRes)
+        // console.log(timeout)
+        await handler(req, res)
+        // await timeout(handler, [req, res], config.timeout, timeoutRes)
       } catch (err: any) {
         // Handle any errors that otherwise managed to escape the proper handlers
         let errorMsg: string = ErrorMessage.UNKNOWN_ERROR
         let errToLog = err
+        // TODO EN: remove this code as well
         if (err === timeoutRes) {
           Counters.timeouts.inc()
           errorMsg = ErrorMessage.TIMEOUT_FROM_SIGNER

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -79,8 +79,9 @@ export function startSigner(
           errorMsg = ErrorMessage.TIMEOUT_FROM_SIGNER
           errToLog = new Error(errorMsg)
         }
-        childLogger.error({ errToLog })
-        if (!res.writableEnded) {
+        childLogger.error({ err: errToLog }, 'Caught error in outer endpoint handler')
+        if (!res.writableEnded && !res.headersSent) {
+          childLogger.info('Responding with error in outer endpoint handler')
           res.status(500).json({
             success: false,
             error: errorMsg,

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -58,7 +58,7 @@ export function startSigner(
     res.send(PromClient.register.metrics())
   })
 
-  const addEndpointWithTimeout = (
+  const addEndpoint = (
     endpoint: SignerEndpoint,
     handler: (req: Request, res: Response) => Promise<void>
   ) =>
@@ -151,17 +151,14 @@ export function startSigner(
     new DomainDisableAction(db, config, new DomainDisableIO(config.api.domains.enabled))
   )
   logger.info('Right before adding meteredSignerEndpoints')
-  addEndpointWithTimeout(SignerEndpoint.PNP_SIGN, pnpSign.handle.bind(pnpSign))
-  addEndpointWithTimeout(SignerEndpoint.PNP_QUOTA, pnpQuota.handle.bind(pnpQuota))
-  addEndpointWithTimeout(SignerEndpoint.DOMAIN_QUOTA_STATUS, domainQuota.handle.bind(domainQuota))
-  addEndpointWithTimeout(SignerEndpoint.DOMAIN_SIGN, domainSign.handle.bind(domainSign))
-  addEndpointWithTimeout(SignerEndpoint.DISABLE_DOMAIN, domainDisable.handle.bind(domainDisable))
+  addEndpoint(SignerEndpoint.PNP_SIGN, pnpSign.handle.bind(pnpSign))
+  addEndpoint(SignerEndpoint.PNP_QUOTA, pnpQuota.handle.bind(pnpQuota))
+  addEndpoint(SignerEndpoint.DOMAIN_QUOTA_STATUS, domainQuota.handle.bind(domainQuota))
+  addEndpoint(SignerEndpoint.DOMAIN_SIGN, domainSign.handle.bind(domainSign))
+  addEndpoint(SignerEndpoint.DISABLE_DOMAIN, domainDisable.handle.bind(domainDisable))
 
-  addEndpointWithTimeout(SignerEndpoint.LEGACY_PNP_SIGN, legacyPnpSign.handle.bind(legacyPnpSign))
-  addEndpointWithTimeout(
-    SignerEndpoint.LEGACY_PNP_QUOTA,
-    legacyPnpQuota.handle.bind(legacyPnpQuota)
-  )
+  addEndpoint(SignerEndpoint.LEGACY_PNP_SIGN, legacyPnpSign.handle.bind(legacyPnpSign))
+  addEndpoint(SignerEndpoint.LEGACY_PNP_QUOTA, legacyPnpQuota.handle.bind(legacyPnpQuota))
 
   const sslOptions = getSslOptions(config)
   if (sslOptions) {

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -69,7 +69,7 @@ export function startSigner(
       } catch (err: any) {
         // Handle any errors that otherwise managed to escape the proper handlers
         childLogger.error({ err }, 'Caught error in outer endpoint handler')
-        if (!res.writableEnded && !res.headersSent) {
+        if (!res.headersSent) {
           childLogger.info('Responding with error in outer endpoint handler')
           res.status(500).json({
             success: false,

--- a/packages/phone-number-privacy/signer/src/server.ts
+++ b/packages/phone-number-privacy/signer/src/server.ts
@@ -65,23 +65,18 @@ export function startSigner(
     app.post(endpoint, async (req, res) => {
       const childLogger: Logger = res.locals.logger
       try {
-        // TODO(2.0.0, timeout) https://github.com/celo-org/celo-monorepo/issues/9845
         await handler(req, res)
       } catch (err: any) {
         // Handle any errors that otherwise managed to escape the proper handlers
-        let errorMsg: string = ErrorMessage.UNKNOWN_ERROR
-        let errToLog = err
-        childLogger.error({ err: errToLog }, 'Caught error in outer endpoint handler')
+        childLogger.error({ err }, 'Caught error in outer endpoint handler')
         if (!res.writableEnded && !res.headersSent) {
           childLogger.info('Responding with error in outer endpoint handler')
           res.status(500).json({
             success: false,
-            error: errorMsg,
+            error: ErrorMessage.UNKNOWN_ERROR,
           })
         } else {
-          // TODO(2.0.0, timeout) https://github.com/celo-org/celo-monorepo/issues/9845
-          // TODO(2.0.0, audit responses) https://github.com/celo-org/celo-monorepo/issues/9859
-          // getting to this error indicates that either timeout or `perform` process
+          // Getting to this error likely indicates that the `perform` process
           // does not terminate after sending a response, and then throws an error.
           childLogger.error('Error in endpoint thrown after response was already sent')
         }

--- a/packages/phone-number-privacy/signer/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/domain.test.ts
@@ -38,8 +38,6 @@ import { KeyProvider } from '../../src/common/key-management/key-provider-base'
 import { config, getVersion, SupportedDatabase, SupportedKeystore } from '../../src/config'
 import { startSigner } from '../../src/server'
 
-// TODO(2.0.0, timeout) revisit flake tracker timeouts under the umbrella of
-// https://github.com/celo-org/celo-monorepo/issues/9845
 jest.setTimeout(20000)
 
 describe('domain', () => {
@@ -346,7 +344,6 @@ describe('domain', () => {
         const appWithShortTimeout = startSigner(configWithShortTimeout, db, keyProvider)
 
         const req = await disableRequest()
-        // TODO EN: double check that this works & why doesn't mocking this function work for the other tests?
         const spy = jest
           .spyOn(
             jest.requireActual('../../src/common/database/wrappers/domain-state'),
@@ -948,7 +945,7 @@ describe('domain', () => {
         expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
           success: false,
           version: expectedVersion,
-          error: ErrorMessage.DATABASE_GET_FAILURE, // TODO EN: this should ideally be DB GET FAILURE
+          error: ErrorMessage.DATABASE_GET_FAILURE,
         })
         expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(
           null

--- a/packages/phone-number-privacy/signer/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/domain.test.ts
@@ -28,6 +28,7 @@ import { LocalWallet } from '@celo/wallet-local'
 import { Knex } from 'knex'
 import request from 'supertest'
 import { initDatabase } from '../../src/common/database/database'
+import { countAndThrowDBError } from '../../src/common/database/utils'
 import {
   createEmptyDomainStateRecord,
   getDomainStateRecord,
@@ -290,41 +291,6 @@ describe('domain', () => {
       })
     })
 
-    it('Should respond with 500 on signer timeout', async () => {
-      const testTimeoutMS = 200
-      const delay = 200
-
-      const configWithShortTimeout = JSON.parse(JSON.stringify(_config))
-      configWithShortTimeout.timeout = testTimeoutMS
-      const appWithShortTimeout = startSigner(configWithShortTimeout, db, keyProvider)
-
-      const req = await disableRequest()
-      // TODO EN: double check that this works & why doesn't mocking this function work for the other tests?
-      const spy = jest
-        .spyOn(
-          jest.requireActual('../../src/common/database/wrappers/domain-state'),
-          'getDomainStateRecord'
-        )
-        .mockImplementationOnce(async () => {
-          await new Promise((resolve) => setTimeout(resolve, testTimeoutMS + delay))
-          return null
-        })
-
-      const res = await request(appWithShortTimeout).post(SignerEndpoint.DISABLE_DOMAIN).send(req)
-      spy.mockRestore()
-
-      expect(res.status).toBe(500)
-      expect(res.body).toStrictEqual<DisableDomainResponse>({
-        success: false,
-        error: ErrorMessage.TIMEOUT_FROM_SIGNER,
-        version: expectedVersion,
-      })
-      // Allow time for non-killed processes to finish
-      await new Promise((resolve) => setTimeout(resolve, delay))
-      // Check that DB state was not updated on timeout
-      expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(null)
-    })
-
     it('Should respond with 503 on disabled api', async () => {
       const configWithApiDisabled: typeof _config = JSON.parse(JSON.stringify(_config))
       configWithApiDisabled.api.domains.enabled = false
@@ -339,6 +305,73 @@ describe('domain', () => {
         success: false,
         version: res.body.version,
         error: WarningMessage.API_UNAVAILABLE,
+      })
+    })
+
+    describe('functionality in case of errors', () => {
+      it('Should respond with 500 on DB insertDomainStateRecord failure', async () => {
+        const req = await disableRequest()
+        const spy = jest
+          .spyOn(
+            jest.requireActual('../../src/common/database/wrappers/domain-state'),
+            'insertDomainStateRecord'
+          )
+          .mockImplementationOnce(() => {
+            // Handle errors in the same way as in insertDomainStateRecord
+            countAndThrowDBError(
+              new Error(),
+              rootLogger(_config.serviceName),
+              ErrorMessage.DATABASE_INSERT_FAILURE
+            )
+          })
+        const res = await request(app).post(SignerEndpoint.DISABLE_DOMAIN).send(req)
+        spy.mockRestore()
+        expect(res.status).toBe(500)
+        expect(res.body).toStrictEqual<DisableDomainResponse>({
+          success: false,
+          version: expectedVersion,
+          error: ErrorMessage.DATABASE_INSERT_FAILURE,
+        })
+        expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(
+          null
+        )
+      })
+
+      it('Should respond with 500 on signer timeout', async () => {
+        const testTimeoutMS = 200
+        const delay = 200
+
+        const configWithShortTimeout = JSON.parse(JSON.stringify(_config))
+        configWithShortTimeout.timeout = testTimeoutMS
+        const appWithShortTimeout = startSigner(configWithShortTimeout, db, keyProvider)
+
+        const req = await disableRequest()
+        // TODO EN: double check that this works & why doesn't mocking this function work for the other tests?
+        const spy = jest
+          .spyOn(
+            jest.requireActual('../../src/common/database/wrappers/domain-state'),
+            'getDomainStateRecord'
+          )
+          .mockImplementationOnce(async () => {
+            await new Promise((resolve) => setTimeout(resolve, testTimeoutMS + delay))
+            return null
+          })
+
+        const res = await request(appWithShortTimeout).post(SignerEndpoint.DISABLE_DOMAIN).send(req)
+        spy.mockRestore()
+
+        expect(res.status).toBe(500)
+        expect(res.body).toStrictEqual<DisableDomainResponse>({
+          success: false,
+          error: ErrorMessage.TIMEOUT_FROM_SIGNER,
+          version: expectedVersion,
+        })
+        // Allow time for non-killed processes to finish
+        await new Promise((resolve) => setTimeout(resolve, delay))
+        // Check that DB state was not updated on timeout
+        expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(
+          null
+        )
       })
     })
   })
@@ -466,6 +499,58 @@ describe('domain', () => {
       })
     })
 
+    it('Should respond with 503 on disabled api', async () => {
+      const configWithApiDisabled: typeof _config = JSON.parse(JSON.stringify(_config))
+      configWithApiDisabled.api.domains.enabled = false
+      const appWithApiDisabled = startSigner(configWithApiDisabled, db, keyProvider)
+
+      const req = await quotaRequest()
+
+      const res = await request(appWithApiDisabled)
+        .post(SignerEndpoint.DOMAIN_QUOTA_STATUS)
+        .send(req)
+
+      expect(res.status).toBe(503)
+      expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+        success: false,
+        version: res.body.version,
+        error: WarningMessage.API_UNAVAILABLE,
+      })
+    })
+
+    describe('functionality in case of errors', () => {
+      it('Should respond with 500 on DB getDomainStateRecordOrEmpty failure', async () => {
+        const req = await quotaRequest()
+        // Mocking getDomainStateRecord directly but requiring the real version of
+        // getDomainStateRecordOrEmpty does not easily work,
+        // which is why we mock the outer call here & use the countAndThrowDBError
+        // helper to get as close as possible to testing a real error.
+        const spy = jest
+          .spyOn(
+            jest.requireActual('../../src/common/database/wrappers/domain-state'),
+            'getDomainStateRecordOrEmpty'
+          )
+          .mockImplementationOnce(() => {
+            countAndThrowDBError(
+              new Error(),
+              rootLogger(_config.serviceName),
+              ErrorMessage.DATABASE_GET_FAILURE
+            )
+          })
+        const res = await request(app).post(SignerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
+        spy.mockRestore()
+        expect(res.status).toBe(500)
+        expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+          success: false,
+          version: expectedVersion,
+          error: ErrorMessage.DATABASE_GET_FAILURE,
+        })
+        expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(
+          null
+        )
+      })
+    })
+
     it('Should respond with 500 on signer timeout', async () => {
       const testTimeoutMS = 200
       const delay = 200
@@ -499,25 +584,6 @@ describe('domain', () => {
       })
       // Allow time for non-killed processes to finish
       await new Promise((resolve) => setTimeout(resolve, delay))
-    })
-
-    it('Should respond with 503 on disabled api', async () => {
-      const configWithApiDisabled: typeof _config = JSON.parse(JSON.stringify(_config))
-      configWithApiDisabled.api.domains.enabled = false
-      const appWithApiDisabled = startSigner(configWithApiDisabled, db, keyProvider)
-
-      const req = await quotaRequest()
-
-      const res = await request(appWithApiDisabled)
-        .post(SignerEndpoint.DOMAIN_QUOTA_STATUS)
-        .send(req)
-
-      expect(res.status).toBe(503)
-      expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-        success: false,
-        version: res.body.version,
-        error: WarningMessage.API_UNAVAILABLE,
-      })
     })
   })
 
@@ -840,39 +906,6 @@ describe('domain', () => {
       })
     })
 
-    it('Should respond with 500 on signer timeout', async () => {
-      const [req, _] = await signatureRequest()
-      const testTimeoutMS = 200
-      const delay = 200
-
-      const spy = jest
-        .spyOn(
-          jest.requireActual('../../src/common/database/wrappers/domain-state'),
-          'getDomainStateRecordOrEmpty'
-        )
-        .mockImplementationOnce(async () => {
-          await new Promise((resolve) => setTimeout(resolve, testTimeoutMS + delay))
-          return createEmptyDomainStateRecord(req.domain)
-        })
-
-      const configWithShortTimeout = JSON.parse(JSON.stringify(_config))
-      configWithShortTimeout.timeout = testTimeoutMS
-      const appWithShortTimeout = startSigner(configWithShortTimeout, db, keyProvider)
-
-      const res = await request(appWithShortTimeout).post(SignerEndpoint.DOMAIN_SIGN).send(req)
-      expect(res.status).toBe(500)
-      expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-        success: false,
-        error: ErrorMessage.TIMEOUT_FROM_SIGNER,
-        version: expectedVersion,
-      })
-      spy.mockRestore()
-      // Allow time for non-killed processes to finish
-      await new Promise((resolve) => setTimeout(resolve, delay))
-      // Check that DB state was not updated on timeout
-      expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(null)
-    })
-
     it('Should respond with 503 on disabled api', async () => {
       const configWithApiDisabled: typeof _config = JSON.parse(JSON.stringify(_config))
       configWithApiDisabled.api.domains.enabled = false
@@ -887,6 +920,104 @@ describe('domain', () => {
         success: false,
         version: res.body.version,
         error: WarningMessage.API_UNAVAILABLE,
+      })
+    })
+
+    describe('functionality in case of errors', () => {
+      it('Should respond with 500 on DB getDomainStateRecord query failure', async () => {
+        const [req, _] = await signatureRequest()
+        // Mocking getDomainStateRecord directly but requiring the real version of
+        // getDomainStateRecordOrEmpty does not easily work,
+        // which is why we mock the outer call here & use the countAndThrowDBError
+        // helper to get as close as possible to testing a real error.
+        const spy = jest
+          .spyOn(
+            jest.requireActual('../../src/common/database/wrappers/domain-state'),
+            'getDomainStateRecordOrEmpty'
+          )
+          .mockImplementationOnce(() => {
+            countAndThrowDBError(
+              new Error(),
+              rootLogger(_config.serviceName),
+              ErrorMessage.DATABASE_GET_FAILURE
+            )
+          })
+        const res = await request(app).post(SignerEndpoint.DOMAIN_SIGN).send(req)
+        spy.mockRestore()
+        expect(res.status).toBe(500)
+        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+          success: false,
+          version: expectedVersion,
+          error: ErrorMessage.DATABASE_GET_FAILURE, // TODO EN: this should ideally be DB GET FAILURE
+        })
+        expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(
+          null
+        )
+      })
+
+      it('Should respond with 500 on DB updateDomainStateRecord failure', async () => {
+        const [req, _] = await signatureRequest()
+        // Same as above (re: getDomainStateRecord, but with insertDomainStateRecord)
+        // which is why we mock the outer call here & use the countAndThrowDBError
+        // helper to get as close as possible to testing a real error.
+        const spy = jest
+          .spyOn(
+            jest.requireActual('../../src/common/database/wrappers/domain-state'),
+            'updateDomainStateRecord'
+          )
+          .mockImplementationOnce(() => {
+            countAndThrowDBError(
+              new Error(),
+              rootLogger(_config.serviceName),
+              ErrorMessage.DATABASE_UPDATE_FAILURE
+            )
+          })
+        const res = await request(app).post(SignerEndpoint.DOMAIN_SIGN).send(req)
+        spy.mockRestore()
+        expect(res.status).toBe(500)
+        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+          success: false,
+          version: expectedVersion,
+          error: ErrorMessage.DATABASE_UPDATE_FAILURE,
+        })
+        expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(
+          null
+        )
+      })
+
+      it('Should respond with 500 on signer timeout', async () => {
+        const [req, _] = await signatureRequest()
+        const testTimeoutMS = 200
+        const delay = 200
+
+        const spy = jest
+          .spyOn(
+            jest.requireActual('../../src/common/database/wrappers/domain-state'),
+            'getDomainStateRecordOrEmpty'
+          )
+          .mockImplementationOnce(async () => {
+            await new Promise((resolve) => setTimeout(resolve, testTimeoutMS + delay))
+            return createEmptyDomainStateRecord(req.domain)
+          })
+
+        const configWithShortTimeout = JSON.parse(JSON.stringify(_config))
+        configWithShortTimeout.timeout = testTimeoutMS
+        const appWithShortTimeout = startSigner(configWithShortTimeout, db, keyProvider)
+
+        const res = await request(appWithShortTimeout).post(SignerEndpoint.DOMAIN_SIGN).send(req)
+        expect(res.status).toBe(500)
+        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+          success: false,
+          error: ErrorMessage.TIMEOUT_FROM_SIGNER,
+          version: expectedVersion,
+        })
+        spy.mockRestore()
+        // Allow time for non-killed processes to finish
+        await new Promise((resolve) => setTimeout(resolve, delay))
+        // Check that DB state was not updated on timeout
+        expect(await getDomainStateRecord(db, req.domain, rootLogger(_config.serviceName))).toBe(
+          null
+        )
       })
     })
   })

--- a/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/legacypnp.test.ts
@@ -56,8 +56,6 @@ const {
   DEK_PUBLIC_KEY,
 } = TestUtils.Values
 
-// TODO(2.0.0, timeout) revisit flake tracker timeouts under the umbrella of
-// https://github.com/celo-org/celo-monorepo/issues/9845
 jest.setTimeout(20000)
 
 const expectedSignature =
@@ -680,7 +678,6 @@ describe('legacyPNP', () => {
             undefined,
             appWithShortTimeout
           )
-          // TODO EN: maybe reset mocks in the beforeEach??
           // Ensure that this is restored before test can fail on assertions
           // to prevent failures in other tests
           spy.mockRestore()

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -49,8 +49,6 @@ const {
   DEK_PUBLIC_KEY,
 } = TestUtils.Values
 
-// TODO(2.0.0, timeout) revisit flake tracker timeouts under the umbrella of
-// https://github.com/celo-org/celo-monorepo/issues/9845
 jest.setTimeout(20000)
 
 const testBlockNumber = 1000000
@@ -417,9 +415,6 @@ describe('pnp', () => {
           })
         })
 
-        // TODO(2.0.0, timeout) https://github.com/celo-org/celo-monorepo/issues/9845
-        // Due to weird timeout handling, the signer continues to return responses
-        // after returning the initial error on timeout.
         it('Should respond with 500 on signer timeout', async () => {
           const testTimeoutMS = 200
           const delay = 100
@@ -450,7 +445,6 @@ describe('pnp', () => {
             undefined,
             appWithShortTimeout
           )
-          // TODO EN: maybe reset mocks in the beforeEach??
           // Ensure that this is restored before test can fail on assertions
           // to prevent failures in other tests
           spy.mockRestore()

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -449,15 +449,19 @@ describe('pnp', () => {
             undefined,
             appWithShortTimeout
           )
-
+          // TODO EN: maybe reset mocks in the beforeEach??
+          // Ensure that this is restored before test can fail on assertions
+          // to prevent failures in other tests
+          spy.mockRestore()
           expect(res.status).toBe(500)
           expect(res.body).toStrictEqual({
             success: false,
             error: ErrorMessage.TIMEOUT_FROM_SIGNER,
+            version: expectedVersion,
           })
-          spy.mockRestore()
           // Allow time for non-killed processes to finish
           await new Promise((resolve) => setTimeout(resolve, delay))
+          console.log('leaving first timeout test')
         })
       })
     })
@@ -951,6 +955,7 @@ describe('pnp', () => {
           expect(res.body).toStrictEqual({
             success: false,
             error: ErrorMessage.TIMEOUT_FROM_SIGNER,
+            version: expectedVersion,
           })
           spy.mockRestore()
           // Allow time for non-killed processes to finish


### PR DESCRIPTION
### Changes
- moves `timeout` errors in signer from outer endpoint handler -> actions, so that timeout errors will roll back DB transactions (as opposed to allowing a process to continue after a timeout error has been thrown/responded to the user, and then charging quota)
  - moves timeout error handling into the controller class
- adds outer error-handling in the server for the combiner & signer (& logs errors where responses are sent multiple times)
- standardizes some error handling in controller (propagates more error messages when standard `ErrorMessages` or `WarningMessages` are thrown); this address some of celo-org/social-connect#17 though does not fully fix everything in that ticket
  - in order to do this, updates DB errors to throw standard errors based on the message (i.e. DATABASE_GET_FAILURE)
- adds/updates unit tests for DB errors & timeouts being thrown

### Related issues

- Fixes celo-org/celo-monorepo#9859
- Fixes celo-org/celo-monorepo#9845

### Backwards compatibility

Yes