### PR TITLE
Made cli consider constitution parameters when showing the required votes for a proposal

### DIFF
--- a/packages/cli/src/commands/governance/show.ts
+++ b/packages/cli/src/commands/governance/show.ts
@@ -128,7 +128,7 @@ export default class Show extends BaseCommand {
         schedule,
       })
 
-      if (Object.keys(requirements).length != 0) {
+      if (Object.keys(requirements).length !== 0) {
         console.log(
           'Note: required is the minimal amount of yes + abstain votes needed to pass the proposal'
         )

--- a/packages/cli/src/commands/governance/show.ts
+++ b/packages/cli/src/commands/governance/show.ts
@@ -115,7 +115,10 @@ export default class Show extends BaseCommand {
       if (record.stage === 'Referendum' || record.stage === 'Execution') {
         // Identify the transaction with the highest constitutional requirement.
         const constitutionThreshold = await governance.getConstitution(proposal)
-        const support = await governance.getSupportWithConstitution(id, constitutionThreshold)
+        const support = await governance.getSupportWithConstitutionThreshold(
+          id,
+          constitutionThreshold
+        )
         requirements = {
           constitutionThreshold,
           ...support,

--- a/packages/cli/src/commands/governance/show.ts
+++ b/packages/cli/src/commands/governance/show.ts
@@ -115,7 +115,7 @@ export default class Show extends BaseCommand {
       if (record.stage === 'Referendum' || record.stage === 'Execution') {
         // Identify the transaction with the highest constitutional requirement.
         const constitutionThreshold = await governance.getConstitution(proposal)
-        const support = await governance.getSupportWithConstution(id, constitutionThreshold)
+        const support = await governance.getSupportWithConstitution(id, constitutionThreshold)
         requirements = {
           constitutionThreshold,
           ...support,

--- a/packages/cli/src/commands/governance/show.ts
+++ b/packages/cli/src/commands/governance/show.ts
@@ -126,8 +126,16 @@ export default class Show extends BaseCommand {
       printValueMapRecursive({
         ...record,
         schedule,
-        requirements,
       })
+
+      if (Object.keys(requirements).length != 0) {
+        console.log(
+          'Note: required is the minimal amount of yes + abstain votes needed to pass the proposal'
+        )
+        printValueMapRecursive({
+          requirements,
+        })
+      }
     } else if (hotfix) {
       const hotfixBuf = toBuffer(hotfix) as Buffer
       const record = await governance.getHotfixRecord(hotfixBuf)

--- a/packages/cli/src/commands/governance/show.ts
+++ b/packages/cli/src/commands/governance/show.ts
@@ -88,6 +88,7 @@ export default class Show extends BaseCommand {
 
       const record = await governance.getProposalRecord(id)
       const proposal = record.proposal
+
       if (!raw) {
         const builder = new ProposalBuilder(this.kit)
         if (res.flags.afterExecutingID) {
@@ -114,7 +115,7 @@ export default class Show extends BaseCommand {
       if (record.stage === 'Referendum' || record.stage === 'Execution') {
         // Identify the transaction with the highest constitutional requirement.
         const constitutionThreshold = await governance.getConstitution(proposal)
-        const support = await governance.getSupport(id)
+        const support = await governance.getSupportWithConstution(id, constitutionThreshold)
         requirements = {
           constitutionThreshold,
           ...support,

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -232,6 +232,14 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
     }
   }
 
+  // function get support doesn't consider constitution parameteres that has an influence
+  // in the total of yes votes required
+  async getSupportWithConstution(proposalID: BigNumber.Value, constitution: BigNumber) {
+    const support = await this.getSupport(proposalID)
+    support.required = support.required.times(constitution)
+    return support
+  }
+
   // simulates proposal.getSupportWithQuorumPadding
   async getSupport(proposalID: BigNumber.Value) {
     const participation = await this.getParticipationParameters()

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -234,7 +234,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
 
   // function get support doesn't consider constitution parameteres that has an influence
   // in the total of yes votes required
-  async getSupportWithConstution(proposalID: BigNumber.Value, constitution: BigNumber) {
+  async getSupportWithConstitution(proposalID: BigNumber.Value, constitution: BigNumber) {
     const support = await this.getSupport(proposalID)
     support.required = support.required.times(constitution)
     return support

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -234,7 +234,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
 
   // function get support doesn't consider constitution parameteres that has an influence
   // in the total of yes votes required
-  async getSupportWithConstitution(proposalID: BigNumber.Value, constitution: BigNumber) {
+  async getSupportWithConstitutionThreshold(proposalID: BigNumber.Value, constitution: BigNumber) {
     const support = await this.getSupport(proposalID)
     support.required = support.required.times(constitution)
     return support


### PR DESCRIPTION
### Description

The formula to get the minimal amount of *yes* votes is actually:

<img width="483" alt="image" src="https://user-images.githubusercontent.com/698027/236209652-89e4856f-7dab-4fa7-aa6e-f7fb92c87dbd.png">

So a function was added to the wrapper to consider this and updated the show cli command to reflect the change.

### Other changes

None

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- N/A

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_