### PR TITLE
Add unit test cases for vote revocation when validators are ineligible

### DIFF
--- a/packages/sdk/contractkit/src/wrappers/Election.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Election.test.ts
@@ -176,6 +176,7 @@ testWithGanache('Election Wrapper', (web3) => {
       })
 
       test('active votes remain unchanged when group becomes ineligible', async () => {
+        await validators.deaffiliate().sendAndWaitForReceipt({ from: validatorAccount })
         const activeVotes = await election.getActiveVotesForGroup(groupAccount)
         expect(activeVotes).toEqual(ONE_HUNDRED_GOLD)
       })


### PR DESCRIPTION
### Description

We saw a bug in kliento when trying to revoke votes from an ineligible validator. While trying to debug that and understand what was going on in `Elections.sol`, I couldn't find unit test cases for that specific case so went ahead and added them. (More than anything, I think it'll be useful documentation of how to call the revoke functions in that edge case (`lesser` and `greater` are not used and don't matter in that case), and make it easier to understand what's going on).

### Tested

- Just adds tests.
