### PR TITLE
store signature in requests table

### DIFF
--- a/packages/phone-number-privacy/signer/src/common/database/migrations/20220923161710_pnp-requests-onchain.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/migrations/20220923161710_pnp-requests-onchain.ts
@@ -9,7 +9,7 @@ export async function up(knex: Knex): Promise<any> {
       t.string(REQUESTS_COLUMNS.blindedQuery).notNullable()
       t.primary([
         REQUESTS_COLUMNS.address,
-        // Note: the order of these should be switched
+        // Note: the order of these should be switched. Done in follow up migration.
         REQUESTS_COLUMNS.timestamp,
         REQUESTS_COLUMNS.blindedQuery,
       ])

--- a/packages/phone-number-privacy/signer/src/common/database/migrations/20230825150243_add_signature_request_column.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/migrations/20230825150243_add_signature_request_column.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex'
+import { REQUESTS_COLUMNS, REQUESTS_TABLE } from '../models/request'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable(REQUESTS_TABLE, (t) => {
+    t.string(REQUESTS_COLUMNS.signature)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable(REQUESTS_TABLE, (t) => {
+    t.dropColumn(REQUESTS_COLUMNS.signature)
+  })
+}

--- a/packages/phone-number-privacy/signer/src/common/database/models/request.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/models/request.ts
@@ -4,22 +4,25 @@ export enum REQUESTS_COLUMNS {
   address = 'caller_address',
   timestamp = 'timestamp',
   blindedQuery = 'blinded_query',
+  signature = 'signature',
 }
 
 export interface PnpSignRequestRecord {
-  //
   [REQUESTS_COLUMNS.address]: string
   [REQUESTS_COLUMNS.timestamp]: Date
   [REQUESTS_COLUMNS.blindedQuery]: string
+  [REQUESTS_COLUMNS.signature]: string
 }
 
 export function toPnpSignRequestRecord(
   account: string,
-  blindedQuery: string
+  blindedQuery: string,
+  signature: string
 ): PnpSignRequestRecord {
   return {
     [REQUESTS_COLUMNS.address]: account,
     [REQUESTS_COLUMNS.timestamp]: new Date(),
     [REQUESTS_COLUMNS.blindedQuery]: blindedQuery,
+    [REQUESTS_COLUMNS.signature]: signature,
   }
 }

--- a/packages/phone-number-privacy/signer/src/common/database/wrappers/request.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/wrappers/request.ts
@@ -10,22 +10,22 @@ import {
 } from '../models/request'
 import { doMeteredSql } from '../utils'
 
-export async function getRequestExists( // TODO try insert, if primary key error, then duplicate request
+export async function getRequestIfExists(
   db: Knex,
   account: string,
   blindedQuery: string,
   logger: Logger
-): Promise<boolean> {
+): Promise<PnpSignRequestRecord | undefined> {
   logger.debug(`Checking if request exists for account: ${account}, blindedQuery: ${blindedQuery}`)
-  return doMeteredSql('getRequestExists', ErrorMessage.DATABASE_GET_FAILURE, logger, async () => {
+  return doMeteredSql('getRequestIfExists', ErrorMessage.DATABASE_GET_FAILURE, logger, async () => {
     const existingRequest = await db<PnpSignRequestRecord>(REQUESTS_TABLE)
       .where({
         [REQUESTS_COLUMNS.address]: account,
-        [REQUESTS_COLUMNS.blindedQuery]: blindedQuery, // TODO are we using the primary key correctly??
+        [REQUESTS_COLUMNS.blindedQuery]: blindedQuery,
       })
       .first()
       .timeout(config.db.timeout)
-    return !!existingRequest // TODO use EXISTS query??
+    return existingRequest
   })
 }
 
@@ -33,13 +33,16 @@ export async function insertRequest(
   db: Knex,
   account: string,
   blindedQuery: string,
+  signature: string,
   logger: Logger,
   trx?: Knex.Transaction
 ): Promise<void> {
-  logger.debug(`Storing salt request for: ${account}, blindedQuery: ${blindedQuery}`)
+  logger.debug(
+    `Storing salt request for: ${account}, blindedQuery: ${blindedQuery}, signature: ${signature}`
+  )
   return doMeteredSql('insertRequest', ErrorMessage.DATABASE_INSERT_FAILURE, logger, async () => {
     const sql = db<PnpSignRequestRecord>(REQUESTS_TABLE)
-      .insert(toPnpSignRequestRecord(account, blindedQuery))
+      .insert(toPnpSignRequestRecord(account, blindedQuery, signature))
       .timeout(config.db.timeout)
     await (trx != null ? sql.transacting(trx) : sql)
   })

--- a/packages/phone-number-privacy/signer/src/pnp/services/request-service.ts
+++ b/packages/phone-number-privacy/signer/src/pnp/services/request-service.ts
@@ -1,16 +1,26 @@
 import { ErrorMessage } from '@celo/phone-number-privacy-common'
 import { Knex } from 'knex'
 import { Context } from '../../common/context'
+import { PnpSignRequestRecord } from '../../common/database/models/request'
 import { getPerformedQueryCount, incrementQueryCount } from '../../common/database/wrappers/account'
-import { getRequestExists, insertRequest } from '../../common/database/wrappers/request'
+import { getRequestIfExists, insertRequest } from '../../common/database/wrappers/request'
 import { wrapError } from '../../common/error'
 import { Histograms, newMeter } from '../../common/metrics'
 import { traceAsyncFunction } from '../../common/tracing-utils'
 
 export interface PnpRequestService {
-  recordRequest(address: string, blindedQuery: string, ctx: Context): Promise<void>
+  recordRequest(
+    address: string,
+    blindedQuery: string,
+    signature: string,
+    ctx: Context
+  ): Promise<void>
   getUsedQuotaForAccount(address: string, ctx: Context): Promise<number>
-  isDuplicateRequest(address: string, blindedQuery: string, ctx: Context): Promise<boolean>
+  getDuplicateRequest(
+    address: string,
+    blindedQuery: string,
+    ctx: Context
+  ): Promise<PnpSignRequestRecord | undefined>
 }
 
 export class DefaultPnpRequestService implements PnpRequestService {
@@ -19,11 +29,12 @@ export class DefaultPnpRequestService implements PnpRequestService {
   public async recordRequest(
     account: string,
     blindedQueryPhoneNumber: string,
+    signature: string,
     ctx: Context
   ): Promise<void> {
     return traceAsyncFunction('DefaultPnpRequestService - recordRequest', async () => {
       return this.db.transaction(async (trx) => {
-        await insertRequest(this.db, account, blindedQueryPhoneNumber, ctx.logger, trx)
+        await insertRequest(this.db, account, blindedQueryPhoneNumber, signature, ctx.logger, trx)
         await incrementQueryCount(this.db, account, ctx.logger, trx)
       })
     })
@@ -45,16 +56,17 @@ export class DefaultPnpRequestService implements PnpRequestService {
     )
   }
 
-  public async isDuplicateRequest(
+  public async getDuplicateRequest(
     account: string,
     blindedQueryPhoneNumber: string,
     ctx: Context
-  ): Promise<boolean> {
+  ): Promise<PnpSignRequestRecord | undefined> {
     try {
-      return getRequestExists(this.db, account, blindedQueryPhoneNumber, ctx.logger)
+      const res = await getRequestIfExists(this.db, account, blindedQueryPhoneNumber, ctx.logger)
+      return res
     } catch (err) {
       ctx.logger.error(err, 'Failed to check if request already exists in db')
-      return false
+      return undefined
     }
   }
 }
@@ -64,9 +76,13 @@ export class MockPnpRequestService implements PnpRequestService {
   public async recordRequest(
     account: string,
     blindedQueryPhoneNumber: string,
+    signature: string,
     ctx: Context
   ): Promise<void> {
-    ctx.logger.info({ account, blindedQueryPhoneNumber }, 'MockPnpRequestService - recordRequest')
+    ctx.logger.info(
+      { account, blindedQueryPhoneNumber, signature },
+      'MockPnpRequestService - recordRequest'
+    )
     return
   }
 
@@ -75,15 +91,15 @@ export class MockPnpRequestService implements PnpRequestService {
     return 0
   }
 
-  public async isDuplicateRequest(
+  public async getDuplicateRequest(
     account: string,
     blindedQueryPhoneNumber: string,
     ctx: Context
-  ): Promise<boolean> {
+  ): Promise<PnpSignRequestRecord | undefined> {
     ctx.logger.info(
       { account, blindedQueryPhoneNumber },
       'MockPnpRequestService - isDuplicateRequest'
     )
-    return false
+    return undefined
   }
 }

--- a/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
+++ b/packages/phone-number-privacy/signer/test/integration/pnp.test.ts
@@ -547,7 +547,7 @@ describe('pnp', () => {
         })
       }
 
-      it.only('Should respond with 200 and warning on repeated valid requests', async () => {
+      it('Should respond with 200 and warning on repeated valid requests', async () => {
         const logger = rootLogger(_config.serviceName)
         const req = getPnpSignRequest(
           ACCOUNT_ADDRESS1,


### PR DESCRIPTION
Stores the signature in the signer requests table and uses it on repeat requests. This is a small optimization that should save time when processing repeat requests. 

Some small formatting and comment changes as drive-by's 