### PR TITLE
Event stream deployment.

### DIFF
--- a/packages/helm-charts/blockscout/templates/blockscout-event-stream.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-event-stream.deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-eventstream
+  name: {{ .Release.Name }}-event-stream
   labels:
     {{- include "celo.blockscout.labels" . | nindent 4 }}
-    component: blockscout-eventstream
+    component: blockscout-event-stream
   annotations:
     {{- include "celo.blockscout.annotations" . | nindent 4 }}
 spec:
@@ -18,7 +18,7 @@ spec:
     matchLabels:
       app: blockscout
       release: {{ .Release.Name }}
-      component: blockscout-eventstream
+      component: blockscout-event-stream
   template:
     metadata:
       {{- if .Values.blockscout.metrics.enabled }}
@@ -30,7 +30,7 @@ spec:
       labels:
         app: blockscout
         release: {{ .Release.Name }}
-        component: blockscout-eventstream
+        component: blockscout-event-stream
         {{- include "celo.blockscout.elixir.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-rbac
@@ -38,7 +38,7 @@ spec:
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
       containers:
-      - name: blockscout-eventstream
+      - name: blockscout-event-stream
         image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}
         imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
         command:

--- a/packages/helm-charts/blockscout/templates/blockscout-event-stream.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-event-stream.deployment.yaml
@@ -11,9 +11,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.blockscout.eventstream.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ .Values.blockscout.eventstream.strategy.rollingUpdate.maxUnavailable }}
-  replicas: {{ .Values.blockscout.eventstream.replicas }}
+      maxSurge: {{ .Values.blockscout.eventStream.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.blockscout.eventStream.strategy.rollingUpdate.maxUnavailable }}
+  replicas: {{ .Values.blockscout.eventStream.replicas }}
   selector:
     matchLabels:
       app: blockscout
@@ -24,7 +24,7 @@ spec:
       {{- if .Values.blockscout.metrics.enabled }}
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port:  "{{ .Values.blockscout.eventstream.port }}"
+        prometheus.io/port:  "{{ .Values.blockscout.eventStream.port }}"
         prometheus.io/scrape: "true"
       {{- end }}
       labels:
@@ -34,7 +34,7 @@ spec:
         {{- include "celo.blockscout.elixir.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-rbac
-      terminationGracePeriodSeconds: {{ .Values.blockscout.eventstream.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.blockscout.eventStream.terminationGracePeriodSeconds }}
       initContainers:
 {{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
       containers:
@@ -56,42 +56,42 @@ spec:
           readOnly: true
         ports:
         - name: health
-          containerPort: {{ .Values.blockscout.eventstream.port }}
-        {{- if .Values.blockscout.eventstream.readinessProbe.enabled }}
+          containerPort: {{ .Values.blockscout.eventStream.port }}
+        {{- if .Values.blockscout.eventStream.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /health/readiness
             port: health
-          initialDelaySeconds: {{ .Values.blockscout.eventstream.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.blockscout.eventstream.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.blockscout.eventstream.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.blockscout.eventstream.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.blockscout.eventstream.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.blockscout.eventStream.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.blockscout.eventStream.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.blockscout.eventStream.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.blockscout.eventStream.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.blockscout.eventStream.readinessProbe.failureThreshold }}
         {{- end }}
-        {{- if .Values.blockscout.eventstream.livenessProbe.enabled }}
+        {{- if .Values.blockscout.eventStream.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /health/liveness
             port: health
-          initialDelaySeconds: {{ .Values.blockscout.eventstream.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.blockscout.eventstream.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.blockscout.eventstream.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.blockscout.eventstream.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.blockscout.eventstream.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.blockscout.eventStream.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.blockscout.eventStream.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.blockscout.eventStream.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.blockscout.eventStream.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.blockscout.eventStream.livenessProbe.failureThreshold }}
         {{- end }}
         resources:
           requests:
-            memory: {{ .Values.blockscout.eventstream.resources.requests.memory }}
-            cpu: {{ .Values.blockscout.eventstream.resources.requests.cpu }}
+            memory: {{ .Values.blockscout.eventStream.resources.requests.memory }}
+            cpu: {{ .Values.blockscout.eventStream.resources.requests.cpu }}
         env:
         - name: METRICS_ENABLED
           value: "{{.Values.blockscout.metrics.enabled}}"
         - name: ENABLE_EVENT_STREAM
-          value: {{ .Values.blockscout.eventstream.enableEventStream | quote }}
+          value: {{ .Values.blockscout.eventStream.enableEventStream | quote }}
         - name: BEANSTALKD_PORT
-          value: {{ .Values.blockscout.eventstream.beanstalkdPort | quote }}
+          value: {{ .Values.blockscout.eventStream.beanstalkdPort | quote }}
         - name: BEANSTALKD_HOST
-          value: {{ .Values.blockscout.eventstream.beanstalkdHost | quote }}
+          value: {{ .Values.blockscout.eventStream.beanstalkdHost | quote }}
         - name: ERLANG_COOKIE
           value: {{ .Values.blockscout.secrets.erlang.cookie }}
         - name: POD_IP

--- a/packages/helm-charts/blockscout/templates/blockscout-eventstream.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-eventstream.deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-eventstream
+  labels:
+    {{- include "celo.blockscout.labels" . | nindent 4 }}
+    component: blockscout-eventstream
+  annotations:
+    {{- include "celo.blockscout.annotations" . | nindent 4 }}
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.blockscout.eventstream.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.blockscout.eventstream.strategy.rollingUpdate.maxUnavailable }}
+  replicas: {{ .Values.blockscout.eventstream.replicas }}
+  selector:
+    matchLabels:
+      app: blockscout
+      release: {{ .Release.Name }}
+      component: blockscout-eventstream
+  template:
+    metadata:
+      {{- if .Values.blockscout.metrics.enabled }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port:  "{{ .Values.blockscout.eventstream.port }}"
+        prometheus.io/scrape: "true"
+      {{- end }}
+      labels:
+        app: blockscout
+        release: {{ .Release.Name }}
+        component: blockscout-eventstream
+        {{- include "celo.blockscout.elixir.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-rbac
+      terminationGracePeriodSeconds: {{ .Values.blockscout.eventstream.terminationGracePeriodSeconds }}
+      initContainers:
+{{ include "celo.blockscout.initContainer.secrets-init" . | indent 6 }}
+      containers:
+      - name: blockscout-eventstream
+        image: {{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}
+        imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
+        command:
+        - /secrets/secrets-init
+        args:
+        - --provider
+        - google
+        - /bin/sh
+        - -c
+        - |
+           exec mix cmd --app event_stream "elixir --cookie $ERLANG_COOKIE --name {{ .Values.blockscout.erlangNodeName}}@$(POD_IP) -S mix phx.server --no-compile" 
+        volumeMounts:
+        - mountPath: /secrets
+          name: temporary-dir
+          readOnly: true
+        ports:
+        - name: health
+          containerPort: {{ .Values.blockscout.eventstream.port }}
+        {{- if .Values.blockscout.eventstream.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /health/readiness
+            port: health
+          initialDelaySeconds: {{ .Values.blockscout.eventstream.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.blockscout.eventstream.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.blockscout.eventstream.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.blockscout.eventstream.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.blockscout.eventstream.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.blockscout.eventstream.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /health/liveness
+            port: health
+          initialDelaySeconds: {{ .Values.blockscout.eventstream.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.blockscout.eventstream.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.blockscout.eventstream.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.blockscout.eventstream.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.blockscout.eventstream.livenessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+          requests:
+            memory: {{ .Values.blockscout.eventstream.resources.requests.memory }}
+            cpu: {{ .Values.blockscout.eventstream.resources.requests.cpu }}
+        env:
+        - name: METRICS_ENABLED
+          value: "{{.Values.blockscout.metrics.enabled}}"
+        - name: ENABLE_EVENT_STREAM
+          value: {{ .Values.blockscout.eventstream.enableEventStream | quote }}
+        - name: BEANSTALKD_PORT
+          value: {{ .Values.blockscout.eventstream.beanstalkdPort | quote }}
+        - name: BEANSTALKD_HOST
+          value: {{ .Values.blockscout.eventstream.beanstalkdHost | quote }}
+        - name: ERLANG_COOKIE
+          value: {{ .Values.blockscout.secrets.erlang.cookie }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: EPMD_SERVICE_NAME
+          value: {{ .Release.Name }}-epmd-service
+      volumes:
+{{ include "celo.blockscout.volume.temporary-dir" . | indent 8 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -106,12 +106,6 @@ spec:
           value: {{ .Values.blockscout.indexer.rpcRegion | quote }}
         - name: PRIMARY_REGION
           value: {{ .Values.blockscout.indexer.primaryRpcRegion | quote }}
-        - name: ENABLE_EVENT_STREAM
-          value: {{ .Values.blockscout.indexer.enableEventStream | quote }}
-        - name: BEANSTALKD_PORT
-          value: {{ .Values.blockscout.indexer.beanstalkdPort | quote }}
-        - name: BEANSTALKD_HOST
-          value: {{ .Values.blockscout.indexer.beanstalkdHost | quote }}
         - name: INDEXER_DISABLE_BLOCK_REWARD_FETCHER
           value: {{ not .Values.blockscout.indexer.fetchers.blockRewards.enabled | quote }}
 {{ include "celo.blockscout.env-vars" $data | indent 8 }}

--- a/packages/helm-charts/blockscout/values-rc1staging-blockscout.yaml
+++ b/packages/helm-charts/blockscout/values-rc1staging-blockscout.yaml
@@ -1,4 +1,6 @@
 blockscout:
+  eventstream:
+    replicas: 1
   indexer:
     db:
       connectionName: celo-testnet-production:us-west1:rc1staging

--- a/packages/helm-charts/blockscout/values-rc1staging-blockscout.yaml
+++ b/packages/helm-charts/blockscout/values-rc1staging-blockscout.yaml
@@ -1,5 +1,5 @@
 blockscout:
-  eventstream:
+  eventStream:
     replicas: 1
   indexer:
     db:

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -1,5 +1,33 @@
 ingressClassName: nginx
 blockscout:
+  eventstream:
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    port: 4000
+    resources:
+      requests:
+        memory: 1000Mi
+        cpu: 2
+    enableEventStream: false
+    beanstalkdPort: ""
+    beanstalkdHost: ""
+    replicas: 0
+    readinessProbe:
+      enabled: false
+      initialDelaySeconds: 30
+      periodSeconds: 5
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
+    livenessProbe:
+      enabled: false
+      initialDelaySeconds: 30
+      periodSeconds: 5
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
   indexer:
     terminationGracePeriodSeconds: 60
     port: 4001
@@ -57,9 +85,6 @@ blockscout:
         cpu: 2
     rpcRegion: "indexer"  
     primaryRpcRegion: "indexer"  
-    enableEventStream: false
-    beanstalkdPort: ""
-    beanstalkdHost: ""
     fetchers:
       blockRewards:
         enabled: false

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -1,6 +1,6 @@
 ingressClassName: nginx
 blockscout:
-  eventstream:
+  eventStream:
     strategy:
       rollingUpdate:
         maxSurge: 1


### PR DESCRIPTION
### Description

Adds a new chart for an "eventstream" app which is to be the source of events for webhook consumption. Event publishing can be configured by configuring and then adding an instance of this app to a given blockscout deployment.

### Other changes

* Removed event stream config from indexer

### Tested

Deployed to rc1staging and checked everything is defined correctly

### Related issues

- Relates to https://github.com/celo-org/data-services/issues/628
