### PR TITLE
Adapt CI test to UltraGreen CIP-52 changes

### DIFF
--- a/packages/celotool/src/e2e-tests/governance_tests.ts
+++ b/packages/celotool/src/e2e-tests/governance_tests.ts
@@ -686,6 +686,7 @@ describe('governance tests', () => {
       this.timeout(0)
       const lockedGold = await kit._web3Contracts.getLockedGold()
       const governance = await kit._web3Contracts.getGovernance()
+      const feeHandler = await kit._web3Contracts.getFeeHandler()
       const gasPriceMinimum = await kit._web3Contracts.getGasPriceMinimum()
       const [group] = await validators.methods.getRegisteredValidatorGroups().call()
 
@@ -714,6 +715,9 @@ describe('governance tests', () => {
 
       const assertGovernanceBalanceChanged = async (blockNumber: number, expected: BigNumber) => {
         await assertBalanceChanged(governance.options.address, blockNumber, expected, goldToken)
+      }
+      const assertFeeHandlerBalanceChanged = async (blockNumber: number, expected: BigNumber) => {
+        await assertBalanceChanged(feeHandler.options.address, blockNumber, expected, goldToken)
       }
 
       const assertReserveBalanceChanged = async (blockNumber: number, expected: BigNumber) => {
@@ -837,10 +841,8 @@ describe('governance tests', () => {
           // Check TS calc'd rewards against what happened
           await assertVotesChanged(blockNumber, expectedVoterRewards)
           await assertLockedGoldBalanceChanged(blockNumber, expectedVoterRewards)
-          await assertGovernanceBalanceChanged(
-            blockNumber,
-            expectedCommunityReward.plus(await blockBaseGasFee(blockNumber))
-          )
+          await assertGovernanceBalanceChanged(blockNumber, expectedCommunityReward)
+          await assertFeeHandlerBalanceChanged(blockNumber, await blockBaseGasFee(blockNumber))
           await assertReserveBalanceChanged(blockNumber, stableTokenSupplyChange.div(exchangeRate))
           await assertGoldTokenTotalSupplyChanged(blockNumber, expectedGoldTotalSupplyChange)
           await assertCarbonOffsettingBalanceChanged(
@@ -852,7 +854,8 @@ describe('governance tests', () => {
           await assertGoldTokenTotalSupplyUnchanged(blockNumber)
           await assertLockedGoldBalanceUnchanged(blockNumber)
           await assertReserveBalanceUnchanged(blockNumber)
-          await assertGovernanceBalanceChanged(blockNumber, await blockBaseGasFee(blockNumber))
+          await assertFeeHandlerBalanceChanged(blockNumber, await blockBaseGasFee(blockNumber))
+          await assertGovernanceBalanceChanged(blockNumber, new BigNumber('0'))
           await assertCarbonOffsettingBalanceUnchanged(blockNumber)
         }
       }

--- a/packages/celotool/src/e2e-tests/transfer_tests.ts
+++ b/packages/celotool/src/e2e-tests/transfer_tests.ts
@@ -198,7 +198,7 @@ describe('Transfer tests', function (this: any) {
 
   let currentGethInstance: GethInstanceConfig
 
-  let governanceAddress: string // set later on using the contract itself
+  let feeHandlerAddress: string // set later on using the contract itself
   const validatorAddress = '0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95'
   const DEF_FROM_PK = 'f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d'
   const FromAddress = '0x5409ed021d9299bf6814279a6a1411a7e866a631'
@@ -280,17 +280,9 @@ describe('Transfer tests', function (this: any) {
       3
     )
 
-    governanceAddress = (await kit._web3Contracts.getGovernance()).options.address
-    // The tests below check the balance of the governance contract (i.e. the community fund)
+    feeHandlerAddress = (await kit._web3Contracts.getFeeHandler()).options.address
+    // The tests below check the balance of the FeeHandler contract (See UltraGreen CIP-52)
     // before and after transactions to verify the correct amount has been received from the fees.
-    // This causes flakiness due to the fund also receiving epoch rewards (if the epoch change is
-    // between the blocks the balance checker uses as its before and after the test will fail due
-    // to the unexpected change from the epoch rewards).
-    // To avoid this, we set the community fund's fraction of epoch rewards to zero.
-    // Another option would have been to make the epoch size large enough so no epoch changes happen
-    // during the test.
-    const epochRewards = await kit._web3Contracts.getEpochRewards()
-    await epochRewards.methods.setCommunityRewardFraction(0).send({ from: validatorAddress })
 
     // Give the account we will send transfers as sufficient gold and dollars.
     const startBalance = TransferAmount.times(500)
@@ -577,7 +569,7 @@ describe('Transfer tests', function (this: any) {
         toAddress,
         txFeeRecipientAddress,
         gatewayFeeRecipientAddress,
-        governanceAddress,
+        feeHandlerAddress,
       ]
       balances = await newBalanceWatcher(kit, accounts)
 
@@ -605,7 +597,7 @@ describe('Transfer tests', function (this: any) {
         if (kit.celoTokens.isStableToken(feeToken)) {
           assert(
             txRes.events.find(
-              (a) => eqAddress(a.to, governanceAddress) && eqAddress(a.from, fromAddress)
+              (a) => eqAddress(a.to, feeHandlerAddress) && eqAddress(a.from, fromAddress)
             )
           )
         }
@@ -649,8 +641,8 @@ describe('Transfer tests', function (this: any) {
     it(`should increment the gateway fee recipient's ${feeToken} balance by the gateway fee`, () =>
       assertEqualBN(balances.delta(gatewayFeeRecipientAddress, feeToken), txRes.fees.gateway))
 
-    it(`should increment the infrastructure fund's ${feeToken} balance by the base portion of the gas fee`, () =>
-      assertEqualBN(balances.delta(governanceAddress, feeToken), txRes.fees.base))
+    it(`should increment the FeeHandler's ${feeToken} balance by the base portion of the gas fee`, () =>
+      assertEqualBN(balances.delta(feeHandlerAddress, feeToken), txRes.fees.base))
 
     it(`should increment the tx fee recipient's ${feeToken} balance by the rest of the gas fee`, () => {
       assertEqualBN(balances.delta(txFeeRecipientAddress, feeToken), txRes.fees.tip)
@@ -875,7 +867,7 @@ describe('Transfer tests', function (this: any) {
                 FromAddress,
                 ToAddress,
                 gatewayFeeRecipientAddress,
-                governanceAddress,
+                feeHandlerAddress,
               ])
 
               await inflationManager.setInflationRateForNextTransfer(new BigNumber(2))
@@ -924,11 +916,11 @@ describe('Transfer tests', function (this: any) {
               )
             })
 
-            it("should halve the infrastructure fund's Celo Dollar balance then increment it by the base portion of the gas fees", () => {
+            it("should halve the FeeHandler's Celo Dollar balance then increment it by the base portion of the gas fees", () => {
               assertEqualBN(
                 balances
-                  .current(governanceAddress, StableToken.cUSD)
-                  .minus(balances.initial(governanceAddress, StableToken.cUSD).idiv(2)),
+                  .current(feeHandlerAddress, StableToken.cUSD)
+                  .minus(balances.initial(feeHandlerAddress, StableToken.cUSD).idiv(2)),
                 expectedFees.base
               )
             })


### PR DESCRIPTION
Transferring the fees to the FeeHandler instead of the Governance contract requires update in the CI tests.

This should be part of the UltraGreen changes, but requires a celo-blockchain version including https://github.com/celo-org/celo-blockchain/pull/2049 (thus the current CI failures for governance and transfers).