### PR TITLE
Easy Beta Releasing

### DIFF
--- a/.changeset/radical-monkey-play.md
+++ b/.changeset/radical-monkey-play.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+add FeeHandler contract info to `celocli network:contracts` command

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - master
+      - prerelease/*
 
 concurrency:
   group: celo-monorepo-${{ github.ref }}
@@ -20,7 +21,7 @@ defaults:
   run:
     shell: bash --login -eo pipefail {0}
 
-env: 
+env:
   # Increment these to force cache rebuilding
   NODE_MODULE_CACHE_VERSION: 4
   NODE_OPTIONS: '--max-old-space-size=4096'
@@ -210,7 +211,7 @@ jobs:
   pre-protocol-test-release:
     name: Protocol Tests Prepare
     runs-on: ['self-hosted', 'monorepo-node18']
-    # container: 
+    # container:
     #   image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:node18
     #   # Required root to install node12
     #   options: --user root
@@ -630,7 +631,7 @@ jobs:
               set -e
               export PATH="/usr/local/go/bin:$HOME/.cargo/bin:${PATH}"
               cd packages/celotool
-              
+
               ./ci_test_validator_order.sh checkout ${CELO_BLOCKCHAIN_BRANCH_TO_TEST}
     steps:
       - uses: actions/cache/restore@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
       - 'prerelease/*'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn pretty-quick --staged --pattern '**/*.+(ts|tsx|js|jsx|sol|java)'
+
+bash scripts/hooks/prereleasecheck.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# recreate this as it was removed in husky 
-HUSKY_GIT_STDIN=$local_ref $local_oid $remote_ref $remote_oid
-
-node ./scripts/hooks/pre-push.js
+# recreate this as it was removed in husky
+HUSKY_GIT_STDIN="$local_ref $local_oid $remote_ref $remote_oid" node ./scripts/hooks/pre-push.js
 
 bash scripts/hooks/prereleasecheck.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+
 # recreate this as it was removed in husky
-HUSKY_GIT_STDIN="$local_ref $local_oid $remote_ref $remote_oid" node ./scripts/hooks/pre-push.js
+while read local_ref local_oid remote_ref remote_oid
+do
+  HUSKY_GIT_STD="$local_ref $local_oid $remote_ref $remote_oid"
+done
+
+HUSKY_GIT_STDIN=$HUSKY_GIT_STD node ./scripts/hooks/pre-push.js
 
 bash scripts/hooks/prereleasecheck.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+node ./scripts/hooks/pre-push.js
+
+bash scripts/hooks/prereleasecheck.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# recreate this as it was removed in husky 
+HUSKY_GIT_STDIN=$local_ref $local_oid $remote_ref $remote_oid
+
 node ./scripts/hooks/pre-push.js
 
 bash scripts/hooks/prereleasecheck.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,24 @@ finally `changeset publish` will go thru and publish to npm the packages that ne
 
 after go ahead and run `git push --follow-tags` to push git tags up to github.
 
-## Pre Releasing
+## Auto Pre-releasing (Recommended)
+
+For Detailed Steps read (scripts/beta-mode.sh)[]
+
+1. Run `yarn beta-enter`
+This will enter into the pre mode of changesets and create a prerelease/beta branch and push it up to origin(github)
+
+Any time a commit is pushed to prerelease/** github will go and open a specially Version Packages (Beta) PR. You can merge this and packages will be published as specified in the branch (should be beta)
+
+2. If you need to release another beta make a changeset and commit it up.
+
+3. When done run `yarn beta-exit`
+This will exit changeset pre mode. Push up.
+
+4. Now you can Open a Pr with your prerelease/? branch against main.
+
+
+## Manual Pre Releasing (discouraged)
 
 changesets has 2 strategies for pre release versions.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "yarn run lerna run build",
     "clean": "yarn run lerna run clean",
     "docs": "yarn run lerna run docs",
-    "cs" : "yarn changeset",
+    "cs": "yarn changeset",
     "check-licenses": "yarn licenses list --prod | grep '\\(─ GPL\\|─ (GPL-[1-9]\\.[0-9]\\+ OR GPL-[1-9]\\.[0-9]\\+)\\)' && echo 'Found GPL license(s). Use 'yarn licenses list --prod' to look up the offending package' || echo 'No GPL licenses found'",
     "report-coverage": "yarn run lerna run test-coverage",
     "test:watch": "node node_modules/jest/bin/jest.js --watch",
@@ -32,13 +32,8 @@
     "celotool": "yarn --cwd packages/celotool run --silent cli",
     "celocli": "yarn --cwd packages/cli run --silent celocli",
     "update-dependency-graph": "ts-node ./scripts/update_dependency_graph.ts",
-    "deprecate-sdks": "ts-node ./scripts/unpublish-sdks.ts"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern '**/*.+(ts|tsx|js|jsx|sol|java)'",
-      "pre-push": "node ./scripts/hooks/pre-push.js"
-    }
+    "deprecate-sdks": "ts-node ./scripts/unpublish-sdks.ts",
+    "prepare": "husky install"
   },
   "workspaces": {
     "packages": [
@@ -61,7 +56,7 @@
     "babel-jest": "^29.1.2",
     "codecov": "^3.6.5",
     "colors": "1.4.0",
-    "husky": "^3.1.0",
+    "husky": "^8.0.0",
     "jest": "^29.0.2",
     "jest-circus": "^29.0.2",
     "jest-junit": "^14.0.1",

--- a/scripts/beta-mode.sh
+++ b/scripts/beta-mode.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Beta Workflow steps
+# 0. Enter any random branch name
+echo "Enter a branch name"
+read branch_name
+# 1. create a prerelease/random branch
+git branch prerelease/$branch_name
+# 2. check it out
+git checkout prerelease/$branch_name
+# 3. enter pre mode (beta)
+yarn cs pre enter beta
+# 4. commit
+git add .changeset/pre.json
+git commit -am "enter beta mode"
+# 5. push
+git push origin prerelease/$branch_name
+# 6. githhub action will automatically trigger and open a Version packages (beta) PR against the prerelease/random branch
+echo "Commit to this prerelease/$branch_name and push up will trigger the github action to open a Version packages (beta) PR"
+# 7. merge that PR to publish or Push up more commits to update
+echo "Merge the Version Packages (beta) PR to publish a beta"
+#    a. if you do merge/publish you will need to add more changesets to initiate a new beta being published
+# 8. repeat 7 if wanted
+# 9. when ready to exit pre mode. `yarn beta-exit`
+echo "when complete with beta mode, run `yarn beta-exit`"
+echo "IMPORTANT: once you exit pre mode you should open a PR to merge your branch into main."
+echo "DONT MERGE the Version Packages PR which is not Beta into prerelease/$branch_name branch"
+# 11. open PR for prerelease into main
+# NOTE: if you want to exit pre mode and not publish a beta, you can run `yarn beta-exit --no-publish
+# TODO right now if you merge the changeset-prerelease Version Packages PR into its BASE it might be possible to end up in a state where pre mode is exited and you merge version packages in and end up pubblishing a regular package
+exit 0

--- a/scripts/hooks/pre-push.js
+++ b/scripts/hooks/pre-push.js
@@ -59,7 +59,7 @@ function getDateFromFirstCommit(fromSHA, toSHA) {
 /// MAIN
 ////////////////////////////////////////////////////////////////
 
-const [remoteName, remoteUrl] = process.env.HUSKY_GIT_PARAMS.split(' ')
+const remoteName = execSync('git remote').toString()
 
 const changes = process.env.HUSKY_GIT_STDIN.split('\n')
   .filter((line) => line !== '')

--- a/scripts/hooks/pre-push.js
+++ b/scripts/hooks/pre-push.js
@@ -59,17 +59,15 @@ function getDateFromFirstCommit(fromSHA, toSHA) {
 /// MAIN
 ////////////////////////////////////////////////////////////////
 
-const remoteName = execSync('git remote').toString()
-
+// must trim otherwise the name will be 'origin\n'
+const remoteName = execSync('git remote').toString().trim()
 const changes = process.env.HUSKY_GIT_STDIN.split('\n')
   .filter((line) => line !== '')
   .map((line) => {
     const [localRef, localSHA, remoteRef, remoteSHA] = line.split(' ')
     return { localRef, localSHA, remoteRef, remoteSHA }
   })
-
 for (const change of changes) {
-  // console.log('Checking commits to push to ', change.remoteRef)
   const [from, to] = getCommitRange(change, remoteName)
 
   const changedFiles = getChangedFiled(from, to)

--- a/scripts/hooks/prereleasecheck.sh
+++ b/scripts/hooks/prereleasecheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+# Ensure that its not possible to commit to a prerelease branch without a pre.json file
+if  [[ $BRANCH == prerelease* ]]; then
+	echo "checking for  pre.json"
+  PRE_FILE=.changeset/pre.json
+  if test -f "$PRE_FILE"; then
+    echo "$PRE_FILE exists."
+  else
+    echo "$PRE_FILE does not exist. Run yarn beta-enter to create it."
+    exit 1
+  fi
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -9480,7 +9480,7 @@ cors@^2.8.1, cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^5.0.7, cosmiconfig@^5.2.1:
+cosmiconfig@^5.0.7:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -12568,11 +12568,6 @@ get-proxy@^1.0.1:
   dependencies:
     rc "^1.1.2"
 
-get-stdin@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
-  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
-
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
@@ -13692,22 +13687,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
-  integrity sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
-  dependencies:
-    chalk "^2.4.2"
-    ci-info "^2.0.0"
-    cosmiconfig "^5.2.1"
-    execa "^1.0.0"
-    get-stdin "^7.0.0"
-    opencollective-postinstall "^2.0.2"
-    pkg-dir "^4.2.0"
-    please-upgrade-node "^3.2.0"
-    read-pkg "^5.2.0"
-    run-node "^1.0.0"
-    slash "^3.0.0"
+husky@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
 hyperlinker@^1.0.0:
   version "1.0.0"
@@ -17974,11 +17957,6 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-opencollective-postinstall@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
-
 opentracing@^0.14.4:
   version "0.14.7"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
@@ -18713,13 +18691,6 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
-
-please-upgrade-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -20234,11 +20205,6 @@ run-async@^2.2.0, run-async@^2.4.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
-run-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
-  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
-
 run-parallel-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz#be80e936f5768623a38a963262d6bef8ff11e7ba"
@@ -20428,11 +20394,6 @@ semaphore@>=1.0.1, semaphore@^1.0.3, semaphore@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.1.0.tgz#aaad8b86b20fe8e9b32b16dc2ee682a8cd26a8aa"
   integrity sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
   version "5.7.1"


### PR DESCRIPTION
### Description

adds a script / workflow for using changeset's pre mode. 

### TLDR run 
`yarn beta-enter`  to initiate the process 

A "Version Packges  (beta)" PR will open. Merging it will release packages

`yarn beta-exit` when complete

### Details

#### beta-mode.sh*
This script runs `changeset `and  `git` commands to ensure the correct branch is commited to and pushed up. 

#### celo-monorepo.yaml
our tests are already configured to run for any branch starting with prerelease/**

#### release.yaml 
as well as running on master, this will automatically open a pr anytime anything is pushed to prerelease/** branch.  As such there is a prepush hook to ensure changesets is in betamode before pushing. 

### Other changes

upgrade husky and fix pre-push.js

### Tested

same as used on social-connect

### Related issues

- Fixes #10679 

### Backwards compatibility

yes

### Documentation

see Release.md