### PR TITLE
Blockscout: Disable block rewards fetcher

### DIFF
--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -62,7 +62,7 @@ blockscout:
     beanstalkdHost: ""
     fetchers:
       blockRewards:
-        enabled: true
+        enabled: false
   api:
     suffix:
       enabled: false


### PR DESCRIPTION
### Description

This PR disables block rewards fetcher for blockscout as we're not using it and it causes unnecessary load on the database.