### PR TITLE
Logging and performanceObserver fixes

### DIFF
--- a/packages/phone-number-privacy/combiner/src/common/combine.ts
+++ b/packages/phone-number-privacy/combiner/src/common/combine.ts
@@ -97,7 +97,7 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
       }
     }
     if (signerFetchResult) {
-      session.logger.debug({
+      session.logger.info({
         message: 'Received signerFetchResult on unsuccessful signer response',
         res: await signerFetchResult.json(),
         status: signerFetchResult.status,

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -171,9 +171,9 @@ export async function meterResponse(
     const eventLoopLag = Date.now() - eventLoopLagMeasurementStart
     logger.info({ eventLoopLag }, 'Measure event loop lag')
   })
-  const startMark = `Begin ${handler.name}`
-  const endMark = `End ${handler.name}`
-  const entryName = `${handler.name} latency`
+  const startMark = `Begin ${endpoint}`
+  const endMark = `End ${endpoint}`
+  const entryName = `${endpoint} latency`
 
   const obs = new PerformanceObserver((list) => {
     const entry = list.getEntriesByName(entryName)[0]
@@ -181,7 +181,7 @@ export async function meterResponse(
       logger.info({ latency: entry }, 'e2e response latency measured')
     }
   })
-  obs.observe({ entryTypes: ['measure'], buffered: true })
+  obs.observe({ entryTypes: ['measure'], buffered: false })
 
   performance.mark(startMark)
   await handler(req, res)


### PR DESCRIPTION
- Initially based off of master to run CI checks before rebasing to the release branch, CI/tests looked good
- PR includes basic changes to logging and performanceObserver