### PR TITLE
Submodule handling fix

### DIFF
--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 60
-        if: false
+        if: true
         with:
           limit-access-to-actor: true
       - name: Generate devchain of previous release

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 60
-        if: true
+        if: false
         with:
           limit-access-to-actor: true
       - name: Generate devchain of previous release

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 [submodule "packages/protocol/lib/mento-core"]
 	path = packages/protocol/lib/mento-core
 	url = https://github.com/mento-protocol/mento-core
-[submodule "lib/memview.sol"]
+[submodule "packages/protocol/lib/memview.sol"]
 	path = packages/protocol/lib/memview.sol
 	url = https://github.com/summa-tx/memview.sol

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -49,14 +49,16 @@ RELEASE_TAG="" yarn build >> $LOG_FILE
 cd packages/protocol
 
 echo "- Create local network"
-if [ -z "$GRANTS_FILE" ]; then
-  yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
-else
-  yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
-fi
-rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-mv build/contracts* $BUILD_DIR
-mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
+# if [ -z "$GRANTS_FILE" ]; then
+#   yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
+# else
+#   yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
+# fi
+# rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+# mv build/contracts* $BUILD_DIR
+# mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
+
+echo "IN ORIGINAL FILE"
 
 # Forcefully remove all submodules and reinitialize them after checkout
 git submodule deinit -f --all

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -34,6 +34,7 @@ echo "- Checkout source code at $BRANCH"
 # Fetching also tags so we can checkout if $BRACH references a tag
 git fetch origin +"$BRANCH" --tags --force >> $LOG_FILE 2>&1
 rm -vrf packages/protocol/lib/memview.sol/* # has to be mentined explicitly as it is not a submodule in previous releases
+ls -la packages/protocol/lib/memview.sol
 git checkout -f --recurse-submodules $BRANCH >> $LOG_FILE 2>&1
 
 echo "- Build monorepo (contract artifacts, migrations, + all dependencies)"
@@ -49,15 +50,15 @@ yarn install >> $LOG_FILE
 RELEASE_TAG="" yarn build >> $LOG_FILE
 cd packages/protocol
 
-echo "- Create local network"
-if [ -z "$GRANTS_FILE" ]; then
-  yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
-else
-  yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
-fi
-rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-mv build/contracts* $BUILD_DIR
-mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
+# echo "- Create local network"
+# if [ -z "$GRANTS_FILE" ]; then
+#   yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
+# else
+#   yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
+# fi
+# rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+# mv build/contracts* $BUILD_DIR
+# mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
 
 # Forcefully remove all submodules and reinitialize them after checkout
 git submodule deinit -f --all

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -33,7 +33,7 @@ done
 echo "- Checkout source code at $BRANCH"
 # Fetching also tags so we can checkout if $BRACH references a tag
 git fetch origin +"$BRANCH" --tags --force >> $LOG_FILE 2>&1
-git checkout $BRANCH >> $LOG_FILE 2>&1
+git checkout -f --recurse-submodules $BRANCH >> $LOG_FILE 2>&1
 
 echo "- Build monorepo (contract artifacts, migrations, + all dependencies)"
 cd ../..
@@ -58,4 +58,4 @@ rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
 mv build/contracts* $BUILD_DIR
 mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
 
-git checkout -
+git checkout -f --recurse-submodules -

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -33,6 +33,7 @@ done
 echo "- Checkout source code at $BRANCH"
 # Fetching also tags so we can checkout if $BRACH references a tag
 git fetch origin +"$BRANCH" --tags --force >> $LOG_FILE 2>&1
+rm -rf packages/protocol/lib/memview.sol # has to be mentined explicitly as it is not a submodule in previous releases
 git checkout -f --recurse-submodules $BRANCH >> $LOG_FILE 2>&1
 
 echo "- Build monorepo (contract artifacts, migrations, + all dependencies)"

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -45,7 +45,7 @@ echo BUILD_DIR: $BUILD_DIR
 TMP_DIR=$(mktemp -d)
 echo "Using temporary directory $TMP_DIR"
 
-[ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo "$TMP_DIR/build/$(echo $BRANCH | sed -e 's/\//_/g')");
+[ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo "build/$(echo $BRANCH | sed -e 's/\//_/g')");
 
 echo "- Checkout source code at $BRANCH" and remote url $REMOTE_URL
 # Clone the repository into the temporary directory
@@ -71,8 +71,9 @@ else
   yarn devchain generate-tar "$BUILD_DIR/devchain.tar.gz" --release_gold_contracts "$GRANTS_FILE"
 fi
 
-
+echo "moving contracts from build/contracts to $TARGET_DIR"" 
 mv build/contracts $TARGET_DIR
+echo "moving $PWD/devchain.tar.gz to $TARGET_DIR"
 mv "$PWD/devchain.tar.gz" $TARGET_DIR/.
 
 # Clean up if necessary

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -41,6 +41,7 @@ echo "Using temporary directory $TMP_DIR"
 echo "Using build directory $BUILD_DIR"
 rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
 BUILD_DIR_ABOSLUTE=$(cd "$BUILD_DIR" && pwd || echo "Error: Failed to find directory")
+echo "ABSOLUTE BUILD DIR: $BUILD_DIR_ABOSLUTE"
 
 
 echo "- Checkout source code at $BRANCH" and remote url $REMOTE_URL

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -33,7 +33,7 @@ done
 echo "- Checkout source code at $BRANCH"
 # Fetching also tags so we can checkout if $BRACH references a tag
 git fetch origin +"$BRANCH" --tags --force >> $LOG_FILE 2>&1
-rm -rf packages/protocol/lib/memview.sol/* # has to be mentined explicitly as it is not a submodule in previous releases
+rm -vrf packages/protocol/lib/memview.sol/* # has to be mentined explicitly as it is not a submodule in previous releases
 git checkout -f --recurse-submodules $BRANCH >> $LOG_FILE 2>&1
 
 echo "- Build monorepo (contract artifacts, migrations, + all dependencies)"

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -60,7 +60,12 @@ mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
 
 # Forcefully remove all submodules and reinitialize them after checkout
 git submodule deinit -f --all
-git config --file .gitmodules --get-regexp path | awk '{ print $2 }' | xargs -I {} rm -rf {}
+while IFS= read -r line; do
+    # Extract the submodule path which is the second part of the line
+    submodule_path=$(echo "$line" | cut -d ' ' -f 2)
+    # Remove the submodule directory
+    rm -rf "$submodule_path"
+done < <(git config --file .gitmodules --get-regexp path)
 rm -rf .git/modules/*
 git checkout -f --recurse-submodules -
 git submodule update --init --recursive

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -30,7 +30,7 @@ done
 [ -z "$BRANCH" ] && echo "Need to set the branch via the -b flag" && exit 1;
 [ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'));
 
-echo "- Checkout source code at $BRANCH"
+echo "- Checkout2 source code at $BRANCH"
 # Fetching also tags so we can checkout if $BRACH references a tag
 git fetch origin +"$BRANCH" --tags --force >> $LOG_FILE 2>&1
 rm -vrf packages/protocol/lib/memview.sol/* # has to be mentined explicitly as it is not a submodule in previous releases

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -x
 
 source ./scripts/bash/utils.sh
 

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -27,34 +27,49 @@ while getopts ':b:rl:d:g:' flag; do
 done
 
 [ -z "$BRANCH" ] && echo "Need to set the branch via the -b flag" && exit 1;
-[ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'));
+
+# Remember the original working directory
+ORIG_PWD=$(pwd)
+
+[ -z "$BUILD_DIR_ORIG" ] && BUILD_DIR_ORIG=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'));
+
+# Create temporary directory
+TMP_DIR=$(mktemp -d)
+echo "Using temporary directory $TMP_DIR"
+
+[ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo "$TMP_DIR/build/$(echo $BRANCH | sed -e 's/\//_/g')");
 
 echo "- Checkout source code at $BRANCH"
-git fetch origin +"$BRANCH" 2>>$LOG_FILE >> $LOG_FILE
-git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
+# Clone the repository into the temporary directory
+git clone . "$TMP_DIR/repo" --branch "$BRANCH" --single-branch
+cd "$TMP_DIR/repo"
+
+# Redirection of logs
+exec 2>>$LOG_FILE >> $LOG_FILE
 
 echo "- Build monorepo (contract artifacts, migrations, + all dependencies)"
-cd ../..
+# Assuming we need to go up two directories to get to the root of the monorepo
+cd ../../..
 
-# Using `yarn reset` to remove node_modules before re-installing using the node version of 
-# the previous release branch. This is useful when node version between branches are incompatible
-yarn run reset >> $LOG_FILE
-# build entire monorepo to account for any required dependencies.
-yarn install >> $LOG_FILE
-yarn run clean >> $LOG_FILE
-# in release v8 and earlier, @celo/contractkit automatically uses set RELEASE_TAG
-# when building, which fails if this differs from `package/protocol`'s build directory.
-RELEASE_TAG="" yarn build >> $LOG_FILE
+# Here, replace the 'yarn' commands as necessary to work within the temp directory structure
+yarn run reset
+yarn install
+yarn run clean
+RELEASE_TAG="" yarn build
 cd packages/protocol
 
 echo "- Create local network"
 if [ -z "$GRANTS_FILE" ]; then
-  yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
+  yarn devchain generate-tar "$BUILD_DIR/devchain.tar.gz"
 else
-  yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
+  yarn devchain generate-tar "$BUILD_DIR/devchain.tar.gz" --release_gold_contracts "$GRANTS_FILE"
 fi
-rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-mv build/contracts $BUILD_DIR
-mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
 
-git checkout -
+cd "$ORIG_PWD"
+
+rm -rf $BUILD_DIR_ORIG && mkdir -p $BUILD_DIR_ORIG
+mv build/contracts $BUILD_DIR_ORIG
+mv "$PWD/devchain.tar.gz" $BUILD_DIR_ORIG/.
+
+# Clean up if necessary
+# rm -rf "$TMP_DIR"

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -33,7 +33,7 @@ done
 echo "- Checkout source code at $BRANCH"
 # Fetching also tags so we can checkout if $BRACH references a tag
 git fetch origin +"$BRANCH" --tags --force >> $LOG_FILE 2>&1
-rm -rf packages/protocol/lib/memview.sol # has to be mentined explicitly as it is not a submodule in previous releases
+rm -rf packages/protocol/lib/memview.sol/* # has to be mentined explicitly as it is not a submodule in previous releases
 git checkout -f --recurse-submodules $BRANCH >> $LOG_FILE 2>&1
 
 echo "- Build monorepo (contract artifacts, migrations, + all dependencies)"

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
 
 source ./scripts/bash/utils.sh
 
@@ -30,46 +29,32 @@ done
 [ -z "$BRANCH" ] && echo "Need to set the branch via the -b flag" && exit 1;
 [ -z "$BUILD_DIR" ] && BUILD_DIR=$(echo build/$(echo $BRANCH | sed -e 's/\//_/g'));
 
-echo "- Checkout2 source code at $BRANCH"
-# Fetching also tags so we can checkout if $BRACH references a tag
-git fetch origin +"$BRANCH" --tags --force >> $LOG_FILE 2>&1
-rm -vrf packages/protocol/lib/memview.sol/* # has to be mentined explicitly as it is not a submodule in previous releases
-ls -la packages/protocol/lib/memview.sol
-git checkout -f --recurse-submodules $BRANCH >> $LOG_FILE 2>&1
+echo "- Checkout source code at $BRANCH"
+git fetch origin +"$BRANCH" 2>>$LOG_FILE >> $LOG_FILE
+git checkout $BRANCH 2>>$LOG_FILE >> $LOG_FILE
 
 echo "- Build monorepo (contract artifacts, migrations, + all dependencies)"
 cd ../..
 
 # Using `yarn reset` to remove node_modules before re-installing using the node version of 
 # the previous release branch. This is useful when node version between branches are incompatible
-
+yarn run reset >> $LOG_FILE
 # build entire monorepo to account for any required dependencies.
 yarn install >> $LOG_FILE
+yarn run clean >> $LOG_FILE
 # in release v8 and earlier, @celo/contractkit automatically uses set RELEASE_TAG
 # when building, which fails if this differs from `package/protocol`'s build directory.
 RELEASE_TAG="" yarn build >> $LOG_FILE
 cd packages/protocol
 
-# echo "- Create local network"
-# if [ -z "$GRANTS_FILE" ]; then
-#   yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
-# else
-#   yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
-# fi
-# rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-# mv build/contracts* $BUILD_DIR
-# mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
+echo "- Create local network"
+if [ -z "$GRANTS_FILE" ]; then
+  yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
+else
+  yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
+fi
+rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+mv build/contracts $BUILD_DIR
+mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
 
-# Forcefully remove all submodules and reinitialize them after checkout
-git submodule deinit -f --all
-while IFS= read -r line; do
-    # Extract the submodule path which is the second part of the line
-    submodule_path=$(echo "$line" | cut -d ' ' -f 2)
-    # Remove the submodule directory
-    echo "removing $submodule_path"
-    rm -rf "$submodule_path"
-done < <(git config --file .gitmodules --get-regexp path)
-rm -rf packages/protocol/lib/memview.sol # has to be mentined explicitly as it is not a submodule in previous releases
-rm -rf .git/modules/*
-git checkout -f --recurse-submodules -
-git submodule update --init --recursive
+git checkout -

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -68,7 +68,7 @@ else
   yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts "$GRANTS_FILE"
 fi
 
-echo "moving contracts from build/contracts to $BUILD_DIR_ABOSLUTE"" 
+echo "moving contracts from build/contracts to $BUILD_DIR_ABOSLUTE"
 mv build/contracts $BUILD_DIR_ABOSLUTE
 echo "moving $PWD/devchain.tar.gz to $BUILD_DIR_ABOSLUTE"
 mv "$PWD/devchain.tar.gz" $BUILD_DIR_ABOSLUTE/.

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -66,8 +66,10 @@ while IFS= read -r line; do
     # Extract the submodule path which is the second part of the line
     submodule_path=$(echo "$line" | cut -d ' ' -f 2)
     # Remove the submodule directory
+    echo "removing $submodule_path"
     rm -rf "$submodule_path"
 done < <(git config --file .gitmodules --get-regexp path)
+rm -rf packages/protocol/lib/memview.sol
 rm -rf .git/modules/*
 git checkout -f --recurse-submodules -
 git submodule update --init --recursive

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -58,4 +58,9 @@ rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
 mv build/contracts* $BUILD_DIR
 mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
 
+# Forcefully remove all submodules and reinitialize them after checkout
+git submodule deinit -f --all
+git config --file .gitmodules --get-regexp path | awk '{ print $2 }' | xargs -I {} rm -rf {}
+rm -rf .git/modules/*
 git checkout -f --recurse-submodules -
+git submodule update --init --recursive

--- a/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
+++ b/packages/protocol/scripts/bash/generate-old-devchain-and-build.sh
@@ -49,16 +49,14 @@ RELEASE_TAG="" yarn build >> $LOG_FILE
 cd packages/protocol
 
 echo "- Create local network"
-# if [ -z "$GRANTS_FILE" ]; then
-#   yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
-# else
-#   yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
-# fi
-# rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
-# mv build/contracts* $BUILD_DIR
-# mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
-
-echo "IN ORIGINAL FILE"
+if [ -z "$GRANTS_FILE" ]; then
+  yarn devchain generate-tar "$PWD/devchain.tar.gz" >> $LOG_FILE
+else
+  yarn devchain generate-tar "$PWD/devchain.tar.gz" --release_gold_contracts $GRANTS_FILE >> $LOG_FILE
+fi
+rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+mv build/contracts* $BUILD_DIR
+mv "$PWD/devchain.tar.gz" $BUILD_DIR/.
 
 # Forcefully remove all submodules and reinitialize them after checkout
 git submodule deinit -f --all
@@ -69,7 +67,7 @@ while IFS= read -r line; do
     echo "removing $submodule_path"
     rm -rf "$submodule_path"
 done < <(git config --file .gitmodules --get-regexp path)
-rm -rf packages/protocol/lib/memview.sol
+rm -rf packages/protocol/lib/memview.sol # has to be mentined explicitly as it is not a submodule in previous releases
 rm -rf .git/modules/*
 git checkout -f --recurse-submodules -
 git submodule update --init --recursive


### PR DESCRIPTION
### Description

Updates generate-old-devchain-and-build.sh in a way that it doesn't do checkout inplace but rather uses tmp directory and then just copies devchain from there.

### Other changes

No other changes

### Tested

By CI