### PR TITLE
Turn Gingerbread off for CIP-35 test

### DIFF
--- a/packages/celotool/src/e2e-tests/cip35_tests.ts
+++ b/packages/celotool/src/e2e-tests/cip35_tests.ts
@@ -137,6 +137,7 @@ function getGethRunConfig(withDonut: boolean, withEspresso: boolean): GethRunCon
       churritoBlock: 0,
       donutBlock: withDonut ? 0 : null,
       espressoBlock: withEspresso ? 0 : null,
+      gingerbreadBlock: null,
     },
     instances: [
       {

--- a/packages/celotool/src/lib/generate_utils.ts
+++ b/packages/celotool/src/lib/generate_utils.ts
@@ -395,6 +395,7 @@ export const generateGenesis = ({
   churritoBlock,
   donutBlock,
   espressoBlock,
+  gingerbreadBlock,
 }: GenesisConfig): string => {
   const genesis: any = { ...TEMPLATE }
 
@@ -410,6 +411,9 @@ export const generateGenesis = ({
   }
   if (typeof espressoBlock === 'number') {
     genesis.config.espressoBlock = espressoBlock
+  }
+  if (typeof gingerbreadBlock === 'number') {
+    genesis.config.gingerbreadBlock = gingerbreadBlock
   }
 
   genesis.config.chainId = chainId
@@ -538,6 +542,9 @@ export const generateGenesisWithMigrations = async ({
   }
   if (genesisConfig.espressoBlock !== undefined) {
     mcConfig.hardforks.espressoBlock = genesisConfig.espressoBlock
+  }
+  if (genesisConfig.gingerbreadBlock !== undefined) {
+    mcConfig.hardforks.gingerbreadBlock = genesisConfig.gingerbreadBlock
   }
   if (genesisConfig.timestamp !== undefined) {
     mcConfig.genesisTimestamp = genesisConfig.timestamp

--- a/packages/celotool/src/lib/interfaces/genesis-config.ts
+++ b/packages/celotool/src/lib/interfaces/genesis-config.ts
@@ -15,4 +15,5 @@ export interface GenesisConfig {
   churritoBlock?: number | null
   donutBlock?: number | null
   espressoBlock?: number | null
+  gingerbreadBlock?: number | null
 }


### PR DESCRIPTION
The CIP-35 test does not work after gingerbread (it uses `gatewayFee` and `gatewayFeeRecipient` fields, which are removed in gingerbread), so that hard fork must be turned off to test CIP-35.

This PR does not change anything yet, but will be required once a more recent celo-blockchain is used to execute the tests.