### PR TITLE
Fix minInstances setting in combiner deployment

### DIFF
--- a/packages/phone-number-privacy/combiner/package.json
+++ b/packages/phone-number-privacy/combiner/package.json
@@ -7,9 +7,10 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "yarn build && firebase serve --only functions",
-    "deploy:staging": "yarn build && firebase deploy --only functions --project celo-phone-number-privacy-stg",
-    "deploy:alfajores": "yarn build && firebase deploy --only functions --project celo-phone-number-privacy",
-    "deploy:mainnet": "yarn build && firebase deploy --only functions --project celo-pgpnp-mainnet",
+    "deploy": "yarn build && firebase deploy --only functions:combiner",
+    "deploy:staging": "yarn deploy --project celo-phone-number-privacy-stg",
+    "deploy:alfajores": "yarn deploy --project celo-phone-number-privacy",
+    "deploy:mainnet": "yarn deploy --project celo-pgpnp-mainnet",
     "config:get:staging": "firebase functions:config:get --project celo-phone-number-privacy-stg",
     "config:get:alfajores": "firebase functions:config:get --project celo-phone-number-privacy",
     "config:get:mainnet": "firebase functions:config:get --project celo-pgpnp-mainnet",

--- a/packages/phone-number-privacy/combiner/src/config.ts
+++ b/packages/phone-number-privacy/combiner/src/config.ts
@@ -31,16 +31,11 @@ export interface OdisConfig {
   }
 }
 
-export interface CloudFunctionConfig {
-  minInstances: number
-}
-
 export interface CombinerConfig {
   serviceName: string
   blockchain: BlockchainConfig
   phoneNumberPrivacy: OdisConfig
   domains: OdisConfig
-  cloudFunction: CloudFunctionConfig
 }
 
 let config: CombinerConfig
@@ -132,9 +127,6 @@ if (DEV_MODE) {
         ]),
       },
     },
-    cloudFunction: {
-      minInstances: 0,
-    },
   }
 } else {
   const functionConfig = functions.config()
@@ -173,11 +165,6 @@ if (DEV_MODE) {
         currentVersion: Number(functionConfig.domains_keys.current_version),
         versions: functionConfig.domains_keys.versions,
       },
-    },
-    cloudFunction: {
-      // Keep instances warm for mainnet functions
-      // @ts-ignore https://firebase.google.com/docs/functions/manage-functions#reduce_the_number_of_cold_starts
-      minInstances: functionConfig.blockchain.provider === FORNO_ALFAJORES ? 0 : 3,
     },
   }
 }

--- a/packages/phone-number-privacy/combiner/src/index.ts
+++ b/packages/phone-number-privacy/combiner/src/index.ts
@@ -6,7 +6,7 @@ import { startCombiner } from './server'
 require('dotenv').config()
 
 export const combiner = functions
-  .region('us-central1')
+  .region('us-central1', 'europe-west3')
   .runWith({
     // Keep instances warm for mainnet functions
     // Defined check required for running tests vs. deployment

--- a/packages/phone-number-privacy/combiner/src/index.ts
+++ b/packages/phone-number-privacy/combiner/src/index.ts
@@ -6,7 +6,11 @@ import { startCombiner } from './server'
 require('dotenv').config()
 
 export const combiner = functions
-  .region('us-central1', 'europe-west3')
-  .runWith(config.cloudFunction)
+  .region('us-central1')
+  .runWith({
+    // Keep instances warm for mainnet functions
+    // Defined check required for running tests vs. deployment
+    minInstances: functions.config().service ? functions.config().service.min_instances : undefined,
+  })
   .https.onRequest(startCombiner(config, getContractKit(config.blockchain)))
 export * from './config'


### PR DESCRIPTION
### Description
- fixed `minInstances` deployment logic which wasn't doing anything before
- removed the `CloudFunctionConfig` from the combiner config since this isn't actually being used (went with the faster solution of directly using the function config setting within deployment in `index.ts`
- drive by: simplifies the deployment commands in package.json to only deploy the `combiner` function (i.e. doesn't try to delete other deployed functions)

### Tested
- deployed to staging/alfajores with minInstances >0, ran e2e tests, dashboards also look good
- deployed staging/alfajores back to minInstances = 0
