### PR TITLE
Added CloudSQL proxy startup check

### DIFF
--- a/packages/helm-charts/blockscout/templates/_helpers.tpl
+++ b/packages/helm-charts/blockscout/templates/_helpers.tpl
@@ -26,7 +26,11 @@ the `volumes` section.
 */ -}}
 {{- define "celo.blockscout.container.db-terminating-sidecar" -}}
 - name: cloudsql-proxy
-  image: gcr.io/cloudsql-docker/gce-proxy:1.11
+  image: gcr.io/cloudsql-docker/gce-proxy:1.19.1-alpine
+  lifecycle:
+    postStart:
+      exec:
+        command: ["/bin/sh", "-c", "until nc -z {{ .Database.proxy.host }}:{{ .Database.proxy.port }}; do sleep 1; done"]
   command:
   - /bin/sh
   args:
@@ -95,7 +99,11 @@ the `volumes` section.
 */ -}}
 {{- define "celo.blockscout.container.db-sidecar" -}}
 - name: cloudsql-proxy
-  image: gcr.io/cloudsql-docker/gce-proxy:1.19.1
+  image: gcr.io/cloudsql-docker/gce-proxy:1.19.1-alpine
+  lifecycle:
+    postStart:
+      exec:
+        command: ["/bin/sh", "-c", "until nc -z {{ .Database.proxy.host }}:{{ .Database.proxy.port }}; do sleep 1; done"]
   command: ["/cloud_sql_proxy",
             "-instances={{ .Database.connectionName }}=tcp:{{ .Database.port }}",
             "-credential_file=/secrets/cloudsql/credentials.json",

--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -36,6 +36,8 @@ spec:
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
       containers:
+{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.api.db }}
+{{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}
       - name: blockscout-api
         image: {{ .Values.blockscout.image.repository }}:api-{{ .Values.blockscout.image.tag }}
         imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
@@ -122,9 +124,7 @@ spec:
         - name: ACCOUNT_POOL_SIZE
           value: {{ .Values.blockscout.web.accountPoolSize | quote }}
         {{- end }}
-{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.api.db }}
 {{ include "celo.blockscout.env-vars" $data | indent 8 }}
-{{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}
       volumes:
 {{ include "celo.blockscout.volume.cloudsql-credentials" . | indent 8 }}
 {{ include "celo.blockscout.volume.temporary-dir" . | indent 8 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-data-migration.job.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-data-migration.job.yaml
@@ -24,6 +24,8 @@ spec:
           initContainers:
             {{ include "celo.blockscout.initContainer.secrets-init" . | nindent 12 }}
           containers:
+{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.indexer.db }}
+{{ include "celo.blockscout.container.db-terminating-sidecar" $data | indent 10 }}
           - name: blockscout-data-migration
             image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}
             imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -50,9 +52,7 @@ spec:
                   secretKeyRef:
                     name: blockscout-data-migration-secret-key-ref
                     key: initial-value
-{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.indexer.db }}
 {{ include "celo.blockscout.env-vars" $data | indent 14 }}
-{{ include "celo.blockscout.container.db-terminating-sidecar" $data | indent 10 }}
           volumes:
             {{ include "celo.blockscout.volume.cloudsql-credentials" . | nindent 12 }}
             {{ include "celo.blockscout.volume.temporary-dir" . | nindent 12 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -38,6 +38,8 @@ spec:
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
       containers:
+{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.indexer.db }}
+{{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}
       - name: blockscout-indexer
         image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}
         imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
@@ -112,9 +114,7 @@ spec:
           value: {{ .Values.blockscout.indexer.beanstalkdHost | quote }}
         - name: INDEXER_DISABLE_BLOCK_REWARD_FETCHER
           value: {{ not .Values.blockscout.indexer.fetchers.blockRewards.enabled | quote }}
-{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.indexer.db }}
 {{ include "celo.blockscout.env-vars" $data | indent 8 }}
-{{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}
       volumes:
 {{ include "celo.blockscout.volume.cloudsql-credentials" . | indent 8 }}
 {{ include "celo.blockscout.volume.temporary-dir" . | indent 8 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-metadata-crawler.cronjob.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-metadata-crawler.cronjob.yaml
@@ -21,6 +21,8 @@ spec:
           initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 10 }}
           containers:
+{{- $data := dict "Values" .Values "Database" .Values.blockscout.indexer.db }}
+{{ include "celo.blockscout.container.db-terminating-sidecar" $data | indent 10 }}
           - name: metadata-crawler
             image: {{ .Values.blockscout.metadataCrawler.image.repository }}:{{ .Values.blockscout.metadataCrawler.image.tag }}
             imagePullPolicy: IfNotPresent
@@ -56,8 +58,6 @@ spec:
             volumeMounts:
             - mountPath: /tmp/pod
               name: temporary-dir
-{{- $data := dict "Values" .Values "Database" .Values.blockscout.indexer.db }}
-{{ include "celo.blockscout.container.db-terminating-sidecar" $data | indent 10 }}
           volumes:
 {{ include "celo.blockscout.volume.cloudsql-credentials" . | indent 12 }}
 {{ include "celo.blockscout.volume.temporary-dir" . | indent 12 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-migration.hook.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-migration.hook.yaml
@@ -19,6 +19,8 @@ spec:
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
       containers:
+{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.indexer.db }}
+{{ include "celo.blockscout.container.db-terminating-sidecar" $data | indent 6 }}
       - name: blockscout-migration
         image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}
         imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
@@ -43,9 +45,7 @@ spec:
         env:
         - name: DROP_DB
           value: "{{ default "false" .Values.blockscout.db.drop }}"
-{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.indexer.db }}
 {{ include "celo.blockscout.env-vars" $data  | indent 8 }}
-{{ include "celo.blockscout.container.db-terminating-sidecar" $data | indent 6 }}
       volumes:
 {{ include "celo.blockscout.volume.cloudsql-credentials" . | indent 8 }}
 {{ include "celo.blockscout.volume.temporary-dir" . | indent 8 }}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -36,6 +36,8 @@ spec:
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
       containers:
+{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.web.db }}
+{{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}
       - name: blockscout-web
         image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}
         imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
@@ -170,9 +172,7 @@ spec:
         - name: DISPLAY_TOKEN_ICONS
           value: {{ .Values.blockscout.web.tokenIcons.enabled | quote }}
         {{- end }}
-{{- $data := dict "Release" .Release "Values" .Values "Database" .Values.blockscout.web.db }}
 {{ include "celo.blockscout.env-vars" $data | indent 8 }}
-{{ include "celo.blockscout.container.db-sidecar" $data | indent 6 }}
       volumes:
 {{ include "celo.blockscout.volume.cloudsql-credentials" . | indent 8 }}
 {{ include "celo.blockscout.volume.temporary-dir" . | indent 8 }}


### PR DESCRIPTION
### Description

Based on [kubelet code](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L900), it starts containers sequentially in the order they are defined in the containers array.
This PR changes the order of containers, so that the `cloudsql-proxy` container always starts first.
There is an additional `postStart` hook that blocks the startup of the main container until the proxy container is fully available. It is awaiting in a loop until the proxy is up, running and connected, guaranteeing that the main container would always have an available DB connection when it starts.

### Other changes

Updates the proxy image to `-alpine` as the main image is based on `distroless` and, hence, doesn't contain any shell.
Terminating `db-sidecar` is now using the same version of the proxy.

### Tested

Tested on rc1staging.

### Related issues

- Fixes https://github.com/celo-org/data-services/issues/462

### Backwards compatibility

Yes.