### PR TITLE
Fix bugs in e2e combiner latency measurement and logging

### DIFF
--- a/packages/phone-number-privacy/combiner/src/common/combine.ts
+++ b/packages/phone-number-privacy/combiner/src/common/combine.ts
@@ -5,7 +5,7 @@ import {
   WarningMessage,
 } from '@celo/phone-number-privacy-common'
 import { Response as FetchResponse } from 'node-fetch'
-import { performance, PerformanceObserver } from 'perf_hooks'
+import { PerformanceObserver } from 'perf_hooks'
 import { OdisConfig } from '../config'
 import { Action } from './action'
 import { IO } from './io'
@@ -31,11 +31,19 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
 
   async distribute(session: Session<R>): Promise<void> {
     const obs = new PerformanceObserver((list) => {
-      const entry = list.getEntries()[0]
-      session.logger.info(
-        { latency: entry, signer: entry!.name },
-        'Signer response latency measured'
-      )
+      // Possible race condition here: if multiple signers take exactly the same
+      // amount of time, the PerformanceObserver callback may be called twice with
+      // both entries present. Node 12 doesn't allow for entries to be deleted by name,
+      // and eliminating the race condition requires a more significant redesign of
+      // the measurement code.
+      // This is only used for monitoring purposes, so a rare
+      // duplicate latency measure for the signer should have minimal impact.
+      list.getEntries().forEach((entry) => {
+        session.logger.info(
+          { latency: entry, signer: entry.name },
+          'Signer response latency measured'
+        )
+      })
     })
     obs.observe({ entryTypes: ['measure'], buffered: true })
 
@@ -50,8 +58,8 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
     // response in time and be aborted
 
     clearTimeout(timeout)
-
-    performance.clearMarks()
+    // DO NOT call performance.clearMarks() as this also deletes marks used to
+    // measure e2e combiner latency.
     obs.disconnect()
   }
 

--- a/packages/phone-number-privacy/combiner/src/pnp/services/log-responses.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/services/log-responses.ts
@@ -118,7 +118,10 @@ export class PnpSignerResponseLogger {
               case ErrorMessage.FAILING_OPEN:
               case ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA:
               case ErrorMessage.FAILURE_TO_GET_DEK:
-                session.logger.error({ warning, service: response.url }, ErrorMessage.FAILING_OPEN)
+                session.logger.error(
+                  { signerWarning: warning, service: response.url },
+                  WarningMessage.SIGNER_FAILED_OPEN
+                )
               default:
                 break
             }

--- a/packages/phone-number-privacy/combiner/test/unit/pnp-response-logger.test.ts
+++ b/packages/phone-number-privacy/combiner/test/unit/pnp-response-logger.test.ts
@@ -645,30 +645,30 @@ describe('pnp response logger', () => {
         {
           params: [
             {
-              warning: ErrorMessage.FAILING_OPEN,
+              signerWarning: ErrorMessage.FAILING_OPEN,
               service: url,
             },
-            ErrorMessage.FAILING_OPEN,
+            WarningMessage.SIGNER_FAILED_OPEN,
           ],
           level: 'error',
         },
         {
           params: [
             {
-              warning: ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
+              signerWarning: ErrorMessage.FAILURE_TO_GET_TOTAL_QUOTA,
               service: url,
             },
-            ErrorMessage.FAILING_OPEN,
+            WarningMessage.SIGNER_FAILED_OPEN,
           ],
           level: 'error',
         },
         {
           params: [
             {
-              warning: ErrorMessage.FAILURE_TO_GET_DEK,
+              signerWarning: ErrorMessage.FAILURE_TO_GET_DEK,
               service: url,
             },
-            ErrorMessage.FAILING_OPEN,
+            WarningMessage.SIGNER_FAILED_OPEN,
           ],
           level: 'error',
         },

--- a/packages/phone-number-privacy/common/src/interfaces/errors.ts
+++ b/packages/phone-number-privacy/common/src/interfaces/errors.ts
@@ -53,6 +53,7 @@ export enum WarningMessage {
   INVALID_NONCE = `CELO_ODIS_WARN_13 BAD_INPUT SequentialDelayDomain nonce check failed on Signer request`,
   SIGNER_RESPONSE_DISCREPANCIES = `CELO_ODIS_WARN_14 SIGNER Discrepancies detected in signer responses`,
   INCONSISTENT_SIGNER_QUERY_MEASUREMENTS = `CELO_ODIS_WARN_15 SIGNER Discrepancy found in signers performed query count measurements`,
+  SIGNER_FAILED_OPEN = `CELO_ODIS_WARN_19 SIGNER Signer failed open on request`,
 }
 
 export type ErrorType = ErrorMessage | WarningMessage

--- a/packages/phone-number-privacy/common/src/utils/authentication.ts
+++ b/packages/phone-number-privacy/common/src/utils/authentication.ts
@@ -47,14 +47,13 @@ export async function authenticateUser<R extends PhoneNumberPrivacyRequest>(
     } catch (err) {
       // getDataEncryptionKey should only throw if there is a full-node connection issue.
       // That is, it does not throw if the DEK is undefined or invalid
-      logger.error(
-        { err, warning: ErrorMessage.FAILURE_TO_GET_DEK },
-        shouldFailOpen ? ErrorMessage.FAILING_OPEN : ErrorMessage.FAILING_CLOSED
-      )
-      warnings.push(
-        ErrorMessage.FAILURE_TO_GET_DEK,
-        shouldFailOpen ? ErrorMessage.FAILING_OPEN : ErrorMessage.FAILING_CLOSED
-      )
+      const failureStatus = shouldFailOpen ? ErrorMessage.FAILING_OPEN : ErrorMessage.FAILING_CLOSED
+      logger.error({
+        err,
+        warning: ErrorMessage.FAILURE_TO_GET_DEK,
+        failureStatus,
+      })
+      warnings.push(ErrorMessage.FAILURE_TO_GET_DEK, failureStatus)
       return shouldFailOpen
     }
     if (!registeredEncryptionKey) {


### PR DESCRIPTION
### Description
Combiner e2e latency measures were wildly (and inconsistently) off in our dashboards & user-defined log metrics. (Ex: some measures of e2e latency were 40 seconds, even 40 min; even though the relevant cloud function execution time clocked in in under a second for each of these

This fixes that bug, which was caused by:
- clearing the stored performance marks after round-trip signer latency was measured in the combiner
- this cleared the starting marks for the e2e tests, which caused e2e measures to use the default start time of 0, resulting in widely varying e2e latency measures

### Tested
- deployed on staging, manually checked logs, checked dashboards
  - e2e latency metrics are now much more reasonable compared to overall Cloud Function execution time
- based change off of master to ensure CI checks pass

### Drive-by change: logging changes
Issue: combiner was not logging `FAILING_OPEN` or `FAILING_CLOSED` due to a logging formatting error (weird bunyan quirk) + could not distinguish combiner vs. signer FAILING_OPEN errors logged, in order to create useful GCP user-defined metrics

Fix: changed logging field names & created a new warning message for the signer failing open (`SIGNER_FAILED_OPEN`) that the combiner will see, for clarity about exactly what is happening here.

Notes:
- the number for the warning message looks weird in comparison to master, but this should make the merge easier against the release 2.4 branch (which contains updated numbers) -- double check this when merging though please in case I missed something here @alecps 🙏 
- added `signerWarning` to distinguish between general searches for errors in the `warning` field in other combiner metrics (and to make it easier to define metrics for this specific field if desired)
- specified new `failureStatus` field in logs for combiner for FAILING_OPEN/FAILING_CLOSED within the combiner (this was not being logged at all before, due to the weird logging error)
