### PR TITLE
Normalise blockscout prometheus endpoints.

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-api.deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       {{- if .Values.blockscout.metrics.enabled}}
       annotations:
-        prometheus.io/path: /metrics/web
+        prometheus.io/path: /metrics
         prometheus.io/port: "4000"
         prometheus.io/scrape: "true"
       {{- end}}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -23,7 +23,7 @@ spec:
     metadata:
       {{- if .Values.blockscout.metrics.enabled}}
       annotations:
-        prometheus.io/path: /metrics/indexer
+        prometheus.io/path: /metrics
         prometheus.io/port: "4001"
         prometheus.io/scrape: "true"
       {{- end}}

--- a/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-web.deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       {{- if .Values.blockscout.metrics.enabled}}
       annotations:
-        prometheus.io/path: /metrics/web
+        prometheus.io/path: /metrics
         prometheus.io/port: "4000"
         prometheus.io/scrape: "true"
       {{- end}}


### PR DESCRIPTION
### Description

Changes the blockscout deployment metadata to look for prometheus metrics on route `/metrics` instead of whatever pod name.

### Tested

* deployed to rc1staging

### Related issues

- Fixes https://github.com/celo-org/data-services/issues/577
