### PR TITLE
reverting circle ci configuration change that added an extra ssh key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,9 +128,6 @@ jobs:
     # Source: https://circleci.com/docs/2.0/configuration-reference/#resource_class
     resource_class: large
     steps:
-      - add_ssh_keys:
-          fingerprints:
-          - "1f:c5:27:aa:2e:4d:ee:65:0d:78:98:5e:ae:14:5d:60"
 
       - restore_cache:
           keys:


### PR DESCRIPTION
### Description

Reverting a change I made to the circle ci configuration adding ssh keys since it wasn't needed.



### Backwards compatibility

Reverting back to previous configuration
### Documentation

_The set of community facing docs that have been added/modified because of this change_