### PR TITLE
Soloseng/fix-test-quota-bypass

### DIFF
--- a/packages/phone-number-privacy/combiner/src/common/combine.ts
+++ b/packages/phone-number-privacy/combiner/src/common/combine.ts
@@ -157,12 +157,12 @@ export abstract class CombineAction<R extends OdisRequest> implements Action<R> 
   }
 
   private addFailureToSession(signer: Signer, errorCode: number | undefined, session: Session<R>) {
-    session.logger.warn(
-      `Received failure from ${session.failedSigners.size}/${this.signers.length} signers`
-    )
     // Tracking failed request count via signer url prevents
     // double counting the same failed request by mistake
     session.failedSigners.add(signer.url)
+    session.logger.warn(
+      `Received failure from ${session.failedSigners.size}/${this.signers.length} signers`
+    )
     if (errorCode) {
       session.incrementErrorCodeCount(errorCode)
     }

--- a/packages/phone-number-privacy/monitor/src/query.ts
+++ b/packages/phone-number-privacy/monitor/src/query.ts
@@ -53,7 +53,7 @@ export const queryOdisForSalt = async (
     console.log(`ODIS salt request timed out after ${timeoutMs} ms`) // tslint:disable-line:no-console
   }, timeoutMs)
   try {
-    const testSessionId = Math.floor(Math.random() * 100).toString()
+    const testSessionId = Math.floor(Math.random() * 100000).toString()
     const res = await OdisUtils.Identifier.getObfuscatedIdentifier(
       phoneNumber,
       OdisUtils.Identifier.IdentifierPrefix.PHONE_NUMBER,

--- a/packages/phone-number-privacy/monitor/src/query.ts
+++ b/packages/phone-number-privacy/monitor/src/query.ts
@@ -29,7 +29,8 @@ const newPrivateKey = async () => {
 export const queryOdisForSalt = async (
   blockchainProvider: string,
   contextName: OdisContextName,
-  timeoutMs: number = 10000
+  timeoutMs: number = 10000,
+  bypassQuota: boolean = false
 ) => {
   console.log(`contextName: ${contextName}`) // tslint:disable-line:no-console
   console.log(`blockchain provider: ${blockchainProvider}`) // tslint:disable-line:no-console
@@ -52,6 +53,7 @@ export const queryOdisForSalt = async (
     console.log(`ODIS salt request timed out after ${timeoutMs} ms`) // tslint:disable-line:no-console
   }, timeoutMs)
   try {
+    const testSessionId = Math.floor(Math.random() * 100).toString()
     const res = await OdisUtils.Identifier.getObfuscatedIdentifier(
       phoneNumber,
       OdisUtils.Identifier.IdentifierPrefix.PHONE_NUMBER,
@@ -61,7 +63,7 @@ export const queryOdisForSalt = async (
       undefined,
       undefined,
       undefined,
-      genSessionID(),
+      bypassQuota ? testSessionId : genSessionID(),
       undefined,
       abortController
     )

--- a/packages/phone-number-privacy/monitor/src/scripts/run-load-test.ts
+++ b/packages/phone-number-privacy/monitor/src/scripts/run-load-test.ts
@@ -1,10 +1,18 @@
 import { OdisContextName } from '@celo/identity/lib/odis/query'
+import { CombinerEndpointPNP } from '@celo/phone-number-privacy-common'
 import yargs from 'yargs'
 import { concurrentLoadTest, serialLoadTest } from '../test'
 
 /* tslint:disable:no-console */
 
-const runLoadTest = (contextName: string, numWorker: number, isSerial: boolean) => {
+const runLoadTest = (
+  contextName: string,
+  numWorker: number,
+  isSerial: boolean,
+  pnpQuotaEndpoint: boolean,
+  timeoutMs: number,
+  bypassQuota: boolean
+) => {
   let blockchainProvider: string
   switch (contextName) {
     case 'alfajoresstaging':
@@ -25,12 +33,26 @@ const runLoadTest = (contextName: string, numWorker: number, isSerial: boolean) 
     process.exit(1)
   }
   if (isSerial) {
-    serialLoadTest(numWorker, blockchainProvider!, contextName as OdisContextName) // tslint:disable-line:no-floating-promises
+    serialLoadTest(
+      numWorker,
+      blockchainProvider!,
+      contextName as OdisContextName,
+      pnpQuotaEndpoint ? CombinerEndpointPNP.PNP_QUOTA : CombinerEndpointPNP.PNP_SIGN,
+      timeoutMs,
+      bypassQuota
+    )
   } else {
-    concurrentLoadTest(numWorker, blockchainProvider!, contextName as OdisContextName) // tslint:disable-line:no-floating-promises
+    concurrentLoadTest(
+      numWorker,
+      blockchainProvider!,
+      contextName as OdisContextName,
+      pnpQuotaEndpoint ? CombinerEndpointPNP.PNP_QUOTA : CombinerEndpointPNP.PNP_SIGN,
+      timeoutMs,
+      bypassQuota
+    )
   }
 }
-// tslint:disable-next-line: no-unused-expression
+
 yargs
   .scriptName('ODIS-load-test')
   .recommendCommands()
@@ -52,8 +74,32 @@ yargs
         })
         .option('isSerial', {
           type: 'boolean',
-          description: 'run test workers in series.',
+          description: 'Run test workers in series.',
+          default: false,
+        })
+        .option('timeoutMs', {
+          type: 'number',
+          description: 'Timout in ms.',
+          default: 10000,
+        })
+        .option('bypassQuota', {
+          type: 'boolean',
+          description: 'Bypass Signer quota check.',
+          default: false,
+        })
+        .option('pnpQuotaEndpoint', {
+          type: 'boolean',
+          description:
+            'Use this flag to load test PNP_QUOTA endpoint instead of PNP_SIGN endpoint.',
           default: false,
         }),
-    (args) => runLoadTest(args.contextName!, args.numWorkers!, args.isSerial)
+    (args) =>
+      runLoadTest(
+        args.contextName!,
+        args.numWorkers!,
+        args.isSerial,
+        args.pnpQuotaEndpoint,
+        args.timeoutMs,
+        args.bypassQuota
+      )
   ).argv

--- a/packages/phone-number-privacy/monitor/src/test.ts
+++ b/packages/phone-number-privacy/monitor/src/test.ts
@@ -13,14 +13,16 @@ export async function testPNPSignQuery(
   blockchainProvider: string,
   contextName: OdisContextName,
   endpoint: CombinerEndpointPNP.PNP_SIGN,
-  timeoutMs?: number
+  timeoutMs?: number,
+  bypassQuota?: boolean
 ) {
   logger.info(`Performing test PNP query for ${endpoint}`)
   try {
     const odisResponse: IdentifierHashDetails = await queryOdisForSalt(
       blockchainProvider,
       contextName,
-      timeoutMs
+      timeoutMs,
+      bypassQuota
     )
     logger.info({ odisResponse }, 'ODIS salt request successful. System is healthy.')
   } catch (err) {
@@ -82,13 +84,14 @@ export async function serialLoadTest(
   endpoint:
     | CombinerEndpointPNP.PNP_QUOTA
     | CombinerEndpointPNP.PNP_SIGN = CombinerEndpointPNP.PNP_SIGN,
-  timeoutMs?: number
+  timeoutMs?: number,
+  bypassQuota?: boolean
 ) {
   for (let i = 0; i < n; i++) {
     try {
       switch (endpoint) {
         case CombinerEndpointPNP.PNP_SIGN:
-          await testPNPSignQuery(blockchainProvider, contextName, endpoint, timeoutMs)
+          await testPNPSignQuery(blockchainProvider, contextName, endpoint, timeoutMs, bypassQuota)
           break
         case CombinerEndpointPNP.PNP_QUOTA:
           await testPNPQuotaQuery(blockchainProvider, contextName, timeoutMs)
@@ -104,7 +107,8 @@ export async function concurrentLoadTest(
   endpoint:
     | CombinerEndpointPNP.PNP_QUOTA
     | CombinerEndpointPNP.PNP_SIGN = CombinerEndpointPNP.PNP_SIGN,
-  timeoutMs?: number
+  timeoutMs?: number,
+  bypassQuota?: boolean
 ) {
   while (true) {
     const reqs = []
@@ -117,7 +121,13 @@ export async function concurrentLoadTest(
         try {
           switch (endpoint) {
             case CombinerEndpointPNP.PNP_SIGN:
-              await testPNPSignQuery(blockchainProvider, contextName, endpoint, timeoutMs)
+              await testPNPSignQuery(
+                blockchainProvider,
+                contextName,
+                endpoint,
+                timeoutMs,
+                bypassQuota
+              )
               break
             case CombinerEndpointPNP.PNP_QUOTA:
               await testPNPQuotaQuery(blockchainProvider, contextName, timeoutMs)


### PR DESCRIPTION
### Description

Bypassing the quota is dependent on the sessionID being a number. 

Modified `Monitor` to generate a random sessionID in the number format, used for e2e and load testing


### Other changes

Changed the position of a log, to more accuratly show the failing signers

### Tested

Load tested locally