### PR TITLE
fix  isNullAddress check

### DIFF
--- a/packages/sdk/base/src/address.test.ts
+++ b/packages/sdk/base/src/address.test.ts
@@ -1,4 +1,4 @@
-import { getAddressChunks } from './address'
+import { getAddressChunks, isNullAddress } from './address'
 
 describe(getAddressChunks, () => {
   test('splits the address into chunks of 4 chars', async () => {
@@ -14,5 +14,26 @@ describe(getAddressChunks, () => {
       'ce10',
       'ce10',
     ])
+  })
+})
+
+describe(isNullAddress, () => {
+  test('returns true for 0x0000000000000000000000000000000000000000', () => {
+    expect(isNullAddress('0x0000000000000000000000000000000000000000')).toBe(true)
+  })
+  test('returns true for 0000000000000000000000000000000000000000', () => {
+    expect(isNullAddress('0000000000000000000000000000000000000000')).toBe(true)
+  })
+
+  test('returns false for 0xce10ce10ce10ce10ce10ce10ce10ce10ce10ce10', () => {
+    expect(isNullAddress('0xce10ce10ce10ce10ce10ce10ce10ce10ce10ce10')).toBe(false)
+  })
+
+  test('returns false for 0x0x0000000000000000000000000000000000000000', () => {
+    expect(isNullAddress('0x0x0000000000000000000000000000000000000000')).toBe(false)
+  })
+
+  test('returns false for 0x000000000000000000000000000000000000ce10', () => {
+    expect(isNullAddress('0x000000000000000000000000000000000000ce10')).toBe(false)
   })
 })

--- a/packages/sdk/base/src/address.ts
+++ b/packages/sdk/base/src/address.ts
@@ -6,7 +6,7 @@ export const eqAddress = (a: Address, b: Address) => normalizeAddress(a) === nor
 
 export const normalizeAddress = (a: Address) => trimLeading0x(a).toLowerCase()
 
-export const isNullAddress = (a: Address) => normalizeAddress(a) === NULL_ADDRESS
+export const isNullAddress = (a: Address) => normalizeAddress(a) === normalizeAddress(NULL_ADDRESS)
 
 export const normalizeAddressWith0x = (a: Address) => ensureLeading0x(a).toLowerCase()
 


### PR DESCRIPTION
### Description

Due to `normalizeAddress` chopping off the `0x` prefix while `NULL_ADDRESS` starts with `0x`,   `isNullAddress` would never return true 

### Other changes
n/a

### Tested

wrote new unit tests

### Related issues

- Fixes #10045 

### Backwards compatibility

yes unless someone was relying on the bug

### Documentation

n/a