### PR TITLE
Use Sourcify when encoding/decoding governance proposals

### DIFF
--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -21,7 +21,7 @@ export async function displaySendTx<A>(
 ) {
   cli.action.start(`Sending Transaction: ${name}`)
   try {
-    const txResult = await txObj.send({ ...tx, gasPrice: 10000000000 })
+    const txResult = await txObj.send(tx)
 
     const txHash = await txResult.getHash()
 

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -21,7 +21,7 @@ export async function displaySendTx<A>(
 ) {
   cli.action.start(`Sending Transaction: ${name}`)
   try {
-    const txResult = await txObj.send(tx)
+    const txResult = await txObj.send({ ...tx, gasPrice: 10000000000 })
 
     const txHash = await txResult.getHash()
 

--- a/packages/sdk/explorer/fixtures/contract.metadata.json
+++ b/packages/sdk/explorer/fixtures/contract.metadata.json
@@ -1626,6 +1626,32 @@
         "constant": true,
         "inputs": [
           {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "otherRole",
+            "type": "bytes32"
+          }
+        ],
+        "name": "isLegacyRole",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
             "internalType": "address",
             "name": "_account",
             "type": "address"

--- a/packages/sdk/explorer/fixtures/contract.metadata.json
+++ b/packages/sdk/explorer/fixtures/contract.metadata.json
@@ -1,0 +1,2869 @@
+{
+  "compiler": {
+    "version": "0.5.13+commit.5b0b510c"
+  },
+  "language": "Solidity",
+  "output": {
+    "abi": [
+      {
+        "inputs": [
+          {
+            "internalType": "bool",
+            "name": "test",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "AccountCreated",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes",
+            "name": "dataEncryptionKey",
+            "type": "bytes"
+          }
+        ],
+        "name": "AccountDataEncryptionKeySet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "string",
+            "name": "metadataURL",
+            "type": "string"
+          }
+        ],
+        "name": "AccountMetadataURLSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          }
+        ],
+        "name": "AccountNameSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "walletAddress",
+            "type": "address"
+          }
+        ],
+        "name": "AccountWalletAddressSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "AttestationSignerAuthorized",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSigner",
+            "type": "address"
+          }
+        ],
+        "name": "AttestationSignerRemoved",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSigner",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "DefaultSignerRemoved",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "DefaultSignerSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSigner",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "IndexedSignerRemoved",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "IndexedSignerSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSigner",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "LegacySignerRemoved",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "LegacySignerSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes",
+            "name": "url",
+            "type": "bytes"
+          }
+        ],
+        "name": "OffchainStorageRootAdded",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bytes",
+            "name": "url",
+            "type": "bytes"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "index",
+            "type": "uint256"
+          }
+        ],
+        "name": "OffchainStorageRootRemoved",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "previousOwner",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "beneficiary",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "fraction",
+            "type": "uint256"
+          }
+        ],
+        "name": "PaymentDelegationSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "registryAddress",
+            "type": "address"
+          }
+        ],
+        "name": "RegistrySet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "SignerAuthorizationCompleted",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "SignerAuthorizationStarted",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "SignerAuthorized",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSigner",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "SignerRemoved",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "ValidatorSignerAuthorized",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSigner",
+            "type": "address"
+          }
+        ],
+        "name": "ValidatorSignerRemoved",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "VoteSignerAuthorized",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSigner",
+            "type": "address"
+          }
+        ],
+        "name": "VoteSignerRemoved",
+        "type": "event"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "EIP712_AUTHORIZE_SIGNER_TYPEHASH",
+        "outputs": [
+          {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "bytes",
+            "name": "url",
+            "type": "bytes"
+          }
+        ],
+        "name": "addStorageRoot",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "attestationSignerToAccount",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "authorizeAttestationSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "authorizeSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "authorizeSignerWithSignature",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "authorizeValidatorSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "ecdsaPublicKey",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "blsPublicKey",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "blsPop",
+            "type": "bytes"
+          }
+        ],
+        "name": "authorizeValidatorSignerWithKeys",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "ecdsaPublicKey",
+            "type": "bytes"
+          }
+        ],
+        "name": "authorizeValidatorSignerWithPublicKey",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "authorizeVoteSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "name": "authorizedBy",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address[]",
+            "name": "accountsToQuery",
+            "type": "address[]"
+          }
+        ],
+        "name": "batchGetMetadataURL",
+        "outputs": [
+          {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes",
+            "name": "",
+            "type": "bytes"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "completeSignerAuthorization",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [],
+        "name": "createAccount",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [],
+        "name": "deletePaymentDelegation",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "eip712DomainSeparator",
+        "outputs": [
+          {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getAttestationSigner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getDataEncryptionKey",
+        "outputs": [
+          {
+            "internalType": "bytes",
+            "name": "",
+            "type": "bytes"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "getDefaultSigner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "getIndexedSigner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_account",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "getLegacySigner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getMetadataURL",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getName",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getOffchainStorageRoots",
+        "outputs": [
+          {
+            "internalType": "bytes",
+            "name": "",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getPaymentDelegation",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "getRoleAuthorizationSigner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getValidatorSigner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "getVersionNumber",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getVoteSigner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "getWalletAddress",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "hasAuthorizedAttestationSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "role",
+            "type": "string"
+          }
+        ],
+        "name": "hasAuthorizedSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "hasAuthorizedValidatorSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "hasAuthorizedVoteSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "hasDefaultSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "hasIndexedSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "hasLegacySigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "registryAddress",
+            "type": "address"
+          }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "initialized",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "isAccount",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "isAuthorizedSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "isDefaultSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "isIndexedSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "isLegacyRole",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_account",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "isLegacySigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "isOwner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "isSigner",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "name": "offchainStorageRoots",
+        "outputs": [
+          {
+            "internalType": "bytes",
+            "name": "",
+            "type": "bytes"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "registry",
+        "outputs": [
+          {
+            "internalType": "contract IRegistry",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [],
+        "name": "removeAttestationSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "removeDefaultSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "removeIndexedSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "removeSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "index",
+            "type": "uint256"
+          }
+        ],
+        "name": "removeStorageRoot",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [],
+        "name": "removeValidatorSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [],
+        "name": "removeVoteSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "dataEncryptionKey",
+            "type": "bytes"
+          },
+          {
+            "internalType": "address",
+            "name": "walletAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "setAccount",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "bytes",
+            "name": "dataEncryptionKey",
+            "type": "bytes"
+          }
+        ],
+        "name": "setAccountDataEncryptionKey",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [],
+        "name": "setEip712DomainSeparator",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "role",
+            "type": "bytes32"
+          }
+        ],
+        "name": "setIndexedSigner",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "metadataURL",
+            "type": "string"
+          }
+        ],
+        "name": "setMetadataURL",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          }
+        ],
+        "name": "setName",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "beneficiary",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fraction",
+            "type": "uint256"
+          }
+        ],
+        "name": "setPaymentDelegation",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "registryAddress",
+            "type": "address"
+          }
+        ],
+        "name": "setRegistry",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "walletAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "setWalletAddress",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "signerToAccount",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "validatorSignerToAccount",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          }
+        ],
+        "name": "voteSignerToAccount",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      }
+    ],
+    "devdoc": {
+      "methods": {
+        "addStorageRoot(bytes)": {
+          "params": {
+            "url": "The URL pointing to the offchain storage root."
+          }
+        },
+        "attestationSignerToAccount(address)": {
+          "details": "Fails if the `signer` is not an account or currently authorized attestation signer.",
+          "params": {
+            "signer": "The address of the account or currently authorized attestation signer."
+          },
+          "return": "The associated account."
+        },
+        "authorizeAttestationSigner(address,uint8,bytes32,bytes32)": {
+          "details": "v, r, s constitute `signer`'s signature on `msg.sender`.",
+          "params": {
+            "r": "Output value r of the ECDSA signature.",
+            "s": "Output value s of the ECDSA signature.",
+            "signer": "The address of the signing key to authorize.",
+            "v": "The recovery id of the incoming ECDSA signature."
+          }
+        },
+        "authorizeSigner(address,bytes32)": {
+          "params": {
+            "role": "The role to authorize signing for.",
+            "signer": "The address of the signing key to authorize."
+          }
+        },
+        "authorizeSignerWithSignature(address,bytes32,uint8,bytes32,bytes32)": {
+          "details": "v, r, s constitute `signer`'s EIP712 signature over `role`, `msg.sender`       and `signer`.",
+          "params": {
+            "r": "Output value r of the ECDSA signature.",
+            "role": "The role to authorize signing for.",
+            "s": "Output value s of the ECDSA signature.",
+            "signer": "The address of the signing key to authorize.",
+            "v": "The recovery id of the incoming ECDSA signature."
+          }
+        },
+        "authorizeValidatorSigner(address,uint8,bytes32,bytes32)": {
+          "details": "v, r, s constitute `signer`'s signature on `msg.sender`.",
+          "params": {
+            "r": "Output value r of the ECDSA signature.",
+            "s": "Output value s of the ECDSA signature.",
+            "signer": "The address of the signing key to authorize.",
+            "v": "The recovery id of the incoming ECDSA signature."
+          }
+        },
+        "authorizeValidatorSignerWithKeys(address,uint8,bytes32,bytes32,bytes,bytes,bytes)": {
+          "details": "v, r, s constitute `signer`'s signature on `msg.sender`.",
+          "params": {
+            "blsPop": "The BLS public key proof-of-possession, which consists of a signature on the  account address. 48 bytes.",
+            "blsPublicKey": "The BLS public key that the validator is using for consensus, should pass  proof of possession. 96 bytes.",
+            "ecdsaPublicKey": "The ECDSA public key corresponding to `signer`.",
+            "r": "Output value r of the ECDSA signature.",
+            "s": "Output value s of the ECDSA signature.",
+            "signer": "The address of the signing key to authorize.",
+            "v": "The recovery id of the incoming ECDSA signature."
+          }
+        },
+        "authorizeValidatorSignerWithPublicKey(address,uint8,bytes32,bytes32,bytes)": {
+          "details": "v, r, s constitute `signer`'s signature on `msg.sender`.",
+          "params": {
+            "ecdsaPublicKey": "The ECDSA public key corresponding to `signer`.",
+            "r": "Output value r of the ECDSA signature.",
+            "s": "Output value s of the ECDSA signature.",
+            "signer": "The address of the signing key to authorize.",
+            "v": "The recovery id of the incoming ECDSA signature."
+          }
+        },
+        "authorizeVoteSigner(address,uint8,bytes32,bytes32)": {
+          "details": "v, r, s constitute `signer`'s signature on `msg.sender`.",
+          "params": {
+            "r": "Output value r of the ECDSA signature.",
+            "s": "Output value s of the ECDSA signature.",
+            "signer": "The address of the signing key to authorize.",
+            "v": "The recovery id of the incoming ECDSA signature."
+          }
+        },
+        "batchGetMetadataURL(address[])": {
+          "params": {
+            "accountsToQuery": "The addresses of the accounts to get the metadata for."
+          },
+          "return": "The length of each string in bytes.All strings concatenated."
+        },
+        "completeSignerAuthorization(address,bytes32)": {
+          "params": {
+            "account": "The address of account that authorized signing.",
+            "role": "The role to finish authorizing for."
+          }
+        },
+        "constructor": {
+          "params": {
+            "test": "Set to true to skip implementation initialization"
+          }
+        },
+        "createAccount()": {
+          "return": "True if account creation succeeded."
+        },
+        "getAttestationSigner(address)": {
+          "params": {
+            "account": "The address of the account."
+          },
+          "return": "The address with which the account can sign attestations."
+        },
+        "getDataEncryptionKey(address)": {
+          "params": {
+            "account": "The address of the account to get the key for"
+          },
+          "return": "dataEncryptionKey secp256k1 public key for data encryption. Preferably compressed."
+        },
+        "getDefaultSigner(address,bytes32)": {
+          "params": {
+            "account": "The address of the account.",
+            "role": "The role of the signer."
+          }
+        },
+        "getIndexedSigner(address,bytes32)": {
+          "params": {
+            "account": "The address of the account.",
+            "role": "The role of the signer."
+          }
+        },
+        "getLegacySigner(address,bytes32)": {
+          "params": {
+            "_account": "The address of the account.",
+            "role": "The role of the signer."
+          }
+        },
+        "getMetadataURL(address)": {
+          "params": {
+            "account": "The address of the account to get the metadata for."
+          },
+          "return": "metadataURL The URL to access the metadata."
+        },
+        "getName(address)": {
+          "params": {
+            "account": "The address of the account to get the name for."
+          },
+          "return": "name The name of the account."
+        },
+        "getOffchainStorageRoots(address)": {
+          "params": {
+            "account": "The account whose storage roots to return."
+          },
+          "return": "Concatenated storage root URLs.Lengths of storage root URLs."
+        },
+        "getPaymentDelegation(address)": {
+          "params": {
+            "account": "Account of the validator."
+          },
+          "return": "Beneficiary address of payment delegated.Fraction of payment delegated."
+        },
+        "getRoleAuthorizationSigner(address,address,bytes32,uint8,bytes32,bytes32)": {
+          "params": {
+            "account": "The `account` property signed over in the EIP712 signature",
+            "r": "Output value r of the ECDSA signature.",
+            "role": "The `role` property signed over in the EIP712 signature",
+            "s": "Output value s of the ECDSA signature.",
+            "signer": "The `signer` property signed over in the EIP712 signature",
+            "v": "The recovery id of the incoming ECDSA signature."
+          },
+          "return": "The address that signed the provided role authorization."
+        },
+        "getValidatorSigner(address)": {
+          "params": {
+            "account": "The address of the account."
+          },
+          "return": "The address with which the account can register a validator or group."
+        },
+        "getVersionNumber()": {
+          "return": "Storage version of the contract.Major version of the contract.Minor version of the contract.Patch version of the contract."
+        },
+        "getVoteSigner(address)": {
+          "params": {
+            "account": "The address of the account."
+          },
+          "return": "The address with which the account can sign votes."
+        },
+        "getWalletAddress(address)": {
+          "params": {
+            "account": "The address of the account to get the wallet address for"
+          },
+          "return": "Wallet address"
+        },
+        "hasAuthorizedAttestationSigner(address)": {
+          "params": {
+            "account": "The address of the account."
+          },
+          "return": "Whether the account has specified a dedicated attestation signer."
+        },
+        "hasAuthorizedSigner(address,string)": {
+          "details": "See `hasIndexedSigner` for more gas efficient call."
+        },
+        "hasAuthorizedValidatorSigner(address)": {
+          "params": {
+            "account": "The address of the account."
+          },
+          "return": "Whether the account has specified a dedicated validator signer."
+        },
+        "hasAuthorizedVoteSigner(address)": {
+          "params": {
+            "account": "The address of the account."
+          },
+          "return": "Whether the account has specified a dedicated vote signer."
+        },
+        "initialize(address)": {
+          "params": {
+            "registryAddress": "The address of the registry core smart contract."
+          }
+        },
+        "isAccount(address)": {
+          "params": {
+            "account": "The address of the account"
+          },
+          "return": "Returns `true` if account exists. Returns `false` otherwise."
+        },
+        "isAuthorizedSigner(address)": {
+          "params": {
+            "signer": "The possibly authorized address."
+          },
+          "return": "Returns `true` if authorized. Returns `false` otherwise."
+        },
+        "isDefaultSigner(address,address,bytes32)": {
+          "params": {
+            "account": "The address of account that authorized signing.",
+            "role": "The role that has been authorized.",
+            "signer": "The address of the signer."
+          }
+        },
+        "isIndexedSigner(address,address,bytes32)": {
+          "params": {
+            "account": "The address of account that authorized signing.",
+            "role": "The role that has been authorized.",
+            "signer": "The address of the signer."
+          }
+        },
+        "isLegacyRole(bytes32)": {
+          "params": {
+            "role": "The role to check"
+          }
+        },
+        "isLegacySigner(address,address,bytes32)": {
+          "params": {
+            "_account": "The address of account that authorized signing.",
+            "role": "The role that has been authorized.",
+            "signer": "The address of the signer."
+          }
+        },
+        "isOwner()": {
+          "details": "Returns true if the caller is the current owner."
+        },
+        "isSigner(address,address,bytes32)": {
+          "params": {
+            "account": "The address of account that authorized signing.",
+            "role": "The role that has been authorized.",
+            "signer": "The address of the signer."
+          }
+        },
+        "owner()": {
+          "details": "Returns the address of the current owner."
+        },
+        "removeDefaultSigner(bytes32)": {
+          "params": {
+            "role": "The role that has been authorized."
+          }
+        },
+        "removeIndexedSigner(bytes32)": {
+          "params": {
+            "role": "The role of the signer."
+          }
+        },
+        "removeSigner(address,bytes32)": {
+          "params": {
+            "role": "The role that has been authorized.",
+            "signer": "The address of the signer."
+          }
+        },
+        "removeStorageRoot(uint256)": {
+          "details": "The order of storage roots may change after this operation (the last storage root will be moved to `index`), be aware of this if removing multiple storage roots at a time.",
+          "params": {
+            "index": "The index of the storage root to be removed in the account's list of storage roots."
+          }
+        },
+        "renounceOwnership()": {
+          "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner.     * NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner."
+        },
+        "setAccount(string,bytes,address,uint8,bytes32,bytes32)": {
+          "details": "v, r, s constitute `signer`'s signature on `msg.sender` (unless the wallet address     is 0x0 or msg.sender).",
+          "params": {
+            "dataEncryptionKey": "secp256k1 public key for data encryption. Preferably compressed.",
+            "name": "A string to set as the name of the account",
+            "r": "Output value r of the ECDSA signature.",
+            "s": "Output value s of the ECDSA signature.",
+            "v": "The recovery id of the incoming ECDSA signature.",
+            "walletAddress": "The wallet address to set for the account"
+          }
+        },
+        "setAccountDataEncryptionKey(bytes)": {
+          "params": {
+            "dataEncryptionKey": "secp256k1 public key for data encryption. Preferably compressed."
+          }
+        },
+        "setIndexedSigner(address,bytes32)": {
+          "params": {
+            "role": "the role to register a default signer for",
+            "signer": "the address to set as default"
+          }
+        },
+        "setMetadataURL(string)": {
+          "params": {
+            "metadataURL": "The URL to access the metadata."
+          }
+        },
+        "setName(string)": {
+          "params": {
+            "name": "The name to set."
+          }
+        },
+        "setPaymentDelegation(address,uint256)": {
+          "details": "Use `deletePaymentDelegation` to unset the payment delegation.",
+          "params": {
+            "beneficiary": "The address that should receive a portion of validator payments.",
+            "fraction": "The fraction of the validator's payment that should be diverted to `beneficiary` every epoch, given as FixidityLib value. Must not be greater than 1."
+          }
+        },
+        "setRegistry(address)": {
+          "params": {
+            "registryAddress": "The address of a registry contract for routing to other contracts."
+          }
+        },
+        "setWalletAddress(address,uint8,bytes32,bytes32)": {
+          "details": "Wallet address can be zero. This means that the owner of the wallet does not want to be paid directly without interaction, and instead wants users to contact them, using the data encryption key, and arrange a payment.v, r, s constitute `signer`'s signature on `msg.sender` (unless the wallet address     is 0x0 or msg.sender).",
+          "params": {
+            "r": "Output value r of the ECDSA signature.",
+            "s": "Output value s of the ECDSA signature.",
+            "v": "The recovery id of the incoming ECDSA signature.",
+            "walletAddress": "The wallet address to set for the account"
+          }
+        },
+        "signerToAccount(address)": {
+          "details": "Fails if the `signer` is not an account or previously authorized signer.",
+          "params": {
+            "signer": "The address of the account or previously authorized signer."
+          },
+          "return": "The associated account."
+        },
+        "transferOwnership(address)": {
+          "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+        },
+        "validatorSignerToAccount(address)": {
+          "details": "Fails if the `signer` is not an account or currently authorized validator.",
+          "params": {
+            "signer": "The address of an account or currently authorized validator signer."
+          },
+          "return": "The associated account."
+        },
+        "voteSignerToAccount(address)": {
+          "details": "Fails if the `signer` is not an account or currently authorized vote signer.",
+          "params": {
+            "signer": "The address of the account or currently authorized vote signer."
+          },
+          "return": "The associated account."
+        }
+      }
+    },
+    "userdoc": {
+      "methods": {
+        "addStorageRoot(bytes)": {
+          "notice": "Adds a new CIP8 storage root."
+        },
+        "attestationSignerToAccount(address)": {
+          "notice": "Returns the account associated with `signer`."
+        },
+        "authorizeAttestationSigner(address,uint8,bytes32,bytes32)": {
+          "notice": "Authorizes an address to sign attestations on behalf of the account."
+        },
+        "authorizeSigner(address,bytes32)": {
+          "notice": "Begin the process of authorizing an address to sign on behalf of the account"
+        },
+        "authorizeSignerWithSignature(address,bytes32,uint8,bytes32,bytes32)": {
+          "notice": "Authorizes an address to act as a signer, for `role`, on behalf of the account."
+        },
+        "authorizeValidatorSigner(address,uint8,bytes32,bytes32)": {
+          "notice": "Authorizes an address to sign consensus messages on behalf of the account."
+        },
+        "authorizeValidatorSignerWithKeys(address,uint8,bytes32,bytes32,bytes,bytes,bytes)": {
+          "notice": "Authorizes an address to sign consensus messages on behalf of the account."
+        },
+        "authorizeValidatorSignerWithPublicKey(address,uint8,bytes32,bytes32,bytes)": {
+          "notice": "Authorizes an address to sign consensus messages on behalf of the account."
+        },
+        "authorizeVoteSigner(address,uint8,bytes32,bytes32)": {
+          "notice": "Authorizes an address to sign votes on behalf of the account."
+        },
+        "batchGetMetadataURL(address[])": {
+          "notice": "Getter for the metadata of multiple accounts."
+        },
+        "completeSignerAuthorization(address,bytes32)": {
+          "notice": "Finish the process of authorizing an address to sign on behalf of the account. "
+        },
+        "constructor": "Sets initialized == true on implementation contracts",
+        "createAccount()": {
+          "notice": "Creates an account."
+        },
+        "deletePaymentDelegation()": {
+          "notice": "Removes a validator's payment delegation by setting benficiary and fraction to 0."
+        },
+        "getAttestationSigner(address)": {
+          "notice": "Returns the attestation signer for the specified account."
+        },
+        "getDataEncryptionKey(address)": {
+          "notice": "Getter for the data encryption key and version."
+        },
+        "getDefaultSigner(address,bytes32)": {
+          "notice": "Returns the default signer for the specified account and  role. If no signer has been specified it will return the account itself."
+        },
+        "getIndexedSigner(address,bytes32)": {
+          "notice": "Returns the indexed signer for the specified account and role.  If no signer has been specified it will return the account itself."
+        },
+        "getLegacySigner(address,bytes32)": {
+          "notice": "Returns the legacy signer for the specified account and  role. If no signer has been specified it will return the account itself."
+        },
+        "getMetadataURL(address)": {
+          "notice": "Getter for the metadata of an account."
+        },
+        "getName(address)": {
+          "notice": "Getter for the name of an account."
+        },
+        "getOffchainStorageRoots(address)": {
+          "notice": "Returns the full list of offchain storage roots for an account."
+        },
+        "getPaymentDelegation(address)": {
+          "notice": "Gets validator payment delegation settings."
+        },
+        "getRoleAuthorizationSigner(address,address,bytes32,uint8,bytes32,bytes32)": {
+          "notice": "Returns the address that signed the provided role authorization."
+        },
+        "getValidatorSigner(address)": {
+          "notice": "Returns the validator signer for the specified account."
+        },
+        "getVersionNumber()": {
+          "notice": "Returns the storage, major, minor, and patch version of the contract."
+        },
+        "getVoteSigner(address)": {
+          "notice": "Returns the vote signer for the specified account."
+        },
+        "getWalletAddress(address)": {
+          "notice": "Getter for the wallet address for an account"
+        },
+        "hasAuthorizedAttestationSigner(address)": {
+          "notice": "Returns if account has specified a dedicated attestation signer."
+        },
+        "hasAuthorizedSigner(address,string)": {
+          "notice": "Checks whether or not the account has a signer registered for the plaintext role."
+        },
+        "hasAuthorizedValidatorSigner(address)": {
+          "notice": "Returns if account has specified a dedicated validator signer."
+        },
+        "hasAuthorizedVoteSigner(address)": {
+          "notice": "Returns if account has specified a dedicated vote signer."
+        },
+        "hasDefaultSigner(address,bytes32)": {
+          "notice": "Checks whether or not the account has an indexed signer registered for a role"
+        },
+        "hasIndexedSigner(address,bytes32)": {
+          "notice": "Checks whether or not the account has an indexed signer registered for the role"
+        },
+        "hasLegacySigner(address,bytes32)": {
+          "notice": "Checks whether or not the account has an indexed signer registered for one of the legacy roles"
+        },
+        "initialize(address)": {
+          "notice": "Used in place of the constructor to allow the contract to be upgradable via proxy."
+        },
+        "isAccount(address)": {
+          "notice": "Check if an account already exists."
+        },
+        "isAuthorizedSigner(address)": {
+          "notice": "Check if an address has been an authorized signer for an account."
+        },
+        "isDefaultSigner(address,address,bytes32)": {
+          "notice": "Whether or not the signer has been registered as the default signer for role"
+        },
+        "isIndexedSigner(address,address,bytes32)": {
+          "notice": "Whether or not the signer has been registered as an indexed signer for role"
+        },
+        "isLegacyRole(bytes32)": {
+          "notice": "Checks whether the role is one of Vote, Validator or Attestation"
+        },
+        "isLegacySigner(address,address,bytes32)": {
+          "notice": "Whether or not the signer has been registered as the legacy signer for role"
+        },
+        "isSigner(address,address,bytes32)": {
+          "notice": "Whether or not the signer has been registered as a signer for role"
+        },
+        "removeAttestationSigner()": {
+          "notice": "Removes the currently authorized attestation signer for the account Note that the signers cannot be reauthorized after they have been removed."
+        },
+        "removeDefaultSigner(bytes32)": {
+          "notice": "Removes the signer for a default role."
+        },
+        "removeIndexedSigner(bytes32)": {
+          "notice": "Removes the currently authorized and indexed signer  for a specific role"
+        },
+        "removeSigner(address,bytes32)": {
+          "notice": "Removes the currently authorized signer for a specific role and  if the signer is indexed, remove that as well."
+        },
+        "removeStorageRoot(uint256)": {
+          "notice": "Removes a CIP8 storage root."
+        },
+        "removeValidatorSigner()": {
+          "notice": "Removes the currently authorized validator signer for the account Note that the signers cannot be reauthorized after they have been removed."
+        },
+        "removeVoteSigner()": {
+          "notice": "Removes the currently authorized vote signer for the account. Note that the signers cannot be reauthorized after they have been removed."
+        },
+        "setAccount(string,bytes,address,uint8,bytes32,bytes32)": {
+          "notice": "Convenience Setter for the dataEncryptionKey and wallet address for an account"
+        },
+        "setAccountDataEncryptionKey(bytes)": {
+          "notice": "Setter for the data encryption key and version."
+        },
+        "setEip712DomainSeparator()": {
+          "notice": "Sets the EIP712 domain separator for the Celo Accounts abstraction."
+        },
+        "setIndexedSigner(address,bytes32)": {
+          "notice": "Set the indexed signer for a specific role"
+        },
+        "setMetadataURL(string)": {
+          "notice": "Setter for the metadata of an account."
+        },
+        "setName(string)": {
+          "notice": "Setter for the name of an account."
+        },
+        "setPaymentDelegation(address,uint256)": {
+          "notice": "Sets validator payment delegation settings."
+        },
+        "setRegistry(address)": {
+          "notice": "Updates the address pointing to a Registry contract."
+        },
+        "setWalletAddress(address,uint8,bytes32,bytes32)": {
+          "notice": "Setter for the wallet address for an account"
+        },
+        "signerToAccount(address)": {
+          "notice": "Returns the account associated with `signer`."
+        },
+        "validatorSignerToAccount(address)": {
+          "notice": "Returns the account associated with `signer`."
+        },
+        "voteSignerToAccount(address)": {
+          "notice": "Returns the account associated with `signer`."
+        }
+      }
+    }
+  },
+  "settings": {
+    "compilationTarget": {
+      "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/Accounts.sol": "Accounts"
+    },
+    "evmVersion": "istanbul",
+    "libraries": {},
+    "optimizer": {
+      "enabled": false,
+      "runs": 200
+    },
+    "remappings": []
+  },
+  "sources": {
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/Accounts.sol": {
+      "keccak256": "0x173da8996b5f86b96e2ee965d8d94d18b5ed6f1b10f1b86683ffdc4da8b874fb",
+      "urls": [
+        "bzz-raw://d9a08dd2d4f855263df926ecc5143aea5de043768c802534c82ed1178bdf5629",
+        "dweb:/ipfs/QmZQPMB92xaHhqHKbBrJCDsEr7yxXFYxxP5vzYC2oeLACA"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/FixidityLib.sol": {
+      "keccak256": "0x2f98fa3b3454621817917bae2830806858a96c9457be2c5b6e0bed5b35aaaba3",
+      "urls": [
+        "bzz-raw://b6bf5cf79debe02093777cc9ddef4616dedd041ccc2618c43ea91c90afd97df6",
+        "dweb:/ipfs/QmXonY3FkVy2jnQvLkgDi4LcaniS5DVZ1zpRZecWKWy9Ro"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/Initializable.sol": {
+      "keccak256": "0xad98825b5d3181f4ce2d2dbe84adeb0cd7960fd80fafb0813539d6d96ba42ab8",
+      "urls": [
+        "bzz-raw://f76468328c78b80eeaaaadb7b186e41da4a34134446fe11bb707106322b8e32f",
+        "dweb:/ipfs/QmNyjyVjPX1GKFibDcJBJyZQ57nhusG3DhPjAGnY7iaU39"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/Signatures.sol": {
+      "keccak256": "0xb11ccc01ac5d81c5496828a92536cfc07378e87c0517fe6f8b429a96c41cb21e",
+      "urls": [
+        "bzz-raw://8c8b5c705c55e4141bf7fa4a6dd5941ebbf81969033476f737db357224075057",
+        "dweb:/ipfs/QmcUySMBWov2uVEzVmwECzFLxiimqzLEip29w9bNvUvRBK"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/UsingRegistry.sol": {
+      "keccak256": "0xfdd9e70bd58259b491ec54779715d7469ab4f804836bf5f63ff86921d0cae056",
+      "urls": [
+        "bzz-raw://e55f23f464e49c42b1f31782dcb88cbd2ca64e050d5f110ccdc2ffd50cd582ff",
+        "dweb:/ipfs/QmfBiet9GbT9S9rn9SG9CkyXQGAMQRuk4EBmChY1m4kv47"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/interfaces/IAccounts.sol": {
+      "keccak256": "0x1ec92ced98458b625f5cc7742e7487c6e9c0042ae86bbd4b5cec293363c543ee",
+      "urls": [
+        "bzz-raw://bf85ce1ac9c145877666436ce0c9c998ab205a7fe8ec39a90332ac01fecad9f2",
+        "dweb:/ipfs/QmYQTztErbUUYf52rAL3xVjFqED91n6Es7RidjDTkuKeM6"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/interfaces/ICeloVersionedContract.sol": {
+      "keccak256": "0x7bf4411df057bec6f7fcc1c25c1f46cd9a8f75118958012b56ecef8a986abd62",
+      "urls": [
+        "bzz-raw://b08c5c589b31ab774f6d1eb73bf67e111e04a0f1b99cd8e2528f021cf4983100",
+        "dweb:/ipfs/Qmao3mnAW1mUixfwtZXvJUCBzK65hzfmvHGgZqHPpXEt3C"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/interfaces/IFeeCurrencyWhitelist.sol": {
+      "keccak256": "0xd4711baf3e38a0abeb3ef48eaab21aeb917f5e0a185cf463fddeb4bf20277b68",
+      "urls": [
+        "bzz-raw://8f350863943ab54dcf4d5ea525c16748f59263bf36c1d85251c1164d0e592032",
+        "dweb:/ipfs/QmXAG6fvVQKM86rVsk6R3ndEoHtS9fcAAVxBApJ5j3LWeK"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/interfaces/IFreezer.sol": {
+      "keccak256": "0x12508a9d528d1b63dc06644e9d97e864acc94f8a763cf8555e90bcdf1b2f8b21",
+      "urls": [
+        "bzz-raw://32df109167a13e684c9b296a0e13dda1899e418788eb59bf59aedd7a3ce65466",
+        "dweb:/ipfs/QmR6BJCRFMSQpBpnSH2vzLE959FhXnmreDocWWc7fUYnnu"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/interfaces/IRegistry.sol": {
+      "keccak256": "0x78ba82722d28e815c117f33d4659404f0707dab1c9b51f1bce5d4c15d6c94537",
+      "urls": [
+        "bzz-raw://0cea84b948896aece11c64b97c22b0f08f86cb45e166a004db4a88a98952cbfa",
+        "dweb:/ipfs/QmR4uSGcs4nmph6duroscchstSwMzWSV8CDvD2SSnWuHbs"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/libraries/ReentrancyGuard.sol": {
+      "keccak256": "0xa2584554532d7004ca3d2d168cd9dfb7694605f1a32431af4d1b7d834fa6b08d",
+      "urls": [
+        "bzz-raw://fb012e7a76145a86b8746b0b10768845d17a5c5ab9cbdcd863fde42028b5632c",
+        "dweb:/ipfs/QmdJi5va3broTVwJJ5uCBSg4T2rwTaAvzSBtnZzETvverK"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/governance/interfaces/IElection.sol": {
+      "keccak256": "0xebcd0d7dbbb2df503967ad63c9ddd437cef89a94ba2cc2f9ce274f41a4c901ee",
+      "urls": [
+        "bzz-raw://84dcf3a9952f1ce9a9110abb1783dfead290fd17c28216c5acb22de9d090921d",
+        "dweb:/ipfs/QmeNoLz8WcHX9GLcBfQChXFHsFDRaVRRXnPXXvB2qVTaSZ"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/governance/interfaces/IGovernance.sol": {
+      "keccak256": "0x1416ade12c83b723dcd0d42c59d5bd7fbe3ad51b83b613c5f76eb524b84530ce",
+      "urls": [
+        "bzz-raw://c189b55fc7a6f5769a3171f84ea4b78828da4ce130e0fc20158aa9403c03ac4d",
+        "dweb:/ipfs/QmREMga9rQTs1uBeGRRiNdNdYQQaSm5dY9LufnMVphtdMw"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/governance/interfaces/ILockedGold.sol": {
+      "keccak256": "0x577d01d8a1fbf47980fb5ffd36de2084ec255889b15671adfecd3a285df4f253",
+      "urls": [
+        "bzz-raw://6b955b6829748cd136fa92c3a434f5419e4eb024d535a854900ad48bd4151b67",
+        "dweb:/ipfs/QmXM5uL5dsKecYyedAzsrZXAp81NtWQErbbVEFccJ6ZqiY"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/governance/interfaces/IValidators.sol": {
+      "keccak256": "0x524a9e48689537421f97296ffd57fa0f2887117f9af9e71dd5ed17e66ba92d2a",
+      "urls": [
+        "bzz-raw://cf5d0c2f6ee9b2c8e270162455177e9c3bac79ac07d4f37c86f7f2ee5978a756",
+        "dweb:/ipfs/QmZTKmytn1Wi3QfU3bHuSaSeYQzRrFKehyngrg37rHD3vV"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/identity/interfaces/IAttestations.sol": {
+      "keccak256": "0x979aaac636fe6a64f97034bf0bf062b5f0efd6e6f9f3fe84e81180f82eeb7a3e",
+      "urls": [
+        "bzz-raw://c1255d08278188247ef81fb09edd2d1d4a019fb0fe80fd3d9850415c5eb5caaf",
+        "dweb:/ipfs/QmcJvqSM35nAR8p8LwVczhnaY6VwTRThNjfCzkzeiAkz45"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/identity/interfaces/IRandom.sol": {
+      "keccak256": "0xd65fd529d133cbde94628b39b0d2f0f4b6d0af2e8f97c0e6b4b2cd476479ed1d",
+      "urls": [
+        "bzz-raw://f2c6fe351990bfdeb55484bd3622d44c8f58579a7212d5cce71a82df846497f5",
+        "dweb:/ipfs/QmRDDTXUqbA6dHfJe4ZS1442JDAfwoHq2eH9LHnQyzsh44"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/stability/interfaces/IExchange.sol": {
+      "keccak256": "0xbfcf77e30fc62218decbb73297d5161b9c490f7e44f75158f1c79674e4b8b83c",
+      "urls": [
+        "bzz-raw://ad0caaddcb552a2c040e827e9336cdec7dfaf629cca9f30e5f5bc12645abde43",
+        "dweb:/ipfs/QmTjnGbfoSkZhNWhrbcYdLjF1LLqAJcviJ2ZKSMH9KWz95"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/stability/interfaces/IReserve.sol": {
+      "keccak256": "0x8da4d702b47a7e60981ca416f2d0f24a3c1dea9ab44f04b695c0fde02c84a38e",
+      "urls": [
+        "bzz-raw://198fb3cd945e374926e3d6bcb2469b7f5c635e78b40417a4b3a1eacabeca234b",
+        "dweb:/ipfs/Qma8RRSqksFCzL5gWTXmGtJvC4Mw1bgquvN33nKhrRwUrD"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/stability/interfaces/ISortedOracles.sol": {
+      "keccak256": "0x8f80e430800fff2f04f3981c4b73a2a374b2c2150543a2de51fcf7ba4fb08789",
+      "urls": [
+        "bzz-raw://f1a472385d5fa1b1cc4ab6ff948cd11f86c55328841d89f39f02b64449d3ac1a",
+        "dweb:/ipfs/QmSYfwR8RJ2nyzt9VJtLKqaUHwAPfz579vhcQP7LRLaqTe"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/stability/interfaces/IStableToken.sol": {
+      "keccak256": "0x091e577acecdf050fe4c41133b11fe330d07050c5fe78b65bfce32ccc29e51c6",
+      "urls": [
+        "bzz-raw://94f7d7578274be8212b8c9a3f0759d884969b05a7f0c64c7c9352102f4e51ab4",
+        "dweb:/ipfs/Qmd3bERcFLrrvpURuzKUg6YCSFisNQ36YpRLWkxEcS1Tkj"
+      ]
+    },
+    "openzeppelin-solidity/contracts/GSN/Context.sol": {
+      "keccak256": "0x90a3995645af7562d84b9d69363ffa5ae7217714ab61e951bf7bc450f40e4061",
+      "urls": [
+        "bzz-raw://216ef9d6b614db4eb46970b4e84903f2534a45572dd30a79f0041f1a5830f436",
+        "dweb:/ipfs/QmNPrJ4MWKUAWzKXpUqeyKRUfosaoANZAqXgvepdrCwZAG"
+      ]
+    },
+    "openzeppelin-solidity/contracts/cryptography/ECDSA.sol": {
+      "keccak256": "0xc89ea7e48ba477b1781b24ae963442fff1bb2af33b6178dad679a3fa2f5ab2de",
+      "urls": [
+        "bzz-raw://b736ddad8143f8f1cd13c20809d4ebce5f5a8c7725081b0b703294078bd506d1",
+        "dweb:/ipfs/QmdhTWCXFCuwG9JaPMjwnhkQoDj9su8R7KMPNvD5z9KeWD"
+      ]
+    },
+    "openzeppelin-solidity/contracts/math/SafeMath.sol": {
+      "keccak256": "0x640b6dee7a4b830bdfd52b5031a07fc2b12209f5b2e29e5d364a7d37f69d8076",
+      "urls": [
+        "bzz-raw://31113152e1ddb78fe7a4197f247591ca894e93f916867beb708d8e747b6cc74f",
+        "dweb:/ipfs/QmbZaJyXdpsYGykVhHH9qpVGQg9DGCxE2QufbCUy3daTgq"
+      ]
+    },
+    "openzeppelin-solidity/contracts/ownership/Ownable.sol": {
+      "keccak256": "0x6fb9d7889769d7cc161225f9ef7a90e468ba9788b253816f8d8b6894d3472c24",
+      "urls": [
+        "bzz-raw://cf4c00fc3c37cc5acf0c82ec6fd97bab67d72c2567fdc0ebf023d9c09b30a08e",
+        "dweb:/ipfs/Qmb7TChG6DsEDX7LooJ4vmxot19f7VXX8S1zUGPeJTWbwZ"
+      ]
+    },
+    "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol": {
+      "keccak256": "0xe5bb0f57cff3e299f360052ba50f1ea0fff046df2be070b6943e0e3c3fdad8a9",
+      "urls": [
+        "bzz-raw://59fd025151435da35faa8093a5c7a17de02de9d08ad27275c5cdf05050820d91",
+        "dweb:/ipfs/QmQMvwEcPhoRXzbXyrdoeRtvLoifUW9Qh7Luho7bmUPRkc"
+      ]
+    }
+  },
+  "version": 1
+}

--- a/packages/sdk/explorer/fixtures/proxy.metadata.json
+++ b/packages/sdk/explorer/fixtures/proxy.metadata.json
@@ -1,0 +1,198 @@
+{
+  "compiler": {
+    "version": "0.5.13+commit.5b0b510c"
+  },
+  "language": "Solidity",
+  "output": {
+    "abi": [
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+          }
+        ],
+        "name": "ImplementationSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          }
+        ],
+        "name": "OwnerSet",
+        "type": "event"
+      },
+      {
+        "payable": true,
+        "stateMutability": "payable",
+        "type": "fallback"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "_getImplementation",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "_getOwner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callbackData",
+            "type": "bytes"
+          }
+        ],
+        "name": "_setAndInitializeImplementation",
+        "outputs": [],
+        "payable": true,
+        "stateMutability": "payable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+          }
+        ],
+        "name": "_setImplementation",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "_transferOwnership",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    ],
+    "devdoc": {
+      "methods": {
+        "_setAndInitializeImplementation(address,bytes)": {
+          "details": "Throws if the initialization callback fails.If the target contract does not need initialization, use setImplementation instead.",
+          "params": {
+            "callbackData": "The abi-encoded function call to perform in the implementation contract.",
+            "implementation": "Address of the new target contract."
+          }
+        },
+        "_setImplementation(address)": {
+          "details": "If the target contract needs to be initialized, call setAndInitializeImplementation instead.",
+          "params": {
+            "implementation": "Address of the new target contract."
+          }
+        },
+        "_transferOwnership(address)": {
+          "params": {
+            "newOwner": "Address of the new owner account."
+          }
+        }
+      }
+    },
+    "userdoc": {
+      "methods": {
+        "_getImplementation()": {
+          "notice": "Returns the implementation address."
+        },
+        "_getOwner()": {
+          "notice": "Returns the Proxy owner's address."
+        },
+        "_setAndInitializeImplementation(address,bytes)": {
+          "notice": "Sets the address of the implementation contract and calls into it."
+        },
+        "_setImplementation(address)": {
+          "notice": "Sets the address of the implementation contract."
+        },
+        "_transferOwnership(address)": {
+          "notice": "Transfers ownership of Proxy to a new owner."
+        }
+      }
+    }
+  },
+  "settings": {
+    "compilationTarget": {
+      "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/proxies/AccountsProxy.sol": "AccountsProxy"
+    },
+    "evmVersion": "istanbul",
+    "libraries": {},
+    "optimizer": {
+      "enabled": false,
+      "runs": 200
+    },
+    "remappings": []
+  },
+  "sources": {
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/Proxy.sol": {
+      "keccak256": "0x650f2a079da45a71970749c9039dece5986835225035b29eca4df1c1dab0d6ac",
+      "urls": [
+        "bzz-raw://cb6c36af368fa26a6fb5f033941536e73ebd1aafad5162f073f318a30f4ee349",
+        "dweb:/ipfs/QmaWNhRtpPU4iGDnWjBYRZobUvJYwGQJvtaPZMtbzjjZB3"
+      ]
+    },
+    "/home/bowd/Workspace/job/celo/celo-monorepo/packages/protocol/contracts/common/proxies/AccountsProxy.sol": {
+      "keccak256": "0x42531c7bfc12cf2e3e33a1b1f7614d82b25e8a2beff194d793446b7639a55d05",
+      "urls": [
+        "bzz-raw://49c99e47f7ed5ad077ac98fd30bee47674959cbb5ce5ac5d21d12bd121ad9711",
+        "dweb:/ipfs/QmNRDQrNYKMqdNgduv4euvrmFxSDqJJ267RzPJY5p6fNte"
+      ]
+    },
+    "openzeppelin-solidity/contracts/utils/Address.sol": {
+      "keccak256": "0x1a8e5072509c5ea7365eb1d48030b9be865140c8fb779968da0a459a0e174a11",
+      "urls": [
+        "bzz-raw://03335b7b07c7c8c8d613cfdd8ec39a0b5ec133ee510bf2fe6cc5a496767bef4b",
+        "dweb:/ipfs/Qmebp4nzPja645c9yXSdJkGq96oU3am3LUnG2K3R7XxyKf"
+      ]
+    }
+  },
+  "version": 1
+}

--- a/packages/sdk/explorer/jest.config.js
+++ b/packages/sdk/explorer/jest.config.js
@@ -1,0 +1,13 @@
+const { nodeFlakeTracking } = require('@celo/flake-tracker/src/jest/config.js')
+
+module.exports = {
+  preset: 'ts-jest',
+  ...nodeFlakeTracking,
+  testMatch: ['<rootDir>/src/**/?(*.)+(spec|test).ts?(x)'],
+  setupFilesAfterEnv: [
+    '@celo/dev-utils/lib/matchers',
+    '<rootDir>/jestSetup.ts',
+    ...nodeFlakeTracking.setupFilesAfterEnv,
+  ],
+  verbose: true,
+}

--- a/packages/sdk/explorer/jestSetup.ts
+++ b/packages/sdk/explorer/jestSetup.ts
@@ -1,0 +1,7 @@
+import { FetchMockSandbox } from 'fetch-mock'
+
+const fetchMockSandbox = require('fetch-mock').sandbox()
+jest.mock('cross-fetch', () => fetchMockSandbox)
+
+// @ts-ignore
+global.fetchMock = fetchMockSandbox as FetchMockSandbox

--- a/packages/sdk/explorer/package.json
+++ b/packages/sdk/explorer/package.json
@@ -22,14 +22,17 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@types/debug": "^4.1.5",
     "@celo/base": "3.0.2-dev",
     "@celo/connect": "3.0.2-dev",
     "@celo/contractkit": "3.0.2-dev",
     "@celo/utils": "3.0.2-dev",
+    "@types/debug": "^4.1.5",
+    "cross-fetch": "^3.1.5",
     "debug": "^4.1.1"
   },
   "devDependencies": {
+    "@types/fetch-mock": "^7.3.5",
+    "fetch-mock": "^9.11.0",
     "web3": "1.3.6"
   },
   "engines": {

--- a/packages/sdk/explorer/src/block-explorer.ts
+++ b/packages/sdk/explorer/src/block-explorer.ts
@@ -177,8 +177,6 @@ export class BlockExplorer {
           signature: selector,
         },
         contract: contractName ? `${contractName}(${address})` : `Unknown(${address})`,
-        // contract: address,
-        // contractName: contractName || 'Unknown'
       }
     }
 

--- a/packages/sdk/explorer/src/block-explorer.ts
+++ b/packages/sdk/explorer/src/block-explorer.ts
@@ -170,8 +170,8 @@ export class BlockExplorer {
     const results = await lookupAddress(address)
     if (results.resp !== null) {
       return results.resp
-    } else if (results.metadata && results.metadata.isProxy()) {
-      const implAddress = await results.metadata.getProxyImplementation()
+    } else if (results.metadata) {
+      const implAddress = await results.metadata.tryGetProxyImplementation()
       if (implAddress) {
         const implResult = await lookupAddress(implAddress)
         return implResult.resp

--- a/packages/sdk/explorer/src/block-explorer.ts
+++ b/packages/sdk/explorer/src/block-explorer.ts
@@ -149,7 +149,7 @@ export class BlockExplorer {
     address: string,
     selector: string
   ): Promise<ContractNameAndMethodAbi | null> => {
-    let metadata = await fetchMetadata(this.kit, address)
+    let metadata = await fetchMetadata(this.kit.connection, address)
     let abi: AbiItem | null = null
     let contractName: string | null = null
 
@@ -161,7 +161,7 @@ export class BlockExplorer {
         const implAddress = await metadata.tryGetProxyImplementation()
         console.log(implAddress)
         if (implAddress) {
-          metadata = await fetchMetadata(this.kit, implAddress)
+          metadata = await fetchMetadata(this.kit.connection, implAddress)
           if (metadata && metadata.abi) {
             abi = metadata?.abiForSelector(selector)
             contractName = metadata?.contractName

--- a/packages/sdk/explorer/src/globals.d.ts
+++ b/packages/sdk/explorer/src/globals.d.ts
@@ -1,0 +1,5 @@
+import { FetchMockSandbox } from 'fetch-mock'
+
+declare global {
+  const fetchMock: FetchMockSandbox
+}

--- a/packages/sdk/explorer/src/sourcify.test.ts
+++ b/packages/sdk/explorer/src/sourcify.test.ts
@@ -1,0 +1,128 @@
+import {
+  Address,
+  Callback,
+  Connection,
+  JsonRpcPayload,
+  JsonRpcResponse,
+  Provider,
+} from '@celo/connect'
+import { ContractKit } from '@celo/contractkit'
+import Web3 from 'web3'
+import { fetchMetadata, Metadata } from './sourcify'
+
+describe('sourcify helpers', () => {
+  let kit: ContractKit
+  const web3: Web3 = new Web3()
+  const address: Address = web3.utils.randomHex(20)
+
+  const mockProvider: Provider = {
+    send: (payload: JsonRpcPayload, callback: Callback<JsonRpcResponse>): void => {
+      callback(null, {
+        jsonrpc: payload.jsonrpc,
+        id: Number(payload.id),
+        result: address,
+      })
+    },
+  }
+
+  beforeEach(() => {
+    fetchMock.reset()
+    web3.setProvider(mockProvider as any)
+    const connection = new Connection(web3)
+    kit = new ContractKit(connection)
+  })
+
+  describe('fetchMetadata()', () => {
+    describe('when a full match exists', () => {
+      it('returns the metadata from the full match', async () => {
+        fetchMock.get(
+          'https://repo.sourcify.dev/contracts/full_match/42220/0xabc/metadata.json',
+          new Metadata(kit, address, {})
+        )
+        const metadata = await fetchMetadata(kit, '42220', '0xabc')
+        expect(metadata).toBeInstanceOf(Metadata)
+      })
+    })
+
+    describe('when a full match does not exist', () => {
+      describe('but a partial match exists', () => {
+        it('returns the metadata from the partial match', async () => {
+          fetchMock
+            .get('https://repo.sourcify.dev/contracts/full_match/42220/0xabc/metadata.json', 400)
+            .get(
+              'https://repo.sourcify.dev/contracts/partial_match/42220/0xabc/metadata.json',
+              new Metadata(kit, address, {})
+            )
+          const metadata = await fetchMetadata(kit, '42220', '0xabc')
+          expect(metadata).toBeInstanceOf(Metadata)
+        })
+      })
+
+      describe('and a partial match does not exist', () => {
+        it('is null', async () => {
+          fetchMock
+            .get('https://repo.sourcify.dev/contracts/full_match/42220/0xabc/metadata.json', 400)
+            .get('https://repo.sourcify.dev/contracts/partial_match/42220/0xabc/metadata.json', 400)
+          const metadata = await fetchMetadata(kit, '42220', '0xabc')
+          expect(metadata).toEqual(null)
+        })
+      })
+    })
+  })
+
+  describe('Metadata', () => {
+    describe('get abi', () => {
+      it('returns the abi when it finds it', () => {
+        const metadata = new Metadata(kit, address, { output: { abi: [{}] } })
+        const abi = metadata.abi
+        expect(abi).not.toBeNull()
+        expect(abi).toEqual([{}])
+      })
+
+      it('returns null when there is no abi', () => {
+        const metadata = new Metadata(kit, address, { output: { other: [{}] } })
+        const abi = metadata.abi
+        expect(abi).toBeNull()
+      })
+    })
+
+    describe('get contractName', () => {
+      describe('when the structure does not contain it', () => {
+        it('returns null', () => {
+          const metadata = new Metadata(kit, address, { output: { abi: [{}] } })
+          const name = metadata.contractName
+          expect(name).toBeNull()
+        })
+      })
+
+      describe('when the structure contains multiple compilation targets', () => {
+        it('returns the first', () => {
+          const metadata = new Metadata(kit, address, {
+            settings: {
+              compilationTarget: {
+                'somefile.sol': 'SomeContract',
+                'otherfile.sol': 'OtherContract',
+              },
+            },
+          })
+          const name = metadata.contractName
+          expect(name).toEqual('SomeContract')
+        })
+      })
+
+      describe('when the structure contains one compilation targets', () => {
+        it('returns it', () => {
+          const metadata = new Metadata(kit, address, {
+            settings: {
+              compilationTarget: {
+                'otherfile.sol': 'OtherContract',
+              },
+            },
+          })
+          const name = metadata.contractName
+          expect(name).toEqual('OtherContract')
+        })
+      })
+    })
+  })
+})

--- a/packages/sdk/explorer/src/sourcify.ts
+++ b/packages/sdk/explorer/src/sourcify.ts
@@ -1,6 +1,25 @@
-import { AbiItem, Address } from '@celo/connect'
+/**
+ * Sourcify (https://sourcify.dev/) helpers for querying
+ * contract metadata when it's available.
+ *
+ * @example
+ * Get the ABI of an arbitrary contract.
+ * ```ts
+ * const metadata = fetchMetadata('42220', '0xF27c7D717B4b7CaD2833a61cb9CA7B61021f9F73')
+ * if (metadata.abi !== null) {
+ *  // do something with it.
+ * }
+ */
+import { AbiCoder, AbiItem, Address, Contract } from '@celo/connect'
+import { ContractKit } from '@celo/contractkit'
+import fetch from 'cross-fetch'
 
-export interface Metadata {
+/**
+ * MetadataResponse interface for the `metadata.json` file that the sourcify repo returns.
+ * All fields are optional because we don't really _know_ what we get from the API, thus
+ * we need to enforce the structure at runtime.
+ */
+export interface MetadataResponse {
   output?: {
     abi?: AbiItem[]
   }
@@ -9,56 +28,120 @@ export interface Metadata {
   }
 }
 
-export const getAbi = (metadata: Metadata): AbiItem[] | undefined => {
-  if (
-    typeof metadata === 'object' &&
-    typeof metadata['output'] === 'object' &&
-    'abi' in metadata['output'] &&
-    Array.isArray(metadata['output']['abi']) &&
-    metadata['output']['abi'].length > 0
-  ) {
-    return metadata['output']['abi']
+/**
+ * Wrapper class for a Metadata response from sourcify.
+ * Because these response's true structure is unknown this wrapper implements
+ * runtime guards and getters.
+ */
+export class Metadata {
+  public abi: AbiItem[] | null = null
+  public contractName: string | null = null
+
+  private contract: Contract | null = null
+  private abiCoder: AbiCoder
+
+  constructor(kit: ContractKit, address: Address, response: any) {
+    this.response = response as MetadataResponse
+    this.abiCoder = kit.connection.getAbiCoder()
+
+    if (this.abi) {
+      this.contract = new kit.web3.eth.Contract(this.abi, address)
+    }
+  }
+
+  set response(value: MetadataResponse) {
+    if (
+      typeof value === 'object' &&
+      typeof value.output === 'object' &&
+      'abi' in value.output &&
+      Array.isArray(value.output.abi) &&
+      value.output.abi.length > 0
+    ) {
+      this.abi = value.output.abi
+    }
+
+    if (
+      typeof value === 'object' &&
+      typeof value.settings === 'object' &&
+      typeof value.settings.compilationTarget === 'object' &&
+      Object.values(value.settings.compilationTarget).length > 0
+    ) {
+      // XXX: Not sure when there are multiple compilationTargets and what should
+      // happen then but defaulting to this for now.
+      const contracts = Object.values(value.settings.compilationTarget)
+      this.contractName = contracts[0]
+    }
+  }
+
+  abiForSignature(callSignature: string): AbiItem | null {
+    if (this.abi) {
+      for (const item of this.abi) {
+        if (
+          item.type == 'function' &&
+          this.abiCoder.encodeFunctionSignature(item) == callSignature
+        ) {
+          return item
+        }
+      }
+    }
+    return null
+  }
+
+  isProxy(): boolean {
+    // todo(bogdan): Improve this to support multiple proxy types, like EIP-1167
+    return this.contract?.methods.getImplementation !== undefined
+  }
+
+  async getProxyImplementation(): Promise<Address | null> {
+    if (this.contract) {
+      return this.contract.methods.getImplementation.call()
+    }
+    return null
   }
 }
 
-export const getContractName = (metadata: Metadata): string | undefined => {
-  if (
-    typeof metadata['settings'] === 'object' &&
-    typeof metadata['settings']['compilationTarget'] === 'object' &&
-    Object.keys(metadata['settings']['compilationTarget']).length > 0
-  ) {
-    // XXX: Not sure when there are multiple compilationTargets and what should
-    // happen then
-    const contracts = Object.values(metadata['settings']['compilationTarget'])
-    return contracts[0]
-  }
-}
-
-const querySourcify = async (
-  matchType: 'full_match' | 'partial_match',
-  chainID: string,
-  contract: Address
-): Promise<Metadata | null> => {
-  const resp = await fetch(
-    `https://repo.sourcify.dev/contracts/${matchType}/${chainID}/${contract}/metadata.json`
-  )
-  if (resp.ok) {
-    return (await resp.json()) as Metadata
-  }
-  return null
-}
-
-export const getContractMetadataFromSourcify = async (
-  chainID: string,
+/**
+ * Fetch the sourcify response and instantiate a Metadata wrapper class around it.
+ * Try a full_match but fallback to partial_match when not strict.
+ * @param chainID the chainID to query
+ * @param contract the address of the contract to query
+ * @param strict only allow full matches https://docs.sourcify.dev/docs/full-vs-partial-match/
+ * @returns Metadata or null
+ */
+export async function fetchMetadata(
+  kit: ContractKit,
+  chainID: string | number,
   contract: Address,
   strict = false
-): Promise<Metadata | null> => {
-  const fullMatchMetadata = await querySourcify('full_match', chainID, contract)
+): Promise<Metadata | null> {
+  const fullMatchMetadata = await querySourcify(kit, 'full_match', chainID, contract)
   if (fullMatchMetadata !== null) {
     return fullMatchMetadata
   } else if (strict) {
     return null
   } else {
-    return querySourcify('partial_match', chainID, contract)
+    return querySourcify(kit, 'partial_match', chainID, contract)
   }
+}
+
+/**
+ * Fetch the sourcify response and instantiate a Metadata wrapper class around it.
+ * @param matchType what type of match to query for https://docs.sourcify.dev/docs/full-vs-partial-match/
+ * @param chainID the chainID to query
+ * @param contract the address of the contract to query
+ * @returns Metadata or null
+ */
+async function querySourcify(
+  kit: ContractKit,
+  matchType: 'full_match' | 'partial_match',
+  chainID: string | number,
+  contract: Address
+): Promise<Metadata | null> {
+  const resp = await fetch(
+    `https://repo.sourcify.dev/contracts/${matchType}/${chainID}/${contract}/metadata.json`
+  )
+  if (resp.ok) {
+    return new Metadata(kit, contract, await resp.json())
+  }
+  return null
 }

--- a/packages/sdk/explorer/src/sourcify.ts
+++ b/packages/sdk/explorer/src/sourcify.ts
@@ -1,0 +1,64 @@
+import { AbiItem, Address } from '@celo/connect'
+
+export interface Metadata {
+  output?: {
+    abi?: AbiItem[]
+  }
+  settings?: {
+    compilationTarget?: Record<string, string>
+  }
+}
+
+export const getAbi = (metadata: Metadata): AbiItem[] | undefined => {
+  if (
+    typeof metadata === 'object' &&
+    typeof metadata['output'] === 'object' &&
+    'abi' in metadata['output'] &&
+    Array.isArray(metadata['output']['abi']) &&
+    metadata['output']['abi'].length > 0
+  ) {
+    return metadata['output']['abi']
+  }
+}
+
+export const getContractName = (metadata: Metadata): string | undefined => {
+  if (
+    typeof metadata['settings'] === 'object' &&
+    typeof metadata['settings']['compilationTarget'] === 'object' &&
+    Object.keys(metadata['settings']['compilationTarget']).length > 0
+  ) {
+    // XXX: Not sure when there are multiple compilationTargets and what should
+    // happen then
+    const contracts = Object.values(metadata['settings']['compilationTarget'])
+    return contracts[0]
+  }
+}
+
+const querySourcify = async (
+  matchType: 'full_match' | 'partial_match',
+  chainID: string,
+  contract: Address
+): Promise<Metadata | null> => {
+  const resp = await fetch(
+    `https://repo.sourcify.dev/contracts/${matchType}/${chainID}/${contract}/metadata.json`
+  )
+  if (resp.ok) {
+    return (await resp.json()) as Metadata
+  }
+  return null
+}
+
+export const getContractMetadataFromSourcify = async (
+  chainID: string,
+  contract: Address,
+  strict = false
+): Promise<Metadata | null> => {
+  const fullMatchMetadata = await querySourcify('full_match', chainID, contract)
+  if (fullMatchMetadata !== null) {
+    return fullMatchMetadata
+  } else if (strict) {
+    return null
+  } else {
+    return querySourcify('partial_match', chainID, contract)
+  }
+}

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -293,7 +293,7 @@ export class ProposalBuilder {
     RegisteredContracts.includes(stripProxy(contract)) ||
     this.getRegistryAddition(contract) !== undefined
 
-  decodeCallToExternalContract = async (
+  buildCallToExternalContract = async (
     tx: ProposalTransactionJSON
   ): Promise<ProposalTransaction> => {
     const abiCoder = this.kit.connection.getAbiCoder()
@@ -326,9 +326,7 @@ export class ProposalBuilder {
     return { input, to, value: tx.value }
   }
 
-  decodeCallToRegistryContract = async (
-    tx: ProposalTransactionJSON
-  ): Promise<ProposalTransaction> => {
+  buildCallToCoreContract = async (tx: ProposalTransactionJSON): Promise<ProposalTransaction> => {
     // Account for canonical registry addresses from current proposal
     const address =
       this.getRegistryAddition(tx.contract) ?? (await this.kit.registry.addressFor(tx.contract))
@@ -363,7 +361,7 @@ export class ProposalBuilder {
 
     // handle sending value to unregistered contracts
     if (this.isRegistryContract(tx.contract)) {
-      return this.decodeCallToRegistryContract(tx)
+      return this.buildCallToCoreContract(tx)
     } else {
       if (!isValidAddress(tx.contract)) {
         throw new Error(
@@ -376,7 +374,7 @@ export class ProposalBuilder {
         return { input: '', to: tx.contract, value: tx.value }
       }
 
-      return this.decodeCallToExternalContract(tx)
+      return this.buildCallToExternalContract(tx)
     }
   }
 

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -304,7 +304,7 @@ export class ProposalBuilder {
     const abiCoder = this.kit.connection.getAbiCoder()
     let methodABI: AbiItem | null = null
 
-    const metadata = await fetchMetadata(this.kit, tx.contract)
+    const metadata = await fetchMetadata(this.kit.connection, tx.contract)
     if (metadata) {
       const potentialABIs = metadata.abiForMethod(tx.function)
       methodABI =

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -293,6 +293,11 @@ export class ProposalBuilder {
     RegisteredContracts.includes(stripProxy(contract)) ||
     this.getRegistryAddition(contract) !== undefined
 
+  /*
+   * @deprecated - use isRegistryContract
+   */
+  isRegistered = this.isRegistryContract
+
   buildCallToExternalContract = async (
     tx: ProposalTransactionJSON
   ): Promise<ProposalTransaction> => {
@@ -325,6 +330,12 @@ export class ProposalBuilder {
 
     return { input, to, value: tx.value }
   }
+
+  /*
+   *  @deprecated use buildCallToExternalContract
+   *
+   */
+  buildFunctionCallToExternalContract = this.buildCallToExternalContract
 
   buildCallToCoreContract = async (tx: ProposalTransactionJSON): Promise<ProposalTransaction> => {
     // Account for canonical registry addresses from current proposal

--- a/yarn.lock
+++ b/yarn.lock
@@ -5109,6 +5109,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fetch-mock@^7.3.5":
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.5.tgz#7aee678c4e7c7e1a168bae8fdab5b8d712e377f6"
+  integrity sha512-sLecm9ohBdGIpYUP9rWk5/XIKY2xHMYTBJIcJuBBM8IJWnYoQ1DAj8F4OVjnfD0API1drlkWEV0LPNk+ACuhsg==
+
 "@types/form-data@*":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
@@ -9664,7 +9669,7 @@ cross-env@^5.1.3, cross-env@^5.1.6:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
 
-cross-fetch@3.0.4, cross-fetch@^2.1.0, cross-fetch@^2.1.1, cross-fetch@^3.0.2, cross-fetch@^3.0.6:
+cross-fetch@3.0.4, cross-fetch@^2.1.0, cross-fetch@^2.1.1, cross-fetch@^3.0.2, cross-fetch@^3.0.6, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -12386,6 +12391,22 @@ fetch-mock@9.10.4:
   integrity sha512-1ExE0cyv4+wHH/4NlSnh8tBBfVMUt6QFIRcuAGN7L4a0SAj7vOXh2z2G9XlEZS2qzgbj9ixDXFFE8gDmsCZ83g==
   dependencies:
     babel-runtime "^6.26.0"
+    core-js "^3.0.0"
+    debug "^4.1.1"
+    glob-to-regexp "^0.4.0"
+    is-subset "^0.1.1"
+    lodash.isequal "^4.5.0"
+    path-to-regexp "^2.2.1"
+    querystring "^0.2.0"
+    whatwg-url "^6.5.0"
+
+fetch-mock@^9.11.0:
+  version "9.11.0"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-9.11.0.tgz#371c6fb7d45584d2ae4a18ee6824e7ad4b637a3f"
+  integrity sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
     core-js "^3.0.0"
     debug "^4.1.1"
     glob-to-regexp "^0.4.0"


### PR DESCRIPTION
### Description

The tooling around governance proposals was initially designed under the assumption that Governance interacts only with Celo core contracts, i.e. contracts that are:
- registered in the `Registry` 
- included in `ContractKit`
- part of the `@celo/protocol` package.

This assumption was first challenged a few months ago when we needed to deploy Reserve funds to a Mobius pool, and we had to interact with external contracts. The tooling was patched in a pretty hacky fashion (#9735) due to time constraints, but the general idea was that the tooling should have additional ways to retrieve metadata about contracts it interacts with.

As we're moving forward with Mento we're moving away from the monorepo, ContractKit, and the Registry, while still having to interact with Governance for upgrades and future releases. This means that unless there's a more general solution we will hit this problem as well. And the community is also slowing moving away from a ContractKit-centric development mentality and more into broader ecosystem tools.

This PR puts forward a future-proof solution to this problem by leveraging [sourcify](https://sourcify.dev) to lookup contract metadata. Therefore governance will be able to decode/encode transactions to any contracts that are verified on Sourcify.

For example, for the Mobius pool liquidity we had this transaction as part of the cgp.json:
```json
  {
    "contract": "0xFa3df877F98ac5ecd87456a7AcCaa948462412f0",
    "function": "addLiquidity(uint256[],uint256,uint256)",
    "args": [
      [
        "5000000000000000000000000",
        "5000000000000"
      ],
      0,
      1661419596
    ],
    "value": "0"
  }
```

We made this work at the time in #9735 by:
(1) Allowing addresses for the `contract` field instead of just Registry names.
(2) Providing a function call signature for the `function` field instead of just a function name
(3) Having a [list of "known functions"](https://github.com/celo-org/celo-monorepo/pull/9735/files#diff-1b843f66c13ec153f0e176e255e2bb25442512a7eaa29ae188b793a3fff5a524R129-R132) so the tooling can turn an on-chain encoded proposal back to human readable. 

> (3) being a hackiest part of that PR

After this PR we can add this transaction as:
```json
  {
    "contract": "0xFa3df877F98ac5ecd87456a7AcCaa948462412f0",
    "function": "addLiquidity",
    "args": [
      [
        "5000000000000000000000000",
        "5000000000000"
      ],
      0,
      1661419596
    ],
    "value": "0"
  }
```

The major difference is that we can remove the arguments from the `function` parameter. And the tooling will output:
```yaml
0: 
  contract: SwapUSDCet(0xFa3df877F98ac5ecd87456a7AcCaa948462412f0)
  function: addLiquidity
  args: 
    0: 
      0: 5000000000000000000000000
      1: 5000000000000
    1: 0
    2: 1661419596
  params: 
    __length__: 3
    amounts: 
      0: 5000000000000000000000000
      1: 5000000000000
    minToMint: 0 
    deadline: 1661419596 (~1.661e+9)
  value: 0
```

What happens is that `0xFa3df877F98ac5ecd87456a7AcCaa948462412f0` is a contract that's verified on sourcify so the tooling downloads the `metadata.json` file from which it can extract the contract name (SwapUSDCet) and the ABI and find the `addLiquidity` function and encode everything with naming the params and all, without relying on any hardcoded values.

![magic](https://media.tenor.com/rrLadwcIvTIAAAAM/unicorn-magic.gif)

The tooling also has some heuristics to determine if the contract passed in is a proxy and look up the implementation to see if it's verified. This is not very fleshed out but is isolated enough to be easily extensible.

It's important to note that if all `@celo/protocol` contracts would be verified on sourcify, this PR could be the first step in making the decoding/encoding part of the governance proposal much leaner.

### Other changes

N/A

### Tested

Added some specs for the sourcify metadata comprehension and tested out locally with different governance json configurations.

### Related issues

- #9735 

### Backwards compatibility

All CLI commands and functions intended for public use are backwards compatible. A few functions added recently and intended for internal use but accessible outside have been removed. Given there small surfaces area and unlikelihood of use this is not considered breaking

### Documentation

Unsure if this requires documentation changes.