### PR TITLE
Calculation of unlockable gold

### DIFF
--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -1472,7 +1472,8 @@ contract Governance is
 
     uint256 maxUsed = 0;
     for (uint256 index = 0; index < dequeued.length; index = index.add(1)) {
-      Proposals.Proposal storage proposal = proposals[dequeued[index]];
+      uint256 proposalId = dequeued[index];
+      Proposals.Proposal storage proposal = proposals[proposalId];
       bool isVotingReferendum = (getProposalDequeuedStage(proposal) == Proposals.Stage.Referendum);
 
       if (!isVotingReferendum) {
@@ -1480,6 +1481,11 @@ contract Governance is
       }
 
       VoteRecord storage voteRecord = voter.referendumVotes[index];
+      // skip if vote record is not for this proposal
+      if (voteRecord.proposalId != proposalId) {
+        continue;
+      }
+
       uint256 votesCast = voteRecord.yesVotes.add(voteRecord.noVotes).add(voteRecord.abstainVotes);
       maxUsed = Math.max(
         maxUsed,
@@ -1515,7 +1521,8 @@ contract Governance is
     Voter storage voter = voters[account];
 
     for (uint256 index = 0; index < dequeued.length; index = index.add(1)) {
-      Proposals.Proposal storage proposal = proposals[dequeued[index]];
+      uint256 proposalId = dequeued[index];
+      Proposals.Proposal storage proposal = proposals[proposalId];
       bool isVotingReferendum = (getProposalDequeuedStage(proposal) == Proposals.Stage.Referendum);
 
       if (!isVotingReferendum) {
@@ -1523,6 +1530,12 @@ contract Governance is
       }
 
       VoteRecord storage voteRecord = voter.referendumVotes[index];
+
+      // skip if vote record is not for this proposal
+      if (voteRecord.proposalId != proposalId) {
+        continue;
+      }
+
       uint256 sumOfVotes = voteRecord.yesVotes.add(voteRecord.noVotes).add(voteRecord.abstainVotes);
 
       if (sumOfVotes > newVotingPower) {

--- a/packages/protocol/contracts/governance/test/GovernanceTest.sol
+++ b/packages/protocol/contracts/governance/test/GovernanceTest.sol
@@ -30,11 +30,15 @@ contract GovernanceTest is Governance(true) {
     _removeVotesWhenRevokingDelegatedVotes(account, maxAmountAllowed);
   }
 
-  function setDeprecatedWeight(address voterAddress, uint256 proposalIndex, uint256 weight)
-    external
-  {
+  function setDeprecatedWeight(
+    address voterAddress,
+    uint256 proposalIndex,
+    uint256 weight,
+    uint256 proposalId
+  ) external {
     Voter storage voter = voters[voterAddress];
     VoteRecord storage voteRecord = voter.referendumVotes[proposalIndex];
     voteRecord.deprecated_weight = weight;
+    voteRecord.proposalId = proposalId;
   }
 }

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -552,8 +552,14 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
     try {
       const proposalIndex = await this.getDequeueIndex(proposalID)
       const res = await this.contract.methods.getVoteRecord(voter, proposalIndex).call()
+      const returnedProposalId = valueToBigNumber(res[0])
+      // Vote record is for a different historical proposal with same index
+      if (returnedProposalId.toString() != proposalID.toString()) {
+        return null
+      }
+
       return {
-        proposalID: valueToBigNumber(res[0]),
+        proposalID: returnedProposalId,
         value: Object.keys(VoteValue)[valueToInt(res[1])] as VoteValue,
         votes: valueToBigNumber(res[2]),
         yesVotes: valueToBigNumber(res[3]),

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -554,7 +554,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
       const res = await this.contract.methods.getVoteRecord(voter, proposalIndex).call()
       const returnedProposalId = valueToBigNumber(res[0])
       // Vote record is for a different historical proposal with same index
-      if (returnedProposalId.toString() != proposalID.toString()) {
+      if (returnedProposalId.toString() !== proposalID.toString()) {
         return null
       }
 


### PR DESCRIPTION
### Description

In current implementation we are reusing indexes of vote record for dequeued proposals. If user voted for historical proposal which index is now being reused for currently dequeued proposal protocol will not allow to unlock gold amount that was used for voting for historical proposal. 

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

Unit test added

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/10575
