### PR TITLE
blockchainparams: remove minimum client version

### DIFF
--- a/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
+++ b/packages/celotool/src/e2e-tests/blockchain_parameters_tests.ts
@@ -64,10 +64,6 @@ describe('Blockchain parameters tests', function (this: any) {
     parameters = await kit.contracts.getBlockchainParameters()
   }
 
-  const setMinimumClientVersion = async (major: number, minor: number, patch: number) => {
-    await parameters.setMinimumClientVersion(major, minor, patch).send({ from: validatorAddress })
-  }
-
   describe('when running a node', () => {
     before(async () => {
       await restartGeth()
@@ -83,20 +79,6 @@ describe('Blockchain parameters tests', function (this: any) {
       await sleep(2)
       const res = await parameters.getBlockGasLimit()
       assert.equal(0, res.comparedTo(23000000))
-    })
-    it('should exit when minimum version is updated', async () => {
-      this.timeout(0)
-      await setMinimumClientVersion(1, 9, 99)
-      // The client checks every 60 seconds and then waits 10 seconds before quitting, so we
-      // may have to wait a little over 70 seconds
-      await sleep(75, true)
-      try {
-        // It should have exited by now, call RPC to trigger error
-        await kit.connection.getBlockNumber()
-      } catch (_) {
-        return
-      }
-      throw new Error('expected failure')
     })
   })
 })

--- a/packages/docs/sdk/docs/connect/classes/_connection_.connection.md
+++ b/packages/docs/sdk/docs/connect/classes/_connection_.connection.md
@@ -318,7 +318,7 @@ ___
 
 *Defined in [connection.ts:327](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/connect/src/connection.ts#L327)*
 
-**`deprecated`** no longer needed since gasPrice is available on minimumClientVersion node rpc
+**`deprecated`** no longer needed since gasPrice is available on node rpc
 
 **Parameters:**
 
@@ -656,7 +656,7 @@ ___
 
 *Defined in [connection.ts:337](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/connect/src/connection.ts#L337)*
 
-**`deprecated`** no longer needed since gasPrice is available on minimumClientVersion node rpc
+**`deprecated`** no longer needed since gasPrice is available on node rpc
 
 **Parameters:**
 

--- a/packages/docs/sdk/docs/contractkit/classes/_kit_.contractkit.md
+++ b/packages/docs/sdk/docs/contractkit/classes/_kit_.contractkit.md
@@ -112,7 +112,7 @@ ___
 
 *Defined in [packages/sdk/contractkit/src/kit.ts:113](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L113)*
 
-**`deprecated`** no longer needed since gasPrice is available on minimumClientVersion node rpc
+**`deprecated`** no longer needed since gasPrice is available on node rpc
 
 ___
 
@@ -246,7 +246,7 @@ ___
 
 *Defined in [packages/sdk/contractkit/src/kit.ts:285](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L285)*
 
-**`deprecated`** no longer needed since gasPrice is available on minimumClientVersion node rpc
+**`deprecated`** no longer needed since gasPrice is available on node rpc
 
 **Parameters:**
 
@@ -472,7 +472,7 @@ ___
 
 *Defined in [packages/sdk/contractkit/src/kit.ts:210](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/kit.ts#L210)*
 
-**`deprecated`** no longer needed since gasPrice is available on minimumClientVersion node rpc
+**`deprecated`** no longer needed since gasPrice is available on node rpc
 
 **Parameters:**
 

--- a/packages/docs/sdk/docs/contractkit/classes/_wrappers_blockchainparameters_.blockchainparameterswrapper.md
+++ b/packages/docs/sdk/docs/contractkit/classes/_wrappers_blockchainparameters_.blockchainparameterswrapper.md
@@ -28,7 +28,6 @@ Network parameters that are configurable by governance.
 * [methodIds](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#methodids)
 * [setBlockGasLimit](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#setblockgaslimit)
 * [setIntrinsicGasForAlternativeFeeCurrency](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#setintrinsicgasforalternativefeecurrency)
-* [setMinimumClientVersion](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#setminimumclientversion)
 * [setUptimeLookbackWindow](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#setuptimelookbackwindow)
 
 ### Accessors
@@ -42,7 +41,6 @@ Network parameters that are configurable by governance.
 * [getEpochSizeNumber](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#getepochsizenumber)
 * [getFirstBlockNumberForEpoch](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#getfirstblocknumberforepoch)
 * [getLastBlockNumberForEpoch](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#getlastblocknumberforepoch)
-* [getMinimumClientVersion](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#getminimumclientversion)
 * [getPastEvents](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#getpastevents)
 * [version](_wrappers_blockchainparameters_.blockchainparameterswrapper.md#version)
 
@@ -259,28 +257,6 @@ Name | Type |
 
 ___
 
-###  setMinimumClientVersion
-
-• **setMinimumClientVersion**: *function* = proxySend(
-    this.connection,
-    this.contract.methods.setMinimumClientVersion
-  )
-
-*Defined in [packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:63](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L63)*
-
-Set minimum client version.
-
-#### Type declaration:
-
-▸ (...`args`: InputArgs): *CeloTransactionObject‹Output›*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`...args` | InputArgs |
-
-___
 
 ###  setUptimeLookbackWindow
 
@@ -387,19 +363,6 @@ Name | Type |
 
 **Returns:** *Promise‹number›*
 
-___
-
-###  getMinimumClientVersion
-
-▸ **getMinimumClientVersion**(): *Promise‹[ClientVersion](../interfaces/_wrappers_blockchainparameters_.clientversion.md)›*
-
-*Defined in [packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:51](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L51)*
-
-Get minimum client version.
-
-**Returns:** *Promise‹[ClientVersion](../interfaces/_wrappers_blockchainparameters_.clientversion.md)›*
-
-___
 
 ###  getPastEvents
 

--- a/packages/docs/sdk/docs/contractkit/interfaces/_wrappers_blockchainparameters_.blockchainparametersconfig.md
+++ b/packages/docs/sdk/docs/contractkit/interfaces/_wrappers_blockchainparameters_.blockchainparametersconfig.md
@@ -12,8 +12,6 @@
 
 * [blockGasLimit](_wrappers_blockchainparameters_.blockchainparametersconfig.md#blockgaslimit)
 * [intrinsicGasForAlternativeFeeCurrency](_wrappers_blockchainparameters_.blockchainparametersconfig.md#intrinsicgasforalternativefeecurrency)
-* [minimumClientVersion](_wrappers_blockchainparameters_.blockchainparametersconfig.md#minimumclientversion)
-
 ## Properties
 
 ###  blockGasLimit
@@ -29,11 +27,3 @@ ___
 • **intrinsicGasForAlternativeFeeCurrency**: *BigNumber*
 
 *Defined in [packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:14](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L14)*
-
-___
-
-###  minimumClientVersion
-
-• **minimumClientVersion**: *[ClientVersion](_wrappers_blockchainparameters_.clientversion.md)*
-
-*Defined in [packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:13](https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L13)*

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -31,7 +31,6 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   uint256 public intrinsicGasForAlternativeFeeCurrency;
   LookbackWindow public uptimeLookbackWindow;
 
-  event MinimumClientVersionSet(uint256 major, uint256 minor, uint256 patch);
   event IntrinsicGasForAlternativeFeeCurrencySet(uint256 gas);
   event BlockGasLimitSet(uint256 limit);
   event UptimeLookbackWindowSet(uint256 window, uint256 activationEpoch);
@@ -60,7 +59,6 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
     uint256 lookbackWindow
   ) external initializer {
     _transferOwnership(msg.sender);
-    setMinimumClientVersion(major, minor, patch);
     setBlockGasLimit(gasLimit);
     setIntrinsicGasForAlternativeFeeCurrency(_gasForNonGoldCurrencies);
     setUptimeLookbackWindow(lookbackWindow);
@@ -75,21 +73,6 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
     return (1, 2, 0, 0);
-  }
-
-  /**
-   * @notice Sets the minimum client version.
-   * @param major Major version.
-   * @param minor Minor version.
-   * @param patch Patch version.
-   * @dev For example if the version is 1.9.2, 1 is the major version, 9 is minor,
-   * and 2 is the patch level.
-   */
-  function setMinimumClientVersion(uint256 major, uint256 minor, uint256 patch) public onlyOwner {
-    minimumClientVersion.major = major;
-    minimumClientVersion.minor = minor;
-    minimumClientVersion.patch = patch;
-    emit MinimumClientVersionSet(major, minor, patch);
   }
 
   /**
@@ -147,20 +130,6 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
     } else {
       return uptimeLookbackWindow.oldValue;
     }
-  }
-
-  /**
-   * @notice Query minimum client version.   
-   * @return Major version number.
-   * @return Minor version number.
-   * @return Patch version number.
-   */
-  function getMinimumClientVersion()
-    external
-    view
-    returns (uint256 major, uint256 minor, uint256 patch)
-  {
-    return (minimumClientVersion.major, minimumClientVersion.minor, minimumClientVersion.patch);
   }
 
 }

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -66,7 +66,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 2, 0, 0);
+    return (1, 3, 0, 0);
   }
 
   /**

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -11,12 +11,6 @@ import "../common/UsingPrecompiles.sol";
 contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   using SafeMath for uint256;
 
-  struct ClientVersion {
-    uint256 major;
-    uint256 minor;
-    uint256 patch;
-  }
-
   struct LookbackWindow {
     // Value for lookbackWindow before `nextValueActivationBlock`
     uint256 oldValue;
@@ -26,7 +20,6 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
     uint256 nextValueActivationEpoch;
   }
 
-  ClientVersion private minimumClientVersion;
   uint256 public blockGasLimit;
   uint256 public intrinsicGasForAlternativeFeeCurrency;
   LookbackWindow public uptimeLookbackWindow;
@@ -43,21 +36,14 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.
-   * @param major Minimum client version that can be used in the chain, major version.
-   * @param minor Minimum client version that can be used in the chain, minor version.
-   * @param patch Minimum client version that can be used in the chain, patch level.
    * @param _gasForNonGoldCurrencies Intrinsic gas for non-gold gas currencies.
    * @param gasLimit Block gas limit.
    * @param lookbackWindow Lookback window for measuring validator uptime.
    */
-  function initialize(
-    uint256 major,
-    uint256 minor,
-    uint256 patch,
-    uint256 _gasForNonGoldCurrencies,
-    uint256 gasLimit,
-    uint256 lookbackWindow
-  ) external initializer {
+  function initialize(uint256 _gasForNonGoldCurrencies, uint256 gasLimit, uint256 lookbackWindow)
+    external
+    initializer
+  {
     _transferOwnership(msg.sender);
     setBlockGasLimit(gasLimit);
     setIntrinsicGasForAlternativeFeeCurrency(_gasForNonGoldCurrencies);
@@ -72,7 +58,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 2, 0, 0);
+    return (2, 2, 0, 0);
   }
 
   /**

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -11,6 +11,13 @@ import "../common/UsingPrecompiles.sol";
 contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   using SafeMath for uint256;
 
+  // obsolete
+  struct ClientVersion {
+    uint256 major;
+    uint256 minor;
+    uint256 patch;
+  }
+
   struct LookbackWindow {
     // Value for lookbackWindow before `nextValueActivationBlock`
     uint256 oldValue;
@@ -20,6 +27,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
     uint256 nextValueActivationEpoch;
   }
 
+  ClientVersion private minimumClientVersion; // obsolete
   uint256 public blockGasLimit;
   uint256 public intrinsicGasForAlternativeFeeCurrency;
   LookbackWindow public uptimeLookbackWindow;
@@ -58,7 +66,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (2, 2, 0, 0);
+    return (1, 2, 0, 0);
   }
 
   /**

--- a/packages/protocol/governanceConstitution.js
+++ b/packages/protocol/governanceConstitution.js
@@ -17,7 +17,6 @@ const DefaultConstitution = {
   },
   BlockchainParameters: {
     default: 0.9,
-    setMinimumClientVersion: 0.9,
     setBlockGasLimit: 0.8,
     setIntrinsicGasForAlternativeFeeCurrency: 0.8,
   },

--- a/packages/protocol/migrations/19_blockchainparams.ts
+++ b/packages/protocol/migrations/19_blockchainparams.ts
@@ -4,11 +4,7 @@ import { config } from '@celo/protocol/migrationsConfig'
 import { BlockchainParametersInstance } from 'types'
 
 const initializeArgs = async (_: string): Promise<any[]> => {
-  const version = config.blockchainParameters.minimumClientVersion
   return [
-    version.major,
-    version.minor,
-    version.patch,
     config.blockchainParameters.gasForNonGoldCurrencies,
     config.blockchainParameters.deploymentBlockGasLimit,
     config.blockchainParameters.uptimeLookbackWindow,

--- a/packages/protocol/migrationsConfig.js
+++ b/packages/protocol/migrationsConfig.js
@@ -35,11 +35,6 @@ const DefaultConfig = {
   },
   blockchainParameters: {
     gasForNonGoldCurrencies: 50000,
-    minimumClientVersion: {
-      major: 1,
-      minor: 0,
-      patch: 0,
-    },
     deploymentBlockGasLimit: 20000000,
     blockGasLimit: 13000000,
     uptimeLookbackWindow: 12,

--- a/packages/protocol/test/governance/network/blockchainparams.ts
+++ b/packages/protocol/test/governance/network/blockchainparams.ts
@@ -20,11 +20,6 @@ const EPOCH = 100
 
 contract('BlockchainParameters', (accounts: string[]) => {
   let blockchainParameters: BlockchainParametersInstance
-  const version = {
-    major: 1,
-    minor: 8,
-    patch: 2,
-  }
   const gasLimit = 7000000
   const gasForNonGoldCurrencies = 50000
 
@@ -150,14 +145,7 @@ contract('BlockchainParameters', (accounts: string[]) => {
     const lookbackWindow = 20
 
     it('should set the variables', async () => {
-      await blockchainParameters.initialize(
-        version.major,
-        version.minor,
-        version.patch,
-        gasForNonGoldCurrencies,
-        gasLimit,
-        lookbackWindow
-      )
+      await blockchainParameters.initialize(gasForNonGoldCurrencies, gasLimit, lookbackWindow)
       assert.equal((await blockchainParameters.blockGasLimit()).toNumber(), gasLimit)
 
       // need to wait an epoch for uptimeLookbackWindow
@@ -169,14 +157,11 @@ contract('BlockchainParameters', (accounts: string[]) => {
     })
     it('should emit correct events', async () => {
       const resp = await blockchainParameters.initialize(
-        version.major,
-        version.minor,
-        version.patch,
         gasForNonGoldCurrencies,
         gasLimit,
         lookbackWindow
       )
-      assert.equal(resp.logs.length, 5)
+      assert.equal(resp.logs.length, 4)
       assertContainSubset(resp.logs[2], {
         event: 'IntrinsicGasForAlternativeFeeCurrencySet',
         args: {

--- a/packages/protocol/test/governance/network/blockchainparams.ts
+++ b/packages/protocol/test/governance/network/blockchainparams.ts
@@ -32,44 +32,6 @@ contract('BlockchainParameters', (accounts: string[]) => {
     blockchainParameters = await BlockchainParameters.new()
   })
 
-  describe('#setMinimumClientVersion()', () => {
-    it('should set the variable', async () => {
-      await blockchainParameters.setMinimumClientVersion(
-        version.major,
-        version.minor,
-        version.patch
-      )
-      const versionQueried = await blockchainParameters.getMinimumClientVersion()
-      assert.equal(version.major, versionQueried[0].toNumber())
-      assert.equal(version.minor, versionQueried[1].toNumber())
-      assert.equal(version.patch, versionQueried[2].toNumber())
-    })
-    it('should emit the MinimumClientVersionSet event', async () => {
-      const resp = await blockchainParameters.setMinimumClientVersion(
-        version.major,
-        version.minor,
-        version.patch
-      )
-      assert.equal(resp.logs.length, 1)
-      const log = resp.logs[0]
-      assertContainSubset(log, {
-        event: 'MinimumClientVersionSet',
-        args: {
-          major: new BigNumber(version.major),
-          minor: new BigNumber(version.minor),
-          patch: new BigNumber(version.patch),
-        },
-      })
-    })
-    it('only owner should be able to set', async () => {
-      await assertRevert(
-        blockchainParameters.setMinimumClientVersion(version.major, version.minor, version.patch, {
-          from: accounts[1],
-        })
-      )
-    })
-  })
-
   describe('#setBlockGasLimit()', () => {
     it('should set the variable', async () => {
       await blockchainParameters.setBlockGasLimit(gasLimit)
@@ -196,10 +158,6 @@ contract('BlockchainParameters', (accounts: string[]) => {
         gasLimit,
         lookbackWindow
       )
-      const versionQueried = await blockchainParameters.getMinimumClientVersion()
-      assert.equal(version.major, versionQueried[0].toNumber())
-      assert.equal(version.minor, versionQueried[1].toNumber())
-      assert.equal(version.patch, versionQueried[2].toNumber())
       assert.equal((await blockchainParameters.blockGasLimit()).toNumber(), gasLimit)
 
       // need to wait an epoch for uptimeLookbackWindow
@@ -219,21 +177,13 @@ contract('BlockchainParameters', (accounts: string[]) => {
         lookbackWindow
       )
       assert.equal(resp.logs.length, 5)
-      assertContainSubset(resp.logs[1], {
-        event: 'MinimumClientVersionSet',
-        args: {
-          major: new BigNumber(version.major),
-          minor: new BigNumber(version.minor),
-          patch: new BigNumber(version.patch),
-        },
-      })
-      assertContainSubset(resp.logs[3], {
+      assertContainSubset(resp.logs[2], {
         event: 'IntrinsicGasForAlternativeFeeCurrencySet',
         args: {
           gas: new BigNumber(gasForNonGoldCurrencies),
         },
       })
-      assertContainSubset(resp.logs[2], {
+      assertContainSubset(resp.logs[1], {
         event: 'BlockGasLimitSet',
         args: {
           limit: new BigNumber(gasLimit),
@@ -246,7 +196,7 @@ contract('BlockchainParameters', (accounts: string[]) => {
           newOwner: accounts[0],
         },
       })
-      assertContainSubset(resp.logs[4], {
+      assertContainSubset(resp.logs[3], {
         event: 'UptimeLookbackWindowSet',
         args: {
           window: new BigNumber(lookbackWindow),

--- a/packages/sdk/connect/src/connection.ts
+++ b/packages/sdk/connect/src/connection.ts
@@ -57,7 +57,7 @@ export class Connection {
   readonly paramsPopulator: TxParamsNormalizer
   rpcCaller!: RpcCaller
 
-  /** @deprecated no longer needed since gasPrice is available on minimumClientVersion node rpc */
+  /** @deprecated no longer needed since gasPrice is available on node rpc */
   private currencyGasPrice: Map<Address, string> = new Map<Address, string>()
 
   constructor(readonly web3: Web3, public wallet?: ReadOnlyWallet, handleRevert = true) {
@@ -341,7 +341,7 @@ export class Connection {
     return toTxResult(this.web3.eth.sendSignedTransaction(signedTransactionData))
   }
 
-  /** @deprecated no longer needed since gasPrice is available on minimumClientVersion node rpc */
+  /** @deprecated no longer needed since gasPrice is available on node rpc */
   fillGasPrice(tx: CeloTx): CeloTx {
     if (tx.feeCurrency && tx.gasPrice === '0' && this.currencyGasPrice.has(tx.feeCurrency)) {
       return {
@@ -351,7 +351,7 @@ export class Connection {
     }
     return tx
   }
-  /** @deprecated no longer needed since gasPrice is available on minimumClientVersion node rpc */
+  /** @deprecated no longer needed since gasPrice is available on node rpc */
   async setGasPriceForCurrency(address: Address, gasPrice: string) {
     this.currencyGasPrice.set(address, gasPrice)
   }

--- a/packages/sdk/contractkit/src/kit.ts
+++ b/packages/sdk/contractkit/src/kit.ts
@@ -109,7 +109,7 @@ export class ContractKit {
   /** helper for interacting with CELO & stable tokens */
   readonly celoTokens: CeloTokens
 
-  /** @deprecated no longer needed since gasPrice is available on minimumClientVersion node rpc */
+  /** @deprecated no longer needed since gasPrice is available on node rpc */
   gasPriceSuggestionMultiplier = 5
 
   constructor(readonly connection: Connection) {
@@ -206,7 +206,7 @@ export class ContractKit {
     this.connection.defaultFeeCurrency = address
   }
 
-  /** @deprecated no longer needed since gasPrice is available on minimumClientVersion node rpc */
+  /** @deprecated no longer needed since gasPrice is available on node rpc */
   async updateGasPriceInConnectionLayer(currency: Address) {
     const gasPriceMinimum = await this.contracts.getGasPriceMinimum()
     const rawGasPrice = await gasPriceMinimum.getGasPriceMinimum(currency)
@@ -281,7 +281,7 @@ export class ContractKit {
   isSyncing(): Promise<boolean> {
     return this.connection.isSyncing()
   }
-  /** @deprecated no longer needed since gasPrice is available on minimumClientVersion node rpc */
+  /** @deprecated no longer needed since gasPrice is available on node rpc */
   async fillGasPrice(tx: CeloTx): Promise<CeloTx> {
     if (tx.feeCurrency && tx.gasPrice === '0') {
       await this.updateGasPriceInConnectionLayer(tx.feeCurrency)

--- a/packages/sdk/contractkit/src/wrappers/BlockChainParameters.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/BlockChainParameters.test.ts
@@ -52,7 +52,6 @@ testWithGanache('BlockChainParametersWrapper', (web3) => {
       const config = await blockchainParamsWrapper.getConfig()
       expect(config.blockGasLimit).toEqual(new BigNumber('20000000'))
       expect(config.intrinsicGasForAlternativeFeeCurrency).toEqual(new BigNumber('50000'))
-      expect(config.minimumClientVersion).toEqual({ major: 1, minor: 0, patch: 0 })
     })
   })
 

--- a/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts
+++ b/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts
@@ -2,15 +2,8 @@ import { BigNumber } from 'bignumber.js'
 import { BlockchainParameters } from '../generated/BlockchainParameters'
 import { BaseWrapper, proxyCall, proxySend, valueToBigNumber, valueToInt } from './BaseWrapper'
 
-export interface ClientVersion {
-  major: number
-  minor: number
-  patch: number
-}
-
 export interface BlockchainParametersConfig {
   blockGasLimit: BigNumber
-  minimumClientVersion: ClientVersion
   intrinsicGasForAlternativeFeeCurrency: BigNumber
 }
 
@@ -46,32 +39,11 @@ export class BlockchainParametersWrapper extends BaseWrapper<BlockchainParameter
   setBlockGasLimit = proxySend(this.connection, this.contract.methods.setBlockGasLimit)
 
   /**
-   * Get minimum client version.
-   */
-  async getMinimumClientVersion(): Promise<ClientVersion> {
-    const v = await this.contract.methods.getMinimumClientVersion().call()
-    return {
-      major: valueToInt(v.major),
-      minor: valueToInt(v.minor),
-      patch: valueToInt(v.patch),
-    }
-  }
-
-  /**
-   * Set minimum client version.
-   */
-  setMinimumClientVersion = proxySend(
-    this.connection,
-    this.contract.methods.setMinimumClientVersion
-  )
-
-  /**
    * Returns current configuration parameters.
    */
   async getConfig(): Promise<BlockchainParametersConfig> {
     return {
       blockGasLimit: await this.getBlockGasLimit(),
-      minimumClientVersion: await this.getMinimumClientVersion(),
       intrinsicGasForAlternativeFeeCurrency: await this.getIntrinsicGasForAlternativeFeeCurrency(),
     }
   }


### PR DESCRIPTION
### Description

This is the code change for [CIP-53](https://github.com/celo-org/celo-proposals/pull/318), which removes the unused mechanism of minimum client versions.

The corresponding change on the client is https://github.com/celo-org/celo-blockchain/pull/2026.

### Backwards compatibility

Not requiring the client to shut down is less strict, so the change is backwards compatible in that regard. The BlockchainParams contract has to be initialized with less parameters, so code deploying that contract has to be updated.

The contract state does not contain the minimum client version anymore. Are there any migration steps I should include in this PR to handle the storage change?

### Documentation

- [ ] Update https://docs.celo.org/community/release-process/blockchain-client
- [ ] Update https://docs.celo.org/protocol/governance
- [ ] Update https://docs.celo.org/validator/node-upgrade