### PR TITLE
Fix combiner e2e tests

### DIFF
--- a/packages/phone-number-privacy/combiner/test/end-to-end/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/domain.test.ts
@@ -33,12 +33,13 @@ import { defined, noNumber, noString } from '@celo/utils/lib/sign-typed-data-uti
 import * as crypto from 'crypto'
 import 'isomorphic-fetch'
 import { getCombinerVersion } from '../../src'
-import { SERVICE_CONTEXT } from './resources'
+import { getServiceContext, OdisAPI } from './resources'
 
 require('dotenv').config()
 
 jest.setTimeout(60000)
 
+const SERVICE_CONTEXT = getServiceContext(OdisAPI.DOMAIN)
 const combinerUrl = SERVICE_CONTEXT.odisUrl
 const fullNodeUrl = process.env.ODIS_BLOCKCHAIN_PROVIDER
 
@@ -94,17 +95,14 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
 
   describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
     const testThatValidRequestSucceeds = async () => {
-      const expectedResult = 'olxWliQnGKtj2RcwmZUw7z8Fo9qpTWeom712GdvWAJ8='
       const res = await odisHardenKey(
         Buffer.from('password'),
         domain,
         SERVICE_CONTEXT,
         authorizer.wallet
       )
+      // odisHardenKey verifies the signature against the service public key
       expect(res.ok).toBe(true)
-      if (res.ok) {
-        expect(res.result.toString('base64')).toEqual(expectedResult)
-      }
     }
 
     it('Should succeed on valid request', async () => {

--- a/packages/phone-number-privacy/combiner/test/end-to-end/legacypnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/legacypnp.test.ts
@@ -23,8 +23,9 @@ import {
   ACCOUNT_ADDRESS_NO_QUOTA,
   DEFAULT_FORNO_URL,
   dekAuthSigner,
+  getServiceContext,
+  OdisAPI,
   PHONE_NUMBER,
-  SERVICE_CONTEXT,
   walletAuthSigner,
 } from './resources'
 
@@ -32,6 +33,7 @@ require('dotenv').config()
 
 jest.setTimeout(60000)
 
+const SERVICE_CONTEXT = getServiceContext(OdisAPI.PNP)
 const combinerUrl = SERVICE_CONTEXT.odisUrl
 const fullNodeUrl = process.env.ODIS_BLOCKCHAIN_PROVIDER
 

--- a/packages/phone-number-privacy/combiner/test/end-to-end/legacypnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/legacypnp.test.ts
@@ -13,6 +13,7 @@ import {
   SignMessageResponseSchema,
   SignMessageResponseSuccess,
 } from '@celo/phone-number-privacy-common'
+import threshold_bls from 'blind-threshold-bls'
 import { randomBytes } from 'crypto'
 import 'isomorphic-fetch'
 import { getCombinerVersion } from '../../src'
@@ -30,11 +31,6 @@ import {
 require('dotenv').config()
 
 jest.setTimeout(60000)
-
-const expectedPhoneHash = '0x0e87c82690efb29b260d7129b9ded5ed313560997863eb5505ff7bcb5315af7a'
-const expectedPepper = 'ekgnxF0UwzEii'
-const expectedUnblindedSignature =
-  'tbrOhZqiuMCwFOCki+ndnDpgTrkTjELvy/UDa85+VIvD3F3Fosp++6n2IDfgHdOA'
 
 const combinerUrl = SERVICE_CONTEXT.odisUrl
 const fullNodeUrl = process.env.ODIS_BLOCKCHAIN_PROVIDER
@@ -65,12 +61,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
         undefined,
         CombinerEndpoint.LEGACY_PNP_SIGN
       )
-      expect(res).toStrictEqual<PhoneNumberHashDetails>({
-        e164Number: PHONE_NUMBER,
-        phoneHash: expectedPhoneHash,
-        pepper: expectedPepper,
-        unblindedSignature: expectedUnblindedSignature,
-      })
+      threshold_bls.verify(
+        Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+        Buffer.from(PHONE_NUMBER),
+        Buffer.from(res.unblindedSignature!, 'base64')
+      )
     })
 
     it('Should succeed when authenticated with DEK', async () => {
@@ -86,12 +81,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
         undefined,
         CombinerEndpoint.LEGACY_PNP_SIGN
       )
-      expect(res).toStrictEqual<PhoneNumberHashDetails>({
-        e164Number: PHONE_NUMBER,
-        phoneHash: expectedPhoneHash,
-        pepper: expectedPepper,
-        unblindedSignature: expectedUnblindedSignature,
-      })
+      threshold_bls.verify(
+        Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+        Buffer.from(PHONE_NUMBER),
+        Buffer.from(res.unblindedSignature!, 'base64')
+      )
     })
 
     it('Should succeed on repeated valid requests', async () => {
@@ -107,12 +101,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
         undefined,
         CombinerEndpoint.LEGACY_PNP_SIGN
       )
-      expect(res1).toStrictEqual<PhoneNumberHashDetails>({
-        e164Number: PHONE_NUMBER,
-        phoneHash: expectedPhoneHash,
-        pepper: expectedPepper,
-        unblindedSignature: expectedUnblindedSignature,
-      })
+      threshold_bls.verify(
+        Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+        Buffer.from(PHONE_NUMBER),
+        Buffer.from(res1.unblindedSignature!, 'base64')
+      )
       const res2 = await OdisUtils.PhoneNumberIdentifier.getPhoneNumberIdentifier(
         PHONE_NUMBER,
         ACCOUNT_ADDRESS,
@@ -219,12 +212,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
           i,
           CombinerEndpoint.LEGACY_PNP_SIGN
         )
-        expect(res).toStrictEqual<PhoneNumberHashDetails>({
-          e164Number: PHONE_NUMBER,
-          phoneHash: expectedPhoneHash,
-          pepper: expectedPepper,
-          unblindedSignature: expectedUnblindedSignature,
-        })
+        threshold_bls.verify(
+          Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+          Buffer.from(PHONE_NUMBER),
+          Buffer.from(res.unblindedSignature!, 'base64')
+        )
       })
     }
 
@@ -241,12 +233,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
         1.5,
         CombinerEndpoint.LEGACY_PNP_SIGN
       )
-      expect(res).toStrictEqual<PhoneNumberHashDetails>({
-        e164Number: PHONE_NUMBER,
-        phoneHash: expectedPhoneHash,
-        pepper: expectedPepper,
-        unblindedSignature: expectedUnblindedSignature,
-      })
+      threshold_bls.verify(
+        Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+        Buffer.from(PHONE_NUMBER),
+        Buffer.from(res.unblindedSignature!, 'base64')
+      )
     })
 
     it(`Should reject to throw ${ErrorMessages.ODIS_INPUT_ERROR} on unsupported key version`, async () => {
@@ -361,9 +352,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
     })
 
     it(`Should reject to throw ${ErrorMessages.ODIS_QUOTA_ERROR} when account has no quota`, async () => {
+      // Ensure it's not a replayed request.
+      const unusedPN = `+1${Date.now()}`
       await expect(
         OdisUtils.PhoneNumberIdentifier.getPhoneNumberIdentifier(
-          PHONE_NUMBER,
+          unusedPN,
           ACCOUNT_ADDRESS_NO_QUOTA,
           dekAuthSigner(0),
           SERVICE_CONTEXT,

--- a/packages/phone-number-privacy/combiner/test/end-to-end/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/pnp.test.ts
@@ -1,6 +1,5 @@
 import { StableToken } from '@celo/contractkit'
 import { OdisUtils } from '@celo/identity'
-import { PhoneNumberHashDetails } from '@celo/identity/lib/odis/phone-number-identifier'
 import { ErrorMessages } from '@celo/identity/lib/odis/query'
 import { PnpClientQuotaStatus } from '@celo/identity/lib/odis/quota'
 import {
@@ -10,6 +9,7 @@ import {
   SignMessageRequest,
   SignMessageResponseSchema,
 } from '@celo/phone-number-privacy-common'
+import threshold_bls from 'blind-threshold-bls'
 import { randomBytes } from 'crypto'
 import 'isomorphic-fetch'
 import { config as signerConfig } from '../../../signer/src/config'
@@ -27,11 +27,6 @@ import {
 require('dotenv').config()
 
 jest.setTimeout(60000)
-
-const expectedPhoneHash = '0x0e87c82690efb29b260d7129b9ded5ed313560997863eb5505ff7bcb5315af7a'
-const expectedPepper = 'ekgnxF0UwzEii'
-const expectedUnblindedSignature =
-  'tbrOhZqiuMCwFOCki+ndnDpgTrkTjELvy/UDa85+VIvD3F3Fosp++6n2IDfgHdOA'
 
 const combinerUrl = SERVICE_CONTEXT.odisUrl
 const fullNodeUrl = process.env.ODIS_BLOCKCHAIN_PROVIDER
@@ -271,12 +266,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
           SERVICE_CONTEXT,
           replayedBlindingFactor
         )
-        expect(res).toStrictEqual<PhoneNumberHashDetails>({
-          e164Number: PHONE_NUMBER,
-          phoneHash: expectedPhoneHash,
-          pepper: expectedPepper,
-          unblindedSignature: expectedUnblindedSignature,
-        })
+        threshold_bls.verify(
+          Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+          Buffer.from(PHONE_NUMBER),
+          Buffer.from(res.unblindedSignature!, 'base64')
+        )
         const quotaRes = await OdisUtils.Quota.getPnpQuotaStatus(
           ACCOUNT_ADDRESS,
           walletAuthSigner,
@@ -293,12 +287,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
           dekAuthSigner(0),
           SERVICE_CONTEXT
         )
-        expect(res).toStrictEqual<PhoneNumberHashDetails>({
-          e164Number: PHONE_NUMBER,
-          phoneHash: expectedPhoneHash,
-          pepper: expectedPepper,
-          unblindedSignature: expectedUnblindedSignature,
-        })
+        threshold_bls.verify(
+          Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+          Buffer.from(PHONE_NUMBER),
+          Buffer.from(res.unblindedSignature!, 'base64')
+        )
         const quotaRes = await OdisUtils.Quota.getPnpQuotaStatus(
           ACCOUNT_ADDRESS,
           dekAuthSigner(0),
@@ -323,12 +316,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
           undefined,
           i
         )
-        expect(res).toStrictEqual<PhoneNumberHashDetails>({
-          e164Number: PHONE_NUMBER,
-          phoneHash: expectedPhoneHash,
-          pepper: expectedPepper,
-          unblindedSignature: expectedUnblindedSignature,
-        })
+        threshold_bls.verify(
+          Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+          Buffer.from(PHONE_NUMBER),
+          Buffer.from(res.unblindedSignature!, 'base64')
+        )
       })
     }
 
@@ -344,12 +336,11 @@ describe(`Running against service deployed at ${combinerUrl} w/ blockchain provi
         undefined,
         1.5
       )
-      expect(res).toStrictEqual<PhoneNumberHashDetails>({
-        e164Number: PHONE_NUMBER,
-        phoneHash: expectedPhoneHash,
-        pepper: expectedPepper,
-        unblindedSignature: expectedUnblindedSignature,
-      })
+      threshold_bls.verify(
+        Buffer.from(SERVICE_CONTEXT.odisPubKey, 'base64'),
+        Buffer.from(PHONE_NUMBER),
+        Buffer.from(res.unblindedSignature!, 'base64')
+      )
     })
 
     it(`Should reject to throw ${ErrorMessages.ODIS_INPUT_ERROR} on unsupported key version`, async () => {

--- a/packages/phone-number-privacy/combiner/test/end-to-end/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/pnp.test.ts
@@ -19,8 +19,9 @@ import {
   ACCOUNT_ADDRESS_NO_QUOTA,
   BLINDED_PHONE_NUMBER,
   dekAuthSigner,
+  getServiceContext,
+  OdisAPI,
   PHONE_NUMBER,
-  SERVICE_CONTEXT,
   walletAuthSigner,
 } from './resources'
 
@@ -28,6 +29,7 @@ require('dotenv').config()
 
 jest.setTimeout(60000)
 
+const SERVICE_CONTEXT = getServiceContext(OdisAPI.PNP)
 const combinerUrl = SERVICE_CONTEXT.odisUrl
 const fullNodeUrl = process.env.ODIS_BLOCKCHAIN_PROVIDER
 

--- a/packages/phone-number-privacy/combiner/test/end-to-end/resources.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/resources.ts
@@ -38,20 +38,39 @@ export const BLINDING_FACTOR = Buffer.from('0IsBvRfkBrkKCIW6HV0/T1zrzjQSe8wRyU3P
 export const BLINDED_PHONE_NUMBER =
   'hZXDhpC5onzBSFa1agZ9vfHzqwJ/QeJg77NGvWiQG/sFWsvHETzZvdWr2GpF3QkB'
 
-const getServiceContext = () => {
-  switch (process.env.CONTEXT_NAME) {
-    case 'alfajores':
-      return ODIS_ALFAJORES_CONTEXT
-    case 'staging':
-      return ODIS_ALFAJORESSTAGING_CONTEXT
-    case 'mainnet':
-      return ODIS_MAINNET_CONTEXT
-    default:
-      throw new Error('CONTEXT_NAME env var is undefined or invalid')
-  }
+export enum OdisAPI {
+  PNP = 'PNP',
+  DOMAIN = 'DOMAIN',
 }
 
-export const SERVICE_CONTEXT: ServiceContext = getServiceContext()
+export const getServiceContext = (api: OdisAPI): ServiceContext => {
+  switch (process.env.CONTEXT_NAME) {
+    case 'alfajores':
+      return {
+        [OdisAPI.PNP]: ODIS_ALFAJORES_CONTEXT,
+        // TODO: temp fix until the identity SDK is updated
+        [OdisAPI.DOMAIN]: {
+          odisUrl: ODIS_ALFAJORES_CONTEXT.odisUrl,
+          odisPubKey:
+            '+ZrxyPvLChWUX/DyPw6TuGwQH0glDJEbSrSxUARyP5PuqYyP/U4WZTV1e0bAUioBZ6QCJMiLpDwTaFvy8VnmM5RBbLQUMrMg5p4+CBCqj6HhsMfcyUj8V0LyuNdStlCB',
+        },
+      }[api]
+    case 'staging':
+      return {
+        // Intentionally the same on staging
+        [OdisAPI.PNP]: ODIS_ALFAJORESSTAGING_CONTEXT,
+        [OdisAPI.DOMAIN]: ODIS_ALFAJORESSTAGING_CONTEXT,
+      }[api]
+    case 'mainnet':
+      return {
+        // TODO: this needs to be updated
+        [OdisAPI.PNP]: ODIS_MAINNET_CONTEXT,
+        [OdisAPI.DOMAIN]: ODIS_MAINNET_CONTEXT,
+      }[api]
+    default:
+      throw new Error('CONTEXT_NAME env var or api is undefined or invalid')
+  }
+}
 
 export const PHONE_HASH_IDENTIFIER = PhoneNumberUtils.getPhoneHash(PHONE_NUMBER)
 

--- a/packages/phone-number-privacy/combiner/test/end-to-end/tmpBackwardsCompatibility.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/tmpBackwardsCompatibility.test.ts
@@ -14,10 +14,11 @@ import {
   DEFAULT_FORNO_URL,
   dekAuthSigner,
   deks,
+  getServiceContext,
+  OdisAPI,
   PHONE_NUMBER,
   PRIVATE_KEY,
   PRIVATE_KEY_NO_QUOTA,
-  SERVICE_CONTEXT,
 } from './resources'
 
 require('dotenv').config()
@@ -29,7 +30,7 @@ contractKit.addAccount(PRIVATE_KEY_NO_QUOTA)
 contractKit.addAccount(PRIVATE_KEY)
 contractKit.defaultAccount = ACCOUNT_ADDRESS
 
-// const combinerUrl = 'https://us-central1-celo-phone-number-privacy-stg.cloudfunctions.net'
+const SERVICE_CONTEXT = getServiceContext(OdisAPI.PNP)
 const combinerUrl = SERVICE_CONTEXT.odisUrl
 
 const fullNodeUrl = process.env.ODIS_BLOCKCHAIN_PROVIDER


### PR DESCRIPTION
- evaluate/verify signatures programmatically instead of statically so that this works for all service contexts (instead of manually needing to update this each time)
  - if we think it's valuable, we can update this to check against different static values for each environment, but for now I don't know if it's necessary/provides more information than just verifying the signatures
- update the domain pubKey for alfajores (only in test resources for now -- do we want to add this to the identity SDK going forwards or deal with this differently?)

### Tested
- tested this against staging & alfajores
  - also updated the combiner config to point to the listed alfajores pubKey