### PR TITLE
getWithdrawableAmount in ReleaseGold.sol

### DIFF
--- a/packages/protocol/contracts/governance/ReleaseGold.sol
+++ b/packages/protocol/contracts/governance/ReleaseGold.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.13;
 
+import "openzeppelin-solidity/contracts/math/Math.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
@@ -788,5 +789,16 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
     uint256 index
   ) external nonReentrant onlyWhenInProperState {
     getElection().revokePending(group, value, lesser, greater, index);
+  }
+
+  /**
+   * Returns currently withdrawable amount.
+  */
+  function getWithdrawableAmount() public view returns (uint256) {
+    return
+      Math.min(
+        Math.min(maxDistribution, getCurrentReleasedTotalAmount()).sub(totalWithdrawn),
+        getRemainingUnlockedBalance()
+      );
   }
 }

--- a/packages/protocol/contracts/governance/ReleaseGold.sol
+++ b/packages/protocol/contracts/governance/ReleaseGold.sol
@@ -792,7 +792,7 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
   }
 
   /**
-   * Returns currently withdrawable amount.
+   * @return The currently withdrawable release amount.
   */
   function getWithdrawableAmount() public view returns (uint256) {
     return

--- a/packages/protocol/test/governance/voting/release_gold.ts
+++ b/packages/protocol/test/governance/voting/release_gold.ts
@@ -2061,7 +2061,7 @@ contract('ReleaseGold', (accounts: string[]) => {
       releaseGoldSchedule.releaseStartTime = Math.round(Date.now() / 1000)
       releaseGoldSchedule.initialDistributionRatio = 500
       await createNewReleaseGoldInstance(releaseGoldSchedule, web3)
-      initialreleaseGoldAmount = releaseGoldSchedule.amountReleasedPerPeriod.multipliedBy(
+      initialReleaseGoldAmount = releaseGoldSchedule.amountReleasedPerPeriod.multipliedBy(
         releaseGoldSchedule.numReleasePeriods
       )
 
@@ -2077,13 +2077,13 @@ contract('ReleaseGold', (accounts: string[]) => {
       })
 
       it('should return the full amount available for this release period', async () => {
-        const expectedWithdrawalAmount = initialreleaseGoldAmount.div(2)
+        const expectedWithdrawalAmount = initialReleaseGoldAmount.div(2)
         const withdrawableAmount = await releaseGoldInstance.getWithdrawableAmount()
         assertEqualBN(withdrawableAmount, expectedWithdrawalAmount)
       })
 
       it('should return only amount not yet withdrawn', async () => {
-        const expectedWithdrawalAmount = initialreleaseGoldAmount.div(2)
+        const expectedWithdrawalAmount = initialReleaseGoldAmount.div(2)
         await releaseGoldInstance.withdraw(expectedWithdrawalAmount.div(2), { from: beneficiary })
 
         const afterWithdrawal = await releaseGoldInstance.getWithdrawableAmount()
@@ -2096,7 +2096,8 @@ contract('ReleaseGold', (accounts: string[]) => {
       await releaseGoldInstance.setMaxDistribution(1000, { from: releaseOwner })
       const timeToTravel = 6 * MONTH + 1 * DAY
       await timeTravel(timeToTravel, web3)
-      const expectedWithdrawalAmount = initialreleaseGoldAmount.div(2)
+      const signerFund = new BigNumber('1000000000000000000')
+      const expectedWithdrawalAmount = initialReleaseGoldAmount.minus(signerFund).div(2)
 
       const authorized = accounts[4]
       const ecdsaPublicKey = await addressToPublicKey(authorized, web3.eth.sign)
@@ -2111,16 +2112,14 @@ contract('ReleaseGold', (accounts: string[]) => {
         { from: beneficiary }
       )
 
-      const signerFund = new BigNumber('1000000000000000000')
-
       const withdrawableAmount = await releaseGoldInstance.getWithdrawableAmount()
-      assertEqualBN(withdrawableAmount, expectedWithdrawalAmount.minus(signerFund.div(2)))
+      assertEqualBN(withdrawableAmount, expectedWithdrawalAmount)
     })
 
     it('should return only up to max distribution', async () => {
       const timeToTravel = 6 * MONTH + 1 * DAY
       await timeTravel(timeToTravel, web3)
-      const expectedWithdrawalAmount = initialreleaseGoldAmount.div(2)
+      const expectedWithdrawalAmount = initialReleaseGoldAmount.div(2)
 
       await releaseGoldInstance.setMaxDistribution(250, { from: releaseOwner })
 

--- a/packages/protocol/test/governance/voting/release_gold.ts
+++ b/packages/protocol/test/governance/voting/release_gold.ts
@@ -2068,7 +2068,7 @@ contract('ReleaseGold', (accounts: string[]) => {
       await releaseGoldInstance.createAccount({ from: beneficiary })
     })
 
-    describe('should return 50% the released amount of gold right after the beginning of the second quarter', async () => {
+    describe('should return 50% of the released amount of gold right after the beginning of the second quarter', async () => {
       beforeEach(async () => {
         await releaseGoldInstance.setMaxDistribution(1000, { from: releaseOwner })
 

--- a/packages/protocol/test/governance/voting/release_gold.ts
+++ b/packages/protocol/test/governance/voting/release_gold.ts
@@ -2082,7 +2082,7 @@ contract('ReleaseGold', (accounts: string[]) => {
         assertEqualBN(withdrawableAmount, expectedWithdrawalAmount)
       })
 
-      it('should return only only amount not yet withdrawn', async () => {
+      it('should return only amount not yet withdrawn', async () => {
         const expectedWithdrawalAmount = initialreleaseGoldAmount.div(2)
         await releaseGoldInstance.withdraw(expectedWithdrawalAmount.div(2), { from: beneficiary })
 
@@ -2117,7 +2117,7 @@ contract('ReleaseGold', (accounts: string[]) => {
       assertEqualBN(withdrawableAmount, expectedWithdrawalAmount.minus(signerFund.div(2)))
     })
 
-    it('should return only up to distribution', async () => {
+    it('should return only up to max distribution', async () => {
       const timeToTravel = 6 * MONTH + 1 * DAY
       await timeTravel(timeToTravel, web3)
       const expectedWithdrawalAmount = initialreleaseGoldAmount.div(2)

--- a/packages/protocol/test/governance/voting/release_gold.ts
+++ b/packages/protocol/test/governance/voting/release_gold.ts
@@ -2051,7 +2051,7 @@ contract('ReleaseGold', (accounts: string[]) => {
   })
 
   describe('#getWithdrawableAmount', () => {
-    let initialreleaseGoldAmount: any
+    let initialReleaseGoldAmount: any
 
     beforeEach(async () => {
       const releaseGoldSchedule = _.clone(releaseGoldDefaultSchedule)

--- a/packages/protocol/test/governance/voting/release_gold.ts
+++ b/packages/protocol/test/governance/voting/release_gold.ts
@@ -2076,7 +2076,7 @@ contract('ReleaseGold', (accounts: string[]) => {
         await timeTravel(timeToTravel, web3)
       })
 
-      it('should return full amount', async () => {
+      it('should return the full amount available for this release period', async () => {
         const expectedWithdrawalAmount = initialreleaseGoldAmount.div(2)
         const withdrawableAmount = await releaseGoldInstance.getWithdrawableAmount()
         assertEqualBN(withdrawableAmount, expectedWithdrawalAmount)

--- a/packages/sdk/contractkit/src/wrappers/ReleaseGold.ts
+++ b/packages/sdk/contractkit/src/wrappers/ReleaseGold.ts
@@ -271,6 +271,16 @@ export class ReleaseGoldWrapper extends BaseWrapperForGoverning<ReleaseGold> {
   )
 
   /**
+   * Returns currently withdrawable amount
+   * @return The amount that can be yet withdrawn
+   */
+  getWithdrawableAmount: () => Promise<BigNumber> = proxyCall(
+    this.contract.methods.getWithdrawableAmount,
+    undefined,
+    valueToBigNumber
+  )
+
+  /**
    * Revoke a Release schedule
    * @return A CeloTransactionObject
    */


### PR DESCRIPTION
### Description

RG Contracts don't have a view getWithdrawableAmount function

RG Contracts need to manually calculate via min(min(maxDistribution, currentReleasedTotalAmount) - totalWithdrawn, getRemainingUnlockedBalance)


### Other changes

Added to contractKit

### Tested

Unit tests added

### Related issues

- Fixes #7977

### Backwards compatibility

Since it is only new view function there are no incompatibilities

### Documentation

No documentation changes