### PR TITLE
Undo changes to @celo/base, @celo/phone-utils and fix bugs & CI

### DIFF
--- a/dependency-graph.json
+++ b/dependency-graph.json
@@ -234,7 +234,6 @@
     "dependencies": [
       "@celo/base",
       "@celo/flake-tracker",
-      "@celo/identity",
       "@celo/typescript",
       "@celo/utils"
     ]

--- a/packages/protocol/test/identity/attestations.ts
+++ b/packages/protocol/test/identity/attestations.ts
@@ -296,11 +296,15 @@ contract('Attestations', (accounts: string[]) => {
     _accounts: string[]
   ): Signature {
     const privateKey = getDerivedKey(KeyOffsets.ATTESTING_KEY_OFFSET, _issuer, _accounts)
-
+    const derivedIssuerAddress = privateKeyToAddress(privateKey)
+    const attestationMessageFromIdentifier = soliditySha3(
+      { type: 'bytes32', value: _identifier },
+      { type: 'address', value: _account }
+    )!
     const { v, r, s } = SignatureUtils.signMessage(
-      soliditySha3({ type: 'bytes32', value: _identifier }, { type: 'address', value: _account })!,
+      attestationMessageFromIdentifier,
       privateKey,
-      _issuer
+      derivedIssuerAddress
     )
     return { v, r, s }
   }

--- a/packages/protocol/test/identity/attestations.ts
+++ b/packages/protocol/test/identity/attestations.ts
@@ -290,17 +290,17 @@ contract('Attestations', (accounts: string[]) => {
   })
 
   function getVerificationCodeSignature(
-    account: string,
-    issuer: string,
-    identifier: string,
-    accounts: string[]
+    _account: string,
+    _issuer: string,
+    _identifier: string,
+    _accounts: string[]
   ): Signature {
-    const privateKey = getDerivedKey(KeyOffsets.ATTESTING_KEY_OFFSET, issuer, accounts)
+    const privateKey = getDerivedKey(KeyOffsets.ATTESTING_KEY_OFFSET, _issuer, accounts)
 
     const { v, r, s } = SignatureUtils.signMessage(
-      soliditySha3({ type: 'bytes32', value: identifier }, { type: 'address', value: account })!,
+      soliditySha3({ type: 'bytes32', value: _identifier }, { type: 'address', value: _account })!,
       privateKey,
-      issuer
+      _issuer
     )
     return { v, r, s }
   }

--- a/packages/protocol/test/identity/attestations.ts
+++ b/packages/protocol/test/identity/attestations.ts
@@ -295,7 +295,7 @@ contract('Attestations', (accounts: string[]) => {
     _identifier: string,
     _accounts: string[]
   ): Signature {
-    const privateKey = getDerivedKey(KeyOffsets.ATTESTING_KEY_OFFSET, _issuer, accounts)
+    const privateKey = getDerivedKey(KeyOffsets.ATTESTING_KEY_OFFSET, _issuer, _accounts)
 
     const { v, r, s } = SignatureUtils.signMessage(
       soliditySha3({ type: 'bytes32', value: _identifier }, { type: 'address', value: _account })!,

--- a/packages/sdk/base/src/attestations.test.ts
+++ b/packages/sdk/base/src/attestations.test.ts
@@ -1,0 +1,72 @@
+import {
+  extractAttestationCodeFromMessage,
+  messageContainsAttestationCode,
+  sanitizeMessageBase64,
+} from './attestations'
+
+const MESSAGE_1 =
+  'Celo : q4BJuVrALpiaroth_dwQ_ps6w8auvNPmi-SVVwstPaFaq8aRq4jeaWSPmI-rZTrJQ_Z0BOUyz9EBNif1Y2XzZQE='
+const MESSAGE_2 =
+  'Celo attestation code: IDOp4SaFdr9d_uNUo3SAUp1x-ZvoLAUAX_txx9dC0Q56mqAfisxNeZjh6LGDz2uMtNSo2SP-z93RkeYeB0rcXgA='
+const MESSAGE_3 =
+  '<#> GTCp4SaFdr9d3uNUo3SAUp1x-ZvoLAUAX3txx9dC0Q56mqAfisxNeZP3WrGDz2uMtNSo2SP-z93RkeYeB0rcWhA= l5k6LvdPDXS'
+const MESSAGE_3_WITH_LINK =
+  '<#> celo://wallet/v/GTCp4SaFdr9d3uNUo3SAUp1x-ZvoLAUAX3txx9dC0Q56mqAfisxNeZP3WrGDz2uMtNSo2SP-z93RkeYeB0rcWhA= l5k6LvdPDXS'
+const MESSAGE_4_UNSANITIZED =
+  '<#> AOvujFUk§HkATAEsmVZRgB2phcFp69eqMqg0ps4Z8688s2-kgmyHybsRWYfTgjYMJv0jmFnjM8KKmb2tThROLAE= l5k6LvdPDXS'
+
+const MESSAGE_1_DECODED =
+  '0xab8049b95ac02e989aae8b61fddc10fe9b3ac3c6aebcd3e68be495570b2d3da15aabc691ab88de69648f988fab653ac943f67404e532cfd1013627f56365f36501'
+const MESSAGE_2_DECODED =
+  '0x2033a9e1268576bf5dfee354a37480529d71f99be82c05005ffb71c7d742d10e7a9aa01f8acc4d7998e1e8b183cf6b8cb4d4a8d923fecfddd191e61e074adc5e00'
+const MESSAGE_3_DECODED =
+  '0x1930a9e1268576bf5ddee354a37480529d71f99be82c05005f7b71c7d742d10e7a9aa01f8acc4d7993f75ab183cf6b8cb4d4a8d923fecfddd191e61e074adc5a10'
+const MESSAGE_4_DECODED =
+  '0x00ebee8c5524fc79004c012c995651801da985c169ebd7aa32a834a6ce19f3af3cb36fa4826c87c9bb115987d382360c26fd239859e333c28a99bdad4e144e2c01'
+
+describe('Attestation Utils', () => {
+  describe('messageContainsAttestationCode', () => {
+    it('should check if a message contains a attestation code', () => {
+      expect(messageContainsAttestationCode(MESSAGE_1)).toBeTruthy()
+      expect(messageContainsAttestationCode(MESSAGE_2)).toBeTruthy()
+      expect(messageContainsAttestationCode(MESSAGE_3)).toBeTruthy()
+      expect(messageContainsAttestationCode(MESSAGE_3_WITH_LINK)).toBeTruthy()
+    })
+
+    it('should fail if a message does not contain a attestation code', () => {
+      expect(messageContainsAttestationCode('asdfasdaf')).toBeFalsy()
+      expect(messageContainsAttestationCode('')).toBeFalsy()
+      expect(messageContainsAttestationCode('Howdy there')).toBeFalsy()
+    })
+  })
+
+  describe('extractAttestationCode', () => {
+    it('should extract the code from a message', () => {
+      expect(extractAttestationCodeFromMessage(MESSAGE_1)).toBe(MESSAGE_1_DECODED)
+      expect(extractAttestationCodeFromMessage(MESSAGE_2)).toBe(MESSAGE_2_DECODED)
+      expect(extractAttestationCodeFromMessage(MESSAGE_3)).toBe(MESSAGE_3_DECODED)
+      expect(extractAttestationCodeFromMessage(MESSAGE_3_WITH_LINK)).toBe(MESSAGE_3_DECODED)
+      expect(extractAttestationCodeFromMessage(MESSAGE_4_UNSANITIZED)).toBe(MESSAGE_4_DECODED)
+    })
+  })
+
+  // TODO Update codes to include deeplink prefix
+  describe('sanitizeBase64', () => {
+    const CODE_1 =
+      'Celo attestation code: NaLrNSYGRQ1JurhgREF1tNF43KDJnO6KaatnD¿hoim1XTq0O0IKNDQuBOF¿Fn5xIAjLQMtWbxbOgrtTBZ1oYAQA='
+    const SANITIZED_CODE_1 =
+      'Celo attestation code: NaLrNSYGRQ1JurhgREF1tNF43KDJnO6KaatnD_hoim1XTq0O0IKNDQuBOF_Fn5xIAjLQMtWbxbOgrtTBZ1oYAQA='
+    const CODE_2 =
+      'Celo attestation code: ZxO§ML8EU5K4a§h0jmjDbbV4a6gNJeBjfN9aa9xG-wsnf8§LYNE052gGuPML9s0Yqc§2YDCfwGgoiviV-IilRwA='
+    const SANITIZED_CODE_2 =
+      'Celo attestation code: ZxO_ML8EU5K4a_h0jmjDbbV4a6gNJeBjfN9aa9xG-wsnf8_LYNE052gGuPML9s0Yqc_2YDCfwGgoiviV-IilRwA='
+    const NORMAL_CODE =
+      'Celo attestation code: T7p-Mn1_L5zJuycAgAxYVqaJDp5r2TORcb775fdVoARbdJ-rNP-LArWCNJzJ6KjuVg0yskkEM8vVtl1PPmOsWwE='
+
+    it('sanitizes correctly', () => {
+      expect(sanitizeMessageBase64(CODE_1)).toBe(SANITIZED_CODE_1)
+      expect(sanitizeMessageBase64(CODE_2)).toBe(SANITIZED_CODE_2)
+      expect(sanitizeMessageBase64(NORMAL_CODE)).toBe(NORMAL_CODE)
+    })
+  })
+})

--- a/packages/sdk/base/src/attestations.ts
+++ b/packages/sdk/base/src/attestations.ts
@@ -1,0 +1,124 @@
+import { getPhoneHash } from './phoneNumbers'
+
+const DEFAULT_NUM_ATTESTATIONS_REQUIRED = 3
+const DEFAULT_ATTESTATION_THRESHOLD = 0.25
+
+// Supported identifer types for attestations
+export enum IdentifierType {
+  PHONE_NUMBER = 0,
+  // In the future, other types like usernames or emails could go here
+}
+
+// Each identifer type has a unique prefix to prevent unlikely but possible collisions
+export function getIdentifierPrefix(type: IdentifierType) {
+  switch (type) {
+    case IdentifierType.PHONE_NUMBER:
+      return 'tel://'
+    default:
+      throw new Error('Unsupported Identifier Type')
+  }
+}
+
+export function hashIdentifier(
+  sha3: (a: string) => string | null,
+  identifier: string,
+  type: IdentifierType,
+  salt?: string
+) {
+  switch (type) {
+    case IdentifierType.PHONE_NUMBER:
+      return getPhoneHash(sha3, identifier, salt)
+    default:
+      throw new Error('Unsupported Identifier Type')
+  }
+}
+
+export function base64ToHex(base64String: string) {
+  return '0x' + Buffer.from(base64String, 'base64').toString('hex')
+}
+
+export function sanitizeMessageBase64(base64String: string) {
+  // Replace occurrences of ¿ with _. Unsure why that is happening right now
+  return base64String.replace(/(¿|§)/gi, '_')
+}
+
+const attestationCodeRegex = new RegExp(
+  /(.* |^)(?:celo:\/\/wallet\/v\/)?([a-zA-Z0-9=\+\/_-]{87,88})($| .*)/
+)
+
+export function messageContainsAttestationCode(message: string) {
+  return attestationCodeRegex.test(message)
+}
+
+export function extractAttestationCodeFromMessage(message: string) {
+  const sanitizedMessage = sanitizeMessageBase64(message)
+
+  if (!messageContainsAttestationCode(sanitizedMessage)) {
+    return null
+  }
+
+  const matches = sanitizedMessage.match(attestationCodeRegex)
+  if (!matches || matches.length < 3) {
+    return null
+  }
+  return base64ToHex(matches[2])
+}
+
+export interface AttestationsStatus {
+  isVerified: boolean
+  numAttestationsRemaining: number
+  total: number
+  completed: number
+}
+
+interface AttestationStat {
+  completed: number
+  total: number
+}
+
+/**
+ * Returns true if an AttestationStat is considered verified using the given factors,
+ * or defaults if factors are ommited.
+ * @param stats AttestationStat of the account's attestation identitifer, retrievable via lookupIdentitfiers
+ * @param numAttestationsRequired Optional number of attestations required.  Will default to
+ *  hardcoded value if absent.
+ * @param attestationThreshold Optional threshold for fraction attestations completed. Will
+ *  default to hardcoded value if absent.
+ */
+export function isAccountConsideredVerified(
+  stats: AttestationStat | undefined,
+  numAttestationsRequired: number = DEFAULT_NUM_ATTESTATIONS_REQUIRED,
+  attestationThreshold: number = DEFAULT_ATTESTATION_THRESHOLD
+): AttestationsStatus {
+  if (!stats) {
+    return {
+      isVerified: false,
+      numAttestationsRemaining: 0,
+      total: 0,
+      completed: 0,
+    }
+  }
+  const numAttestationsRemaining = numAttestationsRequired - stats.completed
+  const fractionAttestation = stats.total < 1 ? 0 : stats.completed / stats.total
+  // 'verified' is a term of convenience to mean that the attestation stats for a
+  // given identifier are beyond a certain threshold of confidence
+  const isVerified = numAttestationsRemaining <= 0 && fractionAttestation >= attestationThreshold
+
+  return {
+    isVerified,
+    numAttestationsRemaining,
+    total: stats.total,
+    completed: stats.completed,
+  }
+}
+
+export const AttestationBase = {
+  IdentifierType,
+  getIdentifierPrefix,
+  hashIdentifier,
+  base64ToHex,
+  sanitizeMessageBase64,
+  messageContainsAttestationCode,
+  extractAttestationCodeFromMessage,
+  isAccountConsideredVerified,
+}

--- a/packages/sdk/base/src/index.ts
+++ b/packages/sdk/base/src/index.ts
@@ -1,6 +1,7 @@
 export * from './account'
 export * from './address'
 export * from './async'
+export * from './attestations'
 export * from './collections'
 export * from './contacts'
 export * from './currencies'

--- a/packages/sdk/base/src/phoneNumbers.test.ts
+++ b/packages/sdk/base/src/phoneNumbers.test.ts
@@ -1,5 +1,5 @@
 import { soliditySha3 } from 'web3-utils'
-import { isE164Number } from './phoneNumbers'
+import { getPhoneHash, isE164Number } from './phoneNumbers'
 const sha3 = (v: string) => soliditySha3({ type: 'string', value: v })
 
 const TEST_PHONE_NUMBERS = {
@@ -30,6 +30,27 @@ const TEST_PHONE_NUMBERS = {
 }
 
 describe('Phone number formatting and utilities', () => {
+  describe('Phone hashing', () => {
+    it('Hashes an valid number without a salt', () => {
+      expect(getPhoneHash(sha3, TEST_PHONE_NUMBERS.VALID_E164, '')).toBe(
+        '0x483128504c69591aed5751690805ba9aad6c390644421dc189f6dbb6e085aadf'
+      )
+    })
+    it('Hashes an valid number with a salt', () => {
+      expect(getPhoneHash(sha3, TEST_PHONE_NUMBERS.VALID_E164, 'abcdefg')).toBe(
+        '0xf08257f6b126597dbd090fecf4f5106cfb59c98ef997644cef16f9349464810c'
+      )
+    })
+    it('Throws for an invalid number', () => {
+      try {
+        getPhoneHash(sha3, TEST_PHONE_NUMBERS.VALID_US_1, '')
+        fail('expected an error')
+      } catch (error) {
+        // Error expected
+      }
+    })
+  })
+
   describe('Other phone helper methods', () => {
     it('checks if number is e164', () => {
       // @ts-ignore

--- a/packages/sdk/base/src/phoneNumbers.ts
+++ b/packages/sdk/base/src/phoneNumbers.ts
@@ -1,3 +1,5 @@
+import { getIdentifierPrefix, IdentifierType } from './attestations'
+
 export interface ParsedPhoneNumber {
   e164Number: string
   displayNumber: string
@@ -6,7 +8,21 @@ export interface ParsedPhoneNumber {
   regionCode?: string
 }
 
+const PHONE_SALT_SEPARATOR = '__'
 const E164_REGEX = /^\+[1-9][0-9]{1,14}$/
+
+export const getPhoneHash = (
+  sha3: (a: string) => string | null,
+  phoneNumber: string,
+  salt?: string
+): string => {
+  if (!phoneNumber || !isE164Number(phoneNumber)) {
+    throw Error('Attempting to hash a non-e164 number: ' + phoneNumber)
+  }
+  const prefix = getIdentifierPrefix(IdentifierType.PHONE_NUMBER)
+  const value = prefix + (salt ? phoneNumber + PHONE_SALT_SEPARATOR + salt : phoneNumber)
+  return sha3(value) as string
+}
 
 export function isE164Number(phoneNumber: string) {
   return E164_REGEX.test(phoneNumber)
@@ -17,5 +33,6 @@ export function anonymizedPhone(phoneNumber: string) {
 }
 
 export const PhoneNumberBase = {
+  getPhoneHash,
   isE164Number,
 }

--- a/packages/sdk/phone-utils/package.json
+++ b/packages/sdk/phone-utils/package.json
@@ -23,7 +23,6 @@
   ],
   "dependencies": {
     "@celo/base": "3.2.1-dev",
-    "@celo/identity": "3.2.1-dev",
     "@celo/utils": "3.2.1-dev",
     "@types/country-data": "^0.0.0",
     "@types/ethereumjs-util": "^5.2.0",

--- a/packages/sdk/phone-utils/src/getPhoneHash.ts
+++ b/packages/sdk/phone-utils/src/getPhoneHash.ts
@@ -1,0 +1,9 @@
+import { getPhoneHash as baseGetPhoneHash } from '@celo/base/lib/phoneNumbers'
+import { soliditySha3 } from 'web3-utils'
+
+const sha3 = (v: string): string | null => soliditySha3({ type: 'string', value: v })
+const getPhoneHash = (phoneNumber: string, salt?: string): string => {
+  return baseGetPhoneHash(sha3, phoneNumber, salt)
+}
+
+export default getPhoneHash

--- a/packages/sdk/phone-utils/src/index.ts
+++ b/packages/sdk/phone-utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './countries'
 export { Countries, LocalizedCountry } from './countries'
 export * from './getCountryEmoji'
+export * from './getPhoneHash'
 export * from './inputValidation'
 export * from './io'
 export {

--- a/packages/sdk/phone-utils/src/phoneNumbers.ts
+++ b/packages/sdk/phone-utils/src/phoneNumbers.ts
@@ -1,12 +1,11 @@
 import { isE164Number, ParsedPhoneNumber } from '@celo/base/lib/phoneNumbers'
-import { OdisUtils } from '@celo/identity'
-import { IdentifierPrefix } from '@celo/identity/lib/odis/identifier'
 import {
   PhoneNumber,
   PhoneNumberFormat,
   PhoneNumberType,
   PhoneNumberUtil,
 } from 'google-libphonenumber'
+import getPhoneHash from './getPhoneHash'
 
 const phoneUtil = PhoneNumberUtil.getInstance()
 const MIN_PHONE_LENGTH = 4
@@ -237,13 +236,6 @@ export function getExampleNumber(
 
   return formatedExample
 }
-
-const getPhoneHash = (phoneNumber: string, salt?: string) =>
-  OdisUtils.Identifier.getIdentifierHash(
-    phoneNumber,
-    IdentifierPrefix.PHONE_NUMBER,
-    salt ? salt : ''
-  )
 
 export const PhoneNumberUtils = {
   getPhoneHash,


### PR DESCRIPTION
### Description

Revert the changes to the `base` and `phone-utils` SDKs to fix CI for #10146. The issue is that moving identifier hashing logic out of `base` (into `identity`) and then having `phone-utils` depend on `identity` is that this creates a tricky circular dependency between a bunch of different packages that is non-trivial to remove.

Also fixes a bug in the new version of `getVerificationCodeSignature` (not using the correct issuer address when generating signatures, causing CI attestations test failures)

Instead, I plan to:
- get the PR merged without the SDK changes
- keep identifier hashing in `base` and have `phone-utils` & `identity` depend on that, which generalizes SDK code but without breaking a lot of old things/introducing a bunch of circular deps (this will be in a separate PR to simplify things)