### PR TITLE
Update header hash calc in slashing test

### DIFF
--- a/packages/celotool/src/e2e-tests/slashing_tests.ts
+++ b/packages/celotool/src/e2e-tests/slashing_tests.ts
@@ -33,6 +33,15 @@ function headerArray(block: any) {
   if (block.gasLimit) {
     headerHashData.push(block.gasLimit)
   }
+  if (block.nonce) {
+    // All these fields are set after GFork, but difficulty is already returned
+    // in RPC as an Eth-compatibility feature before, so we can't use it to
+    // check if we are after GFork
+    headerHashData.push(new BigNumber(block.difficulty).toNumber())
+    headerHashData.push(block.nonce)
+    headerHashData.push(block.sha3Uncles)
+    headerHashData.push(block.mixHash)
+  }
   return headerHashData
 }
 

--- a/packages/celotool/src/e2e-tests/slashing_tests.ts
+++ b/packages/celotool/src/e2e-tests/slashing_tests.ts
@@ -18,7 +18,7 @@ const TMP_PATH = '/tmp/e2e'
 const safeMarginBlocks = 4
 
 function headerArray(block: any) {
-  return [
+  const headerHashData = [
     block.parentHash,
     block.miner,
     block.stateRoot,
@@ -30,6 +30,10 @@ function headerArray(block: any) {
     block.timestamp,
     block.extraData,
   ]
+  if (block.gasLimit) {
+    headerHashData.push(block.gasLimit)
+  }
+  return headerHashData
 }
 
 function headerFromBlock(block: any) {

--- a/packages/celotool/src/e2e-tests/slashing_tests.ts
+++ b/packages/celotool/src/e2e-tests/slashing_tests.ts
@@ -18,31 +18,39 @@ const TMP_PATH = '/tmp/e2e'
 const safeMarginBlocks = 4
 
 function headerArray(block: any) {
-  const headerHashData = [
+  if (!block.nonce) {
+    // Before Gingerbread fork
+    return [
+      block.parentHash,
+      block.miner,
+      block.stateRoot,
+      block.transactionsRoot,
+      block.receiptsRoot,
+      block.logsBloom,
+      block.number,
+      block.gasUsed,
+      block.timestamp,
+      block.extraData,
+    ]
+  }
+  return [
     block.parentHash,
+    block.sha3Uncles,
     block.miner,
     block.stateRoot,
     block.transactionsRoot,
     block.receiptsRoot,
     block.logsBloom,
+    new BigNumber(block.difficulty).toNumber(),
     block.number,
+    block.gasLimit,
     block.gasUsed,
     block.timestamp,
     block.extraData,
+    block.mixHash,
+    block.nonce,
+    block.baseFee,
   ]
-  if (block.gasLimit) {
-    headerHashData.push(block.gasLimit)
-  }
-  if (block.nonce) {
-    // All these fields are set after GFork, but difficulty is already returned
-    // in RPC as an Eth-compatibility feature before, so we can't use it to
-    // check if we are after GFork
-    headerHashData.push(new BigNumber(block.difficulty).toNumber())
-    headerHashData.push(block.nonce)
-    headerHashData.push(block.sha3Uncles)
-    headerHashData.push(block.mixHash)
-  }
-  return headerHashData
 }
 
 function headerFromBlock(block: any) {


### PR DESCRIPTION
### Description

As part of the Gingerbread hardfork ([CIP-62](https://github.com/celo-org/celo-proposals/pull/386/files)), the header hash calculation has been changed to match Ethereum. Older blocks can be detected by the missing header fields and are still hashed as before.

### Related issues

- https://github.com/celo-org/celo-blockchain-planning/issues/100

### Backwards compatibility

The `block.nonce` check takes care of providing backwards compatibility.
