### PR TITLE
Updating prefix off-chain identifier list

### DIFF
--- a/packages/sdk/identity/src/odis/identifier.ts
+++ b/packages/sdk/identity/src/odis/identifier.ts
@@ -3,7 +3,7 @@ import {
   CombinerEndpointPNP,
   KEY_VERSION_HEADER,
   SignMessageRequest,
-  SignMessageResponseSchema,
+  SignMessageResponseSchema
 } from '@celo/phone-number-privacy-common'
 import { soliditySha3 } from '@celo/utils/lib/solidity'
 import { createHash } from 'crypto'
@@ -15,7 +15,7 @@ import {
   EncryptionKeySigner,
   getOdisPnpRequestAuth,
   queryOdis,
-  ServiceContext,
+  ServiceContext
 } from './query'
 
 const debug = debugFactory('kit:odis:identifier')
@@ -51,6 +51,7 @@ export enum IdentifierPrefix {
   DISCORD = 'discord',
   TELEGRAM = 'telegram',
   SIGNAL = 'signal',
+  GITHUB = 'github'
 }
 
 /**

--- a/packages/sdk/identity/src/odis/identifier.ts
+++ b/packages/sdk/identity/src/odis/identifier.ts
@@ -45,7 +45,7 @@ export enum IdentifierPrefix {
   NULL = '',
   PHONE_NUMBER = 'tel',
   EMAIL = 'mailto',
-  TWITTER = 'twit',
+  TWITTER = 'twitter',
   FACEBOOK = 'facebook',
   INSTAGRAM = 'instagram',
   DISCORD = 'discord',


### PR DESCRIPTION
### Description

- Adding GitHub prefix off-chain identifier.
- Proposing change of Twitter identifier, from `twit` to `twitter` to follow social media pattern.

### Other changes

None.

### Tested

None.

### Related issues

None.

### Backwards compatibility

Yes.

### Documentation

None.