### PR TITLE
Soloseng/loadtest-with-DEK

### DIFF
--- a/packages/phone-number-privacy/monitor/src/query.ts
+++ b/packages/phone-number-privacy/monitor/src/query.ts
@@ -18,9 +18,9 @@ import { genSessionID } from '@celo/phone-number-privacy-common/lib/utils/logger
 import { normalizeAddressWith0x, privateKeyToAddress } from '@celo/utils/lib/address'
 import { defined } from '@celo/utils/lib/sign-typed-data-utils'
 import { LocalWallet } from '@celo/wallet-local'
-import { ACCOUNT_ADDRESS, dekAuthSigner, PRIVATE_KEY } from './resources'
+import { ACCOUNT_ADDRESS, dekAuthSigner, generateRandomPhoneNumber, PRIVATE_KEY } from './resources'
 
-const phoneNumber = fetchEnv('PHONE_NUMBER')
+let phoneNumber = fetchEnv('PHONE_NUMBER')
 
 const newPrivateKey = async () => {
   const mnemonic = await generateMnemonic(MnemonicStrength.s256_24words)
@@ -49,6 +49,7 @@ export const queryOdisForSalt = async (
     contractKit.connection.addAccount(PRIVATE_KEY)
     contractKit.defaultAccount = accountAddress
     authSigner = dekAuthSigner(0)
+    phoneNumber = generateRandomPhoneNumber()
   } else {
     const privateKey = await newPrivateKey()
     accountAddress = normalizeAddressWith0x(privateKeyToAddress(privateKey))

--- a/packages/phone-number-privacy/monitor/src/query.ts
+++ b/packages/phone-number-privacy/monitor/src/query.ts
@@ -18,6 +18,7 @@ import { genSessionID } from '@celo/phone-number-privacy-common/lib/utils/logger
 import { normalizeAddressWith0x, privateKeyToAddress } from '@celo/utils/lib/address'
 import { defined } from '@celo/utils/lib/sign-typed-data-utils'
 import { LocalWallet } from '@celo/wallet-local'
+import { ACCOUNT_ADDRESS, dekAuthSigner, PRIVATE_KEY } from './resources'
 
 const phoneNumber = fetchEnv('PHONE_NUMBER')
 
@@ -30,21 +31,33 @@ export const queryOdisForSalt = async (
   blockchainProvider: string,
   contextName: OdisContextName,
   timeoutMs: number = 10000,
-  bypassQuota: boolean = false
+  bypassQuota: boolean = false,
+  useDEK: boolean = false
 ) => {
+  let authSigner: AuthSigner
+  let accountAddress: string
   console.log(`contextName: ${contextName}`) // tslint:disable-line:no-console
   console.log(`blockchain provider: ${blockchainProvider}`) // tslint:disable-line:no-console
+  console.log(`using DEK: ${useDEK}`) // tslint:disable-line:no-console
 
   const serviceContext = getServiceContext(contextName, OdisAPI.PNP)
 
   const contractKit = newKit(blockchainProvider, new LocalWallet())
-  const privateKey = await newPrivateKey()
-  const accountAddress = normalizeAddressWith0x(privateKeyToAddress(privateKey))
-  contractKit.connection.addAccount(privateKey)
-  contractKit.defaultAccount = accountAddress
-  const authSigner: AuthSigner = {
-    authenticationMethod: OdisUtils.Query.AuthenticationMethod.WALLET_KEY,
-    contractKit,
+
+  if (useDEK) {
+    accountAddress = ACCOUNT_ADDRESS
+    contractKit.connection.addAccount(PRIVATE_KEY)
+    contractKit.defaultAccount = accountAddress
+    authSigner = dekAuthSigner(0)
+  } else {
+    const privateKey = await newPrivateKey()
+    accountAddress = normalizeAddressWith0x(privateKeyToAddress(privateKey))
+    contractKit.connection.addAccount(privateKey)
+    contractKit.defaultAccount = accountAddress
+    authSigner = {
+      authenticationMethod: OdisUtils.Query.AuthenticationMethod.WALLET_KEY,
+      contractKit,
+    }
   }
 
   const abortController = new AbortController()

--- a/packages/phone-number-privacy/monitor/src/resources.ts
+++ b/packages/phone-number-privacy/monitor/src/resources.ts
@@ -1,6 +1,5 @@
 import { EncryptionKeySigner } from '@celo/identity/lib/odis/query'
 import { AuthenticationMethod } from '@celo/phone-number-privacy-common'
-import { PhoneNumberUtils } from '@celo/phone-utils'
 import {
   ensureLeading0x,
   normalizeAddressWith0x,
@@ -10,22 +9,6 @@ import 'isomorphic-fetch'
 
 export const PRIVATE_KEY = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
 export const ACCOUNT_ADDRESS = normalizeAddressWith0x(privateKeyToAddress(PRIVATE_KEY)) // 0x1be31a94361a391bbafb2a4ccd704f57dc04d4bb
-
-export const PRIVATE_KEY_NO_QUOTA =
-  '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890000000'
-export const ACCOUNT_ADDRESS_NO_QUOTA = privateKeyToAddress(PRIVATE_KEY_NO_QUOTA)
-
-export const PHONE_NUMBER = '+17777777777'
-export const BLINDING_FACTOR = Buffer.from('0IsBvRfkBrkKCIW6HV0/T1zrzjQSe8wRyU3PKojCnww=', 'base64')
-// BLINDED_PHONE_NUMBER value is dependent on PHONE_NUMBER AND BLINDING_FACTOR
-// hardcoding to avoid importing blind_threshols_bls library
-export const BLINDED_PHONE_NUMBER =
-  'hZXDhpC5onzBSFa1agZ9vfHzqwJ/QeJg77NGvWiQG/sFWsvHETzZvdWr2GpF3QkB'
-
-export const PHONE_HASH_IDENTIFIER = PhoneNumberUtils.getPhoneHash(PHONE_NUMBER)
-
-export const CONTACT_PHONE_NUMBER = '+14155559999'
-export const CONTACT_PHONE_NUMBERS = [CONTACT_PHONE_NUMBER]
 
 interface DEK {
   privateKey: string
@@ -45,6 +28,7 @@ export const deks: DEK[] = [
     address: '0x34332049B07Fab9a2e843A7C8991469d93cF6Ae6',
   },
 ]
+
 // The following code can be used to generate more test DEKs
 // const generateDEKs = (n: number): Promise<DEK[]> => Promise.all([...Array(n).keys()].map(
 //   async () => await deriveDek(await generateMnemonic())
@@ -57,7 +41,9 @@ export const dekAuthSigner = (index: number): EncryptionKeySigner => {
   }
 }
 
-// export const walletAuthSigner: WalletKeySigner = {
-//   authenticationMethod: AuthenticationMethod.WALLET_KEY,
-//   contractKit,
-// }
+export function generateRandomPhoneNumber() {
+  const min = 1000000000 // Smallest 10-digit number
+  const max = 9999999999 // Largest 10-digit number
+  const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min
+  return '+1' + randomNumber.toString()
+}

--- a/packages/phone-number-privacy/monitor/src/resources.ts
+++ b/packages/phone-number-privacy/monitor/src/resources.ts
@@ -1,0 +1,63 @@
+import { EncryptionKeySigner } from '@celo/identity/lib/odis/query'
+import { AuthenticationMethod } from '@celo/phone-number-privacy-common'
+import { PhoneNumberUtils } from '@celo/phone-utils'
+import {
+  ensureLeading0x,
+  normalizeAddressWith0x,
+  privateKeyToAddress,
+} from '@celo/utils/lib/address'
+import 'isomorphic-fetch'
+
+export const PRIVATE_KEY = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+export const ACCOUNT_ADDRESS = normalizeAddressWith0x(privateKeyToAddress(PRIVATE_KEY)) // 0x1be31a94361a391bbafb2a4ccd704f57dc04d4bb
+
+export const PRIVATE_KEY_NO_QUOTA =
+  '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890000000'
+export const ACCOUNT_ADDRESS_NO_QUOTA = privateKeyToAddress(PRIVATE_KEY_NO_QUOTA)
+
+export const PHONE_NUMBER = '+17777777777'
+export const BLINDING_FACTOR = Buffer.from('0IsBvRfkBrkKCIW6HV0/T1zrzjQSe8wRyU3PKojCnww=', 'base64')
+// BLINDED_PHONE_NUMBER value is dependent on PHONE_NUMBER AND BLINDING_FACTOR
+// hardcoding to avoid importing blind_threshols_bls library
+export const BLINDED_PHONE_NUMBER =
+  'hZXDhpC5onzBSFa1agZ9vfHzqwJ/QeJg77NGvWiQG/sFWsvHETzZvdWr2GpF3QkB'
+
+export const PHONE_HASH_IDENTIFIER = PhoneNumberUtils.getPhoneHash(PHONE_NUMBER)
+
+export const CONTACT_PHONE_NUMBER = '+14155559999'
+export const CONTACT_PHONE_NUMBERS = [CONTACT_PHONE_NUMBER]
+
+interface DEK {
+  privateKey: string
+  publicKey: string
+  address: string
+}
+
+export const deks: DEK[] = [
+  {
+    privateKey: 'bf8a2b73baf8402f8fe906ad3f42b560bf14b39f7df7797ece9e293d6f162188',
+    publicKey: '034846bc781cacdafc66f3a77aa9fc3c56a9dadcd683c72be3c446fee8da041070',
+    address: '0x7b33dF2607b85e3211738a49A6Ad6E8Ed4d13F6E',
+  },
+  {
+    privateKey: '0975b0c565abc75b6638a749ea3008cb52676af3eabe4b80e19c516d82330364',
+    publicKey: '03b1ac8c445f0796978018c087b97e8213b32c39e6a8642ae63dce71da33a19f65',
+    address: '0x34332049B07Fab9a2e843A7C8991469d93cF6Ae6',
+  },
+]
+// The following code can be used to generate more test DEKs
+// const generateDEKs = (n: number): Promise<DEK[]> => Promise.all([...Array(n).keys()].map(
+//   async () => await deriveDek(await generateMnemonic())
+// ))
+
+export const dekAuthSigner = (index: number): EncryptionKeySigner => {
+  return {
+    authenticationMethod: AuthenticationMethod.ENCRYPTION_KEY,
+    rawKey: ensureLeading0x(deks[index].privateKey),
+  }
+}
+
+// export const walletAuthSigner: WalletKeySigner = {
+//   authenticationMethod: AuthenticationMethod.WALLET_KEY,
+//   contractKit,
+// }

--- a/packages/phone-number-privacy/monitor/src/resources.ts
+++ b/packages/phone-number-privacy/monitor/src/resources.ts
@@ -5,7 +5,6 @@ import {
   normalizeAddressWith0x,
   privateKeyToAddress,
 } from '@celo/utils/lib/address'
-import 'isomorphic-fetch'
 
 export const PRIVATE_KEY = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
 export const ACCOUNT_ADDRESS = normalizeAddressWith0x(privateKeyToAddress(PRIVATE_KEY)) // 0x1be31a94361a391bbafb2a4ccd704f57dc04d4bb

--- a/packages/phone-number-privacy/monitor/src/scripts/run-load-test.ts
+++ b/packages/phone-number-privacy/monitor/src/scripts/run-load-test.ts
@@ -11,7 +11,8 @@ const runLoadTest = (
   isSerial: boolean,
   pnpQuotaEndpoint: boolean,
   timeoutMs: number,
-  bypassQuota: boolean
+  bypassQuota: boolean,
+  useDEK: boolean
 ) => {
   let blockchainProvider: string
   switch (contextName) {
@@ -39,7 +40,8 @@ const runLoadTest = (
       contextName as OdisContextName,
       pnpQuotaEndpoint ? CombinerEndpointPNP.PNP_QUOTA : CombinerEndpointPNP.PNP_SIGN,
       timeoutMs,
-      bypassQuota
+      bypassQuota,
+      useDEK
     )
   } else {
     concurrentLoadTest(
@@ -48,7 +50,8 @@ const runLoadTest = (
       contextName as OdisContextName,
       pnpQuotaEndpoint ? CombinerEndpointPNP.PNP_QUOTA : CombinerEndpointPNP.PNP_SIGN,
       timeoutMs,
-      bypassQuota
+      bypassQuota,
+      useDEK
     )
   }
 }
@@ -87,6 +90,11 @@ yargs
           description: 'Bypass Signer quota check.',
           default: false,
         })
+        .option('useDEK', {
+          type: 'boolean',
+          description: 'Use Data Encryption Key (DEK) to authenticate.',
+          default: false,
+        })
         .option('pnpQuotaEndpoint', {
           type: 'boolean',
           description:
@@ -100,6 +108,7 @@ yargs
         args.isSerial,
         args.pnpQuotaEndpoint,
         args.timeoutMs,
-        args.bypassQuota
+        args.bypassQuota,
+        args.useDEK
       )
   ).argv

--- a/packages/phone-number-privacy/monitor/src/test.ts
+++ b/packages/phone-number-privacy/monitor/src/test.ts
@@ -14,7 +14,8 @@ export async function testPNPSignQuery(
   contextName: OdisContextName,
   endpoint: CombinerEndpointPNP.PNP_SIGN,
   timeoutMs?: number,
-  bypassQuota?: boolean
+  bypassQuota?: boolean,
+  useDEK?: boolean
 ) {
   logger.info(`Performing test PNP query for ${endpoint}`)
   try {
@@ -22,7 +23,8 @@ export async function testPNPSignQuery(
       blockchainProvider,
       contextName,
       timeoutMs,
-      bypassQuota
+      bypassQuota,
+      useDEK
     )
     logger.info({ odisResponse }, 'ODIS salt request successful. System is healthy.')
   } catch (err) {
@@ -85,13 +87,21 @@ export async function serialLoadTest(
     | CombinerEndpointPNP.PNP_QUOTA
     | CombinerEndpointPNP.PNP_SIGN = CombinerEndpointPNP.PNP_SIGN,
   timeoutMs?: number,
-  bypassQuota?: boolean
+  bypassQuota?: boolean,
+  useDEK?: boolean
 ) {
   for (let i = 0; i < n; i++) {
     try {
       switch (endpoint) {
         case CombinerEndpointPNP.PNP_SIGN:
-          await testPNPSignQuery(blockchainProvider, contextName, endpoint, timeoutMs, bypassQuota)
+          await testPNPSignQuery(
+            blockchainProvider,
+            contextName,
+            endpoint,
+            timeoutMs,
+            bypassQuota,
+            useDEK
+          )
           break
         case CombinerEndpointPNP.PNP_QUOTA:
           await testPNPQuotaQuery(blockchainProvider, contextName, timeoutMs)
@@ -108,7 +118,8 @@ export async function concurrentLoadTest(
     | CombinerEndpointPNP.PNP_QUOTA
     | CombinerEndpointPNP.PNP_SIGN = CombinerEndpointPNP.PNP_SIGN,
   timeoutMs?: number,
-  bypassQuota?: boolean
+  bypassQuota?: boolean,
+  useDEK?: boolean
 ) {
   while (true) {
     const reqs = []
@@ -126,7 +137,8 @@ export async function concurrentLoadTest(
                 contextName,
                 endpoint,
                 timeoutMs,
-                bypassQuota
+                bypassQuota,
+                useDEK
               )
               break
             case CombinerEndpointPNP.PNP_QUOTA:

--- a/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/endpoints/sign/io.ts
@@ -1,6 +1,7 @@
 import { ContractKit } from '@celo/contractkit'
 import {
   authenticateUser,
+  AuthenticationMethod,
   ErrorType,
   hasValidAccountParam,
   hasValidBlindedPhoneNumberParam,
@@ -75,6 +76,12 @@ export class PnpSignIO extends IO<SignMessageRequest> {
     warnings: ErrorType[],
     logger: Logger
   ): Promise<boolean> {
+    const authMethod = request.body.authenticationMethod
+
+    if (authMethod && authMethod === AuthenticationMethod.WALLET_KEY) {
+      Counters.requestsWithWalletAddress.inc()
+    }
+
     return authenticateUser(
       request,
       this.kit,


### PR DESCRIPTION
### Description

Added option to run load test with DEK. 
By default, it will use `WaletKeySigner`

### Other changes

Added a counter for request received with `WalletKeySigner`. This should fix the grafana dashboard `Signature requests w/ wallet address (Need to fix)`

### Tested

ran a short test. First is with DEK, second is without.

[signer dashboard](https://clabs.grafana.net/d/L-vRdgz4z/odis-signer?orgId=1&var-cluster_name=staging-odis0-centralus&var-cluster_name=staging-odis1-centralus&var-cluster_name=staging-odis2-centralus&from=1691766178527&to=1691767379932)

[combiner dashboard](https://clabs.grafana.net/d/f2UwnAdVk/odis-combiner?orgId=1&var-environment=celo-phone-number-privacy-stg&from=1691766146144&to=1691767271671)

### Backwards compatibility

compatible, as all added features are optional