### PR TITLE
chore: remove binanceus from usdc configs

### DIFF
--- a/packages/helm-charts/oracle/USDCBRL.yaml
+++ b/packages/helm-charts/oracle/USDCBRL.yaml
@@ -20,9 +20,6 @@ oracle:
       {exchange: 'BITSO', symbol: 'USDBRL', toInvert: false }
     ],
     [
-      {exchange: 'BITSO', symbol: 'USDBRL', toInvert: false }
-    ],
-    [
       {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
       {exchange: 'BINANCE', symbol: 'USDTBRL', toInvert: false }
     ],

--- a/packages/helm-charts/oracle/USDCBRL.yaml
+++ b/packages/helm-charts/oracle/USDCBRL.yaml
@@ -20,7 +20,6 @@ oracle:
       {exchange: 'BITSO', symbol: 'USDBRL', toInvert: false }
     ],
     [
-      {exchange: 'BINANCEUS', symbol: 'USDCUSD', toInvert: false},
       {exchange: 'BITSO', symbol: 'USDBRL', toInvert: false }
     ],
     [

--- a/packages/helm-charts/oracle/USDCEUR.yaml
+++ b/packages/helm-charts/oracle/USDCEUR.yaml
@@ -28,7 +28,6 @@ oracle:
         {exchange: 'KRAKEN', symbol: 'EURUSD', toInvert: true}
       ],
       [
-        {exchange: 'BINANCEUS', symbol: 'USDCUSD', toInvert: false},
         {exchange: 'KRAKEN', symbol: 'EURUSD', toInvert: true}
       ],
     ]"

--- a/packages/helm-charts/oracle/USDCEUR.yaml
+++ b/packages/helm-charts/oracle/USDCEUR.yaml
@@ -27,9 +27,6 @@ oracle:
         {exchange: 'KRAKEN', symbol: 'USDCUSD', toInvert: false},
         {exchange: 'KRAKEN', symbol: 'EURUSD', toInvert: true}
       ],
-      [
-        {exchange: 'KRAKEN', symbol: 'EURUSD', toInvert: true}
-      ],
     ]"
   minPriceSourceCount: 2
   reportStrategy: BLOCK_BASED


### PR DESCRIPTION
### Description

Due to the Binance US recent issues the USDCEUR and USDCBRL pair is trading at a discounted rate (because of the problems with USD withdrawals), which is causing the clients to stop reporting due to the following error:

`"message":"Max price cross-sectional deviation too large (0.02774727286026238157 >= 0.01 )","name":"Error","stack":"Error: Max price cross-sectional deviation too large (0.02774727286026238157 >= 0.01`

This removes the exchange from the config until we find a better solution