### PR TITLE
ODIS 2.0 PR fixes 2

### DIFF
--- a/packages/phone-number-privacy/combiner/jest.config.js
+++ b/packages/phone-number-privacy/combiner/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   collectCoverageFrom: ['./src/**'],
   coverageThreshold: {
     global: {
-      lines: 59, // TODO(2.0.0) make this higher in testing audit ticket (https://github.com/celo-org/celo-monorepo/issues/9811)
+      lines: 80,
     },
   },
 }

--- a/packages/phone-number-privacy/combiner/src/common/combine.ts
+++ b/packages/phone-number-privacy/combiner/src/common/combine.ts
@@ -29,7 +29,7 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
     this.combine(session)
   }
 
-  async distribute(session: Session<R>): Promise<Session<R>> {
+  async distribute(session: Session<R>): Promise<void> {
     const obs = new PerformanceObserver((list) => {
       const entry = list.getEntries()[0]
       session.logger.info(
@@ -51,8 +51,6 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
 
     performance.clearMarks()
     obs.disconnect()
-
-    return session
   }
 
   protected async forwardToSigner(signer: Signer, session: Session<R>): Promise<void> {

--- a/packages/phone-number-privacy/combiner/src/common/crypto-clients/bls-crypto-client.ts
+++ b/packages/phone-number-privacy/combiner/src/common/crypto-clients/bls-crypto-client.ts
@@ -25,7 +25,7 @@ export class BLSCryptographyClient extends CryptoClient {
    * On error, logs and throws exception for not enough signatures,
    * and drops the invalid signature for future requests using this instance.
    */
-  protected _combinePartialBlindedSignatures(blindedMessage: string, logger: Logger): string {
+  protected _combineBlindedSignatureShares(blindedMessage: string, logger: Logger): string {
     // Optimistically attempt to combine unverified signatures
     // If combination or verification fails, iterate through each signature and remove invalid ones
     // We do this since partial signature verification incurs higher latencies

--- a/packages/phone-number-privacy/combiner/src/common/crypto-clients/crypto-client.ts
+++ b/packages/phone-number-privacy/combiner/src/common/crypto-clients/crypto-client.ts
@@ -25,7 +25,7 @@ export abstract class CryptoClient {
   /*
    * Computes the signature for the blinded phone number using subclass-specific
    * logic defined in _combineBlindedSignatureShares.
-   * Throws an exception if not enough valid signatures.
+   * Throws an exception if not enough valid signatures or on aggregation failure.
    */
   public combineBlindedSignatureShares(blindedMessage: string, logger: Logger): string {
     if (!this.hasSufficientSignatures()) {

--- a/packages/phone-number-privacy/combiner/src/common/crypto-clients/crypto-client.ts
+++ b/packages/phone-number-privacy/combiner/src/common/crypto-clients/crypto-client.ts
@@ -24,10 +24,10 @@ export abstract class CryptoClient {
 
   /*
    * Computes the signature for the blinded phone number using subclass-specific
-   * logic defined in _combinePartialBlindedSignatures.
+   * logic defined in _combineBlindedSignatureShares.
    * Throws an exception if not enough valid signatures.
    */
-  public combinePartialBlindedSignatures(blindedMessage: string, logger: Logger): string {
+  public combineBlindedSignatureShares(blindedMessage: string, logger: Logger): string {
     if (!this.hasSufficientSignatures()) {
       const { threshold } = this.keyVersionInfo
       logger.error(
@@ -38,17 +38,14 @@ export abstract class CryptoClient {
         `${ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES} ${this.allSignaturesLength}/${threshold}`
       )
     }
-    return this._combinePartialBlindedSignatures(blindedMessage, logger)
+    return this._combineBlindedSignatureShares(blindedMessage, logger)
   }
 
   /*
    * Computes the signature for the blinded phone number.
    * Must be implemented by subclass.
    */
-  protected abstract _combinePartialBlindedSignatures(
-    blindedMessage: string,
-    logger: Logger
-  ): string
+  protected abstract _combineBlindedSignatureShares(blindedMessage: string, logger: Logger): string
 
   /**
    * Returns total number of signatures received; must be implemented by subclass.

--- a/packages/phone-number-privacy/combiner/src/common/crypto-clients/domain-crypto-client.ts
+++ b/packages/phone-number-privacy/combiner/src/common/crypto-clients/domain-crypto-client.ts
@@ -32,8 +32,9 @@ export class DomainCryptoClient extends CryptoClient {
         return result.toString('base64')
       }
     } catch (error) {
+      logger.error(ErrorMessage.SIGNATURE_AGGREGATION_FAILURE)
       logger.error(error)
     }
-    throw new Error(ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES)
+    throw new Error(ErrorMessage.SIGNATURE_AGGREGATION_FAILURE)
   }
 }

--- a/packages/phone-number-privacy/combiner/src/common/crypto-clients/domain-crypto-client.ts
+++ b/packages/phone-number-privacy/combiner/src/common/crypto-clients/domain-crypto-client.ts
@@ -25,7 +25,7 @@ export class DomainCryptoClient extends CryptoClient {
    * Verification of partial signatures is not possible server-side
    * (i.e. without the client's blinding factor).
    */
-  protected _combinePartialBlindedSignatures(_blindedMessage: string, logger: Logger): string {
+  protected _combineBlindedSignatureShares(_blindedMessage: string, logger: Logger): string {
     try {
       const result = this.poprfCombiner.blindAggregate(this.allSigsAsArray)
       if (result !== undefined) {

--- a/packages/phone-number-privacy/combiner/src/common/io.ts
+++ b/packages/phone-number-privacy/combiner/src/common/io.ts
@@ -82,7 +82,9 @@ export abstract class IO<R extends OdisRequest> {
     try {
       this.getKeyVersionInfo(request, logger)
       return true
-    } catch {
+    } catch (err) {
+      logger.debug('Error caught in requestHasSupportedKeyVersion')
+      logger.debug(err)
       return false
     }
   }

--- a/packages/phone-number-privacy/combiner/src/common/sign.ts
+++ b/packages/phone-number-privacy/combiner/src/common/sign.ts
@@ -72,9 +72,11 @@ export abstract class SignAction<R extends OdisSignatureRequest> extends Combine
           )
           // Close outstanding requests
           session.abort.abort()
-        } catch {
+        } catch (err) {
           // One or more signatures failed verification and were discarded.
-          // Error has already been logged, continue to collect signatures.
+          session.logger.info('Error caught in receiveSuccess')
+          session.logger.info(err)
+          // Continue to collect signatures.
         }
       }
     }

--- a/packages/phone-number-privacy/combiner/src/common/sign.ts
+++ b/packages/phone-number-privacy/combiner/src/common/sign.ts
@@ -66,7 +66,7 @@ export abstract class SignAction<R extends OdisSignatureRequest> extends Combine
       // BLS threshold signatures can be combined without all partial signatures
       if (session.crypto.hasSufficientSignatures()) {
         try {
-          session.crypto.combinePartialBlindedSignatures(
+          session.crypto.combineBlindedSignatureShares(
             this.parseBlindedMessage(session.request.body),
             session.logger
           )

--- a/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
@@ -16,7 +16,7 @@ export class DomainSignAction extends SignAction<DomainRestrictedSignatureReques
 
     if (session.crypto.hasSufficientSignatures()) {
       try {
-        const combinedSignature = session.crypto.combinePartialBlindedSignatures(
+        const combinedSignature = session.crypto.combineBlindedSignatureShares(
           this.parseBlindedMessage(session.request.body),
           session.logger
         )

--- a/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/domain/endpoints/sign/action.ts
@@ -27,8 +27,10 @@ export class DomainSignAction extends SignAction<DomainRestrictedSignatureReques
           combinedSignature,
           this.thresholdStateService.findThresholdDomainState(session)
         )
-      } catch {
+      } catch (err) {
         // May fail upon combining signatures if too many sigs are invalid
+        session.logger.error('Combining signatures failed in combine')
+        session.logger.error(err)
         // Fallback to handleMissingSignatures
       }
     }

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/sign/action.ts
@@ -18,7 +18,7 @@ export class PnpSignAction extends SignAction<SignMessageRequest> {
 
     if (session.crypto.hasSufficientSignatures()) {
       try {
-        const combinedSignature = session.crypto.combinePartialBlindedSignatures(
+        const combinedSignature = session.crypto.combineBlindedSignatureShares(
           this.parseBlindedMessage(session.request.body),
           session.logger
         )

--- a/packages/phone-number-privacy/combiner/test/unit/bls-signature.test.ts
+++ b/packages/phone-number-privacy/combiner/test/unit/bls-signature.test.ts
@@ -70,7 +70,7 @@ describe(`BLS service computes signature`, () => {
       }
     }
 
-    const actual = blsCryptoClient.combinePartialBlindedSignatures(
+    const actual = blsCryptoClient.combineBlindedSignatureShares(
       blindedMsg,
       rootLogger(config.serviceName)
     )
@@ -116,7 +116,7 @@ describe(`BLS service computes signature`, () => {
     signatures.forEach(async (signature) => {
       blsCryptoClient.addSignature(signature)
     })
-    const actual = blsCryptoClient.combinePartialBlindedSignatures(
+    const actual = blsCryptoClient.combineBlindedSignatureShares(
       blindedMsg,
       rootLogger(config.serviceName)
     )
@@ -163,7 +163,7 @@ describe(`BLS service computes signature`, () => {
       blsCryptoClient.addSignature(signature)
     })
     try {
-      blsCryptoClient.combinePartialBlindedSignatures(blindedMsg, rootLogger(config.serviceName))
+      blsCryptoClient.combineBlindedSignatureShares(blindedMsg, rootLogger(config.serviceName))
       throw new Error('Expected failure with missing signatures')
     } catch (e: any) {
       expect(e.message.includes('Not enough partial signatures')).toBeTruthy()
@@ -208,7 +208,7 @@ describe(`BLS service computes signature`, () => {
     expect(blsCryptoClient.hasSufficientSignatures()).toBeTruthy()
     // Should fail since 1/3 sigs are invalid
     try {
-      blsCryptoClient.combinePartialBlindedSignatures(blindedMsg, rootLogger(config.serviceName))
+      blsCryptoClient.combineBlindedSignatureShares(blindedMsg, rootLogger(config.serviceName))
     } catch (e: any) {
       expect(e.message.includes('Not enough partial signatures')).toBeTruthy()
     }
@@ -217,7 +217,7 @@ describe(`BLS service computes signature`, () => {
 
     blsCryptoClient.addSignature(signatures[3])
     expect(blsCryptoClient.hasSufficientSignatures()).toBeTruthy()
-    const actual = blsCryptoClient.combinePartialBlindedSignatures(
+    const actual = blsCryptoClient.combineBlindedSignatureShares(
       blindedMsg,
       rootLogger(config.serviceName)
     )
@@ -269,7 +269,7 @@ describe(`BLS service computes signature`, () => {
     expect(blsCryptoClient.hasSufficientSignatures()).toBeTruthy()
     // Should fail since signature from url3 was generated with the wrong key version
     try {
-      blsCryptoClient.combinePartialBlindedSignatures(blindedMsg, rootLogger(config.serviceName))
+      blsCryptoClient.combineBlindedSignatureShares(blindedMsg, rootLogger(config.serviceName))
     } catch (e: any) {
       expect(e.message.includes('Not enough partial signatures')).toBeTruthy()
     }
@@ -279,7 +279,7 @@ describe(`BLS service computes signature`, () => {
 
     blsCryptoClient.addSignature(signatures[3])
     expect(blsCryptoClient.hasSufficientSignatures()).toBeTruthy()
-    const actual = blsCryptoClient.combinePartialBlindedSignatures(
+    const actual = blsCryptoClient.combineBlindedSignatureShares(
       blindedMsg,
       rootLogger(config.serviceName)
     )

--- a/packages/phone-number-privacy/common/jest.config.js
+++ b/packages/phone-number-privacy/common/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   collectCoverageFrom: ['./src/**'],
   coverageThreshold: {
     global: {
-      lines: 78, // TODO(2.0.0) make this higher in testing audit ticket (https://github.com/celo-org/celo-monorepo/issues/9811)
+      lines: 80,
     },
   },
 }

--- a/packages/phone-number-privacy/common/src/interfaces/errors.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/errors.ts
@@ -31,6 +31,7 @@ export enum ErrorMessage {
   FAILING_CLOSED = `CELO_ODIS_ERR_28 NODE_ERR Failing closed on full-node error`,
   CAUGHT_ERROR_IN_ENDPOINT_HANDLER = `CELO_ODIS_ERR_29 Caught error in outer endpoint handler`,
   ERROR_AFTER_RESPONSE_SENT = `CELO_ODIS_ERR_30 Error in endpoint thrown after response was already sent`,
+  SIGNATURE_AGGREGATION_FAILURE = 'CELO_ODIS_ERR_31 SIG_ERR Failed to blind aggregate signature shares',
 }
 
 export enum WarningMessage {

--- a/packages/phone-number-privacy/common/src/utils/key-version.ts
+++ b/packages/phone-number-privacy/common/src/utils/key-version.ts
@@ -17,7 +17,9 @@ export function requestHasValidKeyVersion(
   try {
     getRequestKeyVersion(request, logger)
     return true
-  } catch {
+  } catch (err) {
+    logger.debug('Error caught in requestHasValidKeyVersion')
+    logger.debug(err)
     return false
   }
 }
@@ -49,7 +51,9 @@ export function responseHasExpectedKeyVersion(
   let responseKeyVersion
   try {
     responseKeyVersion = getResponseKeyVersion(response, logger)
-  } catch {
+  } catch (err) {
+    logger.debug('Error caught in responseHasExpectedKeyVersion')
+    logger.debug(err)
     return false
   }
 

--- a/packages/phone-number-privacy/signer/jest.config.js
+++ b/packages/phone-number-privacy/signer/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   collectCoverageFrom: ['./src/**'],
   coverageThreshold: {
     global: {
-      lines: 79, // TODO(2.0.0) make this higher in testing audit ticket (https://github.com/celo-org/celo-monorepo/issues/9811)
+      lines: 80,
     },
   },
 }

--- a/packages/phone-number-privacy/signer/package.json
+++ b/packages/phone-number-privacy/signer/package.json
@@ -11,7 +11,7 @@
     "clean": "tsc -b . --clean",
     "build": "tsc -b .",
     "lint": "tslint --project .",
-    "test": "jest --testPathIgnorePatterns test/end-to-end",
+    "test": "SKIP_KNOWN_FLAKES=false jest --testPathIgnorePatterns test/end-to-end",
     "test:debughandles": "jest --watch --runInBand --detectOpenHandles --testPathIgnorePatterns test/end-to-end",
     "test:debug": "node --inspect ../../../node_modules/.bin/jest --runInBand",
     "test:coverage": "yarn test --coverage",


### PR DESCRIPTION
### Description
- rename `_combinePartialBlindedSignatures` -> `_combineBlindedSignatureShares`
- minor error handling changes (new error message thrown from POPRF combine failures, added some debug logging in various places where we are generally catching errors)
- updated test coverage thresholds to 80 for all three packages and removed TODOs
- changed distribute return type to `void`

