### PR TITLE
prevent loadtest from crashing on error response

### DIFF
--- a/packages/phone-number-privacy/monitor/src/test.ts
+++ b/packages/phone-number-privacy/monitor/src/test.ts
@@ -126,9 +126,13 @@ export async function concurrentRPSLoadTest(
   }
 
   const testFn = async () => {
-    await (endpoint === CombinerEndpointPNP.PNP_SIGN
-      ? testPNPSignQuery(blockchainProvider, contextName, undefined, bypassQuota, useDEK)
-      : testPNPQuotaQuery(blockchainProvider, contextName))
+    try {
+      await (endpoint === CombinerEndpointPNP.PNP_SIGN
+        ? testPNPSignQuery(blockchainProvider, contextName, undefined, bypassQuota, useDEK)
+        : testPNPQuotaQuery(blockchainProvider, contextName))
+    } catch (_) {
+      logger.error('load test request failed')
+    }
   }
 
   return doRPSTest(measureLatency(testFn), rps, duration)


### PR DESCRIPTION
### Description

loadtest kept crashing when any of the requests returned an a 401 or 500 response.

