### PR TITLE
Nit: Removes "Draft" from titles in Ethers and Viem migration guides

### DIFF
--- a/packages/sdk/contractkit/MIGRATION-TO-ETHERS.md
+++ b/packages/sdk/contractkit/MIGRATION-TO-ETHERS.md
@@ -1,4 +1,4 @@
-# Draft: Migration document from Contractkit
+# Migration document from Contractkit
 
 Hello devs 🌱 this is a migration path away from contractkit. This aims to give examples to help you move to [ethers](https://docs.ethers.org/).
 

--- a/packages/sdk/contractkit/MIGRATION-TO-VIEM.md
+++ b/packages/sdk/contractkit/MIGRATION-TO-VIEM.md
@@ -1,4 +1,4 @@
-# Draft: Migration document from Contractkit
+# Migration document from Contractkit
 
 Hello devs 🌱 this is a migration path away from contractkit. This aims to give examples to help you move to [viem](https://viem.sh/).
 


### PR DESCRIPTION
### Description

Minuscule typo fix in Ethers and Viem migration guides published earlier in today:
- #10228

### Tested

No tests, markdown only.