### PR TITLE
Fix dequeueProposalIfReady() for expired proposals.

### DIFF
--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -220,7 +220,7 @@ contract Governance is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 3, 2, 0);
+    return (1, 3, 1, 0);
   }
 
   /**

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -220,7 +220,7 @@ contract Governance is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 3, 1, 0);
+    return (1, 3, 2, 0);
   }
 
   /**
@@ -1265,6 +1265,12 @@ contract Governance is
     // solhint-disable-next-line not-rely-on-time
     if (now >= lastDequeue.add(dequeueFrequency)) {
       Proposals.Proposal storage proposal = proposals[proposalId];
+
+      if (_isQueuedProposalExpired(proposal)) {
+        emit ProposalExpired(proposalId);
+        return isProposalDequeued;
+      }
+
       // Updating refunds back to proposer
       refundedDeposits[proposal.proposer] = refundedDeposits[proposal.proposer].add(
         proposal.deposit

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -3576,7 +3576,7 @@ contract('Governance', (accounts: string[]) => {
     })
   })
 
-  describe.only('#dequeueProposalIfReady()', () => {
+  describe('#dequeueProposalIfReady()', () => {
     it('should not update lastDequeue proposal does not exist in the queue', async () => {
       const nonExistentProposalId = 7
       const originalLastDequeue = await governance.lastDequeue()

--- a/packages/protocol/test/governance/network/governance.ts
+++ b/packages/protocol/test/governance/network/governance.ts
@@ -3576,17 +3576,17 @@ contract('Governance', (accounts: string[]) => {
     })
   })
 
-  describe('#dequeueProposalIfReady()', () => {
+  describe.only('#dequeueProposalIfReady()', () => {
     it('should not update lastDequeue proposal does not exist in the queue', async () => {
       const nonExistentProposalId = 7
       const originalLastDequeue = await governance.lastDequeue()
       await timeTravel(dequeueFrequency, web3)
-      await assertRevert(governance.dequeueProposalIfReady(nonExistentProposalId))
-
+      await governance.dequeueProposalIfReady(nonExistentProposalId)
       assert.equal((await governance.getQueueLength()).toNumber(), 0)
       assert.equal((await governance.lastDequeue()).toNumber(), originalLastDequeue.toNumber())
     })
     describe('when a proposal exists', () => {
+      const proposalId = 1
       beforeEach(async () => {
         await governance.propose(
           [transactionSuccess1.value],
@@ -3599,18 +3599,35 @@ contract('Governance', (accounts: string[]) => {
         )
       })
 
+      it('should not update `dequeued` when proposal has expired', async () => {
+        await timeTravel(queueExpiry, web3)
+        await governance.dequeueProposalIfReady(proposalId)
+        const dequeued = await governance.getDequeue()
+        assert.equal(dequeued.length, 0)
+      })
+
+      it('should update `dequeued` when proposal has not expired', async () => {
+        await timeTravel(dequeueFrequency, web3)
+        await governance.dequeueProposalIfReady(proposalId)
+        const dequeued = await governance.getDequeue()
+        assert.include(
+          dequeued.map((x) => x.toNumber()),
+          proposalId
+        )
+      })
+
       it('should update lastDequeue', async () => {
         const originalLastDequeue = await governance.lastDequeue()
 
         await timeTravel(dequeueFrequency, web3)
-        await governance.dequeueProposalIfReady(1)
+        await governance.dequeueProposalIfReady(proposalId)
 
         assert.equal((await governance.getQueueLength()).toNumber(), 0)
         assert.isTrue((await governance.lastDequeue()).toNumber() > originalLastDequeue.toNumber())
       })
 
       it('should still be valid if not dequeued or expired', async () => {
-        await governance.dequeueProposalIfReady(1)
+        await governance.dequeueProposalIfReady(proposalId)
         const isQueuedProposalExpired = await governance.isQueuedProposalExpired(1)
         assert.isFalse(isQueuedProposalExpired)
       })


### PR DESCRIPTION
### Description

Because this introduces a tiny bug which allows expired PRoposals to enter into the dequeued list. Those just need to be deleted w/o entering the list!
Thanks to @pahor167  for extra pointing this out.

Reverts celo-org/celo-monorepo#10268

### Tested

Unit test.

### Related issues

- Fixes #10091 

### Documentation
no need