### PR TITLE
Verify released contracts

### DIFF
--- a/packages/protocol/.env.json
+++ b/packages/protocol/.env.json
@@ -1,3 +1,3 @@
 {
-  "celoScanApiKey": "[Insert Celo scan Api]"
+  "celoScanApiKey": "[InsertCeloScanApiKey]"
 }

--- a/packages/protocol/.env.json
+++ b/packages/protocol/.env.json
@@ -1,0 +1,3 @@
+{
+  "celoScanApiKey": "[Insert Celo scan Api]"
+}

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -133,4 +133,17 @@ Compared to the normal test command, quicktest will:
 1. Not run the pretest script of building solidity (will still be run as part of truffle test) and compiling typescript. This works because truffle can run typescript "natively".
 2. Only migrate selected migrations as set in `backupmigrations.sh` (you'll likely need at least one compilation step since truffle seems to only run compiled migrations)
 
+## Verify released smart contracts
+1. Update CeloScanApi in env.json file
+2. Run verification command
+
+```bash
+yarn truffle-verify [ContractName]@[Contract address]  --network [network]
+```
+
+example:
+```bash
+yarn truffle-verify Reserve@0x907f37a0e9b003df15500c025f7acb496a726aa0  --network mainnet 
+```
+
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -40,7 +40,8 @@
     "truffle:migrate": "truffle migrate",
     "devchain": "ts-node scripts/devchain.ts",
     "view-tags": "git for-each-ref 'refs/tags/core-contracts.*' --sort=-committerdate --format='%(color:magenta)%(committerdate:short) %(color:blue)%(tree) %(color:green)github.com/celo-org/celo-monorepo/releases/tag/%(color:yellow)%(refname:short)'",
-    "generate-stabletoken-files": "ts-node ./scripts/generate-stabletoken-files.ts"
+    "generate-stabletoken-files": "ts-node ./scripts/generate-stabletoken-files.ts",
+    "truffle-verify": "yarn truffle run verify"
   },
   "dependencies": {
     "@0x/sol-compiler": "^4.8.3",
@@ -115,6 +116,7 @@
     "ts-node": "8.3.0",
     "typechain": "1.0.5",
     "typechain-target-truffle": "1.0.2",
-    "yargs": "^14.0.0"
+    "yargs": "^14.0.0",
+    "truffle-plugin-verify": "^0.6.3"
   }
 }

--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -13,6 +13,8 @@ const argv = require('minimist')(process.argv.slice(2), {
   boolean: ['reset'],
 })
 
+const { celoScanApiKey } = require('./.env.json')
+
 const SOLC_VERSION = '0.5.13'
 const ALFAJORES_NETWORKID = 44787
 const BAKLAVA_NETWORKID = 62320
@@ -214,7 +216,10 @@ if (process.argv.includes('--forno')) {
 }
 
 module.exports = {
-  plugins: ['truffle-security', 'truffle-plugin-blockscout-verify'],
+  plugins: ['truffle-plugin-verify'],
+  api_keys: {
+    celoscan: celoScanApiKey,
+  },
   compilers: {
     solc: {
       version: SOLC_VERSION,
@@ -239,7 +244,10 @@ if (process.argv.includes('--gas')) {
         },
       },
     },
-    plugins: ['truffle-security', 'truffle-plugin-blockscout-verify'],
+    plugins: ['truffle-plugin-verify'],
+    api_keys: {
+      celoscan: celoScanApiKey,
+    },
     networks,
     reporter: 'eth-gas-reporter',
     reporterOptions: {


### PR DESCRIPTION
### Description

Ability to verify smart contracts both on BlockScout and CeloScan

### Other changes

No other changes

### Tested

Successfully verified multiple smart contracts

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/10365

### Backwards compatibility

-

### Documentation

Readme updated