### PR TITLE
Enable direct web-app --> ODIS interactions

### DIFF
--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -40,6 +40,7 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
   // enable cross origin resource sharing from any domain so odis can be interacted with from web apps
   app.use(function (_, res, next) {
     res.header('Access-Control-Allow-Origin', '*')
+    res.header('Access-Control-Allow-Methods', 'DELETE, PUT, GET, POST, OPTIONS')
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
     next()
   })

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -37,6 +37,13 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
   // (https://github.com/celo-org/celo-monorepo/issues/9809)
   app.use(express.json({ limit: '0.2mb' }), loggerMiddleware(config.serviceName))
 
+  // enable cross origin resource sharing from any domain so odis can be interacted with from web apps
+  app.use(function (_, res, next) {
+    res.header('Access-Control-Allow-Origin', '*')
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    next()
+  })
+
   kit = kit ?? getContractKit(config.blockchain)
 
   const pnpThresholdStateService = new PnpThresholdStateService()

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -38,7 +38,7 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
   app.use(express.json({ limit: '0.2mb' }), loggerMiddleware(config.serviceName))
 
   // enable cross origin resource sharing from any domain so odis can be interacted with from web apps
-  app.use(function (_, res, next) {
+  app.use((_, res, next) => {
     res.header('Access-Control-Allow-Origin', '*')
     res.header('Access-Control-Allow-Methods', 'DELETE, PUT, GET, POST, OPTIONS')
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')


### PR DESCRIPTION
### Description

Enables CORS for all routes of  combiner so that it is possible to build browser only apps that use odis 

### Other changes

n/a

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #9965 

### Backwards compatibility


### Documentation

n/a