### PR TITLE
catch require module not found errors  

### DIFF
--- a/packages/sdk/contractkit/src/identity/metadata.ts
+++ b/packages/sdk/contractkit/src/identity/metadata.ts
@@ -63,7 +63,7 @@ export class IdentityMetadataWrapper {
   static fromFile(contractKitOrAccountsWrapper: KitOrAccountsWrapper, path: string) {
     let readFileSync
     try {
-      var fs = require('fs')
+      const fs = require('fs')
       readFileSync = fs.readFileSync
     } catch {
       console.error('cant read from file in browser or environment without native fs module')

--- a/packages/sdk/contractkit/src/identity/metadata.ts
+++ b/packages/sdk/contractkit/src/identity/metadata.ts
@@ -61,7 +61,13 @@ export class IdentityMetadataWrapper {
   }
 
   static fromFile(contractKitOrAccountsWrapper: KitOrAccountsWrapper, path: string) {
-    const { readFileSync } = require('fs')
+    let readFileSync
+    try {
+      var fs = require('fs')
+      readFileSync = fs.readFileSync
+    } catch {
+      console.error('cant read from file in browser or environment without native fs module')
+    }
     return this.fromRawString(contractKitOrAccountsWrapper, readFileSync(path, 'utf-8'))
   }
 

--- a/packages/sdk/contractkit/src/setupForKits.ts
+++ b/packages/sdk/contractkit/src/setupForKits.ts
@@ -24,8 +24,13 @@ export function ensureCurrentProvider(web3: Web3) {
 export function getWeb3ForKit(url: string, options: Web3HttpProviderOptions | undefined) {
   let web3: Web3
   if (url.endsWith('.ipc')) {
-    const net = require('net')
-    web3 = new Web3(new Web3.providers.IpcProvider(url, net))
+    try {
+      const net = require('net')
+      web3 = new Web3(new Web3.providers.IpcProvider(url, net))
+    } catch (e) {
+      console.error('.ipc only works in environments with native net module')
+    }
+    web3 = new Web3(url)
   } else if (url.toLowerCase().startsWith('http')) {
     web3 = new Web3(new Web3.providers.HttpProvider(url, options))
   } else {

--- a/packages/sdk/identity/src/offchain/storage-writers.ts
+++ b/packages/sdk/identity/src/offchain/storage-writers.ts
@@ -15,7 +15,12 @@ export class LocalStorageWriter extends StorageWriter {
   }
 
   protected async writeToFs(data: string | Buffer, dataPath: string): Promise<void> {
-    const { promises } = await import('fs')
+    try {
+      // use var because its scoping means we can import inside try but use outside of it and keep the types.
+      var { promises } = await import('fs')
+    } catch {
+      console.error('tried to write to filesystem but fs module does not exist')
+    }
     const directory = parse(dataPath).dir
     await promises.mkdir(join(this.root, directory), { recursive: true })
     await promises.writeFile(join(this.root, dataPath), data)

--- a/packages/sdk/identity/src/offchain/storage-writers.ts
+++ b/packages/sdk/identity/src/offchain/storage-writers.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'child_process'
+import { promises } from 'fs'
 import { join, parse } from 'path'
 import { resolvePath } from './utils'
-
 export abstract class StorageWriter {
   abstract write(_data: Buffer, _dataPath: string): Promise<void>
 }
@@ -15,12 +15,6 @@ export class LocalStorageWriter extends StorageWriter {
   }
 
   protected async writeToFs(data: string | Buffer, dataPath: string): Promise<void> {
-    try {
-      // use var because its scoping means we can import inside try but use outside of it and keep the types.
-      var { promises } = await import('fs')
-    } catch {
-      console.error('tried to write to filesystem but fs module does not exist')
-    }
     const directory = parse(dataPath).dir
     await promises.mkdir(join(this.root, directory), { recursive: true })
     await promises.writeFile(join(this.root, dataPath), data)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7418,11 +7418,6 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
-"blind-threshold-bls@git+https://github.com/celo-org/blind-threshold-bls-wasm.git#e1e2f8a":
-  version "0.1.0"
-  uid e1e2f8a1ab5154c2f0b1c55cb0d61fbb1d907208
-  resolved "git+https://github.com/celo-org/blind-threshold-bls-wasm.git#e1e2f8a1ab5154c2f0b1c55cb0d61fbb1d907208"
-
 "blind-threshold-bls@https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a":
   version "0.1.0"
   resolved "https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a1ab5154c2f0b1c55cb0d61fbb1d907208"


### PR DESCRIPTION
### Description


wrapp require statements for node native modules in try/catch so that we can just ignore them and use these in browser without needing to stub out at webpack level 


### Other changes



### Tested



### Related issues

- Fixes #
### Backwards compatibility


### Documentation

