### PR TITLE
'fs' import fix

### DIFF
--- a/packages/sdk/contractkit/src/identity/metadata.ts
+++ b/packages/sdk/contractkit/src/identity/metadata.ts
@@ -5,7 +5,6 @@ import { AddressType, SignatureType } from '@celo/utils/lib/io'
 import { guessSigner, verifySignature } from '@celo/utils/lib/signatureUtils'
 import fetch from 'cross-fetch'
 import { isLeft } from 'fp-ts/lib/Either'
-import { readFileSync } from 'fs'
 import * as t from 'io-ts'
 import { PathReporter } from 'io-ts/lib/PathReporter'
 import { ContractKit } from '../kit'
@@ -62,6 +61,7 @@ export class IdentityMetadataWrapper {
   }
 
   static fromFile(contractKitOrAccountsWrapper: KitOrAccountsWrapper, path: string) {
+    const { readFileSync } = require('fs')
     return this.fromRawString(contractKitOrAccountsWrapper, readFileSync(path, 'utf-8'))
   }
 

--- a/packages/sdk/contractkit/src/setupForKits.ts
+++ b/packages/sdk/contractkit/src/setupForKits.ts
@@ -1,4 +1,3 @@
-import net from 'net'
 import Web3 from 'web3'
 import { HttpProviderOptions as Web3HttpProviderOptions } from 'web3-providers-http'
 export type HttpProviderOptions = Web3HttpProviderOptions
@@ -25,6 +24,7 @@ export function ensureCurrentProvider(web3: Web3) {
 export function getWeb3ForKit(url: string, options: Web3HttpProviderOptions | undefined) {
   let web3: Web3
   if (url.endsWith('.ipc')) {
+    const net = require('net')
     web3 = new Web3(new Web3.providers.IpcProvider(url, net))
   } else if (url.toLowerCase().startsWith('http')) {
     web3 = new Web3(new Web3.providers.HttpProvider(url, options))

--- a/packages/sdk/identity/src/offchain/storage-writers.ts
+++ b/packages/sdk/identity/src/offchain/storage-writers.ts
@@ -1,5 +1,4 @@
 import { spawnSync } from 'child_process'
-import * as fs from 'fs'
 import { join, parse } from 'path'
 import { resolvePath } from './utils'
 
@@ -16,9 +15,10 @@ export class LocalStorageWriter extends StorageWriter {
   }
 
   protected async writeToFs(data: string | Buffer, dataPath: string): Promise<void> {
+    const { promises } = await import('fs')
     const directory = parse(dataPath).dir
-    await fs.promises.mkdir(join(this.root, directory), { recursive: true })
-    await fs.promises.writeFile(join(this.root, dataPath), data)
+    await promises.mkdir(join(this.root, directory), { recursive: true })
+    await promises.writeFile(join(this.root, dataPath), data)
   }
 }
 


### PR DESCRIPTION


### Description
switch imports of 'fs' module to be either sync require statements (for sync functions) or async imports (for async functions)

This should fix the 'fs' is not a module issue that comes up when using contractkit in a Create React App

There are still some fs imports but they are all in scripts so i believe they can be left


### Other changes

n/a

### Tested



### Related issues

- Fixes  https://github.com/celo-org/celo-monorepo/discussions/9578

### Backwards compatibility

shouldnt break anything

### Documentation

n/a