### PR TITLE
Fix error status code bug

### DIFF
--- a/packages/phone-number-privacy/combiner/package.json
+++ b/packages/phone-number-privacy/combiner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/phone-number-privacy-combiner",
-  "version": "2.0.1-dev",
+  "version": "2.0.2-dev",
   "description": "Orchestrates and combines threshold signatures for use in ODIS",
   "author": "Celo",
   "license": "Apache-2.0",

--- a/packages/phone-number-privacy/combiner/src/common/combine.ts
+++ b/packages/phone-number-privacy/combiner/src/common/combine.ts
@@ -111,7 +111,7 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
         signer: signer.url,
       })
     }
-    return this.addFailureToSession(signer, signerFetchResult?.status ?? 502, session)
+    return this.addFailureToSession(signer, signerFetchResult?.status, session)
   }
 
   protected async receiveSuccess(

--- a/packages/phone-number-privacy/combiner/src/index.ts
+++ b/packages/phone-number-privacy/combiner/src/index.ts
@@ -6,7 +6,7 @@ import { startCombiner } from './server'
 require('dotenv').config()
 
 export const combiner = functions
-  .region('us-central1', 'europe-west3')
+  .region('us-central1')
   .runWith({
     // Keep instances warm for mainnet functions
     // Defined check required for running tests vs. deployment

--- a/packages/phone-number-privacy/combiner/test/end-to-end/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/end-to-end/domain.test.ts
@@ -8,7 +8,6 @@ import {
   requestOdisDomainQuotaStatus,
 } from '@celo/encrypted-backup'
 import { OdisUtils } from '@celo/identity'
-import { ErrorMessages, getServiceContext, OdisAPI } from '@celo/identity/lib/odis/query'
 import {
   CombinerEndpoint,
   DisableDomainRequest,
@@ -38,6 +37,8 @@ import { getTestContextName } from './resources'
 require('dotenv').config()
 
 jest.setTimeout(60000)
+
+const { ErrorMessages, getServiceContext, OdisAPI } = OdisUtils.Query
 
 const SERVICE_CONTEXT = getServiceContext(getTestContextName(), OdisAPI.DOMAIN)
 const combinerUrl = SERVICE_CONTEXT.odisUrl

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -1263,6 +1263,7 @@ describe('domainService', () => {
       poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
     })
 
+    // This previously incorrectly returned 502 instead of 429
     it('Should respond with 429 on out of quota', async () => {
       const noQuotaDomain = authenticatedDomain([
         { delay: 0, resetTimer: noBool, batchSize: defined(0), repetitions: defined(0) },

--- a/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/domain.test.ts
@@ -157,14 +157,16 @@ describe('domainService', () => {
     salt: defined('himalayanPink'),
   })
 
+  const DEFAULT_PUB_KEY =
+    TestUtils.Values.DOMAINS_THRESHOLD_DEV_PUBKEYS[config.domains.keys.currentVersion - 1]
   const signatureRequest = async (
     _domain?: SequentialDelayDomain,
     _nonce?: number,
-    keyVersion: number = config.domains.keys.currentVersion
+    _pubKey: string = DEFAULT_PUB_KEY
   ): Promise<[DomainRestrictedSignatureRequest<SequentialDelayDomain>, PoprfClient]> => {
     const domain = _domain ?? authenticatedDomain()
     const poprfClient = new PoprfClient(
-      Buffer.from(TestUtils.Values.DOMAINS_THRESHOLD_DEV_PUBKEYS[keyVersion - 1], 'base64'),
+      Buffer.from(_pubKey, 'base64'),
       domainHash(domain),
       Buffer.from('test message', 'utf8')
     )
@@ -233,772 +235,60 @@ describe('domainService', () => {
 
   const signerMigrationsPath = '../signer/dist/common/database/migrations'
 
-  const expectedEvals: string[] = [
-    '3QLFPV6VvnhhnZ7mOu0xm7BUUJIUVY6vEHvZONOtZ/c=',
-    'BBG0fAZJ6VNQwjge+3vOCF3uBo5KCs2+er/f/2QcV58=',
-    '1/otd1fW1nhUoU3ubjFDS8/RX0OClvHDsmGdnz6fZVE=',
-  ]
-  const expectedEval = expectedEvals[config.domains.keys.currentVersion - 1]
+  describe('with n=3, t=2', () => {
+    const expectedEvals: string[] = [
+      '3QLFPV6VvnhhnZ7mOu0xm7BUUJIUVY6vEHvZONOtZ/c=',
+      'BBG0fAZJ6VNQwjge+3vOCF3uBo5KCs2+er/f/2QcV58=',
+      '1/otd1fW1nhUoU3ubjFDS8/RX0OClvHDsmGdnz6fZVE=',
+    ]
+    const expectedEval = expectedEvals[config.domains.keys.currentVersion - 1]
 
-  beforeAll(async () => {
-    keyProvider1 = new MockKeyProvider(
-      new Map([
-        [`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V1],
-        [`${DefaultKeyName.DOMAINS}-2`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V2],
-        [`${DefaultKeyName.DOMAINS}-3`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V3],
-      ])
-    )
-    keyProvider2 = new MockKeyProvider(
-      new Map([
-        [`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V1],
-        [`${DefaultKeyName.DOMAINS}-2`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V2],
-        [`${DefaultKeyName.DOMAINS}-3`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V3],
-      ])
-    )
-    keyProvider3 = new MockKeyProvider(
-      new Map([
-        [`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_3_V1],
-        [`${DefaultKeyName.DOMAINS}-2`, DOMAINS_THRESHOLD_DEV_PK_SHARE_3_V2],
-        [`${DefaultKeyName.DOMAINS}-3`, DOMAINS_THRESHOLD_DEV_PK_SHARE_3_V3],
-      ])
-    )
+    beforeAll(async () => {
+      keyProvider1 = new MockKeyProvider(
+        new Map([
+          [`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V1],
+          [`${DefaultKeyName.DOMAINS}-2`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V2],
+          [`${DefaultKeyName.DOMAINS}-3`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V3],
+        ])
+      )
+      keyProvider2 = new MockKeyProvider(
+        new Map([
+          [`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V1],
+          [`${DefaultKeyName.DOMAINS}-2`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V2],
+          [`${DefaultKeyName.DOMAINS}-3`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V3],
+        ])
+      )
+      keyProvider3 = new MockKeyProvider(
+        new Map([
+          [`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_3_V1],
+          [`${DefaultKeyName.DOMAINS}-2`, DOMAINS_THRESHOLD_DEV_PK_SHARE_3_V2],
+          [`${DefaultKeyName.DOMAINS}-3`, DOMAINS_THRESHOLD_DEV_PK_SHARE_3_V3],
+        ])
+      )
 
-    app = startCombiner(combinerConfig, getContractKit(combinerConfig.blockchain))
-  })
+      app = startCombiner(combinerConfig, getContractKit(combinerConfig.blockchain))
+    })
 
-  beforeEach(async () => {
-    signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
-    signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
-    signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
-  })
-
-  afterEach(async () => {
-    await signerDB1?.destroy()
-    await signerDB2?.destroy()
-    await signerDB3?.destroy()
-    signer1?.close()
-    signer2?.close()
-    signer3?.close()
-  })
-
-  describe('when signers are operating correctly', () => {
     beforeEach(async () => {
-      signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
-      signer2 = startSigner(signerConfig, signerDB2, keyProvider2).listen(3002)
-      signer3 = startSigner(signerConfig, signerDB3, keyProvider3).listen(3003)
+      signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
     })
 
-    describe(`${CombinerEndpoint.DISABLE_DOMAIN}`, () => {
-      it('Should respond with 200 on valid request', async () => {
-        const res = await request(app)
-          .post(CombinerEndpoint.DISABLE_DOMAIN)
-          .send(await disableRequest())
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<DisableDomainResponse>({
-          success: true,
-          version: res.body.version,
-          status: { disabled: true, counter: 0, timer: 0, now: res.body.status.now },
-        })
-      })
-
-      it('Should respond with 200 on repeated valid requests', async () => {
-        const req = await disableRequest()
-        const res1 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(req)
-        expect(res1.status).toBe(200)
-        const expectedResponse: DisableDomainResponse = {
-          success: true,
-          version: res1.body.version,
-          status: { disabled: true, counter: 0, timer: 0, now: res1.body.status.now },
-        }
-        expect(res1.body).toStrictEqual<DisableDomainResponse>(expectedResponse)
-        const res2 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(req)
-        expect(res2.status).toBe(200)
-        expectedResponse.status.now = res2.body.status.now
-        expect(res2.body).toStrictEqual<DisableDomainResponse>(expectedResponse)
-      })
-
-      it('Should respond with 200 on extra request fields', async () => {
-        const req = await disableRequest()
-        // @ts-ignore Intentionally adding an extra field to the request type
-        req.options.extraField = noString
-
-        const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(req)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<DisableDomainResponse>({
-          success: true,
-          version: res.body.version,
-          status: { disabled: true, counter: 0, timer: 0, now: res.body.status.now },
-        })
-      })
-
-      it('Should respond with 400 on missing request fields', async () => {
-        const badRequest = await disableRequest()
-        // @ts-ignore Intentionally deleting required field
-        delete badRequest.domain.version
-
-        const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<DisableDomainResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on unknown domain', async () => {
-        // Create a requests with an invalid domain identifier.
-        const unknownRequest = await disableRequest()
-        // @ts-ignore UnknownDomain is (intentionally) not a valid domain identifier.
-        unknownRequest.domain.name = 'UnknownDomain'
-
-        const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(unknownRequest)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<DisableDomainResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on bad encoding', async () => {
-        const badRequest1 = await disableRequest()
-        // @ts-ignore Intentionally not JSON
-        badRequest1.domain = 'Freddy'
-
-        const res1 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest1)
-
-        expect(res1.status).toBe(400)
-        expect(res1.body).toStrictEqual<DisableDomainResponse>({
-          success: false,
-          version: res1.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-
-        const badRequest2 = ''
-
-        const res2 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest2)
-
-        expect(res2.status).toBe(400)
-        expect(res2.body).toStrictEqual<DisableDomainResponse>({
-          success: false,
-          version: res2.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 401 on failed auth', async () => {
-        // Create a manipulated request, which will have a bad signature.
-        const badRequest = await disableRequest()
-        badRequest.domain.salt = defined('badSalt')
-
-        const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest)
-
-        expect(res.status).toBe(401)
-        expect(res.body).toStrictEqual<DisableDomainResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.UNAUTHENTICATED_USER,
-        })
-      })
-
-      it('Should respond with 503 on disabled api', async () => {
-        const configWithApiDisabled: typeof combinerConfig = JSON.parse(
-          JSON.stringify(combinerConfig)
-        )
-        configWithApiDisabled.domains.enabled = false
-        const appWithApiDisabled = startCombiner(
-          configWithApiDisabled,
-          getContractKit(configWithApiDisabled.blockchain)
-        )
-        const req = await disableRequest()
-
-        const res = await request(appWithApiDisabled)
-          .post(CombinerEndpoint.DISABLE_DOMAIN)
-          .send(req)
-
-        expect(res.status).toBe(503)
-        expect(res.body).toStrictEqual<DisableDomainResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.API_UNAVAILABLE,
-        })
-      })
+    afterEach(async () => {
+      await signerDB1?.destroy()
+      await signerDB2?.destroy()
+      await signerDB3?.destroy()
+      signer1?.close()
+      signer2?.close()
+      signer3?.close()
     })
 
-    describe(`${CombinerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
-      it('Should respond with 200 on valid request', async () => {
-        const res = await request(app)
-          .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
-          .send(await quotaRequest())
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: true,
-          version: res.body.version,
-          status: { disabled: false, counter: 0, timer: 0, now: res.body.status.now },
-        })
-      })
-
-      it('Should respond with 200 on repeated valid requests', async () => {
-        const req = await quotaRequest()
-        const res1 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
-        const expectedResponse: DomainQuotaStatusResponse = {
-          success: true,
-          version: res1.body.version,
-          status: { disabled: false, counter: 0, timer: 0, now: res1.body.status.now },
-        }
-
-        expect(res1.status).toBe(200)
-        expect(res1.body).toStrictEqual<DomainQuotaStatusResponse>(expectedResponse)
-
-        const res2 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
-        expect(res2.status).toBe(200)
-        // Prevent flakiness due to slight timing inconsistencies
-        expectedResponse.status.now = res2.body.status.now
-        expect(res2.body).toStrictEqual<DomainQuotaStatusResponse>(expectedResponse)
-      })
-
-      it('Should respond with 200 on extra request fields', async () => {
-        const req = await quotaRequest()
-        // @ts-ignore Intentionally adding an extra field to the request type
-        req.options.extraField = noString
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: true,
-          version: res.body.version,
-          status: { disabled: false, counter: 0, timer: 0, now: res.body.status.now },
-        })
-      })
-
-      it('Should respond with 400 on missing request fields', async () => {
-        const badRequest = await quotaRequest()
-        // @ts-ignore Intentionally deleting required field
-        delete badRequest.domain.version
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on unknown domain', async () => {
-        // Create a requests with an invalid domain identifier.
-        const unknownRequest = await quotaRequest()
-        // @ts-ignore UnknownDomain is (intentionally) not a valid domain identifier.
-        unknownRequest.domain.name = 'UnknownDomain'
-
-        const res = await request(app)
-          .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
-          .send(unknownRequest)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on bad encoding', async () => {
-        const badRequest1 = await quotaRequest()
-        // @ts-ignore Intentionally not JSON
-        badRequest1.domain = 'Freddy'
-
-        const res1 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest1)
-
-        expect(res1.status).toBe(400)
-        expect(res1.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: false,
-          version: res1.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-
-        const badRequest2 = ''
-
-        const res2 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest2)
-
-        expect(res2.status).toBe(400)
-        expect(res2.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: false,
-          version: res2.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 401 on failed auth', async () => {
-        // Create a manipulated request, which will have a bad signature.
-        const badRequest = await quotaRequest()
-        badRequest.domain.salt = defined('badSalt')
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
-
-        expect(res.status).toBe(401)
-        expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.UNAUTHENTICATED_USER,
-        })
-      })
-
-      it('Should respond with 503 on disabled api', async () => {
-        const configWithApiDisabled: typeof combinerConfig = JSON.parse(
-          JSON.stringify(combinerConfig)
-        )
-        configWithApiDisabled.domains.enabled = false
-        const appWithApiDisabled = startCombiner(
-          configWithApiDisabled,
-          getContractKit(configWithApiDisabled.blockchain)
-        )
-
-        const req = await quotaRequest()
-
-        const res = await request(appWithApiDisabled)
-          .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
-          .send(req)
-
-        expect(res.status).toBe(503)
-        expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.API_UNAVAILABLE,
-        })
-      })
-    })
-
-    describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
-      it('Should respond with 200 on valid request', async () => {
-        const [req, poprfClient] = await signatureRequest()
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: true,
-          version: res.body.version,
-          signature: res.body.signature,
-          status: {
-            disabled: false,
-            counter: 1,
-            timer: res.body.status.timer,
-            now: res.body.status.now,
-          },
-        })
-        const evaluation = poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
-        expect(evaluation.toString('base64')).toEqual(expectedEval)
-      })
-
-      for (let i = 1; i <= 3; i++) {
-        it(`Should respond with 200 on valid request with key version header ${i}`, async () => {
-          const [req, poprfClient] = await signatureRequest(undefined, undefined, i)
-
-          const res = await request(app)
-            .post(CombinerEndpoint.DOMAIN_SIGN)
-            .set(KEY_VERSION_HEADER, i.toString())
-            .send(req)
-
-          expect(res.status).toBe(200)
-          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-            success: true,
-            version: res.body.version,
-            signature: res.body.signature,
-            status: {
-              disabled: false,
-              counter: 1,
-              timer: res.body.status.timer,
-              now: res.body.status.now,
-            },
-          })
-          const evaluation = poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
-          expect(evaluation.toString('base64')).toEqual(expectedEvals[i - 1])
-        })
-      }
-
-      it('Should respond with 200 if nonce > domainState', async () => {
-        const [req, poprfClient] = await signatureRequest(undefined, 2)
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: true,
-          version: res.body.version,
-          signature: res.body.signature,
-          status: {
-            disabled: false,
-            counter: 1, // counter gets incremented, not set to nonce value
-            timer: res.body.status.timer,
-            now: res.body.status.now,
-          },
-        })
-        const evaluation = poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
-        expect(evaluation.toString('base64')).toEqual(expectedEval)
-      })
-
-      it('Should respond with 200 on repeated valid requests', async () => {
-        const [req1, poprfClient] = await signatureRequest()
-
-        const res1 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
-        expect(res1.status).toBe(200)
-        expect(res1.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: true,
-          version: res1.body.version,
-          signature: res1.body.signature,
-          status: {
-            disabled: false,
-            counter: 1,
-            timer: res1.body.status.timer,
-            now: res1.body.status.now,
-          },
-        })
-        const eval1 = poprfClient.unblindResponse(Buffer.from(res1.body.signature, 'base64'))
-        expect(eval1.toString('base64')).toEqual(expectedEval)
-
-        // submit identical request with nonce set to 1
-        req1.options.nonce = defined(1)
-        req1.options.signature = noString
-        req1.options.signature = defined(
-          await wallet.signTypedData(walletAddress, domainRestrictedSignatureRequestEIP712(req1))
-        )
-        const res2 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
-
-        expect(res2.status).toBe(200)
-        expect(res2.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: true,
-          version: res2.body.version,
-          signature: res2.body.signature,
-          status: {
-            disabled: false,
-            counter: 2,
-            timer: res2.body.status.timer,
-            now: res2.body.status.now,
-          },
-        })
-        const eval2 = poprfClient.unblindResponse(Buffer.from(res1.body.signature, 'base64'))
-        expect(eval2).toEqual(eval1)
-      })
-
-      it('Should respond with 200 on extra request fields', async () => {
-        const [req, poprfClient] = await signatureRequest()
-        // @ts-ignore Intentionally adding an extra field to the request type
-        req.options.extraField = noString
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: true,
-          version: res.body.version,
-          signature: res.body.signature,
-          status: {
-            disabled: false,
-            counter: 1,
-            timer: res.body.status.timer,
-            now: res.body.status.now,
-          },
-        })
-        const evaluation = poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
-        expect(evaluation.toString('base64')).toEqual(expectedEval)
-      })
-
-      it('Should respond with 400 on missing request fields', async () => {
-        const [badRequest, _] = await signatureRequest()
-        // @ts-ignore Intentionally deleting required field
-        delete badRequest.domain.version
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on unknown domain', async () => {
-        // Create a requests with an invalid domain identifier.
-        const [unknownRequest, _] = await signatureRequest()
-        // @ts-ignore UnknownDomain is (intentionally) not a valid domain identifier.
-        unknownRequest.domain.name = 'UnknownDomain'
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(unknownRequest)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on bad encoding', async () => {
-        const [badRequest1, _] = await signatureRequest()
-        // @ts-ignore Intentionally not JSON
-        badRequest1.domain = 'Freddy'
-
-        const res1 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest1)
-
-        expect(res1.status).toBe(400)
-        expect(res1.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res1.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-
-        const badRequest2 = ''
-
-        const res2 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest2)
-
-        expect(res2.status).toBe(400)
-        expect(res2.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res2.body.version,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on unsupported key version', async () => {
-        const [badRequest, _] = await signatureRequest()
-
-        const res = await request(app)
-          .post(CombinerEndpoint.DOMAIN_SIGN)
-          .set(KEY_VERSION_HEADER, '4')
-          .send(badRequest)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.INVALID_KEY_VERSION_REQUEST,
-        })
-      })
-
-      it('Should respond with 401 on failed auth', async () => {
-        // Create a manipulated request, which will have a bad signature.
-        const [badRequest, _] = await signatureRequest()
-        badRequest.domain.salt = defined('badSalt')
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
-
-        expect(res.status).toBe(401)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.UNAUTHENTICATED_USER,
-        })
-      })
-
-      it('Should respond with 401 on invalid nonce', async () => {
-        // Request must be sent first since nonce check is >= 0
-        const [req1, _] = await signatureRequest()
-        const res1 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
-
-        expect(res1.status).toBe(200)
-        expect(res1.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: true,
-          version: res1.body.version,
-          signature: res1.body.signature,
-          status: {
-            disabled: false,
-            counter: 1,
-            timer: res1.body.status.timer,
-            now: res1.body.status.now,
-          },
-        })
-        const res2 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
-        expect(res2.status).toBe(401)
-        expect(res2.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res2.body.version,
-          error: WarningMessage.INVALID_NONCE,
-        })
-      })
-
-      it('Should respond with 429 on out of quota', async () => {
-        const noQuotaDomain = authenticatedDomain([
-          { delay: 0, resetTimer: noBool, batchSize: defined(0), repetitions: defined(0) },
-        ])
-        const [badRequest, _] = await signatureRequest(noQuotaDomain)
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
-
-        expect(res.status).toBe(429)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.EXCEEDED_QUOTA,
-        })
-      })
-
-      it('Should respond with 429 on request too early', async () => {
-        // This domain won't accept requests until ~10 seconds after test execution
-        const noQuotaDomain = authenticatedDomain([
-          {
-            delay: Math.floor(Date.now() / 1000) + 10,
-            resetTimer: noBool,
-            batchSize: defined(2),
-            repetitions: defined(1),
-          },
-        ])
-        const [badRequest, _] = await signatureRequest(noQuotaDomain)
-
-        const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
-
-        expect(res.status).toBe(429)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.EXCEEDED_QUOTA,
-        })
-      })
-
-      it('Should respond with 429 when requesting a signature from a disabled domain', async () => {
-        const testDomain = authenticatedDomain()
-        const resDisable = await request(app)
-          .post(CombinerEndpoint.DISABLE_DOMAIN)
-          .send(await disableRequest(testDomain))
-        expect(resDisable.status).toBe(200)
-        expect(resDisable.body).toStrictEqual<DisableDomainResponse>({
-          success: true,
-          version: resDisable.body.version,
-          status: { disabled: true, counter: 0, timer: 0, now: resDisable.body.status.now },
-        })
-      })
-
-      it('Should respond with 503 on disabled api', async () => {
-        const configWithApiDisabled: typeof combinerConfig = JSON.parse(
-          JSON.stringify(combinerConfig)
-        )
-        configWithApiDisabled.domains.enabled = false
-        const appWithApiDisabled = startCombiner(
-          configWithApiDisabled,
-          getContractKit(configWithApiDisabled.blockchain)
-        )
-
-        const [req, _] = await signatureRequest()
-
-        const res = await request(appWithApiDisabled).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
-
-        expect(res.status).toBe(503)
-        expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-          success: false,
-          version: res.body.version,
-          error: WarningMessage.API_UNAVAILABLE,
-        })
-      })
-    })
-  })
-
-  describe('when signers are not operating correctly', () => {
-    // In this case (1/3 signers are correct), response unblinding is guaranteed to fail
-    // Testing 2/3 signers is flaky since the combiner sometimes combines two
-    // correct signatures and returns, and sometimes combines one wrong/one correct
-    // since it cannot verify the sigs server-side.
-    describe('when 1/3 signers return correct signatures', () => {
+    describe('when signers are operating correctly', () => {
       beforeEach(async () => {
-        // Signer 1 & 2's v1 keys are misconfigured to point to the v3 share
-        const badKeyProvider1 = new MockKeyProvider(
-          new Map([[`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V3]])
-        )
-        const badKeyProvider2 = new MockKeyProvider(
-          new Map([[`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V3]])
-        )
-        signer1 = startSigner(signerConfig, signerDB1, badKeyProvider1).listen(3001)
-        signer2 = startSigner(signerConfig, signerDB2, badKeyProvider2).listen(3002)
-        signer3 = startSigner(signerConfig, signerDB3, keyProvider3).listen(3003)
-      })
-
-      describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
-        it('Should respond with 200 on valid request', async () => {
-          // Ensure requested keyVersion is one that signer1 does not have
-          const [req, poprfClient] = await signatureRequest(undefined, undefined, 1)
-          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
-
-          expect(res.status).toBe(200)
-          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-            success: true,
-            version: res.body.version,
-            signature: res.body.signature,
-            status: {
-              disabled: false,
-              counter: 1,
-              timer: res.body.status.timer,
-              now: res.body.status.now,
-            },
-          })
-          expect(() =>
-            poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
-          ).toThrow(/verification failed/)
-        })
-      })
-    })
-
-    describe('when 2/3 of signers are disabled', () => {
-      beforeEach(async () => {
-        const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
-        configWithApiDisabled.api.domains.enabled = false
-        signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
-        signer2 = startSigner(configWithApiDisabled, signerDB2, keyProvider2).listen(3002)
-        signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3).listen(3003)
-      })
-
-      describe(`${CombinerEndpoint.DISABLE_DOMAIN}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const res = await request(app)
-            .post(CombinerEndpoint.DISABLE_DOMAIN)
-            .send(await disableRequest())
-          expect(res.status).toBe(503) // majority error code in this case
-          expect(res.body).toStrictEqual<DisableDomainResponse>({
-            success: false,
-            version: res.body.version,
-            error: ErrorMessage.THRESHOLD_DISABLE_DOMAIN_FAILURE,
-          })
-        })
-      })
-
-      describe(`${CombinerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const res = await request(app)
-            .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
-            .send(await quotaRequest())
-          expect(res.status).toBe(503) // majority error code in this case
-          expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-            success: false,
-            version: res.body.version,
-            error: ErrorMessage.THRESHOLD_DOMAIN_QUOTA_STATUS_FAILURE,
-          })
-        })
-      })
-
-      describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const [req, _] = await signatureRequest()
-          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
-          expect(res.status).toBe(503) // majority error code in this case
-          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
-            success: false,
-            version: res.body.version,
-            error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
-          })
-        })
-      })
-    })
-
-    describe('when 1/3 of signers are disabled', () => {
-      beforeEach(async () => {
-        const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
-        configWithApiDisabled.api.domains.enabled = false
         signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
         signer2 = startSigner(signerConfig, signerDB2, keyProvider2).listen(3002)
-        signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3).listen(3003)
+        signer3 = startSigner(signerConfig, signerDB3, keyProvider3).listen(3003)
       })
 
       describe(`${CombinerEndpoint.DISABLE_DOMAIN}`, () => {
@@ -1013,6 +303,132 @@ describe('domainService', () => {
             status: { disabled: true, counter: 0, timer: 0, now: res.body.status.now },
           })
         })
+
+        it('Should respond with 200 on repeated valid requests', async () => {
+          const req = await disableRequest()
+          const res1 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(req)
+          expect(res1.status).toBe(200)
+          const expectedResponse: DisableDomainResponse = {
+            success: true,
+            version: res1.body.version,
+            status: { disabled: true, counter: 0, timer: 0, now: res1.body.status.now },
+          }
+          expect(res1.body).toStrictEqual<DisableDomainResponse>(expectedResponse)
+          const res2 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(req)
+          expect(res2.status).toBe(200)
+          expectedResponse.status.now = res2.body.status.now
+          expect(res2.body).toStrictEqual<DisableDomainResponse>(expectedResponse)
+        })
+
+        it('Should respond with 200 on extra request fields', async () => {
+          const req = await disableRequest()
+          // @ts-ignore Intentionally adding an extra field to the request type
+          req.options.extraField = noString
+
+          const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(req)
+
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<DisableDomainResponse>({
+            success: true,
+            version: res.body.version,
+            status: { disabled: true, counter: 0, timer: 0, now: res.body.status.now },
+          })
+        })
+
+        it('Should respond with 400 on missing request fields', async () => {
+          const badRequest = await disableRequest()
+          // @ts-ignore Intentionally deleting required field
+          delete badRequest.domain.version
+
+          const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<DisableDomainResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 on unknown domain', async () => {
+          // Create a requests with an invalid domain identifier.
+          const unknownRequest = await disableRequest()
+          // @ts-ignore UnknownDomain is (intentionally) not a valid domain identifier.
+          unknownRequest.domain.name = 'UnknownDomain'
+
+          const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(unknownRequest)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<DisableDomainResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 on bad encoding', async () => {
+          const badRequest1 = await disableRequest()
+          // @ts-ignore Intentionally not JSON
+          badRequest1.domain = 'Freddy'
+
+          const res1 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest1)
+
+          expect(res1.status).toBe(400)
+          expect(res1.body).toStrictEqual<DisableDomainResponse>({
+            success: false,
+            version: res1.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+
+          const badRequest2 = ''
+
+          const res2 = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest2)
+
+          expect(res2.status).toBe(400)
+          expect(res2.body).toStrictEqual<DisableDomainResponse>({
+            success: false,
+            version: res2.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 401 on failed auth', async () => {
+          // Create a manipulated request, which will have a bad signature.
+          const badRequest = await disableRequest()
+          badRequest.domain.salt = defined('badSalt')
+
+          const res = await request(app).post(CombinerEndpoint.DISABLE_DOMAIN).send(badRequest)
+
+          expect(res.status).toBe(401)
+          expect(res.body).toStrictEqual<DisableDomainResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.UNAUTHENTICATED_USER,
+          })
+        })
+
+        it('Should respond with 503 on disabled api', async () => {
+          const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+            JSON.stringify(combinerConfig)
+          )
+          configWithApiDisabled.domains.enabled = false
+          const appWithApiDisabled = startCombiner(
+            configWithApiDisabled,
+            getContractKit(configWithApiDisabled.blockchain)
+          )
+          const req = await disableRequest()
+
+          const res = await request(appWithApiDisabled)
+            .post(CombinerEndpoint.DISABLE_DOMAIN)
+            .send(req)
+
+          expect(res.status).toBe(503)
+          expect(res.body).toStrictEqual<DisableDomainResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.API_UNAVAILABLE,
+          })
+        })
       })
 
       describe(`${CombinerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
@@ -1025,6 +441,142 @@ describe('domainService', () => {
             success: true,
             version: res.body.version,
             status: { disabled: false, counter: 0, timer: 0, now: res.body.status.now },
+          })
+        })
+
+        it('Should respond with 200 on repeated valid requests', async () => {
+          const req = await quotaRequest()
+          const res1 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
+          const expectedResponse: DomainQuotaStatusResponse = {
+            success: true,
+            version: res1.body.version,
+            status: { disabled: false, counter: 0, timer: 0, now: res1.body.status.now },
+          }
+
+          expect(res1.status).toBe(200)
+          expect(res1.body).toStrictEqual<DomainQuotaStatusResponse>(expectedResponse)
+
+          const res2 = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
+          expect(res2.status).toBe(200)
+          // Prevent flakiness due to slight timing inconsistencies
+          expectedResponse.status.now = res2.body.status.now
+          expect(res2.body).toStrictEqual<DomainQuotaStatusResponse>(expectedResponse)
+        })
+
+        it('Should respond with 200 on extra request fields', async () => {
+          const req = await quotaRequest()
+          // @ts-ignore Intentionally adding an extra field to the request type
+          req.options.extraField = noString
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(req)
+
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+            success: true,
+            version: res.body.version,
+            status: { disabled: false, counter: 0, timer: 0, now: res.body.status.now },
+          })
+        })
+
+        it('Should respond with 400 on missing request fields', async () => {
+          const badRequest = await quotaRequest()
+          // @ts-ignore Intentionally deleting required field
+          delete badRequest.domain.version
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 on unknown domain', async () => {
+          // Create a requests with an invalid domain identifier.
+          const unknownRequest = await quotaRequest()
+          // @ts-ignore UnknownDomain is (intentionally) not a valid domain identifier.
+          unknownRequest.domain.name = 'UnknownDomain'
+
+          const res = await request(app)
+            .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
+            .send(unknownRequest)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 on bad encoding', async () => {
+          const badRequest1 = await quotaRequest()
+          // @ts-ignore Intentionally not JSON
+          badRequest1.domain = 'Freddy'
+
+          const res1 = await request(app)
+            .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
+            .send(badRequest1)
+
+          expect(res1.status).toBe(400)
+          expect(res1.body).toStrictEqual<DomainQuotaStatusResponse>({
+            success: false,
+            version: res1.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+
+          const badRequest2 = ''
+
+          const res2 = await request(app)
+            .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
+            .send(badRequest2)
+
+          expect(res2.status).toBe(400)
+          expect(res2.body).toStrictEqual<DomainQuotaStatusResponse>({
+            success: false,
+            version: res2.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 401 on failed auth', async () => {
+          // Create a manipulated request, which will have a bad signature.
+          const badRequest = await quotaRequest()
+          badRequest.domain.salt = defined('badSalt')
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_QUOTA_STATUS).send(badRequest)
+
+          expect(res.status).toBe(401)
+          expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.UNAUTHENTICATED_USER,
+          })
+        })
+
+        it('Should respond with 503 on disabled api', async () => {
+          const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+            JSON.stringify(combinerConfig)
+          )
+          configWithApiDisabled.domains.enabled = false
+          const appWithApiDisabled = startCombiner(
+            configWithApiDisabled,
+            getContractKit(configWithApiDisabled.blockchain)
+          )
+
+          const req = await quotaRequest()
+
+          const res = await request(appWithApiDisabled)
+            .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
+            .send(req)
+
+          expect(res.status).toBe(503)
+          expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.API_UNAVAILABLE,
           })
         })
       })
@@ -1049,60 +601,681 @@ describe('domainService', () => {
           const evaluation = poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
           expect(evaluation.toString('base64')).toEqual(expectedEval)
         })
-      })
-    })
 
-    describe('when signers timeout', () => {
-      beforeEach(async () => {
-        const testTimeoutMS = 0
+        for (let i = 1; i <= 3; i++) {
+          it(`Should respond with 200 on valid request with key version header ${i}`, async () => {
+            const [req, poprfClient] = await signatureRequest(
+              undefined,
+              undefined,
+              TestUtils.Values.DOMAINS_THRESHOLD_DEV_PUBKEYS[i - 1]
+            )
 
-        const configWithShortTimeout: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
-        configWithShortTimeout.timeout = testTimeoutMS
-        // Test this with all signers timing out to decrease possibility of race conditions
-        signer1 = startSigner(configWithShortTimeout, signerDB1, keyProvider1).listen(3001)
-        signer2 = startSigner(configWithShortTimeout, signerDB2, keyProvider2).listen(3002)
-        signer3 = startSigner(configWithShortTimeout, signerDB3, keyProvider3).listen(3003)
-      })
+            const res = await request(app)
+              .post(CombinerEndpoint.DOMAIN_SIGN)
+              .set(KEY_VERSION_HEADER, i.toString())
+              .send(req)
 
-      describe(`${CombinerEndpoint.DISABLE_DOMAIN}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const res = await request(app)
-            .post(CombinerEndpoint.DISABLE_DOMAIN)
-            .send(await disableRequest())
-          expect(res.status).toBe(500) // majority error code in this case
-          expect(res.body).toStrictEqual<DisableDomainResponse>({
-            success: false,
-            version: res.body.version,
-            error: ErrorMessage.THRESHOLD_DISABLE_DOMAIN_FAILURE,
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+              success: true,
+              version: res.body.version,
+              signature: res.body.signature,
+              status: {
+                disabled: false,
+                counter: 1,
+                timer: res.body.status.timer,
+                now: res.body.status.now,
+              },
+            })
+            const evaluation = poprfClient.unblindResponse(
+              Buffer.from(res.body.signature, 'base64')
+            )
+            expect(evaluation.toString('base64')).toEqual(expectedEvals[i - 1])
           })
-        })
-      })
+        }
 
-      describe(`${CombinerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const res = await request(app)
-            .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
-            .send(await quotaRequest())
-          expect(res.status).toBe(500) // majority error code in this case
-          expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
-            success: false,
-            version: res.body.version,
-            error: ErrorMessage.THRESHOLD_DOMAIN_QUOTA_STATUS_FAILURE,
-          })
-        })
-      })
+        it('Should respond with 200 if nonce > domainState', async () => {
+          const [req, poprfClient] = await signatureRequest(undefined, 2)
 
-      describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const [req, _] = await signatureRequest()
           const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
-          expect(res.status).toBe(500) // majority error code in this case
+
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: true,
+            version: res.body.version,
+            signature: res.body.signature,
+            status: {
+              disabled: false,
+              counter: 1, // counter gets incremented, not set to nonce value
+              timer: res.body.status.timer,
+              now: res.body.status.now,
+            },
+          })
+          const evaluation = poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
+          expect(evaluation.toString('base64')).toEqual(expectedEval)
+        })
+
+        it('Should respond with 200 on repeated valid requests', async () => {
+          const [req1, poprfClient] = await signatureRequest()
+
+          const res1 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
+          expect(res1.status).toBe(200)
+          expect(res1.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: true,
+            version: res1.body.version,
+            signature: res1.body.signature,
+            status: {
+              disabled: false,
+              counter: 1,
+              timer: res1.body.status.timer,
+              now: res1.body.status.now,
+            },
+          })
+          const eval1 = poprfClient.unblindResponse(Buffer.from(res1.body.signature, 'base64'))
+          expect(eval1.toString('base64')).toEqual(expectedEval)
+
+          // submit identical request with nonce set to 1
+          req1.options.nonce = defined(1)
+          req1.options.signature = noString
+          req1.options.signature = defined(
+            await wallet.signTypedData(walletAddress, domainRestrictedSignatureRequestEIP712(req1))
+          )
+          const res2 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
+
+          expect(res2.status).toBe(200)
+          expect(res2.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: true,
+            version: res2.body.version,
+            signature: res2.body.signature,
+            status: {
+              disabled: false,
+              counter: 2,
+              timer: res2.body.status.timer,
+              now: res2.body.status.now,
+            },
+          })
+          const eval2 = poprfClient.unblindResponse(Buffer.from(res1.body.signature, 'base64'))
+          expect(eval2).toEqual(eval1)
+        })
+
+        it('Should respond with 200 on extra request fields', async () => {
+          const [req, poprfClient] = await signatureRequest()
+          // @ts-ignore Intentionally adding an extra field to the request type
+          req.options.extraField = noString
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: true,
+            version: res.body.version,
+            signature: res.body.signature,
+            status: {
+              disabled: false,
+              counter: 1,
+              timer: res.body.status.timer,
+              now: res.body.status.now,
+            },
+          })
+          const evaluation = poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
+          expect(evaluation.toString('base64')).toEqual(expectedEval)
+        })
+
+        it('Should respond with 400 on missing request fields', async () => {
+          const [badRequest, _] = await signatureRequest()
+          // @ts-ignore Intentionally deleting required field
+          delete badRequest.domain.version
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
+
+          expect(res.status).toBe(400)
           expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
             success: false,
             version: res.body.version,
-            error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
+            error: WarningMessage.INVALID_INPUT,
           })
         })
+
+        it('Should respond with 400 on unknown domain', async () => {
+          // Create a requests with an invalid domain identifier.
+          const [unknownRequest, _] = await signatureRequest()
+          // @ts-ignore UnknownDomain is (intentionally) not a valid domain identifier.
+          unknownRequest.domain.name = 'UnknownDomain'
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(unknownRequest)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 on bad encoding', async () => {
+          const [badRequest1, _] = await signatureRequest()
+          // @ts-ignore Intentionally not JSON
+          badRequest1.domain = 'Freddy'
+
+          const res1 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest1)
+
+          expect(res1.status).toBe(400)
+          expect(res1.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res1.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+
+          const badRequest2 = ''
+
+          const res2 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest2)
+
+          expect(res2.status).toBe(400)
+          expect(res2.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res2.body.version,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 on unsupported key version', async () => {
+          const [badRequest, _] = await signatureRequest()
+
+          const res = await request(app)
+            .post(CombinerEndpoint.DOMAIN_SIGN)
+            .set(KEY_VERSION_HEADER, '4')
+            .send(badRequest)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.INVALID_KEY_VERSION_REQUEST,
+          })
+        })
+
+        it('Should respond with 401 on failed auth', async () => {
+          // Create a manipulated request, which will have a bad signature.
+          const [badRequest, _] = await signatureRequest()
+          badRequest.domain.salt = defined('badSalt')
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
+
+          expect(res.status).toBe(401)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.UNAUTHENTICATED_USER,
+          })
+        })
+
+        it('Should respond with 401 on invalid nonce', async () => {
+          // Request must be sent first since nonce check is >= 0
+          const [req1, _] = await signatureRequest()
+          const res1 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
+
+          expect(res1.status).toBe(200)
+          expect(res1.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: true,
+            version: res1.body.version,
+            signature: res1.body.signature,
+            status: {
+              disabled: false,
+              counter: 1,
+              timer: res1.body.status.timer,
+              now: res1.body.status.now,
+            },
+          })
+          const res2 = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req1)
+          expect(res2.status).toBe(401)
+          expect(res2.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res2.body.version,
+            error: WarningMessage.INVALID_NONCE,
+          })
+        })
+
+        it('Should respond with 429 on out of quota', async () => {
+          const noQuotaDomain = authenticatedDomain([
+            { delay: 0, resetTimer: noBool, batchSize: defined(0), repetitions: defined(0) },
+          ])
+          const [badRequest, _] = await signatureRequest(noQuotaDomain)
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
+
+          expect(res.status).toBe(429)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.EXCEEDED_QUOTA,
+          })
+        })
+
+        it('Should respond with 429 on request too early', async () => {
+          // This domain won't accept requests until ~10 seconds after test execution
+          const noQuotaDomain = authenticatedDomain([
+            {
+              delay: Math.floor(Date.now() / 1000) + 10,
+              resetTimer: noBool,
+              batchSize: defined(2),
+              repetitions: defined(1),
+            },
+          ])
+          const [badRequest, _] = await signatureRequest(noQuotaDomain)
+
+          const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
+
+          expect(res.status).toBe(429)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.EXCEEDED_QUOTA,
+          })
+        })
+
+        it('Should respond with 429 when requesting a signature from a disabled domain', async () => {
+          const testDomain = authenticatedDomain()
+          const resDisable = await request(app)
+            .post(CombinerEndpoint.DISABLE_DOMAIN)
+            .send(await disableRequest(testDomain))
+          expect(resDisable.status).toBe(200)
+          expect(resDisable.body).toStrictEqual<DisableDomainResponse>({
+            success: true,
+            version: resDisable.body.version,
+            status: { disabled: true, counter: 0, timer: 0, now: resDisable.body.status.now },
+          })
+        })
+
+        it('Should respond with 503 on disabled api', async () => {
+          const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+            JSON.stringify(combinerConfig)
+          )
+          configWithApiDisabled.domains.enabled = false
+          const appWithApiDisabled = startCombiner(
+            configWithApiDisabled,
+            getContractKit(configWithApiDisabled.blockchain)
+          )
+
+          const [req, _] = await signatureRequest()
+
+          const res = await request(appWithApiDisabled).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+
+          expect(res.status).toBe(503)
+          expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+            success: false,
+            version: res.body.version,
+            error: WarningMessage.API_UNAVAILABLE,
+          })
+        })
+      })
+    })
+
+    describe('when signers are not operating correctly', () => {
+      // In this case (1/3 signers are correct), response unblinding is guaranteed to fail
+      // Testing 2/3 signers is flaky since the combiner sometimes combines two
+      // correct signatures and returns, and sometimes combines one wrong/one correct
+      // since it cannot verify the sigs server-side.
+      describe('when 1/3 signers return correct signatures', () => {
+        beforeEach(async () => {
+          // Signer 1 & 2's v1 keys are misconfigured to point to the v3 share
+          const badKeyProvider1 = new MockKeyProvider(
+            new Map([[`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_1_V3]])
+          )
+          const badKeyProvider2 = new MockKeyProvider(
+            new Map([[`${DefaultKeyName.DOMAINS}-1`, DOMAINS_THRESHOLD_DEV_PK_SHARE_2_V3]])
+          )
+          signer1 = startSigner(signerConfig, signerDB1, badKeyProvider1).listen(3001)
+          signer2 = startSigner(signerConfig, signerDB2, badKeyProvider2).listen(3002)
+          signer3 = startSigner(signerConfig, signerDB3, keyProvider3).listen(3003)
+        })
+
+        describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
+          it('Should respond with 200 on valid request', async () => {
+            // Ensure requested keyVersion is one that signer1 does not have
+            const [req, poprfClient] = await signatureRequest(
+              undefined,
+              undefined,
+              TestUtils.Values.DOMAINS_THRESHOLD_DEV_PUBKEY_V1
+            )
+            const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+              success: true,
+              version: res.body.version,
+              signature: res.body.signature,
+              status: {
+                disabled: false,
+                counter: 1,
+                timer: res.body.status.timer,
+                now: res.body.status.now,
+              },
+            })
+            expect(() =>
+              poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
+            ).toThrow(/verification failed/)
+          })
+        })
+      })
+
+      describe('when 2/3 of signers are disabled', () => {
+        beforeEach(async () => {
+          const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
+          configWithApiDisabled.api.domains.enabled = false
+          signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
+          signer2 = startSigner(configWithApiDisabled, signerDB2, keyProvider2).listen(3002)
+          signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3).listen(3003)
+        })
+
+        describe(`${CombinerEndpoint.DISABLE_DOMAIN}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const res = await request(app)
+              .post(CombinerEndpoint.DISABLE_DOMAIN)
+              .send(await disableRequest())
+            expect(res.status).toBe(503) // majority error code in this case
+            expect(res.body).toStrictEqual<DisableDomainResponse>({
+              success: false,
+              version: res.body.version,
+              error: ErrorMessage.THRESHOLD_DISABLE_DOMAIN_FAILURE,
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const res = await request(app)
+              .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
+              .send(await quotaRequest())
+            expect(res.status).toBe(503) // majority error code in this case
+            expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+              success: false,
+              version: res.body.version,
+              error: ErrorMessage.THRESHOLD_DOMAIN_QUOTA_STATUS_FAILURE,
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const [req, _] = await signatureRequest()
+            const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+            expect(res.status).toBe(503) // majority error code in this case
+            expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+              success: false,
+              version: res.body.version,
+              error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
+            })
+          })
+        })
+      })
+
+      describe('when 1/3 of signers are disabled', () => {
+        beforeEach(async () => {
+          const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
+          configWithApiDisabled.api.domains.enabled = false
+          signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
+          signer2 = startSigner(signerConfig, signerDB2, keyProvider2).listen(3002)
+          signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3).listen(3003)
+        })
+
+        describe(`${CombinerEndpoint.DISABLE_DOMAIN}`, () => {
+          it('Should respond with 200 on valid request', async () => {
+            const res = await request(app)
+              .post(CombinerEndpoint.DISABLE_DOMAIN)
+              .send(await disableRequest())
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<DisableDomainResponse>({
+              success: true,
+              version: res.body.version,
+              status: { disabled: true, counter: 0, timer: 0, now: res.body.status.now },
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
+          it('Should respond with 200 on valid request', async () => {
+            const res = await request(app)
+              .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
+              .send(await quotaRequest())
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+              success: true,
+              version: res.body.version,
+              status: { disabled: false, counter: 0, timer: 0, now: res.body.status.now },
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
+          it('Should respond with 200 on valid request', async () => {
+            const [req, poprfClient] = await signatureRequest()
+            const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+              success: true,
+              version: res.body.version,
+              signature: res.body.signature,
+              status: {
+                disabled: false,
+                counter: 1,
+                timer: res.body.status.timer,
+                now: res.body.status.now,
+              },
+            })
+            const evaluation = poprfClient.unblindResponse(
+              Buffer.from(res.body.signature, 'base64')
+            )
+            expect(evaluation.toString('base64')).toEqual(expectedEval)
+          })
+        })
+      })
+
+      describe('when signers timeout', () => {
+        beforeEach(async () => {
+          const testTimeoutMS = 0
+
+          const configWithShortTimeout: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
+          configWithShortTimeout.timeout = testTimeoutMS
+          // Test this with all signers timing out to decrease possibility of race conditions
+          signer1 = startSigner(configWithShortTimeout, signerDB1, keyProvider1).listen(3001)
+          signer2 = startSigner(configWithShortTimeout, signerDB2, keyProvider2).listen(3002)
+          signer3 = startSigner(configWithShortTimeout, signerDB3, keyProvider3).listen(3003)
+        })
+
+        describe(`${CombinerEndpoint.DISABLE_DOMAIN}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const res = await request(app)
+              .post(CombinerEndpoint.DISABLE_DOMAIN)
+              .send(await disableRequest())
+            expect(res.status).toBe(500) // majority error code in this case
+            expect(res.body).toStrictEqual<DisableDomainResponse>({
+              success: false,
+              version: res.body.version,
+              error: ErrorMessage.THRESHOLD_DISABLE_DOMAIN_FAILURE,
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.DOMAIN_QUOTA_STATUS}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const res = await request(app)
+              .post(CombinerEndpoint.DOMAIN_QUOTA_STATUS)
+              .send(await quotaRequest())
+            expect(res.status).toBe(500) // majority error code in this case
+            expect(res.body).toStrictEqual<DomainQuotaStatusResponse>({
+              success: false,
+              version: res.body.version,
+              error: ErrorMessage.THRESHOLD_DOMAIN_QUOTA_STATUS_FAILURE,
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.DOMAIN_SIGN}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const [req, _] = await signatureRequest()
+            const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+            expect(res.status).toBe(500) // majority error code in this case
+            expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+              success: false,
+              version: res.body.version,
+              error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
+            })
+          })
+        })
+      })
+    })
+  })
+
+  // Ensure the same behavior when a minority of signers can block the threshold.
+  // On failure, the majority error code should not reflect the abort.
+  describe('with n=5, t=4', () => {
+    let keyProvider4: KeyProvider
+    let keyProvider5: KeyProvider
+    let signerDB4: Knex
+    let signerDB5: Knex
+    let signer4: Server | HttpsServer
+    let signer5: Server | HttpsServer
+
+    const combinerConfigLargerN: typeof config = JSON.parse(JSON.stringify(combinerConfig))
+    combinerConfigLargerN.domains.odisServices.signers = JSON.stringify([
+      {
+        url: 'http://localhost:3001',
+        fallbackUrl: 'http://localhost:3001/fallback',
+      },
+      {
+        url: 'http://localhost:3002',
+        fallbackUrl: 'http://localhost:3002/fallback',
+      },
+      {
+        url: 'http://localhost:3003',
+        fallbackUrl: 'http://localhost:3003/fallback',
+      },
+      {
+        url: 'http://localhost:3004',
+        fallbackUrl: 'http://localhost:3004/fallback',
+      },
+      {
+        url: 'http://localhost:3005',
+        fallbackUrl: 'http://localhost:3005/fallback',
+      },
+    ])
+    const DOMAINS_PUBKEY_N5_T4 =
+      'gEAedm5Gq+6s/r4ohLrduNmb7IznkYxHQ46+IW0iwEjcjWCi3lkJuItDVa3EXaoBKF4yFAa7wtuX7I8hB3m730XdEpd/77C2GOVGtwDshtCgajSzx7+0zvrnat5QmTkB'
+
+    combinerConfigLargerN.domains.keys.versions = JSON.stringify([
+      {
+        keyVersion: 1,
+        threshold: 4,
+        polynomial:
+          '040000000000000080401e766e46abeeacfebe2884baddb8d99bec8ce7918c47438ebe216d22c048dc8d60a2de5909b88b4355adc45daa01285e321406bbc2db97ec8f210779bbdf45dd12977fefb0b618e546b700ec86d0a06a34b3c7bfb4cefae76ade50993901bbf28cb0b2245e5de0926ce13338440e3b5a378dfe10ba41f61d145d9d5df29ce32abba7562804919101e4803bb47301da265654875d06a0c355b93918ff58efe29c6225d42c2b60c4efbdf7984e3b1ed4e997d53e719aa93fdc10171202460055955ad375e460a181f701a22f543365622c4a5f6ad16fce62e24584b77c23db48312840d0301197c3529cda8b712e01897a2cefab5437f658c59a2a3d880315c3268de1128b333a51d36b2999bf587d25ec82f3695db4c75f9825baf88a460002b11295e74511608041574063faa86f27251a2766861ada6a89bf45454aa4b933992f80622a810b8aead298964f37004ad57215433da765e1d3aae5d9b57ad2d9afcdf77f227e48040ac5701abce7995f94ac0c4c70996333396620e6cf8e00',
+        pubKey: DOMAINS_PUBKEY_N5_T4,
+      },
+    ])
+
+    beforeAll(async () => {
+      keyProvider1 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.DOMAINS}-1`,
+            '01000000fa9f3c7a0ed050b3b4ab9df241e3e3e2069e36c96369b2bf378d7edd66e37a0e',
+          ],
+        ])
+      )
+      keyProvider2 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.DOMAINS}-1`,
+            '02000000b03e8d5203edb8b27a9c56185df0ee94e8be45f0c91e116beac68c851cc4ba10',
+          ],
+        ])
+      )
+      keyProvider3 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.DOMAINS}-1`,
+            '03000000bad95bc039a5418bd57e7f5bad4bf6c19ff85e523462925e226e6ac0a6770005',
+          ],
+        ])
+      )
+      keyProvider4 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.DOMAINS}-1`,
+            '040000002ffdcc94fd5322e4f3e0d7ba00b591c38f77e584b61b59dd6e62cc6cfed5fd06',
+          ],
+        ])
+      )
+      keyProvider5 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.DOMAINS}-1`,
+            '05000000243505a19a546f5002511f9527fe03401908cd6427991f69b2380e355fec0d0d',
+          ],
+        ])
+      )
+      app = startCombiner(combinerConfigLargerN, getContractKit(combinerConfigLargerN.blockchain))
+    })
+
+    beforeEach(async () => {
+      signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB4 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB5 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+
+      signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
+      signer2 = startSigner(signerConfig, signerDB2, keyProvider2).listen(3002)
+      signer3 = startSigner(signerConfig, signerDB3, keyProvider3).listen(3003)
+      signer4 = startSigner(signerConfig, signerDB4, keyProvider4).listen(3004)
+      signer5 = startSigner(signerConfig, signerDB5, keyProvider5).listen(3005)
+    })
+
+    afterEach(async () => {
+      await signerDB1?.destroy()
+      await signerDB2?.destroy()
+      await signerDB3?.destroy()
+      await signerDB4?.destroy()
+      await signerDB5?.destroy()
+      signer1?.close()
+      signer2?.close()
+      signer3?.close()
+      signer4?.close()
+      signer5?.close()
+    })
+
+    it('Should respond with 200 on valid request', async () => {
+      const [req, poprfClient] = await signatureRequest(undefined, undefined, DOMAINS_PUBKEY_N5_T4)
+      const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(req)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+        success: true,
+        version: res.body.version,
+        signature: res.body.signature,
+        status: {
+          disabled: false,
+          counter: 1,
+          timer: res.body.status.timer,
+          now: res.body.status.now,
+        },
+      })
+      poprfClient.unblindResponse(Buffer.from(res.body.signature, 'base64'))
+    })
+
+    it('Should respond with 429 on out of quota', async () => {
+      const noQuotaDomain = authenticatedDomain([
+        { delay: 0, resetTimer: noBool, batchSize: defined(0), repetitions: defined(0) },
+      ])
+      const [badRequest, _] = await signatureRequest(noQuotaDomain, undefined, DOMAINS_PUBKEY_N5_T4)
+
+      const res = await request(app).post(CombinerEndpoint.DOMAIN_SIGN).send(badRequest)
+
+      expect(res.status).toBe(429)
+      expect(res.body).toStrictEqual<DomainRestrictedSignatureResponse>({
+        success: false,
+        version: res.body.version,
+        error: WarningMessage.EXCEEDED_QUOTA,
       })
     })
   })

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -196,73 +196,8 @@ describe('pnpService', () => {
 
   const message = Buffer.from('test message', 'utf8')
 
-  const expectedSignatures: string[] = [
-    'xgFMQtcgAMHJAEX/m9B4VFopYtxqPFSw0024sWzRYvQDvnmFqhXOPdnRDfa8WCEA',
-    'wUuFV8yFBXGyEzKbyWjBChG6dER264nwjOsqErd/UZieVKE0oDMZcMDG+qObu4QB',
-    'PJHqBGavcQG3NGFl3hiR8GymeDNumxbl1DnCJzWz+Ik5yCN2ZpAITBe24RTX0iMA',
-  ]
-  const expectedSignature = expectedSignatures[config.phoneNumberPrivacy.keys.currentVersion - 1]
-
-  const expectedUnblindedSigs: string[] = [
-    'lOASnDJNbJBTMYfkbU4fMiK7FcNwSyqZo8iQSM95X8YK+/158be4S1A+jcQsCUYA',
-    'QIT7HtHTe/d0Tq40Mf3rpHCT8qY20+8q7ZW9PXHFMWGvwSGhk7l3Pfwnx8YdXomB',
-    'XW//DolLzaXYS/gk9WBHfeKy5HKrGjuF/OpCok/i6fprE4AGFH2PjE7zeKTfOQ+A',
-  ]
-  const expectedUnblindedSig =
-    expectedUnblindedSigs[config.phoneNumberPrivacy.keys.currentVersion - 1]
-
   // In current setup, the same mocked kit is used for the combiner and signers
   const mockKit = newKit('dummyKit')
-
-  beforeAll(async () => {
-    keyProvider1 = new MockKeyProvider(
-      new Map([
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, PNP_THRESHOLD_DEV_PK_SHARE_1_V1],
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-2`, PNP_THRESHOLD_DEV_PK_SHARE_1_V2],
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-3`, PNP_THRESHOLD_DEV_PK_SHARE_1_V3],
-      ])
-    )
-    keyProvider2 = new MockKeyProvider(
-      new Map([
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, PNP_THRESHOLD_DEV_PK_SHARE_2_V1],
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-2`, PNP_THRESHOLD_DEV_PK_SHARE_2_V2],
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-3`, PNP_THRESHOLD_DEV_PK_SHARE_2_V3],
-      ])
-    )
-    keyProvider3 = new MockKeyProvider(
-      new Map([
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, PNP_THRESHOLD_DEV_PK_SHARE_3_V1],
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-2`, PNP_THRESHOLD_DEV_PK_SHARE_3_V2],
-        [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-3`, PNP_THRESHOLD_DEV_PK_SHARE_3_V3],
-      ])
-    )
-    app = startCombiner(combinerConfig, mockKit)
-  })
-
-  beforeEach(async () => {
-    signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
-    signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
-    signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
-
-    userSeed = new Uint8Array(32)
-    for (let i = 0; i < userSeed.length - 1; i++) {
-      userSeed[i] = i
-    }
-
-    blindedMsgResult = threshold_bls.blind(message, userSeed)
-
-    mockGetDataEncryptionKey.mockReset().mockReturnValue(DEK_PUBLIC_KEY)
-    mockGetWalletAddress.mockReset().mockReturnValue(mockAccount)
-  })
-
-  afterEach(async () => {
-    await signerDB1?.destroy()
-    await signerDB2?.destroy()
-    await signerDB3?.destroy()
-    signer1?.close()
-    signer2?.close()
-    signer3?.close()
-  })
 
   const sendPnpSignRequest = async (
     req: SignMessageRequest,
@@ -316,309 +251,181 @@ describe('pnpService', () => {
     return res
   }
 
-  describe('when signers are operating correctly', () => {
-    beforeEach(async () => {
-      signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
-      signer2 = startSigner(signerConfig, signerDB2, keyProvider2, mockKit).listen(3002)
-      signer3 = startSigner(signerConfig, signerDB3, keyProvider3, mockKit).listen(3003)
+  describe('with n=3, t=2', () => {
+    const expectedSignatures: string[] = [
+      'xgFMQtcgAMHJAEX/m9B4VFopYtxqPFSw0024sWzRYvQDvnmFqhXOPdnRDfa8WCEA',
+      'wUuFV8yFBXGyEzKbyWjBChG6dER264nwjOsqErd/UZieVKE0oDMZcMDG+qObu4QB',
+      'PJHqBGavcQG3NGFl3hiR8GymeDNumxbl1DnCJzWz+Ik5yCN2ZpAITBe24RTX0iMA',
+    ]
+    const expectedSignature = expectedSignatures[config.phoneNumberPrivacy.keys.currentVersion - 1]
+
+    const expectedUnblindedSigs: string[] = [
+      'lOASnDJNbJBTMYfkbU4fMiK7FcNwSyqZo8iQSM95X8YK+/158be4S1A+jcQsCUYA',
+      'QIT7HtHTe/d0Tq40Mf3rpHCT8qY20+8q7ZW9PXHFMWGvwSGhk7l3Pfwnx8YdXomB',
+      'XW//DolLzaXYS/gk9WBHfeKy5HKrGjuF/OpCok/i6fprE4AGFH2PjE7zeKTfOQ+A',
+    ]
+    const expectedUnblindedSig =
+      expectedUnblindedSigs[config.phoneNumberPrivacy.keys.currentVersion - 1]
+
+    beforeAll(async () => {
+      keyProvider1 = new MockKeyProvider(
+        new Map([
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, PNP_THRESHOLD_DEV_PK_SHARE_1_V1],
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-2`, PNP_THRESHOLD_DEV_PK_SHARE_1_V2],
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-3`, PNP_THRESHOLD_DEV_PK_SHARE_1_V3],
+        ])
+      )
+      keyProvider2 = new MockKeyProvider(
+        new Map([
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, PNP_THRESHOLD_DEV_PK_SHARE_2_V1],
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-2`, PNP_THRESHOLD_DEV_PK_SHARE_2_V2],
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-3`, PNP_THRESHOLD_DEV_PK_SHARE_2_V3],
+        ])
+      )
+      keyProvider3 = new MockKeyProvider(
+        new Map([
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, PNP_THRESHOLD_DEV_PK_SHARE_3_V1],
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-2`, PNP_THRESHOLD_DEV_PK_SHARE_3_V2],
+          [`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-3`, PNP_THRESHOLD_DEV_PK_SHARE_3_V3],
+        ])
+      )
+      app = startCombiner(combinerConfig, mockKit)
     })
 
-    describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
-      const totalQuota = 10
-      const weiTocusd = new BigNumber(1e18)
-      beforeAll(async () => {
-        mockOdisPaymentsTotalPaidCUSD.mockReturnValue(
-          weiTocusd.multipliedBy(totalQuota).multipliedBy(signerConfig.quota.queryPriceInCUSD)
-        )
+    beforeEach(async () => {
+      signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+
+      userSeed = new Uint8Array(32)
+      for (let i = 0; i < userSeed.length - 1; i++) {
+        userSeed[i] = i
+      }
+
+      blindedMsgResult = threshold_bls.blind(message, userSeed)
+
+      mockGetDataEncryptionKey.mockReset().mockReturnValue(DEK_PUBLIC_KEY)
+      mockGetWalletAddress.mockReset().mockReturnValue(mockAccount)
+    })
+
+    afterEach(async () => {
+      await signerDB1?.destroy()
+      await signerDB2?.destroy()
+      await signerDB3?.destroy()
+      signer1?.close()
+      signer2?.close()
+      signer3?.close()
+    })
+
+    describe('when signers are operating correctly', () => {
+      beforeEach(async () => {
+        signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
+        signer2 = startSigner(signerConfig, signerDB2, keyProvider2, mockKit).listen(3002)
+        signer3 = startSigner(signerConfig, signerDB3, keyProvider3, mockKit).listen(3003)
       })
 
-      const queryCountParams = [
-        { signerQueries: [0, 0, 0], expectedQueryCount: 0, expectedWarnings: [] },
-        {
-          signerQueries: [1, 0, 0],
-          expectedQueryCount: 0,
-          expectedWarnings: [WarningMessage.SIGNER_RESPONSE_DISCREPANCIES],
-        }, // does not reach threshold
-        {
-          signerQueries: [1, 1, 0],
-          expectedQueryCount: 1,
-          expectedWarnings: [WarningMessage.SIGNER_RESPONSE_DISCREPANCIES],
-        }, // threshold reached
-        {
-          signerQueries: [0, 1, 1],
-          expectedQueryCount: 1,
-          expectedWarnings: [WarningMessage.SIGNER_RESPONSE_DISCREPANCIES],
-        }, // order of signers shouldn't matter
-        {
-          signerQueries: [1, 4, 9],
-          expectedQueryCount: 4,
-          expectedWarnings: [
-            WarningMessage.SIGNER_RESPONSE_DISCREPANCIES,
-            WarningMessage.INCONSISTENT_SIGNER_QUERY_MEASUREMENTS,
-          ],
-        },
-      ]
-      queryCountParams.forEach(({ signerQueries, expectedQueryCount, expectedWarnings }) => {
-        it(`should get ${expectedQueryCount} performedQueryCount given signer responses of ${signerQueries}`, async () => {
-          await useQuery(signerQueries[0], signer1)
-          await useQuery(signerQueries[1], signer2)
-          await useQuery(signerQueries[2], signer3)
+      describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
+        const totalQuota = 10
+        const weiTocusd = new BigNumber(1e18)
+        beforeAll(async () => {
+          mockOdisPaymentsTotalPaidCUSD.mockReturnValue(
+            weiTocusd.multipliedBy(totalQuota).multipliedBy(signerConfig.quota.queryPriceInCUSD)
+          )
+        })
 
+        const queryCountParams = [
+          { signerQueries: [0, 0, 0], expectedQueryCount: 0, expectedWarnings: [] },
+          {
+            signerQueries: [1, 0, 0],
+            expectedQueryCount: 0,
+            expectedWarnings: [WarningMessage.SIGNER_RESPONSE_DISCREPANCIES],
+          }, // does not reach threshold
+          {
+            signerQueries: [1, 1, 0],
+            expectedQueryCount: 1,
+            expectedWarnings: [WarningMessage.SIGNER_RESPONSE_DISCREPANCIES],
+          }, // threshold reached
+          {
+            signerQueries: [0, 1, 1],
+            expectedQueryCount: 1,
+            expectedWarnings: [WarningMessage.SIGNER_RESPONSE_DISCREPANCIES],
+          }, // order of signers shouldn't matter
+          {
+            signerQueries: [1, 4, 9],
+            expectedQueryCount: 4,
+            expectedWarnings: [
+              WarningMessage.SIGNER_RESPONSE_DISCREPANCIES,
+              WarningMessage.INCONSISTENT_SIGNER_QUERY_MEASUREMENTS,
+            ],
+          },
+        ]
+        queryCountParams.forEach(({ signerQueries, expectedQueryCount, expectedWarnings }) => {
+          it(`should get ${expectedQueryCount} performedQueryCount given signer responses of ${signerQueries}`, async () => {
+            await useQuery(signerQueries[0], signer1)
+            await useQuery(signerQueries[1], signer2)
+            await useQuery(signerQueries[2], signer3)
+
+            const req = {
+              account: ACCOUNT_ADDRESS1,
+            }
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await getCombinerQuotaResponse(req, authorization)
+
+            expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
+              success: true,
+              version: expectedVersion,
+              performedQueryCount: expectedQueryCount,
+              totalQuota,
+              blockNumber: testBlockNumber,
+              warnings: expectedWarnings,
+            })
+          })
+        })
+
+        it('Should respond with 200 on valid request', async () => {
           const req = {
             account: ACCOUNT_ADDRESS1,
           }
           const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
           const res = await getCombinerQuotaResponse(req, authorization)
-
+          expect(res.status).toBe(200)
           expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
             success: true,
             version: expectedVersion,
-            performedQueryCount: expectedQueryCount,
+            performedQueryCount: 0,
             totalQuota,
             blockNumber: testBlockNumber,
-            warnings: expectedWarnings,
+            warnings: [],
           })
         })
-      })
 
-      it('Should respond with 200 on valid request', async () => {
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          performedQueryCount: 0,
-          totalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-      })
-
-      it('Should respond with 200 on repeated valid requests', async () => {
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res1 = await getCombinerQuotaResponse(req, authorization)
-        expect(res1.status).toBe(200)
-        expect(res1.body).toStrictEqual<PnpQuotaResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          performedQueryCount: 0,
-          totalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-        const res2 = await getCombinerQuotaResponse(req, authorization)
-        expect(res2.status).toBe(200)
-        expect(res2.body).toStrictEqual<PnpQuotaResponseSuccess>(res1.body)
-      })
-
-      it('Should respond with 200 on extra request fields', async () => {
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-          extraField: 'dummy',
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          performedQueryCount: 0,
-          totalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-      })
-
-      it('Should respond with 200 when authenticated with DEK', async () => {
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-          authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
-        }
-        const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
-        const res = await getCombinerQuotaResponse(req, authorization)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          performedQueryCount: 0,
-          totalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-      })
-
-      it('Should respond with a warning when there are slight discrepancies in total quota', async () => {
-        mockOdisPaymentsTotalPaidCUSD.mockReturnValueOnce(
-          weiTocusd.multipliedBy(totalQuota + 1).multipliedBy(signerConfig.quota.queryPriceInCUSD)
-        )
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          performedQueryCount: 0,
-          totalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [
-            WarningMessage.SIGNER_RESPONSE_DISCREPANCIES,
-            WarningMessage.INCONSISTENT_SIGNER_QUOTA_MEASUREMENTS +
-              ', using threshold signer as best guess',
-          ],
-        })
-      })
-
-      it('Should respond with 500 when there are large discrepancies in total quota', async () => {
-        mockOdisPaymentsTotalPaidCUSD.mockReturnValueOnce(weiTocusd.multipliedBy(totalQuota + 15))
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-        expect(res.status).toBe(500)
-        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
-        })
-      })
-
-      it('Should respond with 400 on missing request fields', async () => {
-        // @ts-ignore Intentionally missing required fields
-        const req: PnpQuotaRequest = {}
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 with invalid address', async () => {
-        const req = {
-          account: 'not an address',
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 401 on failed WALLET_KEY auth', async () => {
-        // Request from one account, signed by another account
-        const req = {
-          account: ACCOUNT_ADDRESS2,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-
-        expect(res.status).toBe(401)
-        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.UNAUTHENTICATED_USER,
-        })
-      })
-
-      it('Should respond with 401 on failed DEK auth', async () => {
-        const req = {
-          account: ACCOUNT_ADDRESS2,
-          AuthenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-
-        expect(res.status).toBe(401)
-        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.UNAUTHENTICATED_USER,
-        })
-      })
-
-      it('Should respond with 502 when insufficient signer responses', async () => {
-        await signerDB1?.destroy()
-        await signerDB2?.destroy()
-        signer1?.close()
-        signer2?.close()
-
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await getCombinerQuotaResponse(req, authorization)
-
-        expect(res.status).toBe(502)
-        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
-        })
-      })
-
-      it('Should respond with 503 on disabled api', async () => {
-        const configWithApiDisabled: typeof combinerConfig = JSON.parse(
-          JSON.stringify(combinerConfig)
-        )
-        configWithApiDisabled.phoneNumberPrivacy.enabled = false
-        const appWithApiDisabled = startCombiner(configWithApiDisabled, mockKit)
-        const req = {
-          account: ACCOUNT_ADDRESS1,
-        }
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await request(appWithApiDisabled)
-          .post(CombinerEndpoint.PNP_QUOTA)
-          .set('Authorization', authorization)
-          .send(req)
-        expect(res.status).toBe(503)
-        expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.API_UNAVAILABLE,
-        })
-      })
-
-      describe('functionality in case of errors', () => {
-        it('Should respond with 200 on failure to fetch DEK when shouldFailOpen is true', async () => {
-          mockGetDataEncryptionKey.mockReset().mockImplementation(() => {
-            throw new Error()
-          })
-
+        it('Should respond with 200 on repeated valid requests', async () => {
           const req = {
             account: ACCOUNT_ADDRESS1,
-            authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
           }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res1 = await getCombinerQuotaResponse(req, authorization)
+          expect(res1.status).toBe(200)
+          expect(res1.body).toStrictEqual<PnpQuotaResponseSuccess>({
+            success: true,
+            version: expectedVersion,
+            performedQueryCount: 0,
+            totalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          })
+          const res2 = await getCombinerQuotaResponse(req, authorization)
+          expect(res2.status).toBe(200)
+          expect(res2.body).toStrictEqual<PnpQuotaResponseSuccess>(res1.body)
+        })
 
-          // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
-          const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
-          const authorization = getPnpRequestAuthorization(req, differentPk)
-
-          const combinerConfigWithFailOpenEnabled: typeof combinerConfig = JSON.parse(
-            JSON.stringify(combinerConfig)
-          )
-          combinerConfigWithFailOpenEnabled.phoneNumberPrivacy.shouldFailOpen = true
-          const appWithFailOpenEnabled = startCombiner(combinerConfigWithFailOpenEnabled, mockKit)
-          const res = await getCombinerQuotaResponse(req, authorization, appWithFailOpenEnabled)
+        it('Should respond with 200 on extra request fields', async () => {
+          const req = {
+            account: ACCOUNT_ADDRESS1,
+            extraField: 'dummy',
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
 
           expect(res.status).toBe(200)
           expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
@@ -630,310 +437,214 @@ describe('pnpService', () => {
             warnings: [],
           })
         })
-      })
-    })
 
-    describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
-      let req: SignMessageRequest
-
-      beforeEach(async () => {
-        mockOdisPaymentsTotalPaidCUSD.mockReturnValue(onChainPaymentsDefault)
-        req = getSignRequest(blindedMsgResult)
-      })
-
-      it('Should respond with 200 on valid request', async () => {
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          signature: expectedSignature,
-          performedQueryCount: 1,
-          totalQuota: expectedTotalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-        const unblindedSig = threshold_bls.unblind(
-          Buffer.from(res.body.signature, 'base64'),
-          blindedMsgResult.blindingFactor
-        )
-
-        expect(Buffer.from(unblindedSig).toString('base64')).toEqual(expectedUnblindedSig)
-      })
-
-      for (let i = 1; i <= 3; i++) {
-        it(`Should respond with 200 on valid request with key version header ${i}`, async () => {
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await sendPnpSignRequest(req, authorization, app, i.toString())
+        it('Should respond with 200 when authenticated with DEK', async () => {
+          const req = {
+            account: ACCOUNT_ADDRESS1,
+            authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
+          }
+          const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
+          const res = await getCombinerQuotaResponse(req, authorization)
 
           expect(res.status).toBe(200)
-          expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+          expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
             success: true,
             version: expectedVersion,
-            signature: expectedSignatures[i - 1],
-            performedQueryCount: 1,
-            totalQuota: expectedTotalQuota,
+            performedQueryCount: 0,
+            totalQuota,
             blockNumber: testBlockNumber,
             warnings: [],
           })
+        })
 
-          const unblindedSig = threshold_bls.unblind(
-            Buffer.from(res.body.signature, 'base64'),
-            blindedMsgResult.blindingFactor
+        it('Should respond with a warning when there are slight discrepancies in total quota', async () => {
+          mockOdisPaymentsTotalPaidCUSD.mockReturnValueOnce(
+            weiTocusd.multipliedBy(totalQuota + 1).multipliedBy(signerConfig.quota.queryPriceInCUSD)
           )
-
-          expect(Buffer.from(unblindedSig).toString('base64')).toEqual(expectedUnblindedSigs[i - 1])
-        })
-      }
-
-      it('Should respond with 200 on repeated valid requests', async () => {
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res1 = await sendPnpSignRequest(req, authorization, app)
-        const expectedResponse: SignMessageResponseSuccess = {
-          success: true,
-          version: expectedVersion,
-          signature: expectedSignature,
-          performedQueryCount: 1,
-          totalQuota: expectedTotalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        }
-
-        expect(res1.status).toBe(200)
-        expect(res1.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
-
-        const res2 = await sendPnpSignRequest(req, authorization, app)
-        expect(res2.status).toBe(200)
-        // Do not expect performedQueryCount to increase since this is a duplicate request
-        expect(res2.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
-      })
-
-      it('Should increment performedQueryCount on request from the same account with a new message', async () => {
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res1 = await sendPnpSignRequest(req, authorization, app)
-        const expectedResponse: SignMessageResponseSuccess = {
-          success: true,
-          version: expectedVersion,
-          signature: expectedSignature,
-          performedQueryCount: 1,
-          totalQuota: expectedTotalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        }
-
-        expect(res1.status).toBe(200)
-        expect(res1.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
-
-        // Second request for the same account but with new message
-        const message2 = Buffer.from('second test message', 'utf8')
-        const blindedMsg2 = threshold_bls.blind(message2, userSeed)
-        const req2 = getSignRequest(blindedMsg2)
-        const authorization2 = getPnpRequestAuthorization(req2, PRIVATE_KEY1)
-
-        // Expect performedQueryCount to increase
-        expectedResponse.performedQueryCount++
-        expectedResponse.signature =
-          'PWvuSYIA249x1dx+qzgl6PKSkoulXXE/P4WHJvGmtw77pCRilEWTn3xSp+6JS9+A'
-        const res2 = await sendPnpSignRequest(req2, authorization2, app)
-        expect(res2.status).toBe(200)
-        expect(res2.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
-      })
-
-      it('Should respond with 200 on extra request fields', async () => {
-        // @ts-ignore Intentionally adding an extra field to the request type
-        req.extraField = 'dummyString'
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          signature: expectedSignature,
-          performedQueryCount: 1,
-          totalQuota: expectedTotalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-      })
-
-      it('Should respond with 200 when authenticated with DEK', async () => {
-        req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
-        const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
-        const res = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          signature: expectedSignature,
-          performedQueryCount: 1,
-          totalQuota: expectedTotalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-      })
-
-      it('Should respond with 200 on invalid key version', async () => {
-        req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
-        const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
-        const res = await sendPnpSignRequest(req, authorization, app, 'invalid')
-
-        expect(res.status).toBe(200)
-        expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          signature: expectedSignature,
-          performedQueryCount: 1,
-          totalQuota: expectedTotalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-      })
-
-      it('Should get the same unblinded signatures from the same message (different seed)', async () => {
-        const authorization1 = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res1 = await sendPnpSignRequest(req, authorization1, app)
-
-        expect(res1.status).toBe(200)
-        expect(res1.body).toStrictEqual<SignMessageResponseSuccess>({
-          success: true,
-          version: expectedVersion,
-          signature: expectedSignature,
-          performedQueryCount: 1,
-          totalQuota: expectedTotalQuota,
-          blockNumber: testBlockNumber,
-          warnings: [],
-        })
-
-        const secondUserSeed = new Uint8Array(userSeed)
-        secondUserSeed[0]++
-        // Ensure request is identical except for blinded message
-        const req2 = { ...req }
-        const blindedMsgResult2 = threshold_bls.blind(message, secondUserSeed)
-        req2.blindedQueryPhoneNumber = Buffer.from(blindedMsgResult2.message).toString('base64')
-
-        // Sanity check
-        expect(req2.blindedQueryPhoneNumber).not.toEqual(req.blindedQueryPhoneNumber)
-
-        const authorization2 = getPnpRequestAuthorization(req2, PRIVATE_KEY1)
-        const res2 = await sendPnpSignRequest(req2, authorization2, app)
-        expect(res2.status).toBe(200)
-        const unblindedSig1 = threshold_bls.unblind(
-          Buffer.from(res1.body.signature, 'base64'),
-          blindedMsgResult.blindingFactor
-        )
-        const unblindedSig2 = threshold_bls.unblind(
-          Buffer.from(res2.body.signature, 'base64'),
-          blindedMsgResult2.blindingFactor
-        )
-        expect(Buffer.from(unblindedSig1).toString('base64')).toEqual(expectedUnblindedSig)
-        expect(unblindedSig1).toEqual(unblindedSig2)
-      })
-
-      it('Should respond with 400 on missing request fields', async () => {
-        // @ts-ignore Intentionally deleting required field
-        delete req.account
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.INVALID_INPUT,
-        })
-      })
-
-      it('Should respond with 400 on unsupported key version', async () => {
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await sendPnpSignRequest(req, authorization, app, '4')
-        expect(res.status).toBe(400)
-        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.INVALID_KEY_VERSION_REQUEST,
-        })
-      })
-
-      it('Should respond with 401 on failed WALLET_KEY auth', async () => {
-        req.account = mockAccount
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res.status).toBe(401)
-        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.UNAUTHENTICATED_USER,
-        })
-      })
-
-      it('Should respond with 401 on failed DEK auth', async () => {
-        req.account = mockAccount
-        req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
-        const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
-        const authorization = getPnpRequestAuthorization(req, differentPk)
-        const res = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res.status).toBe(401)
-        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.UNAUTHENTICATED_USER,
-        })
-      })
-
-      it('Should respond with 403 on out of quota', async () => {
-        mockOdisPaymentsTotalPaidCUSD.mockReturnValue(new BigNumber(0))
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await sendPnpSignRequest(req, authorization, app)
-
-        expect(res.status).toBe(403)
-        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.EXCEEDED_QUOTA,
-        })
-      })
-
-      it('Should respond with 503 on disabled api', async () => {
-        const configWithApiDisabled: typeof combinerConfig = JSON.parse(
-          JSON.stringify(combinerConfig)
-        )
-        configWithApiDisabled.phoneNumberPrivacy.enabled = false
-        const appWithApiDisabled = startCombiner(configWithApiDisabled, mockKit)
-
-        const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-        const res = await sendPnpSignRequest(req, authorization, appWithApiDisabled)
-
-        expect(res.status).toBe(503)
-        expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-          success: false,
-          version: expectedVersion,
-          error: WarningMessage.API_UNAVAILABLE,
-        })
-      })
-
-      describe('functionality in case of errors', () => {
-        it('Should return 200 on failure to fetch DEK when shouldFailOpen is true', async () => {
-          mockGetDataEncryptionKey.mockImplementation(() => {
-            throw new Error()
+          const req = {
+            account: ACCOUNT_ADDRESS1,
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
+            success: true,
+            version: expectedVersion,
+            performedQueryCount: 0,
+            totalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [
+              WarningMessage.SIGNER_RESPONSE_DISCREPANCIES,
+              WarningMessage.INCONSISTENT_SIGNER_QUOTA_MEASUREMENTS +
+                ', using threshold signer as best guess',
+            ],
           })
+        })
 
-          req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
-          // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
-          const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
-          const authorization = getPnpRequestAuthorization(req, differentPk)
+        it('Should respond with 500 when there are large discrepancies in total quota', async () => {
+          mockOdisPaymentsTotalPaidCUSD.mockReturnValueOnce(weiTocusd.multipliedBy(totalQuota + 15))
+          const req = {
+            account: ACCOUNT_ADDRESS1,
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
+          expect(res.status).toBe(500)
+          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
+          })
+        })
 
-          const combinerConfigWithFailOpenEnabled: typeof combinerConfig = JSON.parse(
+        it('Should respond with 400 on missing request fields', async () => {
+          // @ts-ignore Intentionally missing required fields
+          const req: PnpQuotaRequest = {}
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 with invalid address', async () => {
+          const req = {
+            account: 'not an address',
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 401 on failed WALLET_KEY auth', async () => {
+          // Request from one account, signed by another account
+          const req = {
+            account: ACCOUNT_ADDRESS2,
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
+
+          expect(res.status).toBe(401)
+          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.UNAUTHENTICATED_USER,
+          })
+        })
+
+        it('Should respond with 401 on failed DEK auth', async () => {
+          const req = {
+            account: ACCOUNT_ADDRESS2,
+            AuthenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
+
+          expect(res.status).toBe(401)
+          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.UNAUTHENTICATED_USER,
+          })
+        })
+
+        it('Should respond with 500 when insufficient signer responses', async () => {
+          await signerDB1?.destroy()
+          await signerDB2?.destroy()
+          signer1?.close()
+          signer2?.close()
+
+          const req = {
+            account: ACCOUNT_ADDRESS1,
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await getCombinerQuotaResponse(req, authorization)
+
+          expect(res.status).toBe(500)
+          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
+          })
+        })
+
+        it('Should respond with 503 on disabled api', async () => {
+          const configWithApiDisabled: typeof combinerConfig = JSON.parse(
             JSON.stringify(combinerConfig)
           )
-          combinerConfigWithFailOpenEnabled.phoneNumberPrivacy.shouldFailOpen = true
-          const appWithFailOpenEnabled = startCombiner(combinerConfigWithFailOpenEnabled, mockKit)
-          const res = await sendPnpSignRequest(req, authorization, appWithFailOpenEnabled)
+          configWithApiDisabled.phoneNumberPrivacy.enabled = false
+          const appWithApiDisabled = startCombiner(configWithApiDisabled, mockKit)
+          const req = {
+            account: ACCOUNT_ADDRESS1,
+          }
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await request(appWithApiDisabled)
+            .post(CombinerEndpoint.PNP_QUOTA)
+            .set('Authorization', authorization)
+            .send(req)
+          expect(res.status).toBe(503)
+          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.API_UNAVAILABLE,
+          })
+        })
+
+        describe('functionality in case of errors', () => {
+          it('Should respond with 200 on failure to fetch DEK when shouldFailOpen is true', async () => {
+            mockGetDataEncryptionKey.mockReset().mockImplementation(() => {
+              throw new Error()
+            })
+
+            const req = {
+              account: ACCOUNT_ADDRESS1,
+              authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
+            }
+
+            // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
+            const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+            const authorization = getPnpRequestAuthorization(req, differentPk)
+
+            const combinerConfigWithFailOpenEnabled: typeof combinerConfig = JSON.parse(
+              JSON.stringify(combinerConfig)
+            )
+            combinerConfigWithFailOpenEnabled.phoneNumberPrivacy.shouldFailOpen = true
+            const appWithFailOpenEnabled = startCombiner(combinerConfigWithFailOpenEnabled, mockKit)
+            const res = await getCombinerQuotaResponse(req, authorization, appWithFailOpenEnabled)
+
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
+              success: true,
+              version: expectedVersion,
+              performedQueryCount: 0,
+              totalQuota,
+              blockNumber: testBlockNumber,
+              warnings: [],
+            })
+          })
+        })
+      })
+
+      describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
+        let req: SignMessageRequest
+
+        beforeEach(async () => {
+          mockOdisPaymentsTotalPaidCUSD.mockReturnValue(onChainPaymentsDefault)
+          req = getSignRequest(blindedMsgResult)
+        })
+
+        it('Should respond with 200 on valid request', async () => {
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await sendPnpSignRequest(req, authorization, app)
 
           expect(res.status).toBe(200)
           expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
@@ -949,23 +660,211 @@ describe('pnpService', () => {
             Buffer.from(res.body.signature, 'base64'),
             blindedMsgResult.blindingFactor
           )
+
           expect(Buffer.from(unblindedSig).toString('base64')).toEqual(expectedUnblindedSig)
         })
 
-        it('Should return 401 on failure to fetch DEK when shouldFailOpen is false', async () => {
-          mockGetDataEncryptionKey.mockImplementation(() => {
-            throw new Error()
+        for (let i = 1; i <= 3; i++) {
+          it(`Should respond with 200 on valid request with key version header ${i}`, async () => {
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await sendPnpSignRequest(req, authorization, app, i.toString())
+
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+              success: true,
+              version: expectedVersion,
+              signature: expectedSignatures[i - 1],
+              performedQueryCount: 1,
+              totalQuota: expectedTotalQuota,
+              blockNumber: testBlockNumber,
+              warnings: [],
+            })
+
+            const unblindedSig = threshold_bls.unblind(
+              Buffer.from(res.body.signature, 'base64'),
+              blindedMsgResult.blindingFactor
+            )
+
+            expect(Buffer.from(unblindedSig).toString('base64')).toEqual(
+              expectedUnblindedSigs[i - 1]
+            )
+          })
+        }
+
+        it('Should respond with 200 on repeated valid requests', async () => {
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res1 = await sendPnpSignRequest(req, authorization, app)
+          const expectedResponse: SignMessageResponseSuccess = {
+            success: true,
+            version: expectedVersion,
+            signature: expectedSignature,
+            performedQueryCount: 1,
+            totalQuota: expectedTotalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          }
+
+          expect(res1.status).toBe(200)
+          expect(res1.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
+
+          const res2 = await sendPnpSignRequest(req, authorization, app)
+          expect(res2.status).toBe(200)
+          // Do not expect performedQueryCount to increase since this is a duplicate request
+          expect(res2.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
+        })
+
+        it('Should increment performedQueryCount on request from the same account with a new message', async () => {
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res1 = await sendPnpSignRequest(req, authorization, app)
+          const expectedResponse: SignMessageResponseSuccess = {
+            success: true,
+            version: expectedVersion,
+            signature: expectedSignature,
+            performedQueryCount: 1,
+            totalQuota: expectedTotalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          }
+
+          expect(res1.status).toBe(200)
+          expect(res1.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
+
+          // Second request for the same account but with new message
+          const message2 = Buffer.from('second test message', 'utf8')
+          const blindedMsg2 = threshold_bls.blind(message2, userSeed)
+          const req2 = getSignRequest(blindedMsg2)
+          const authorization2 = getPnpRequestAuthorization(req2, PRIVATE_KEY1)
+
+          // Expect performedQueryCount to increase
+          expectedResponse.performedQueryCount++
+          expectedResponse.signature =
+            'PWvuSYIA249x1dx+qzgl6PKSkoulXXE/P4WHJvGmtw77pCRilEWTn3xSp+6JS9+A'
+          const res2 = await sendPnpSignRequest(req2, authorization2, app)
+          expect(res2.status).toBe(200)
+          expect(res2.body).toStrictEqual<SignMessageResponseSuccess>(expectedResponse)
+        })
+
+        it('Should respond with 200 on extra request fields', async () => {
+          // @ts-ignore Intentionally adding an extra field to the request type
+          req.extraField = 'dummyString'
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await sendPnpSignRequest(req, authorization, app)
+
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+            success: true,
+            version: expectedVersion,
+            signature: expectedSignature,
+            performedQueryCount: 1,
+            totalQuota: expectedTotalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          })
+        })
+
+        it('Should respond with 200 when authenticated with DEK', async () => {
+          req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
+          const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
+          const res = await sendPnpSignRequest(req, authorization, app)
+
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+            success: true,
+            version: expectedVersion,
+            signature: expectedSignature,
+            performedQueryCount: 1,
+            totalQuota: expectedTotalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          })
+        })
+
+        it('Should respond with 200 on invalid key version', async () => {
+          req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
+          const authorization = getPnpRequestAuthorization(req, DEK_PRIVATE_KEY)
+          const res = await sendPnpSignRequest(req, authorization, app, 'invalid')
+
+          expect(res.status).toBe(200)
+          expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+            success: true,
+            version: expectedVersion,
+            signature: expectedSignature,
+            performedQueryCount: 1,
+            totalQuota: expectedTotalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
+          })
+        })
+
+        it('Should get the same unblinded signatures from the same message (different seed)', async () => {
+          const authorization1 = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res1 = await sendPnpSignRequest(req, authorization1, app)
+
+          expect(res1.status).toBe(200)
+          expect(res1.body).toStrictEqual<SignMessageResponseSuccess>({
+            success: true,
+            version: expectedVersion,
+            signature: expectedSignature,
+            performedQueryCount: 1,
+            totalQuota: expectedTotalQuota,
+            blockNumber: testBlockNumber,
+            warnings: [],
           })
 
-          req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const secondUserSeed = new Uint8Array(userSeed)
+          secondUserSeed[0]++
+          // Ensure request is identical except for blinded message
+          const req2 = { ...req }
+          const blindedMsgResult2 = threshold_bls.blind(message, secondUserSeed)
+          req2.blindedQueryPhoneNumber = Buffer.from(blindedMsgResult2.message).toString('base64')
 
-          const combinerConfigWithFailOpenDisabled: typeof combinerConfig = JSON.parse(
-            JSON.stringify(combinerConfig)
+          // Sanity check
+          expect(req2.blindedQueryPhoneNumber).not.toEqual(req.blindedQueryPhoneNumber)
+
+          const authorization2 = getPnpRequestAuthorization(req2, PRIVATE_KEY1)
+          const res2 = await sendPnpSignRequest(req2, authorization2, app)
+          expect(res2.status).toBe(200)
+          const unblindedSig1 = threshold_bls.unblind(
+            Buffer.from(res1.body.signature, 'base64'),
+            blindedMsgResult.blindingFactor
           )
-          combinerConfigWithFailOpenDisabled.phoneNumberPrivacy.shouldFailOpen = false
-          const appWithFailOpenDisabled = startCombiner(combinerConfigWithFailOpenDisabled, mockKit)
-          const res = await sendPnpSignRequest(req, authorization, appWithFailOpenDisabled)
+          const unblindedSig2 = threshold_bls.unblind(
+            Buffer.from(res2.body.signature, 'base64'),
+            blindedMsgResult2.blindingFactor
+          )
+          expect(Buffer.from(unblindedSig1).toString('base64')).toEqual(expectedUnblindedSig)
+          expect(unblindedSig1).toEqual(unblindedSig2)
+        })
+
+        it('Should respond with 400 on missing request fields', async () => {
+          // @ts-ignore Intentionally deleting required field
+          delete req.account
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await sendPnpSignRequest(req, authorization, app)
+
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.INVALID_INPUT,
+          })
+        })
+
+        it('Should respond with 400 on unsupported key version', async () => {
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await sendPnpSignRequest(req, authorization, app, '4')
+          expect(res.status).toBe(400)
+          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.INVALID_KEY_VERSION_REQUEST,
+          })
+        })
+
+        it('Should respond with 401 on failed WALLET_KEY auth', async () => {
+          req.account = mockAccount
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await sendPnpSignRequest(req, authorization, app)
 
           expect(res.status).toBe(401)
           expect(res.body).toStrictEqual<SignMessageResponseFailure>({
@@ -974,218 +873,500 @@ describe('pnpService', () => {
             error: WarningMessage.UNAUTHENTICATED_USER,
           })
         })
+
+        it('Should respond with 401 on failed DEK auth', async () => {
+          req.account = mockAccount
+          req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
+          const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+          const authorization = getPnpRequestAuthorization(req, differentPk)
+          const res = await sendPnpSignRequest(req, authorization, app)
+
+          expect(res.status).toBe(401)
+          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.UNAUTHENTICATED_USER,
+          })
+        })
+
+        it('Should respond with 403 on out of quota', async () => {
+          mockOdisPaymentsTotalPaidCUSD.mockReturnValue(new BigNumber(0))
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await sendPnpSignRequest(req, authorization, app)
+
+          expect(res.status).toBe(403)
+          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.EXCEEDED_QUOTA,
+          })
+        })
+
+        it('Should respond with 503 on disabled api', async () => {
+          const configWithApiDisabled: typeof combinerConfig = JSON.parse(
+            JSON.stringify(combinerConfig)
+          )
+          configWithApiDisabled.phoneNumberPrivacy.enabled = false
+          const appWithApiDisabled = startCombiner(configWithApiDisabled, mockKit)
+
+          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+          const res = await sendPnpSignRequest(req, authorization, appWithApiDisabled)
+
+          expect(res.status).toBe(503)
+          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+            success: false,
+            version: expectedVersion,
+            error: WarningMessage.API_UNAVAILABLE,
+          })
+        })
+
+        describe('functionality in case of errors', () => {
+          it('Should return 200 on failure to fetch DEK when shouldFailOpen is true', async () => {
+            mockGetDataEncryptionKey.mockImplementation(() => {
+              throw new Error()
+            })
+
+            req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
+            // NOT the dek private key, so authentication would fail if getDataEncryptionKey succeeded
+            const differentPk = '0x00000000000000000000000000000000000000000000000000000000ddddbbbb'
+            const authorization = getPnpRequestAuthorization(req, differentPk)
+
+            const combinerConfigWithFailOpenEnabled: typeof combinerConfig = JSON.parse(
+              JSON.stringify(combinerConfig)
+            )
+            combinerConfigWithFailOpenEnabled.phoneNumberPrivacy.shouldFailOpen = true
+            const appWithFailOpenEnabled = startCombiner(combinerConfigWithFailOpenEnabled, mockKit)
+            const res = await sendPnpSignRequest(req, authorization, appWithFailOpenEnabled)
+
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+              success: true,
+              version: expectedVersion,
+              signature: expectedSignature,
+              performedQueryCount: 1,
+              totalQuota: expectedTotalQuota,
+              blockNumber: testBlockNumber,
+              warnings: [],
+            })
+            const unblindedSig = threshold_bls.unblind(
+              Buffer.from(res.body.signature, 'base64'),
+              blindedMsgResult.blindingFactor
+            )
+            expect(Buffer.from(unblindedSig).toString('base64')).toEqual(expectedUnblindedSig)
+          })
+
+          it('Should return 401 on failure to fetch DEK when shouldFailOpen is false', async () => {
+            mockGetDataEncryptionKey.mockImplementation(() => {
+              throw new Error()
+            })
+
+            req.authenticationMethod = AuthenticationMethod.ENCRYPTION_KEY
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+
+            const combinerConfigWithFailOpenDisabled: typeof combinerConfig = JSON.parse(
+              JSON.stringify(combinerConfig)
+            )
+            combinerConfigWithFailOpenDisabled.phoneNumberPrivacy.shouldFailOpen = false
+            const appWithFailOpenDisabled = startCombiner(
+              combinerConfigWithFailOpenDisabled,
+              mockKit
+            )
+            const res = await sendPnpSignRequest(req, authorization, appWithFailOpenDisabled)
+
+            expect(res.status).toBe(401)
+            expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+              success: false,
+              version: expectedVersion,
+              error: WarningMessage.UNAUTHENTICATED_USER,
+            })
+          })
+        })
+      })
+    })
+
+    // For testing combiner code paths when signers do not behave as expected
+    describe('when signers are not operating correctly', () => {
+      beforeEach(() => {
+        mockOdisPaymentsTotalPaidCUSD.mockReturnValue(onChainPaymentsDefault)
+      })
+
+      describe('when 2/3 signers return correct signatures', () => {
+        beforeEach(async () => {
+          const badBlsShare1 =
+            '000000002e50aa714ef6b865b5de89c56969ef9f8f27b6b0a6d157c9cc01c574ac9df604'
+
+          const badKeyProvider1 = new MockKeyProvider(
+            new Map([[`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, badBlsShare1]])
+          )
+          signer1 = startSigner(signerConfig, signerDB1, badKeyProvider1, mockKit).listen(3001)
+          signer2 = startSigner(signerConfig, signerDB2, keyProvider2, mockKit).listen(3002)
+          signer3 = startSigner(signerConfig, signerDB3, keyProvider3, mockKit).listen(3003)
+        })
+
+        describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
+          it('Should respond with 200 on valid request', async () => {
+            const req = getSignRequest(blindedMsgResult)
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await sendPnpSignRequest(req, authorization, app)
+
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+              success: true,
+              version: expectedVersion,
+              signature: expectedSignature,
+              performedQueryCount: 1,
+              totalQuota: expectedTotalQuota,
+              blockNumber: testBlockNumber,
+              warnings: [],
+            })
+            const unblindedSig = threshold_bls.unblind(
+              Buffer.from(res.body.signature, 'base64'),
+              blindedMsgResult.blindingFactor
+            )
+            expect(Buffer.from(unblindedSig).toString('base64')).toEqual(expectedUnblindedSig)
+          })
+        })
+      })
+
+      describe('when 1/3 signers return correct signatures', () => {
+        beforeEach(async () => {
+          const badBlsShare1 =
+            '000000002e50aa714ef6b865b5de89c56969ef9f8f27b6b0a6d157c9cc01c574ac9df604'
+          const badBlsShare2 =
+            '01000000b8f0ef841dcf8d7bd1da5e8025e47d729eb67f513335784183b8fa227a0b9a0b'
+
+          const badKeyProvider1 = new MockKeyProvider(
+            new Map([[`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, badBlsShare1]])
+          )
+
+          const badKeyProvider2 = new MockKeyProvider(
+            new Map([[`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, badBlsShare2]])
+          )
+
+          signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
+          signer2 = startSigner(signerConfig, signerDB2, badKeyProvider1, mockKit).listen(3002)
+          signer3 = startSigner(signerConfig, signerDB3, badKeyProvider2, mockKit).listen(3003)
+        })
+
+        describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
+          it('Should respond with 500 even if request is valid', async () => {
+            const req = getSignRequest(blindedMsgResult)
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await sendPnpSignRequest(req, authorization, app)
+
+            expect(res.status).toBe(500)
+            expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+              success: false,
+              version: expectedVersion,
+              error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
+            })
+          })
+        })
+      })
+
+      describe('when 2/3 of signers are disabled', () => {
+        beforeEach(async () => {
+          const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
+          configWithApiDisabled.api.phoneNumberPrivacy.enabled = false
+          signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
+          signer2 = startSigner(configWithApiDisabled, signerDB2, keyProvider2, mockKit).listen(
+            3002
+          )
+          signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3, mockKit).listen(
+            3003
+          )
+        })
+
+        describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const req = {
+              account: ACCOUNT_ADDRESS1,
+            }
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await getCombinerQuotaResponse(req, authorization)
+            expect(res.status).toBe(503) // majority error code in this case
+            expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+              success: false,
+              version: expectedVersion,
+              error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const req = getSignRequest(blindedMsgResult)
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await sendPnpSignRequest(req, authorization, app)
+
+            expect(res.status).toBe(503) // majority error code in this case
+            expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+              success: false,
+              version: expectedVersion,
+              error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
+            })
+          })
+        })
+      })
+
+      describe('when 1/3 of signers are disabled', () => {
+        beforeEach(async () => {
+          const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
+          configWithApiDisabled.api.phoneNumberPrivacy.enabled = false
+          signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
+          signer2 = startSigner(signerConfig, signerDB2, keyProvider2, mockKit).listen(3002)
+          signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3, mockKit).listen(
+            3003
+          )
+        })
+
+        describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
+          it('Should respond with 200 on valid request', async () => {
+            const req = {
+              account: ACCOUNT_ADDRESS1,
+            }
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await getCombinerQuotaResponse(req, authorization)
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
+              success: true,
+              version: expectedVersion,
+              performedQueryCount: 0,
+              totalQuota: expectedTotalQuota,
+              blockNumber: testBlockNumber,
+              warnings: [],
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
+          it('Should respond with 200 on valid request', async () => {
+            const req = getSignRequest(blindedMsgResult)
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await sendPnpSignRequest(req, authorization, app)
+            expect(res.status).toBe(200)
+            expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+              success: true,
+              version: expectedVersion,
+              signature: expectedSignature,
+              performedQueryCount: 1,
+              totalQuota: expectedTotalQuota,
+              blockNumber: testBlockNumber,
+              warnings: [],
+            })
+          })
+        })
+      })
+
+      describe('when signers timeout', () => {
+        beforeEach(async () => {
+          const testTimeoutMS = 0
+
+          const configWithShortTimeout: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
+          configWithShortTimeout.timeout = testTimeoutMS
+          // Test this with all signers timing out to decrease possibility of race conditions
+          signer1 = startSigner(configWithShortTimeout, signerDB1, keyProvider1, mockKit).listen(
+            3001
+          )
+          signer2 = startSigner(configWithShortTimeout, signerDB2, keyProvider2, mockKit).listen(
+            3002
+          )
+          signer3 = startSigner(configWithShortTimeout, signerDB3, keyProvider3, mockKit).listen(
+            3003
+          )
+        })
+
+        describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const req = {
+              account: ACCOUNT_ADDRESS1,
+            }
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await getCombinerQuotaResponse(req, authorization)
+            expect(res.status).toBe(500)
+            expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
+              success: false,
+              version: expectedVersion,
+              error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
+            })
+          })
+        })
+
+        describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
+          it('Should fail to reach threshold of signers on valid request', async () => {
+            const req = getSignRequest(blindedMsgResult)
+            const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+            const res = await sendPnpSignRequest(req, authorization, app)
+            expect(res.status).toBe(500)
+            expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+              success: false,
+              version: expectedVersion,
+              error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
+            })
+          })
+        })
       })
     })
   })
 
-  // For testing combiner code paths when signers do not behave as expected
-  describe('when signers are not operating correctly', () => {
-    beforeEach(() => {
+  // Ensure the same behavior when a minority of signers can block the threshold.
+  // On failure, the majority error code should not reflect the abort.
+  describe('with n=5, t=4', () => {
+    let keyProvider4: KeyProvider
+    let keyProvider5: KeyProvider
+    let signerDB4: Knex
+    let signerDB5: Knex
+    let signer4: Server | HttpsServer
+    let signer5: Server | HttpsServer
+
+    const combinerConfigLargerN: typeof config = JSON.parse(JSON.stringify(combinerConfig))
+    combinerConfigLargerN.phoneNumberPrivacy.odisServices.signers = JSON.stringify([
+      {
+        url: 'http://localhost:3001',
+        fallbackUrl: 'http://localhost:3001/fallback',
+      },
+      {
+        url: 'http://localhost:3002',
+        fallbackUrl: 'http://localhost:3002/fallback',
+      },
+      {
+        url: 'http://localhost:3003',
+        fallbackUrl: 'http://localhost:3003/fallback',
+      },
+      {
+        url: 'http://localhost:3004',
+        fallbackUrl: 'http://localhost:3004/fallback',
+      },
+      {
+        url: 'http://localhost:3005',
+        fallbackUrl: 'http://localhost:3005/fallback',
+      },
+    ])
+    combinerConfigLargerN.phoneNumberPrivacy.keys.versions = JSON.stringify([
+      {
+        keyVersion: 1,
+        threshold: 4,
+        polynomial:
+          '04000000000000007e196818fb4a5677ab97ef04a8b6e188e253d822c0689e37626fe9690d3a60283e74f2c38ec768f32870d73c7e11ff005ad65aa45707922dfc78d1fd54d64200da22a87d82b93783e2f9ee83ec290e25951c0dac2fb856871eba991731367a80b5f92e54b90901594c5e4d56beb15c44a437e78b90eb01bd4770b9c130feaf42c68d28d4e51415949d692936d3689e000f192e4fdcb03d45d1ffcd3615132046a3c8400e30cecaedf8d9bf275ead903e06ef0552a8326159f5361f8c8d16208197367a3115d3f15651082337e125005814a3f94c307e2205864803cc45dbb1b7e11738edec1d0630973830d0a74d0e0113c6ab677f087fb919728b8e1cb4f0004c6b59b4dcf28be7b4b9a5e9522e216b4d70278eff131717ff121b4203a2668093c54c6287cf9b09dd611627872f40f018f7e5a63eed5c94ead63fcd59515b1b8948482a5b7bdf07f91014d0097bba009316a8219c2074d16de09d557c2e7109112ade0d3f68248df7acfbbc4891acbb313d20021be70664d7a114a7fa6d9e01',
+        pubKey:
+          'fhloGPtKVnerl+8EqLbhiOJT2CLAaJ43Ym/paQ06YCg+dPLDjsdo8yhw1zx+Ef8AWtZapFcHki38eNH9VNZCANoiqH2CuTeD4vnug+wpDiWVHA2sL7hWhx66mRcxNnqA',
+      },
+    ])
+
+    beforeAll(async () => {
+      keyProvider1 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`,
+            '00000000a49c8a293839ccb24bbcc7b833b0d57fe2f6087d33271750e7d6cf40897f520c',
+          ],
+        ])
+      )
+      keyProvider2 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`,
+            '01000000c0866754b43a0e7c6f86c6732c1bc1bc1900f71a0ccab81fcd4048c5ff2edb02',
+          ],
+        ])
+      )
+      keyProvider3 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`,
+            '02000000c24271a9dd0827e2939e5afbd5cd1c6705fa40d6e962fb288bbc7201921efa10',
+          ],
+        ])
+      )
+      keyProvider4 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`,
+            '030000006320e2a99d4ce6a491a6354feda06051966a056dffbb0e7c8431b246d863ac09',
+          ],
+        ])
+      )
+      keyProvider5 = new MockKeyProvider(
+        new Map([
+          [
+            `${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`,
+            '04000000606ff4d6ddae61ac454009af2a49aeb4c297410ef9d3f3ab751c1c4fe5a99c0a',
+          ],
+        ])
+      )
+      app = startCombiner(combinerConfigLargerN, mockKit)
+    })
+
+    let req: SignMessageRequest
+
+    beforeEach(async () => {
+      signerDB1 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB2 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB3 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB4 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+      signerDB5 = await initSignerDatabase(signerConfig, signerMigrationsPath)
+
+      signer1 = startSigner(signerConfig, signerDB1, keyProvider1).listen(3001)
+      signer2 = startSigner(signerConfig, signerDB2, keyProvider2).listen(3002)
+      signer3 = startSigner(signerConfig, signerDB3, keyProvider3).listen(3003)
+      signer4 = startSigner(signerConfig, signerDB4, keyProvider4).listen(3004)
+      signer5 = startSigner(signerConfig, signerDB5, keyProvider5).listen(3005)
+
+      userSeed = new Uint8Array(32)
+      for (let i = 0; i < userSeed.length - 1; i++) {
+        userSeed[i] = i
+      }
+
+      blindedMsgResult = threshold_bls.blind(message, userSeed)
+      req = getSignRequest(blindedMsgResult)
+    })
+
+    afterEach(async () => {
+      await signerDB1?.destroy()
+      await signerDB2?.destroy()
+      await signerDB3?.destroy()
+      await signerDB4?.destroy()
+      await signerDB5?.destroy()
+      signer1?.close()
+      signer2?.close()
+      signer3?.close()
+      signer4?.close()
+      signer5?.close()
+    })
+
+    it('Should respond with 200 on valid request', async () => {
       mockOdisPaymentsTotalPaidCUSD.mockReturnValue(onChainPaymentsDefault)
+
+      const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+      const res = await sendPnpSignRequest(req, authorization, app)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
+        success: true,
+        version: expectedVersion,
+        signature: res.body.signature,
+        performedQueryCount: 1,
+        totalQuota: expectedTotalQuota,
+        blockNumber: testBlockNumber,
+        warnings: [],
+      })
+      threshold_bls.unblind(
+        Buffer.from(res.body.signature, 'base64'),
+        blindedMsgResult.blindingFactor
+      )
     })
 
-    describe('when 2/3 signers return correct signatures', () => {
-      beforeEach(async () => {
-        const badBlsShare1 =
-          '000000002e50aa714ef6b865b5de89c56969ef9f8f27b6b0a6d157c9cc01c574ac9df604'
+    it('Should respond with 403 on out of quota', async () => {
+      mockOdisPaymentsTotalPaidCUSD.mockReturnValue(new BigNumber(0))
 
-        const badKeyProvider1 = new MockKeyProvider(
-          new Map([[`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, badBlsShare1]])
-        )
-        signer1 = startSigner(signerConfig, signerDB1, badKeyProvider1, mockKit).listen(3001)
-        signer2 = startSigner(signerConfig, signerDB2, keyProvider2, mockKit).listen(3002)
-        signer3 = startSigner(signerConfig, signerDB3, keyProvider3, mockKit).listen(3003)
-      })
+      const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
+      const res = await sendPnpSignRequest(req, authorization, app)
 
-      describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
-        it('Should respond with 200 on valid request', async () => {
-          const req = getSignRequest(blindedMsgResult)
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await sendPnpSignRequest(req, authorization, app)
-
-          expect(res.status).toBe(200)
-          expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
-            success: true,
-            version: expectedVersion,
-            signature: expectedSignature,
-            performedQueryCount: 1,
-            totalQuota: expectedTotalQuota,
-            blockNumber: testBlockNumber,
-            warnings: [],
-          })
-          const unblindedSig = threshold_bls.unblind(
-            Buffer.from(res.body.signature, 'base64'),
-            blindedMsgResult.blindingFactor
-          )
-          expect(Buffer.from(unblindedSig).toString('base64')).toEqual(expectedUnblindedSig)
-        })
-      })
-    })
-
-    describe('when 1/3 signers return correct signatures', () => {
-      beforeEach(async () => {
-        const badBlsShare1 =
-          '000000002e50aa714ef6b865b5de89c56969ef9f8f27b6b0a6d157c9cc01c574ac9df604'
-        const badBlsShare2 =
-          '01000000b8f0ef841dcf8d7bd1da5e8025e47d729eb67f513335784183b8fa227a0b9a0b'
-
-        const badKeyProvider1 = new MockKeyProvider(
-          new Map([[`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, badBlsShare1]])
-        )
-
-        const badKeyProvider2 = new MockKeyProvider(
-          new Map([[`${DefaultKeyName.PHONE_NUMBER_PRIVACY}-1`, badBlsShare2]])
-        )
-
-        signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
-        signer2 = startSigner(signerConfig, signerDB2, badKeyProvider1, mockKit).listen(3002)
-        signer3 = startSigner(signerConfig, signerDB3, badKeyProvider2, mockKit).listen(3003)
-      })
-
-      describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
-        it('Should respond with 500 even if request is valid', async () => {
-          const req = getSignRequest(blindedMsgResult)
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await sendPnpSignRequest(req, authorization, app)
-
-          expect(res.status).toBe(500)
-          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-            success: false,
-            version: expectedVersion,
-            error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
-          })
-        })
-      })
-    })
-
-    describe('when 2/3 of signers are disabled', () => {
-      beforeEach(async () => {
-        const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
-        configWithApiDisabled.api.phoneNumberPrivacy.enabled = false
-        signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
-        signer2 = startSigner(configWithApiDisabled, signerDB2, keyProvider2, mockKit).listen(3002)
-        signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3, mockKit).listen(3003)
-      })
-
-      describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const req = {
-            account: ACCOUNT_ADDRESS1,
-          }
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await getCombinerQuotaResponse(req, authorization)
-          expect(res.status).toBe(503) // majority error code in this case
-          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-            success: false,
-            version: expectedVersion,
-            error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
-          })
-        })
-      })
-
-      describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const req = getSignRequest(blindedMsgResult)
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await sendPnpSignRequest(req, authorization, app)
-
-          expect(res.status).toBe(503) // majority error code in this case
-          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-            success: false,
-            version: expectedVersion,
-            error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
-          })
-        })
-      })
-    })
-
-    describe('when 1/3 of signers are disabled', () => {
-      beforeEach(async () => {
-        const configWithApiDisabled: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
-        configWithApiDisabled.api.phoneNumberPrivacy.enabled = false
-        signer1 = startSigner(signerConfig, signerDB1, keyProvider1, mockKit).listen(3001)
-        signer2 = startSigner(signerConfig, signerDB2, keyProvider2, mockKit).listen(3002)
-        signer3 = startSigner(configWithApiDisabled, signerDB3, keyProvider3, mockKit).listen(3003)
-      })
-
-      describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
-        it('Should respond with 200 on valid request', async () => {
-          const req = {
-            account: ACCOUNT_ADDRESS1,
-          }
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await getCombinerQuotaResponse(req, authorization)
-          expect(res.status).toBe(200)
-          expect(res.body).toStrictEqual<PnpQuotaResponseSuccess>({
-            success: true,
-            version: expectedVersion,
-            performedQueryCount: 0,
-            totalQuota: expectedTotalQuota,
-            blockNumber: testBlockNumber,
-            warnings: [],
-          })
-        })
-      })
-
-      describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
-        it('Should respond with 200 on valid request', async () => {
-          const req = getSignRequest(blindedMsgResult)
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await sendPnpSignRequest(req, authorization, app)
-          expect(res.status).toBe(200)
-          expect(res.body).toStrictEqual<SignMessageResponseSuccess>({
-            success: true,
-            version: expectedVersion,
-            signature: expectedSignature,
-            performedQueryCount: 1,
-            totalQuota: expectedTotalQuota,
-            blockNumber: testBlockNumber,
-            warnings: [],
-          })
-        })
-      })
-    })
-
-    describe('when signers timeout', () => {
-      beforeEach(async () => {
-        const testTimeoutMS = 0
-
-        const configWithShortTimeout: SignerConfig = JSON.parse(JSON.stringify(signerConfig))
-        configWithShortTimeout.timeout = testTimeoutMS
-        // Test this with all signers timing out to decrease possibility of race conditions
-        signer1 = startSigner(configWithShortTimeout, signerDB1, keyProvider1, mockKit).listen(3001)
-        signer2 = startSigner(configWithShortTimeout, signerDB2, keyProvider2, mockKit).listen(3002)
-        signer3 = startSigner(configWithShortTimeout, signerDB3, keyProvider3, mockKit).listen(3003)
-      })
-
-      describe(`${CombinerEndpoint.PNP_QUOTA}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const req = {
-            account: ACCOUNT_ADDRESS1,
-          }
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await getCombinerQuotaResponse(req, authorization)
-          expect(res.status).toBe(500)
-          expect(res.body).toStrictEqual<PnpQuotaResponseFailure>({
-            success: false,
-            version: expectedVersion,
-            error: ErrorMessage.THRESHOLD_PNP_QUOTA_STATUS_FAILURE,
-          })
-        })
-      })
-
-      describe(`${CombinerEndpoint.PNP_SIGN}`, () => {
-        it('Should fail to reach threshold of signers on valid request', async () => {
-          const req = getSignRequest(blindedMsgResult)
-          const authorization = getPnpRequestAuthorization(req, PRIVATE_KEY1)
-          const res = await sendPnpSignRequest(req, authorization, app)
-          expect(res.status).toBe(500)
-          expect(res.body).toStrictEqual<SignMessageResponseFailure>({
-            success: false,
-            version: expectedVersion,
-            error: ErrorMessage.NOT_ENOUGH_PARTIAL_SIGNATURES,
-          })
-        })
+      expect(res.status).toBe(403)
+      expect(res.body).toStrictEqual<SignMessageResponseFailure>({
+        success: false,
+        version: expectedVersion,
+        error: WarningMessage.EXCEEDED_QUOTA,
       })
     })
   })

--- a/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/combiner/test/integration/pnp.test.ts
@@ -557,6 +557,7 @@ describe('pnpService', () => {
           })
         })
 
+        // This previously returned 502 instead of 500
         it('Should respond with 500 when insufficient signer responses', async () => {
           await signerDB1?.destroy()
           await signerDB2?.destroy()

--- a/packages/phone-number-privacy/monitor/package.json
+++ b/packages/phone-number-privacy/monitor/package.json
@@ -27,7 +27,7 @@
     "@celo/encrypted-backup": "3.0.2-dev",
     "@celo/identity": "3.0.2-dev",
     "@celo/wallet-local": "3.0.2-dev",
-    "@celo/phone-number-privacy-common": "2.0.1",
+    "@celo/phone-number-privacy-common": "2.0.2-dev",
     "@celo/utils": "3.0.2-dev",
     "firebase-admin": "^9.12.0",
     "firebase-functions": "^3.15.7"

--- a/packages/phone-number-privacy/monitor/src/index.ts
+++ b/packages/phone-number-privacy/monitor/src/index.ts
@@ -10,18 +10,18 @@ if (!contextName || !blockchainProvider) {
 
 // New functions do not overwrite ODIS 1.0 monitor function.
 export const odisMonitorScheduleFunctionLegacyPNP = functions
-  .region('us-central1', 'europe-west3')
+  .region('us-central1')
   .pubsub.schedule('every 5 minutes')
   .onRun(async () =>
     testPNPQuery(blockchainProvider, contextName, CombinerEndpointPNP.LEGACY_PNP_SIGN)
   )
 
 export const odisMonitorScheduleFunctionPNP = functions
-  .region('us-central1', 'europe-west3')
+  .region('us-central1')
   .pubsub.schedule('every 5 minutes')
   .onRun(async () => testPNPQuery(blockchainProvider, contextName, CombinerEndpointPNP.PNP_SIGN))
 
 export const odisMonitorScheduleFunctionDomains = functions
-  .region('us-central1', 'europe-west3')
+  .region('us-central1')
   .pubsub.schedule('every 5 minutes')
   .onRun(async () => testDomainsQuery(contextName))

--- a/packages/sdk/encrypted-backup/package.json
+++ b/packages/sdk/encrypted-backup/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@celo/base": "3.0.2-dev",
     "@celo/identity": "3.0.2-dev",
-    "@celo/phone-number-privacy-common": "2.0.1",
+    "@celo/phone-number-privacy-common": "2.0.2-dev",
     "@celo/poprf": "^0.1.9",
     "@celo/utils": "3.0.2-dev",
     "@types/debug": "^4.1.5",

--- a/packages/sdk/identity/package.json
+++ b/packages/sdk/identity/package.json
@@ -28,7 +28,7 @@
     "@celo/base": "3.0.2-dev",
     "@celo/utils": "3.0.2-dev",
     "@celo/contractkit": "3.0.2-dev",
-    "@celo/phone-number-privacy-common": "2.0.1",
+    "@celo/phone-number-privacy-common": "2.0.2-dev",
     "@types/debug": "^4.1.5",
     "bignumber.js": "^9.0.0",
     "blind-threshold-bls": "https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,11 +1334,6 @@
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-3.0.0.tgz#698b2c3da99f3f76e1b5c1936bfa4fa37d37bb7c"
   integrity sha512-SBVaruEw4QLLGB8a0+J79O6GuG4gEtXmw9jV+2tqMO1Dc7v6vu0TwochgIA7QPGzFo6Z/FTXcf/dBnJgSRSIJA==
 
-"@celo/base@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/base/-/base-3.0.1.tgz#9ffaed3732a63fee26c636c11258288a7bc8700c"
-  integrity sha512-677Zkp65h2l2cmRkXiIdBS4/RUZlb4pr1n81xwD4egRIUld7on7k51yYIF9LLHkdtFGEJ6aKahJAP3TPvvM7pQ==
-
 "@celo/bls12377js@0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@celo/bls12377js/-/bls12377js-0.1.1.tgz#ba3574f41697cdba96c10ae96bb1aac057285798"
@@ -1372,19 +1367,6 @@
     debug "^4.1.1"
     utf8 "3.0.0"
 
-"@celo/connect@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/connect/-/connect-3.0.1.tgz#45f63d6169e3e65ccb76e60b85364e9b084f42be"
-  integrity sha512-6QaRac00nVjv7Ti0kCTyE1sw2igsylCaUvF5f3SNgZuMIBm5F6nU3n7QEkUOF2g+NYpxqG3G7oZB4atNJR64Ug==
-  dependencies:
-    "@celo/base" "3.0.1"
-    "@celo/utils" "3.0.1"
-    "@types/debug" "^4.1.5"
-    "@types/utf8" "^2.1.6"
-    bignumber.js "^9.0.0"
-    debug "^4.1.1"
-    utf8 "3.0.0"
-
 "@celo/contractkit@1.5.2", "@celo/contractkit@^1.2.0":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-1.5.2.tgz#be15d570f3044a190dabb6bbe53d5081c78ea605"
@@ -1412,25 +1394,6 @@
     "@celo/connect" "3.0.0"
     "@celo/utils" "3.0.0"
     "@celo/wallet-local" "3.0.0"
-    "@types/bn.js" "^5.1.0"
-    "@types/debug" "^4.1.5"
-    bignumber.js "^9.0.0"
-    cross-fetch "^3.0.6"
-    debug "^4.1.1"
-    fp-ts "2.1.1"
-    io-ts "2.0.1"
-    semver "^7.3.5"
-    web3 "1.3.6"
-
-"@celo/contractkit@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-3.0.1.tgz#837665668cd70a15712a5c3aca0ef1b5a9642562"
-  integrity sha512-4yqxeU5Vk/yi/A+RHC4pCBnHusp5SbCdxS94cOe19yGmAWDHfx6XSGw7P2nTt8vDvnjolE1uHumfe+KNGa7s8g==
-  dependencies:
-    "@celo/base" "3.0.1"
-    "@celo/connect" "3.0.1"
-    "@celo/utils" "3.0.1"
-    "@celo/wallet-local" "3.0.1"
     "@types/bn.js" "^5.1.0"
     "@types/debug" "^4.1.5"
     bignumber.js "^9.0.0"
@@ -1562,24 +1525,6 @@
     io-ts "2.0.1"
     is-base64 "^1.1.0"
 
-"@celo/phone-number-privacy-common@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/phone-number-privacy-common/-/phone-number-privacy-common-2.0.1.tgz#988c28b70744dbf05cd2b639bea53311755fe381"
-  integrity sha512-pnPFupeXh8jakc/cueR0o7OBU3xTgDQv64L8RktHeRmJnVRniI/pz/ZBislkP6OKrqwbWLvMUbOlW5nm325vdg==
-  dependencies:
-    "@celo/base" "3.0.1"
-    "@celo/contractkit" "3.0.1"
-    "@celo/phone-utils" "3.0.1"
-    "@celo/utils" "3.0.1"
-    bignumber.js "^9.0.0"
-    bunyan "1.8.12"
-    bunyan-debug-stream "2.0.0"
-    bunyan-gke-stackdriver "0.1.2"
-    dotenv "^8.2.0"
-    elliptic "^6.5.4"
-    io-ts "2.0.1"
-    is-base64 "^1.1.0"
-
 "@celo/phone-utils@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@celo/phone-utils/-/phone-utils-3.0.0.tgz#73f87efc81ec3b5c92b3638102703c437d7bc128"
@@ -1587,22 +1532,6 @@
   dependencies:
     "@celo/base" "3.0.0"
     "@celo/utils" "3.0.0"
-    "@types/country-data" "^0.0.0"
-    "@types/ethereumjs-util" "^5.2.0"
-    "@types/google-libphonenumber" "^7.4.23"
-    "@types/node" "^10.12.18"
-    country-data "^0.0.31"
-    fp-ts "2.1.1"
-    google-libphonenumber "^3.2.27"
-    io-ts "2.0.1"
-
-"@celo/phone-utils@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/phone-utils/-/phone-utils-3.0.1.tgz#28ca1c89119a07f89b495d35f52d10df5dfe1a7b"
-  integrity sha512-kDoUOhcaxGJkJqCb2bcqk11VsUsVlcnEDsMtzDHHIUmUmgE858z2u+Wtw4Zj6kx/L8F8tewxUTAKd/iIa/UP5g==
-  dependencies:
-    "@celo/base" "3.0.1"
-    "@celo/utils" "3.0.1"
     "@types/country-data" "^0.0.0"
     "@types/ethereumjs-util" "^5.2.0"
     "@types/google-libphonenumber" "^7.4.23"
@@ -1708,23 +1637,6 @@
     web3-eth-abi "1.3.6"
     web3-utils "1.3.6"
 
-"@celo/utils@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/utils/-/utils-3.0.1.tgz#2c9b03712c020414b31db9b39e57671009ff0976"
-  integrity sha512-mwCG6zuUKLBBmQfcjteHWKlKMkgxHuSugxFA8IkTEb4izfwRyue3/IhYZ/DxTIh906Xgb3CGTdEfxAfrjy8fhg==
-  dependencies:
-    "@celo/base" "3.0.1"
-    "@types/bn.js" "^5.1.0"
-    "@types/elliptic" "^6.4.9"
-    "@types/ethereumjs-util" "^5.2.0"
-    "@types/node" "^10.12.18"
-    bignumber.js "^9.0.0"
-    elliptic "^6.5.4"
-    ethereumjs-util "^5.2.0"
-    io-ts "2.0.1"
-    web3-eth-abi "1.3.6"
-    web3-utils "1.3.6"
-
 "@celo/wallet-base@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/wallet-base/-/wallet-base-1.5.2.tgz#ae8df425bf3c702277bb1b63a761a2ec8429e7aa"
@@ -1755,21 +1667,6 @@
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
 
-"@celo/wallet-base@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/wallet-base/-/wallet-base-3.0.1.tgz#b2a26fb7624773fd5b4b44de4aadc0cc51a9ff24"
-  integrity sha512-Pb2vqwwXsoreqdGep0ZakVQhGoq3rtG9XhESPIcshwE50eAWAMAK+POlhRGkttrVAuXBZXfre+sYLBTivfSB1A==
-  dependencies:
-    "@celo/base" "3.0.1"
-    "@celo/connect" "3.0.1"
-    "@celo/utils" "3.0.1"
-    "@types/debug" "^4.1.5"
-    "@types/ethereumjs-util" "^5.2.0"
-    bignumber.js "^9.0.0"
-    debug "^4.1.1"
-    eth-lib "^0.2.8"
-    ethereumjs-util "^5.2.0"
-
 "@celo/wallet-local@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/wallet-local/-/wallet-local-1.5.2.tgz#66ea5fb763e19724309e3d56f312f1a342e12b91"
@@ -1790,18 +1687,6 @@
     "@celo/connect" "3.0.0"
     "@celo/utils" "3.0.0"
     "@celo/wallet-base" "3.0.0"
-    "@types/ethereumjs-util" "^5.2.0"
-    eth-lib "^0.2.8"
-    ethereumjs-util "^5.2.0"
-
-"@celo/wallet-local@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@celo/wallet-local/-/wallet-local-3.0.1.tgz#c8d4ca52edb8485d6c2e13cbbc16cb5ca2ef387b"
-  integrity sha512-bA1zbotg67NKnbdKgF3dply5uFRIUp3Gh4MIVavZn4+OwYjvOF2eh9t91oU6hyKkne6rzStuxh7PbbHFZX7DNw==
-  dependencies:
-    "@celo/connect" "3.0.1"
-    "@celo/utils" "3.0.1"
-    "@celo/wallet-base" "3.0.1"
     "@types/ethereumjs-util" "^5.2.0"
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"


### PR DESCRIPTION
### Description
- ODIS combiner currently returns a 502 error when failing fast (i.e. out of quota received from several signers, so the request is aborted since the threshold cannot be reached) instead of the actual returned errors from the signers
  - this happens when the number of responses required to block a threshold from being reached is a minority (i.e. for N=5,T=4, 2 are required to block a threshold, which is less than N/2). Our tests haven't checked this case before now.
  - it also logs `CELO_ODIS_ERR_08 SIG_ERR Inconsistent responses from signers` almost always, which is a regression from ODIS 1.0
- Fix: remove the automatic replacement of no status received with a 502 (which happens for any aborted request), which is creating this weird dynamic. This way, real error codes can be propagated/grouped. If no error codes are returned, this will eventually resolve to a 500, however common situations like 403s/429s will be handled properly.

### Tested
- added integration tests for N=5,T=4 (just for signing success + out of quota) for domains + PNP
- deployed combiner to staging
  - passes e2e tests
  - looks like the signer inconsistencies errors are gone but will look into this more
