### PR TITLE
Combiner no quota cache

### DIFF
--- a/packages/phone-number-privacy/combiner/src/common/combine.ts
+++ b/packages/phone-number-privacy/combiner/src/common/combine.ts
@@ -3,15 +3,15 @@ import {
   KeyVersionInfo,
   OdisRequest,
   OdisResponse,
-  responseHasExpectedKeyVersion,
   SignerEndpoint,
   WarningMessage,
+  responseHasExpectedKeyVersion,
 } from '@celo/phone-number-privacy-common'
 import Logger from 'bunyan'
 import { Request } from 'express'
 import * as t from 'io-ts'
 import { PerformanceObserver } from 'perf_hooks'
-import { fetchSignerResponseWithFallback, SignerResponse } from './io'
+import { SignerResponse, fetchSignerResponseWithFallback } from './io'
 
 export interface Signer {
   url: string
@@ -90,10 +90,11 @@ export async function thresholdCallToSigners<R extends OdisRequest>(
         })
 
         if (!signerFetchResult.ok) {
+          const data = await signerFetchResult.json()
           // used for log based metrics
           logger.info({
             message: 'Received signerFetchResult on unsuccessful signer response',
-            res: await signerFetchResult.json(),
+            res: data,
             status: signerFetchResult.status,
             signer: signer.url,
           })
@@ -108,6 +109,7 @@ export async function thresholdCallToSigners<R extends OdisRequest>(
             logger.warn('Not possible to reach a threshold of signer responses. Failing fast')
             manualAbort.abort()
           }
+          responses.push({ res: data, url: signer.url })
           return
         }
 

--- a/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/action.ts
+++ b/packages/phone-number-privacy/combiner/src/pnp/endpoints/quota/action.ts
@@ -16,6 +16,7 @@ import { Signer, thresholdCallToSigners } from '../../../common/combine'
 import { errorResult, ResultHandler } from '../../../common/handlers'
 import { getKeyVersionInfo } from '../../../common/io'
 import { getCombinerVersion, OdisConfig } from '../../../config'
+import { NoQuotaCache } from '../../../utils/no-quota-cache'
 import { AccountService } from '../../services/account-services'
 import { logPnpSignerResponseDiscrepancies } from '../../services/log-responses'
 import { findCombinerQuotaState } from '../../services/threshold-state'
@@ -23,7 +24,8 @@ import { findCombinerQuotaState } from '../../services/threshold-state'
 export function pnpQuota(
   signers: Signer[],
   config: OdisConfig,
-  accountService: AccountService
+  accountService: AccountService,
+  noQuotaCache: NoQuotaCache
 ): ResultHandler<PnpQuotaRequest> {
   return async (request, response) => {
     const logger = response.locals.logger
@@ -36,6 +38,24 @@ export function pnpQuota(
 
     if (!(await authenticateUser(request, logger, accountService.getAccount, warnings))) {
       return errorResult(401, WarningMessage.UNAUTHENTICATED_USER)
+    }
+
+    const account = request.body.account
+    if (noQuotaCache.maximumQuouaReached(account)) {
+      const quota = noQuotaCache.getTotalQuota(account)
+      // can exist a race condition between the hasQuota and getTotalQuota but that's highly improbable
+      if (quota !== undefined) {
+        return {
+          status: 200,
+          body: {
+            success: true,
+            version: getCombinerVersion(),
+            performedQueryCount: quota,
+            totalQuota: quota,
+            warnings,
+          },
+        }
+      }
     }
 
     // TODO remove this, we shouldn't need keyVersionInfo for non-signing endpoints
@@ -57,6 +77,11 @@ export function pnpQuota(
     if (signerResponses.length >= threshold) {
       try {
         const quotaStatus = findCombinerQuotaState(keyVersionInfo, signerResponses, warnings)
+
+        if (quotaStatus.performedQueryCount === quotaStatus.totalQuota) {
+          // Sets that there is not more quota for that account
+          noQuotaCache.setNoMoreQuota(account, quotaStatus.totalQuota)
+        }
         return {
           status: 200,
           body: {

--- a/packages/phone-number-privacy/combiner/src/server.ts
+++ b/packages/phone-number-privacy/combiner/src/server.ts
@@ -29,6 +29,7 @@ import {
   ContractKitAccountService,
   MockAccountService,
 } from './pnp/services/account-services'
+import { NoQuotaCache } from './utils/no-quota-cache'
 
 require('events').EventEmitter.defaultMaxListeners = 15
 
@@ -70,6 +71,7 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
     : new ContractKitAccountService(logger, kit)
 
   const accountService = new CachingAccountService(baseAccountService)
+  const noQuotaCache = new NoQuotaCache()
 
   const pnpSigners: Signer[] = JSON.parse(config.phoneNumberPrivacy.odisServices.signers)
   const domainSigners: Signer[] = JSON.parse(config.domains.odisServices.signers)
@@ -80,14 +82,14 @@ export function startCombiner(config: CombinerConfig, kit?: ContractKit) {
     CombinerEndpoint.PNP_QUOTA,
     createHandler(
       phoneNumberPrivacy.enabled,
-      pnpQuota(pnpSigners, config.phoneNumberPrivacy, accountService)
+      pnpQuota(pnpSigners, config.phoneNumberPrivacy, accountService, noQuotaCache)
     )
   )
   app.post(
     CombinerEndpoint.PNP_SIGN,
     createHandler(
       phoneNumberPrivacy.enabled,
-      pnpSign(pnpSigners, config.phoneNumberPrivacy, accountService)
+      pnpSign(pnpSigners, config.phoneNumberPrivacy, accountService, noQuotaCache)
     )
   )
   app.post(

--- a/packages/phone-number-privacy/combiner/src/utils/no-quota-cache.ts
+++ b/packages/phone-number-privacy/combiner/src/utils/no-quota-cache.ts
@@ -3,10 +3,10 @@ import { LRUCache } from 'lru-cache'
 // Stores if an address does not have more quota with its totalQuota number
 export class NoQuotaCache {
   private cache: LRUCache<string, number, any>
-  constructor() {
+  constructor(seconds: number = 5) {
     this.cache = new LRUCache({
       max: 500,
-      ttl: 5 * 1000, // 5 seconds
+      ttl: seconds * 1000,
       allowStale: false,
     })
   }

--- a/packages/phone-number-privacy/combiner/src/utils/no-quota-cache.ts
+++ b/packages/phone-number-privacy/combiner/src/utils/no-quota-cache.ts
@@ -1,0 +1,31 @@
+import { LRUCache } from 'lru-cache'
+
+// Stores if an address does not have more quota with its totalQuota number
+export class NoQuotaCache {
+  private cache: LRUCache<string, number, any>
+  constructor() {
+    this.cache = new LRUCache({
+      max: 500,
+      ttl: 5 * 1000, // 5 seconds
+      allowStale: false,
+    })
+  }
+
+  maximumQuouaReached = (address: string): boolean => {
+    const dek = this.cache.get(address)
+
+    return dek !== undefined
+  }
+
+  getTotalQuota = (address: string): number | undefined => {
+    return this.cache.get(address)
+  }
+
+  setNoMoreQuota = (address: string, totalQuota: number) => {
+    const previousQuota = this.cache.get(address)
+    // Checking if the quotas are not the same to avoid refreshing the ttl
+    if (!previousQuota || previousQuota < totalQuota) {
+      this.cache.set(address, totalQuota)
+    }
+  }
+}

--- a/packages/phone-number-privacy/combiner/test/unit/no-quota-cache.test.ts
+++ b/packages/phone-number-privacy/combiner/test/unit/no-quota-cache.test.ts
@@ -1,0 +1,61 @@
+import { sleep } from '@celo/base'
+import { NoQuotaCache } from '../../src/utils/no-quota-cache'
+
+describe(`NoQuotaCache`, () => {
+  let noQuotaCache: NoQuotaCache
+  beforeEach(() => {
+    noQuotaCache = new NoQuotaCache(1)
+  })
+
+  it('should maintain a value', async () => {
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 10)
+
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    expect(noQuotaCache.getTotalQuota('ADDRESS1')).toBe(10)
+  })
+
+  it('should return undefined if a key expired', async () => {
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 10)
+
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    await sleep(1100)
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(false)
+    expect(noQuotaCache.getTotalQuota('ADDRESS1')).toBe(undefined)
+  })
+
+  it('should not refresh a key if it saves the same value', async () => {
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 10)
+
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    await sleep(600)
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 10)
+    await sleep(600)
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(false)
+    expect(noQuotaCache.getTotalQuota('ADDRESS1')).toBe(undefined)
+  })
+
+  it('should not refresh a key if it saves the value is smaller', async () => {
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 10)
+
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    await sleep(600)
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 5)
+    await sleep(600)
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(false)
+    expect(noQuotaCache.getTotalQuota('ADDRESS1')).toBe(undefined)
+  })
+
+  it('should refresh a key if it saves the value is bigger', async () => {
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 10)
+
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    await sleep(600)
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    noQuotaCache.setNoMoreQuota('ADDRESS1', 20)
+    await sleep(600)
+    expect(noQuotaCache.maximumQuouaReached('ADDRESS1')).toBe(true)
+    expect(noQuotaCache.getTotalQuota('ADDRESS1')).toBe(20)
+  })
+})


### PR DESCRIPTION
### Description

Depends on #10534 

Cache when the signers for an specific account have no quota (that will be cached for 5s, waiting for a new block to check if the quota was restored)