### PR TITLE
Set values for rc1staging webhooks.

### DIFF
--- a/packages/helm-charts/blockscout/Chart.yaml
+++ b/packages/helm-charts/blockscout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: blockscout
 version: 0.0.2
-description: Chart which is used to deploy a blockscout setup for a celo testnet
+description: Chart which is used to deploy a blockscout setup for a celo testnet 
 keywords:
 - ethereum
 - blockchain

--- a/packages/helm-charts/blockscout/templates/blockscout-event-stream.deployment.yaml
+++ b/packages/helm-charts/blockscout/templates/blockscout-event-stream.deployment.yaml
@@ -86,12 +86,14 @@ spec:
         env:
         - name: METRICS_ENABLED
           value: "{{.Values.blockscout.metrics.enabled}}"
-        - name: ENABLE_EVENT_STREAM
+        - name: ENABLE_BEANSTALKD
           value: {{ .Values.blockscout.eventStream.enableEventStream | quote }}
         - name: BEANSTALKD_PORT
           value: {{ .Values.blockscout.eventStream.beanstalkdPort | quote }}
         - name: BEANSTALKD_HOST
           value: {{ .Values.blockscout.eventStream.beanstalkdHost | quote }}
+        - name: BEANSTALKD_TUBE
+          value: {{ .Values.blockscout.eventStream.beanstalkdTube | quote }}
         - name: ERLANG_COOKIE
           value: {{ .Values.blockscout.secrets.erlang.cookie }}
         - name: POD_IP

--- a/packages/helm-charts/blockscout/values-rc1staging-blockscout.yaml
+++ b/packages/helm-charts/blockscout/values-rc1staging-blockscout.yaml
@@ -1,6 +1,10 @@
 blockscout:
   eventStream:
     replicas: 1
+    enableEventStream: true
+    beanstalkdPort: "11300"
+    beanstalkdHost: "rc1staging-webhooks-beanstalkd.webhooks.svc.cluster.local"
+    beanstalkdTube: "incoming"
   indexer:
     db:
       connectionName: celo-testnet-production:us-west1:rc1staging
@@ -14,9 +18,6 @@ blockscout:
       requests:
         memory: 12Gi
         cpu: 5
-    enableEventStream: true
-    beanstalkdPort: "11300"
-    beanstalkdHost: "rc1staging-governance-notifications-beanstalkd.event-notifications.svc.cluster.local"
   api:
     autoscaling:
       maxReplicas: 2

--- a/packages/helm-charts/blockscout/values.yaml
+++ b/packages/helm-charts/blockscout/values.yaml
@@ -13,6 +13,7 @@ blockscout:
     enableEventStream: false
     beanstalkdPort: ""
     beanstalkdHost: ""
+    beanstalkdTube: ""
     replicas: 0
     readinessProbe:
       enabled: false


### PR DESCRIPTION
### Description

Sets some environment vars for rc1staging blockscout to allow connection to the beanstalkd queue.

### Tested

Deployed to rc1staging and asserted values are passed to app 

### Related issues

- relates to https://github.com/celo-org/data-services/issues/653

> Note: the k8s service is misconfigured and connection isn't possible yet, this requires a change in the webhooks repo