### PR TITLE
make package install test slightly more useful

### DIFF
--- a/.github/workflows/cron-npm-install.yml
+++ b/.github/workflows/cron-npm-install.yml
@@ -20,10 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         package:
-        - '@celo/typescript'
-        - '@celo/utils'
-        - '@celo/contractkit'
-        - '@celo/celocli'
+        - '@celo/utils@beta'
+        - '@celo/contractkit@beta'
+        - '@celo/celocli@beta'
     steps:
       - name: Install @celo/celocli dependencies
         if: matrix.package == '@celo/celocli'
@@ -31,7 +30,7 @@ jobs:
           apt update
           apt install -y libusb-1.0-0-dev libudev-dev
       - name: Installing npm package
-        run: yarn add ${{ matrix.package }}@beta
+        run: yarn add ${{ matrix.package }}
       - name: Test celocli command
         if: matrix.package == '@celo/celocli'
         run: |

--- a/.github/workflows/cron-npm-install.yml
+++ b/.github/workflows/cron-npm-install.yml
@@ -25,7 +25,7 @@ jobs:
         - '@celo/celocli@beta'
     steps:
       - name: Install @celo/celocli dependencies
-        if: matrix.package == '@celo/celocli'
+        if: matrix.package == '@celo/celocli@beta'
         run: |
           apt update
           apt install -y libusb-1.0-0-dev libudev-dev

--- a/.github/workflows/cron-npm-install.yml
+++ b/.github/workflows/cron-npm-install.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           apt update
           apt install -y libusb-1.0-0-dev libudev-dev
+          yarn global add node-gyp
       - name: Installing npm package
         run: yarn add ${{ matrix.package }}
       - name: Test celocli command

--- a/.github/workflows/cron-npm-install.yml
+++ b/.github/workflows/cron-npm-install.yml
@@ -15,7 +15,7 @@ jobs:
     name: ${{ matrix.package }} NPM package install
     runs-on: ubuntu-latest
     container:
-      image: node:16-bullseye
+      image: node:18-bullseye
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +31,7 @@ jobs:
           apt update
           apt install -y libusb-1.0-0-dev libudev-dev
       - name: Installing npm package
-        run: yarn add ${{ matrix.package }}
+        run: yarn add ${{ matrix.package }}@beta
       - name: Test celocli command
         if: matrix.package == '@celo/celocli'
         run: |


### PR DESCRIPTION
### Description

supported version of node is 18 not 16

install latest beta, at least then this tests has some chance of catching an issue before the package is live.

