### PR TITLE
add back legacy accounts table for now

### DIFF
--- a/packages/phone-number-privacy/signer/scripts/run-migrations.ts
+++ b/packages/phone-number-privacy/signer/scripts/run-migrations.ts
@@ -6,7 +6,7 @@ import { config } from '../src/config'
 async function start() {
   console.info('Running migrations')
   console.warn('It is no longer necessary to run db migrations seperately prior to startup')
-  await initDatabase(config, undefined)
+  await initDatabase(config, undefined, false)
 }
 
 start()

--- a/packages/phone-number-privacy/signer/src/common/database/migrations/20200330212224_create-accounts-table.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/migrations/20200330212224_create-accounts-table.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex'
+import { ACCOUNTS_COLUMNS, ACCOUNTS_TABLE } from '../models/account'
+
+export async function up(knex: Knex): Promise<any> {
+  // This check was necessary to switch from using .ts migrations to .js migrations.
+  if (!(await knex.schema.hasTable(ACCOUNTS_TABLE.LEGACY))) {
+    return knex.schema.createTable(ACCOUNTS_TABLE.LEGACY, (t) => {
+      t.string(ACCOUNTS_COLUMNS.address).notNullable().primary()
+      t.dateTime(ACCOUNTS_COLUMNS.createdAt).notNullable()
+      t.integer(ACCOUNTS_COLUMNS.numLookups).unsigned()
+    })
+  }
+  return null
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.dropTable(ACCOUNTS_TABLE.LEGACY)
+}

--- a/packages/phone-number-privacy/signer/src/common/database/migrations/20200811163913_create_requests_table.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/migrations/20200811163913_create_requests_table.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex'
+import { REQUESTS_COLUMNS, REQUESTS_TABLE } from '../models/request'
+
+export async function up(knex: Knex): Promise<any> {
+  // This check was necessary to switch from using .ts migrations to .js migrations.
+  if (!(await knex.schema.hasTable(REQUESTS_TABLE.LEGACY))) {
+    return knex.schema.createTable(REQUESTS_TABLE.LEGACY, (t) => {
+      t.string(REQUESTS_COLUMNS.address).notNullable()
+      t.dateTime(REQUESTS_COLUMNS.timestamp).notNullable()
+      t.string(REQUESTS_COLUMNS.blindedQuery).notNullable()
+      t.primary([
+        REQUESTS_COLUMNS.address,
+        REQUESTS_COLUMNS.timestamp,
+        REQUESTS_COLUMNS.blindedQuery,
+      ])
+    })
+  }
+  return null
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.dropTable(REQUESTS_TABLE.LEGACY)
+}

--- a/packages/phone-number-privacy/signer/src/common/database/migrations/20210421212301_create-indices.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/migrations/20210421212301_create-indices.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex'
+import { ACCOUNTS_COLUMNS, ACCOUNTS_TABLE } from '../models/account'
+
+export async function up(knex: Knex): Promise<any> {
+  if (!(await knex.schema.hasTable(ACCOUNTS_TABLE.LEGACY))) {
+    throw new Error('Unexpected error: Could not find ACCOUNTS_TABLE.LEGACY')
+  }
+  return knex.schema.alterTable(ACCOUNTS_TABLE.LEGACY, (t) => {
+    t.index(ACCOUNTS_COLUMNS.address)
+  })
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.alterTable(ACCOUNTS_TABLE.LEGACY, (t) => {
+    t.dropIndex(ACCOUNTS_COLUMNS.address)
+  })
+}

--- a/packages/phone-number-privacy/signer/src/common/database/models/account.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/models/account.ts
@@ -1,5 +1,6 @@
 export enum ACCOUNTS_TABLE {
   ONCHAIN = 'accountsOnChain',
+  LEGACY = 'accounts', // TODO figure out right way to drop this table now that it's no longer in use
 }
 
 export enum ACCOUNTS_COLUMNS {

--- a/packages/phone-number-privacy/signer/src/common/database/models/request.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/models/request.ts
@@ -1,4 +1,5 @@
 export enum REQUESTS_TABLE {
+  LEGACY = 'requests',
   ONCHAIN = 'requestsOnChain',
 }
 


### PR DESCRIPTION
If we delete migrations files I'm pretty sure Knex will complain during deployment. Let's leave the table be for now and create a follow up ticket to properly remove it. 