### PR TITLE
Remove timestamp as pk

### DIFF
--- a/packages/phone-number-privacy/signer/src/common/database/migrations/20230828164352_alter-request-index.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/migrations/20230828164352_alter-request-index.ts
@@ -1,0 +1,30 @@
+import { Knex } from 'knex'
+import { REQUESTS_COLUMNS, REQUESTS_TABLE } from '../models/request'
+
+export async function up(knex: Knex): Promise<void> {
+  // Delete repeated rows (caller_address, blinded_query) with different timestamps
+  await knex.raw(deleteDuplicatedRequestsQueryStr())
+  return knex.schema.alterTable(REQUESTS_TABLE, (t) => {
+    // Removes primary index
+    t.dropPrimary()
+    // Sets the primary index as the pair (address, blindedQuery)
+    t.primary([REQUESTS_COLUMNS.address, REQUESTS_COLUMNS.blindedQuery])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable(REQUESTS_TABLE, (t) => {
+    t.dropPrimary()
+    t.primary([REQUESTS_COLUMNS.address, REQUESTS_COLUMNS.blindedQuery, REQUESTS_COLUMNS.timestamp])
+  })
+}
+
+function deleteDuplicatedRequestsQueryStr() {
+  return 'DELETE Req FROM requestsOnChain Req INNER JOIN ( \
+  SELECT *, RANK() OVER(PARTITION BY caller_address, blinded_query ORDER BY timestamp) rank \
+    FROM requestsOnChain \
+  ) Ranked ON Req.caller_address = Ranked.caller_address AND \
+      Req.blinded_query = Ranked.blinded_query AND \
+      Req.timestamp = Ranked.timestamp \
+    WHERE rank > 1'
+}

--- a/packages/phone-number-privacy/signer/src/common/database/wrappers/request.ts
+++ b/packages/phone-number-privacy/signer/src/common/database/wrappers/request.ts
@@ -43,7 +43,10 @@ export async function insertRequest(
   return doMeteredSql('insertRequest', ErrorMessage.DATABASE_INSERT_FAILURE, logger, async () => {
     const sql = db<PnpSignRequestRecord>(REQUESTS_TABLE)
       .insert(toPnpSignRequestRecord(account, blindedQuery, signature))
+      .onConflict([REQUESTS_COLUMNS.address, REQUESTS_COLUMNS.blindedQuery])
+      .ignore()
       .timeout(config.db.timeout)
+
     await (trx != null ? sql.transacting(trx) : sql)
   })
 }


### PR DESCRIPTION
### Description

Removes the timestamp from the primaryKey

***This PR should be merged only if we decide not to support MSSQL***

To reduce times, we remove the whole insertion of the request as a transaction, to avoid locking everything waiting for the request to be signed.
So, we are checking the quota, and signing and then saving. This, in a concurrent scenario, can create 2 (or more) request for the same parameters, and if we leave the uniqueness without the timestamp could fail.

The solution on this PR, removes the timestamp from the PK, and instead of inserting the row, will just insert it if was not existing from before due to an index conflict (the signature will be the same).

This scenario could be done in 1 request as in this PR, or locking -> consulting -> inserting
The second solution adds an unnecessary request per insertion just because of an edge case.
The first solution is the optimal, but, **Mssql doesn't support that statement**

As we added a pruning mechanism of the requests, this is a nice to have, if in the future we are not supporting MSSQL anymore