### PR TITLE
removes account check on payment delgations. 

### DIFF
--- a/packages/cli/src/commands/account/set-payment-delegation.ts
+++ b/packages/cli/src/commands/account/set-payment-delegation.ts
@@ -1,7 +1,6 @@
 import { valueToFixidityString } from '@celo/contractkit/lib/wrappers/BaseWrapper'
 import { flags } from '@oclif/command'
 import { BaseCommand } from '../../base'
-import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx } from '../../utils/cli'
 import { Flags } from '../../utils/command'
 
@@ -27,7 +26,6 @@ export default class SetPaymentDelegation extends BaseCommand {
     this.kit.defaultAccount = res.flags.account
     const accounts = await this.kit.contracts.getAccounts()
 
-    await newCheckBuilder(this).isAccount(res.flags.beneficiary).runChecks()
     await displaySendTx(
       'setPaymentDelegation',
       accounts.setPaymentDelegation(


### PR DESCRIPTION
### Description

This PR removes the requirement for the payment delegation beneficiary account address to be registered and is related to the account:set-payment-delegation command from https://github.com/celo-org/celo-monorepo/pull/9700

Thank you to @aaronmboyd for helping to test this command and bringing attention to this here, https://github.com/celo-org/celo-monorepo/pull/9700#issuecomment-1284124018


### Tested

@jcortejoso RAN ON balkava 

### Related issues

- Fixes #9766 

- REPLACES https://github.com/celo-org/celo-monorepo/pull/9962

### Backwards compatibility

YES
### Documentation

