### PR TITLE
s/applications/devtooling/g

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,20 +8,20 @@
 # directory and file-level owners. Feel free to add to this!
 
 /packages/celotool/ @celo-org/devopsre
-/packages/cli/ @celo-org/applications
-/packages/dev-utils/ @celo-org/applications
-/packages/docs/ @celo-org/applications @celo-org/devrel
-/packages/env-tests/ @celo-org/applications
-/packages/faucet/ @celo-org/applications
+/packages/cli/ @celo-org/devtooling
+/packages/dev-utils/ @celo-org/devtooling
+/packages/docs/ @celo-org/devtooling @celo-org/devrel
+/packages/env-tests/ @celo-org/devtooling
+/packages/faucet/ @celo-org/devtooling
 /packages/helm-charts/ @celo-org/devopsre
 /packages/helm-charts/blockscout/ @celo-org/data-services @celo-org/devopsre
 /packages/helm-charts/oracle/ @celo-org/mento  @celo-org/devopsre
 /packages/metadata-crawler/ @celo-org/data-services
 /packages/phone-number-privacy/ @celo-org/identity
 /packages/protocol/ @celo-org/primitives @celo-org/identity
-/packages/sdk/ @celo-org/applications
-/packages/sdk/identity/  @celo-org/identity @celo-org/applications
-/packages/sdk/contractkit/ @celo-org/applications
+/packages/sdk/ @celo-org/devtooling
+/packages/sdk/identity/  @celo-org/identity @celo-org/devtooling
+/packages/sdk/contractkit/ @celo-org/devtooling
 /packages/terraform-modules-public/ @celo-org/devopsre
 /packages/terraform-modules/ @celo-org/devopsre
-/packages/typescript/ @celo-org/applications
+/packages/typescript/ @celo-org/devtooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,16 +11,14 @@
 /packages/cli/ @celo-org/devtooling
 /packages/dev-utils/ @celo-org/devtooling
 /packages/docs/ @celo-org/devtooling @celo-org/devrel
-/packages/env-tests/ @celo-org/devtooling
+/packages/env-tests/ @celo-org/primitives
 /packages/faucet/ @celo-org/devtooling
 /packages/helm-charts/ @celo-org/devopsre
 /packages/helm-charts/blockscout/ @celo-org/data-services @celo-org/devopsre
 /packages/helm-charts/oracle/ @celo-org/mento  @celo-org/devopsre
 /packages/metadata-crawler/ @celo-org/data-services
-/packages/phone-number-privacy/ @celo-org/identity
 /packages/protocol/ @celo-org/primitives @celo-org/identity
 /packages/sdk/ @celo-org/devtooling
-/packages/sdk/identity/  @celo-org/identity @celo-org/devtooling
 /packages/sdk/contractkit/ @celo-org/devtooling
 /packages/terraform-modules-public/ @celo-org/devopsre
 /packages/terraform-modules/ @celo-org/devopsre


### PR DESCRIPTION
### Description

s/applications/devtooling/g

### Tested

GitHub CODEOWNERS file validation.

### Backwards compatibility

This is not backwards compatible: previous mentions of @celo-org/applications are broken.