### PR TITLE
GitHub Workflow refactor. Run in org-runners

### DIFF
--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     steps:
       - name: Restore .git cache
@@ -147,7 +147,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -170,7 +170,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     needs: install-dependencies
     steps:
       - uses: actions/cache/restore@v3
@@ -206,7 +206,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -228,7 +228,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
       # Required root to install node12
       options: --user root
     timeout-minutes: 30
@@ -282,7 +282,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks, pre-protocol-test-release]
     if: |
@@ -319,7 +319,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks]
     if: |
@@ -399,7 +399,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -434,7 +434,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -481,7 +481,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -513,7 +513,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -552,7 +552,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -590,7 +590,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks, contractkit-tests]
     if: |
@@ -690,7 +690,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks]
     # Disable as certora license is not active

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     steps:
       - name: Restore .git cache
@@ -147,7 +147,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -170,7 +170,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     needs: install-dependencies
     steps:
       - uses: actions/cache/restore@v3
@@ -206,7 +206,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -228,7 +228,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
       # Required root to install node12
       options: --user root
     timeout-minutes: 30
@@ -285,7 +285,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks, pre-protocol-test-release]
     if: |
@@ -322,7 +322,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks]
     if: |
@@ -402,7 +402,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -437,7 +437,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -484,7 +484,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -516,7 +516,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -555,7 +555,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -593,7 +593,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks, contractkit-tests]
     if: |
@@ -693,7 +693,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks]
     # Disable as certora license is not active

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -1,5 +1,5 @@
-name: celo-monorepo
-run-name: celo-monorepo tests
+name: celo-monorepo CI/CD
+run-name: celo-monorepo CI/CD for ${{ github.head_ref || github.ref_name }}
 
 # Dockefile for the self-hosted runner:
 # https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfile-monorepo
@@ -17,7 +17,7 @@ on:
       - '**/*.md'
 
 concurrency:
-  group: circle-ci-${{ github.ref }}
+  group: celo-monorepo-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -26,7 +26,7 @@ defaults:
 
 env:
   # Increment these to force cache rebuilding
-  NODE_MODULE_CACHE_VERSION: 3
+  NODE_MODULE_CACHE_VERSION: 4
   NODE_OPTIONS: '--max-old-space-size=4096'
   TERM: dumb
   GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Dorg.gradle.configureondemand=true -Dorg.gradle.jvmargs="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError"'
@@ -45,7 +45,10 @@ jobs:
       # Adding a initial comma so ',<path>' matches also for the first file
       all_modified_files: ',${{ steps.changed-files.outputs.all_modified_files }}'
     # runs-on: ubuntu-latest
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     steps:
       - name: Restore .git cache
@@ -121,7 +124,7 @@ jobs:
         run: |
           # This fails if there is any change
           if ! git diff-index HEAD --; then
-            echo "Git changes detected while building. If this is unexpected, bump NODE_MODULE_CACHE_VERSION in .github/workflows/circleci.yml"
+            echo "Git changes detected while building. If this is unexpected, bump NODE_MODULE_CACHE_VERSION in .github/workflows/celo-monorepo.yml"
             exit 1
           fi
       - name: Build packages
@@ -141,7 +144,10 @@ jobs:
       - run: echo ",${{ steps.changed-files.outputs.all_modified_files }}"
   lint-checks:
     name: Lint code
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -161,7 +167,10 @@ jobs:
       - run: yarn run lint
   general_test:
     name: General jest test
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     needs: install-dependencies
     steps:
       - uses: actions/cache/restore@v3
@@ -194,7 +203,10 @@ jobs:
           path: test-results/jest
   wallet-test:
     name: Wallet test
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -213,7 +225,10 @@ jobs:
           yarn run lerna --scope '@celo/wallet-*' run test
   pre-protocol-test-release:
     name: Protocol Tests Prepare
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     # Comment lint-checks dependency to speed up (as this is a dependency for many other jobs)
     # needs: [install-dependencies, lint-checks]
@@ -262,7 +277,10 @@ jobs:
           yarn --cwd packages/protocol test:generate-old-devchain-and-build -b $RELEASE_TAG -d .tmp/released_chain -l /dev/stdout -g scripts/truffle/releaseGoldExampleConfigs.json
   protocol-test-release:
     name: Protocol Test Release
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks, pre-protocol-test-release]
     if: |
@@ -296,7 +314,10 @@ jobs:
   protocol-test-matrix:
     # Keeping name short because GitHub UI does not handle long names well
     name: ${{ matrix.name }}
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks]
     if: |
@@ -373,7 +394,10 @@ jobs:
             ${{ matrix.command }}
   contractkit-tests:
     name: ContractKit Tests
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -405,7 +429,10 @@ jobs:
           yarn --cwd=packages/sdk/contractkit test
   cli-tests:
     name: CeloCli Tests
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -449,7 +476,10 @@ jobs:
           yarn --cwd=packages/cli run celocli account:new
   typescript-tests:
     name: Typescript package Tests
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -478,7 +508,10 @@ jobs:
           npm install $RUNNER_WORKSPACE/celo-monorepo/packages/typescript/*.tgz
   base-test:
     name: SDK Base package Tests
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -514,7 +547,10 @@ jobs:
           npm install $RUNNER_WORKSPACE/celo-monorepo/packages/sdk/base/*.tgz
   utils-test:
     name: SDK Utils package Tests
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -549,7 +585,10 @@ jobs:
   end-to-end-geth-matrix:
     # Keeping name short because GitHub UI does not handle long names well
     name: e2e ${{ matrix.name }}
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks, contractkit-tests]
     if: |
@@ -646,7 +685,10 @@ jobs:
   # NOTE: This has not been fully tested as we don't have a license for certora
   certora-test:
     name: Certora test ${{ matrix.name }}
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ['self-hosted', 'org', '8-cpu']
+    container:
+      # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks]
     # Disable as certora license is not active

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     steps:
       - name: Restore .git cache
@@ -147,7 +147,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -170,7 +170,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     needs: install-dependencies
     steps:
       - uses: actions/cache/restore@v3
@@ -206,7 +206,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -228,7 +228,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
       # Required root to install node12
       options: --user root
     timeout-minutes: 30
@@ -282,7 +282,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks, pre-protocol-test-release]
     if: |
@@ -319,7 +319,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks]
     if: |
@@ -399,7 +399,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -434,7 +434,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -481,7 +481,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -513,7 +513,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -552,7 +552,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -590,7 +590,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks, contractkit-tests]
     if: |
@@ -690,7 +690,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:7e3f85d107a7a4e5ac9a1066203dea8da3e890ab
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks]
     # Disable as certora license is not active

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -270,6 +270,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12.22.11
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 20
+        if: true
+        with:
+          limit-access-to-actor: true
       - name: Generate devchain of previous release
         run: |
           echo "Comparing against $RELEASE_TAG"

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     steps:
       - name: Restore .git cache
@@ -147,7 +147,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -170,7 +170,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     needs: install-dependencies
     steps:
       - uses: actions/cache/restore@v3
@@ -206,7 +206,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -228,7 +228,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
       # Required root to install node12
       options: --user root
     timeout-minutes: 30
@@ -273,7 +273,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 20
-        if: true
+        if: false
         with:
           limit-access-to-actor: true
       - name: Generate devchain of previous release
@@ -288,7 +288,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks, pre-protocol-test-release]
     if: |
@@ -325,7 +325,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks]
     if: |
@@ -405,7 +405,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -440,7 +440,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -487,7 +487,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -519,7 +519,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -558,7 +558,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -596,7 +596,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks, contractkit-tests]
     if: |
@@ -696,7 +696,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:932c35e1721150ff9e7d0502e5f197443d7884aa
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:13efc59f03aa761fc79aadd085f95bb465cc5a6c
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks]
     # Disable as certora license is not active

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     steps:
       - name: Restore .git cache
@@ -147,7 +147,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -170,7 +170,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     needs: install-dependencies
     steps:
       - uses: actions/cache/restore@v3
@@ -206,7 +206,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: install-dependencies
     steps:
@@ -228,7 +228,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
       # Required root to install node12
       options: --user root
     timeout-minutes: 30
@@ -282,7 +282,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks, pre-protocol-test-release]
     if: |
@@ -319,7 +319,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks]
     if: |
@@ -399,7 +399,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -434,7 +434,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -481,7 +481,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -513,7 +513,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -552,7 +552,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: [install-dependencies]
     if: |
@@ -590,7 +590,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 60
     needs: [install-dependencies, lint-checks, contractkit-tests]
     if: |
@@ -690,7 +690,7 @@ jobs:
     runs-on: ['self-hosted', 'org', '8-cpu']
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:58f9bfd888ff9a85360b1e47f208cd0bd55a4705
     timeout-minutes: 30
     needs: [install-dependencies, lint-checks]
     # Disable as certora license is not active

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -229,6 +229,8 @@ jobs:
     container:
       # Update image at https://github.com/celo-org/infrastructure/blob/master/terraform/root-modules/gcp/integration-tests-gke/files/github-arc/Dockerfiles/Dockerfile-monorepo
       image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
+      # Required root to install node12
+      options: --user root
     timeout-minutes: 30
     # Comment lint-checks dependency to speed up (as this is a dependency for many other jobs)
     # needs: [install-dependencies, lint-checks]

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -270,12 +270,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12.22.11
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 20
-        if: false
-        with:
-          limit-access-to-actor: true
+      # Workaround for https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor
+      - name: Configure git safe directories
+        run: git config --global --add safe.directory '*'
       - name: Generate devchain of previous release
         run: |
           echo "Comparing against $RELEASE_TAG"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,15 +23,6 @@ steps:
   ]
   waitFor: ['-']
 
-- id: "docker:phone-number-privacy-signer"
-  name: gcr.io/kaniko-project/executor:v0.16.0
-  args: [
-    "--dockerfile=dockerfiles/phone-number-privacy/Dockerfile",
-    "--cache=true",
-    "--destination=us.gcr.io/$PROJECT_ID/celo-monorepo:phone-number-privacy-$COMMIT_SHA"
-  ]
-  waitFor: ['-']
-
 options:
  machineType: 'N1_HIGHCPU_8'
 


### PR DESCRIPTION
### Description

Refactor to the general GitHub Workflow:

* Run in org-runners instead of repository runners
* Specify the container image where the jobs run at job level (make it more portable --> we can use GitHub's runners without worrying the dependencies the runner has installed)
* Renamed the workflow now that the migration from CircleCi is done