### PR TITLE
Re-add getBlindedPhoneNumber to combiner & signer packages

### DIFF
--- a/packages/phone-number-privacy/combiner/test/end-to-end/legacypnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/legacypnp.test.ts
@@ -13,11 +13,10 @@ import {
   SignMessageResponseSchema,
   SignMessageResponseSuccess,
 } from '@celo/phone-number-privacy-common'
-import * as bls from 'blind-threshold-bls'
-import btoa from 'btoa'
 import { randomBytes } from 'crypto'
 import 'isomorphic-fetch'
 import { getCombinerVersion } from '../../src'
+import { getBlindedPhoneNumber } from '../utils'
 import {
   ACCOUNT_ADDRESS,
   ACCOUNT_ADDRESS_NO_QUOTA,
@@ -31,19 +30,6 @@ import {
 require('dotenv').config()
 
 jest.setTimeout(60000)
-
-function getBlindedPhoneNumber(phoneNumber: string, blindingFactor: Buffer): string {
-  const blindedPhoneNumber = bls.blind(Buffer.from(phoneNumber), blindingFactor).message
-  return uint8ArrayToBase64(blindedPhoneNumber)
-}
-
-function uint8ArrayToBase64(bytes: Uint8Array) {
-  let binary = ''
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i])
-  }
-  return btoa(binary)
-}
 
 const expectedPhoneHash = '0x0e87c82690efb29b260d7129b9ded5ed313560997863eb5505ff7bcb5315af7a'
 const expectedPepper = 'ekgnxF0UwzEii'

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -35,6 +35,7 @@ import { Server } from 'net'
 import request from 'supertest'
 import config, { getCombinerVersion } from '../../src/config'
 import { startCombiner } from '../../src/server'
+import { getBlindedPhoneNumber } from '../utils'
 
 const {
   ContractRetrieval,
@@ -43,7 +44,6 @@ const {
   createMockOdisPayments,
   createMockWeb3,
   getPnpRequestAuthorization,
-  getBlindedPhoneNumber,
 } = TestUtils.Utils
 const {
   PRIVATE_KEY1,

--- a/packages/phone-number-privacy/combiner/test/utils.ts
+++ b/packages/phone-number-privacy/combiner/test/utils.ts
@@ -1,0 +1,6 @@
+import threshold_bls from 'blind-threshold-bls'
+
+export function getBlindedPhoneNumber(phoneNumber: string, blindingFactor: Buffer): string {
+  const blindedPhoneNumber = threshold_bls.blind(Buffer.from(phoneNumber), blindingFactor).message
+  return Buffer.from(blindedPhoneNumber).toString('base64')
+}

--- a/packages/phone-number-privacy/signer/test/end-to-end/get-blinded-sig.test.ts
+++ b/packages/phone-number-privacy/signer/test/end-to-end/get-blinded-sig.test.ts
@@ -15,6 +15,7 @@ import 'isomorphic-fetch'
 import Web3 from 'web3'
 import { getWalletAddress } from '../../src/common/web3/contracts'
 import { config, getSignerVersion } from '../../src/config'
+import { getBlindedPhoneNumber } from './utils'
 
 require('dotenv').config()
 
@@ -29,7 +30,7 @@ const {
   PRIVATE_KEY2,
   PRIVATE_KEY3,
 } = TestUtils.Values
-const { replenishQuota, registerWalletAddress, getBlindedPhoneNumber } = TestUtils.Utils
+const { replenishQuota, registerWalletAddress } = TestUtils.Utils
 
 const ODIS_SIGNER = process.env.ODIS_SIGNER_SERVICE_URL
 const ODIS_PUBLIC_POLYNOMIAL = process.env[

--- a/packages/phone-number-privacy/signer/test/end-to-end/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/end-to-end/pnp.test.ts
@@ -16,6 +16,7 @@ import threshold_bls from 'blind-threshold-bls'
 import { randomBytes } from 'crypto'
 import 'isomorphic-fetch'
 import { config, getSignerVersion } from '../../src/config'
+import { getBlindedPhoneNumber } from './utils'
 
 require('dotenv').config()
 
@@ -29,12 +30,7 @@ const {
   PRIVATE_KEY2,
   PRIVATE_KEY3,
 } = TestUtils.Values
-const {
-  getBlindedPhoneNumber,
-  getPnpQuotaRequest,
-  getPnpRequestAuthorization,
-  getPnpSignRequest,
-} = TestUtils.Utils
+const { getPnpQuotaRequest, getPnpRequestAuthorization, getPnpSignRequest } = TestUtils.Utils
 
 const ODIS_SIGNER_URL = process.env.ODIS_SIGNER_SERVICE_URL
 const ODIS_PUBLIC_POLYNOMIAL = process.env[

--- a/packages/phone-number-privacy/signer/test/end-to-end/utils.ts
+++ b/packages/phone-number-privacy/signer/test/end-to-end/utils.ts
@@ -1,0 +1,7 @@
+import threshold_bls from 'blind-threshold-bls'
+
+console.log('using new utils')
+export function getBlindedPhoneNumber(phoneNumber: string, blindingFactor: Buffer): string {
+  const blindedPhoneNumber = threshold_bls.blind(Buffer.from(phoneNumber), blindingFactor).message
+  return Buffer.from(blindedPhoneNumber).toString('base64')
+}


### PR DESCRIPTION
### Description

- gets tests working again after removal of `getBlindedPhoneNumber`, and simplifies the function a bit
- tested that this works with the e2e signer tests on staging 