### PR TITLE
eliminate need to import protocol into contractkit

### DIFF
--- a/packages/protocol/lib/web3-utils.ts
+++ b/packages/protocol/lib/web3-utils.ts
@@ -6,6 +6,7 @@ import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { signTransaction } from '@celo/protocol/lib/signing-utils'
 import { privateKeyToAddress } from '@celo/utils/lib/address'
 import { BuildArtifacts } from '@openzeppelin/upgrades'
+import truffleContract from '@truffle/contract'
 import { createInterfaceAdapter } from '@truffle/interface-adapter'
 import { BigNumber } from 'bignumber.js'
 import path from 'path'
@@ -15,9 +16,6 @@ import { StableTokenInstance } from 'types/mento'
 import Web3 from 'web3'
 import { ContractPackage } from '../contractPackages'
 import { ArtifactsSingleton } from './artifactsSingleton'
-
-
-const truffleContract = require('@truffle/contract');
 
 
 export async function sendTransactionWithPrivateKey<T>(
@@ -151,10 +149,10 @@ export function checkFunctionArgsLength(args: any[], abi: any) {
 export async function setInitialProxyImplementation<
   ContractInstance extends Truffle.ContractInstance
 >(web3: Web3, artifacts: any, contractName: string, contractPackage?: ContractPackage, ...args: any[]): Promise<ContractInstance> {
-  
+
   const wrappedArtifacts = ArtifactsSingleton.getInstance(contractPackage, artifacts)
   const Contract = wrappedArtifacts.require(contractName)
-  
+
   // getProxy function supports the case the proxy is in a different package
   // which is the case for GasPriceMimimum
   const ContractProxy = wrappedArtifacts.getProxy(contractName, artifacts)
@@ -213,7 +211,7 @@ export async function getDeployedProxiedContract<ContractInstance extends Truffl
 ): Promise<ContractInstance> {
 
   const Contract: Truffle.Contract<ContractInstance> = customArtifacts.require(contractName)
-  
+
   let Proxy:ProxyContract
   // this wrap avoids a lot of rewrite
   const overloadedArtifact = ArtifactsSingleton.wrap(customArtifacts)
@@ -313,11 +311,11 @@ export function deploymentForContract<ContractInstance extends Truffle.ContractI
   let ContractProxy
   if (artifactPath) {
     Contract = makeTruffleContractForMigration(name, artifactPath, web3)
-    
+
     // This supports the case the proxy is in a different package
     if (artifactPath.proxiesPath){
       if (artifactPath.proxiesPath == "/"){
-        ContractProxy = artifacts.require(name + 'Proxy')  
+        ContractProxy = artifacts.require(name + 'Proxy')
       } else {
         throw "Loading proxies for custom path not supported"
       }

--- a/packages/protocol/test/compatibility/verify-bytecode.ts
+++ b/packages/protocol/test/compatibility/verify-bytecode.ts
@@ -12,7 +12,7 @@ import { NULL_ADDRESS } from '@celo/utils/lib/address'
 import { assert } from 'chai'
 import { RegistryInstance } from 'types'
 
-import truffleContract = require('@truffle/contract')
+import truffleContract from '@truffle/contract'
 
 const Registry = artifacts.require('Registry')
 const Proxy = artifacts.require('Proxy')

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@celo/odis-identifiers": "^1.0.0",
     "@celo/dev-utils": "0.0.1",
-    "@celo/protocol": "1.0.1",
     "@types/debug": "^4.1.5",
     "fetch-mock": "9.10.4",
     "ganache": "npm:@celo/ganache@7.8.0-unofficial.0",

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@celo/odis-identifiers": "^1.0.0",
     "@celo/dev-utils": "0.0.1",
+    "@celo/protocol": "1.0.1",
     "@types/debug": "^4.1.5",
     "fetch-mock": "9.10.4",
     "ganache": "npm:@celo/ganache@7.8.0-unofficial.0",

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -48,6 +48,7 @@
     "@celo/odis-identifiers": "^1.0.0",
     "@celo/dev-utils": "0.0.1",
     "@celo/protocol": "1.0.1",
+    "@truffle/contract": "^4.6.10",
     "@types/debug": "^4.1.5",
     "fetch-mock": "9.10.4",
     "ganache": "npm:@celo/ganache@7.8.0-unofficial.0",

--- a/packages/sdk/contractkit/src/globals.d.ts
+++ b/packages/sdk/contractkit/src/globals.d.ts
@@ -1,1 +1,3 @@
 declare const fetchMock
+
+declare module '@truffle/contract'

--- a/packages/sdk/contractkit/src/utils/getParsedSignatureOfAddress.ts
+++ b/packages/sdk/contractkit/src/utils/getParsedSignatureOfAddress.ts
@@ -1,0 +1,14 @@
+import { Connection } from '@celo/connect'
+import { parseSignature } from '@celo/utils/lib/signatureUtils'
+import Web3 from 'web3'
+
+export const getParsedSignatureOfAddress = async (
+  sha3: Web3['utils']['soliditySha3'],
+  sign: Connection['sign'],
+  address: string,
+  signer: string
+) => {
+  const addressHash = sha3({ type: 'address', value: address })!
+  const signature = await sign(addressHash, signer)
+  return parseSignature(addressHash, signature, signer)
+}

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -1,4 +1,4 @@
-import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -1,12 +1,12 @@
+import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import { addressToPublicKey, parseSignature } from '@celo/utils/lib/signatureUtils'
+import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
 import { ContractKit, newKitFromWeb3 } from '../kit'
 import { AccountsWrapper } from './Accounts'
 import { valueToBigNumber, valueToFixidityString } from './BaseWrapper'
 import { LockedGoldWrapper } from './LockedGold'
 import { ValidatorsWrapper } from './Validators'
-
 jest.setTimeout(10 * 1000)
 
 /*
@@ -36,10 +36,13 @@ testWithGanache('Accounts Wrapper', (web3) => {
     await lockedGold.lock().sendAndWaitForReceipt({ from: account, value: minLockedGoldValue })
   }
 
-  const getParsedSignatureOfAddress = async (address: string, signer: string) => {
-    const addressHash = web3.utils.soliditySha3({ type: 'address', value: address })!
-    const signature = await kit.connection.sign(addressHash, signer)
-    return parseSignature(addressHash, signature, signer)
+  function getParsedSignatureOfAddressForTest(address: string, signer: string) {
+    return getParsedSignatureOfAddress(
+      web3.utils.soliditySha3,
+      kit.connection.sign,
+      address,
+      signer
+    )
   }
 
   beforeAll(async () => {
@@ -69,7 +72,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const account = accounts[0]
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeAttestationSigner(signer, sig)
     ).sendAndWaitForReceipt({
@@ -83,7 +86,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const account = accounts[0]
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeAttestationSigner(signer, sig)
     ).sendAndWaitForReceipt({
@@ -107,7 +110,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const account = accounts[0]
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeValidatorSigner(signer, sig, validators)
     ).sendAndWaitForReceipt({ from: account })
@@ -121,7 +124,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
     await setupValidator(account)
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeValidatorSigner(signer, sig, validators)
     ).sendAndWaitForReceipt({ from: account })
@@ -137,7 +140,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
     await setupValidator(account)
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeValidatorSignerAndBls(signer, sig, newBlsPublicKey, newBlsPoP)
     ).sendAndWaitForReceipt({ from: account })

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -1,8 +1,9 @@
 import { NativeSigner, Signature, Signer } from '@celo/base/lib/signatureUtils'
 import { Address, CeloTransactionObject, toTransactionObject } from '@celo/connect'
+import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import {
-  hashMessageWithPrefix,
   LocalSigner,
+  hashMessageWithPrefix,
   parseSignature,
   signedMessageToPublicKey,
 } from '@celo/utils/lib/signatureUtils'
@@ -496,9 +497,7 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
   }
 
   private async getParsedSignatureOfAddress(address: Address, signer: string, signerFn: Signer) {
-    const hash = soliditySha3({ type: 'address', value: address })
-    const signature = await signerFn.sign(hash!)
-    return parseSignature(hash!, signature, signer)
+    return getParsedSignatureOfAddress(soliditySha3, signerFn.sign, address, signer)
   }
 
   private keccak256(value: string | BN): string {

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -1,6 +1,6 @@
 import { NativeSigner, Signature, Signer } from '@celo/base/lib/signatureUtils'
 import { Address, CeloTransactionObject, toTransactionObject } from '@celo/connect'
-import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import {
   LocalSigner,
   hashMessageWithPrefix,

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -1,9 +1,8 @@
 import { NativeSigner, Signature, Signer } from '@celo/base/lib/signatureUtils'
 import { Address, CeloTransactionObject, toTransactionObject } from '@celo/connect'
-import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import {
-  LocalSigner,
   hashMessageWithPrefix,
+  LocalSigner,
   parseSignature,
   signedMessageToPublicKey,
 } from '@celo/utils/lib/signatureUtils'
@@ -11,6 +10,7 @@ import { soliditySha3 } from '@celo/utils/lib/solidity'
 import { authorizeSigner as buildAuthorizeSignerTypedData } from '@celo/utils/lib/typed-data-constructors'
 import type BN from 'bn.js' // just the types
 import { Accounts } from '../generated/Accounts'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import { newContractVersion } from '../versions'
 import {
   proxyCall,

--- a/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
@@ -1,5 +1,5 @@
+import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import { getParsedSignatureOfAddress } from '@celo/protocol/lib/signing-utils'
 import { newKitFromWeb3 } from '../kit'
 import { EscrowWrapper } from './Escrow'
 import { FederatedAttestationsWrapper } from './FederatedAttestations'
@@ -9,6 +9,15 @@ testWithGanache('Escrow Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   const TEN_CUSD = kit.web3.utils.toWei('10', 'ether')
   const TIMESTAMP = 1665080820
+
+  function getParsedSignatureOfAddressForTest(address, signer) {
+    return getParsedSignatureOfAddress(
+      web3.utils.soliditySha3,
+      kit.connection.sign,
+      address,
+      signer
+    )
+  }
 
   let accounts: string[] = []
   let escrow: EscrowWrapper
@@ -59,7 +68,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
     const receiver: string = accounts[2]
     const withdrawKeyAddress: string = accounts[3]
     const oneDayInSecs: number = 86400
-    const parsedSig = await getParsedSignatureOfAddress(web3, receiver, withdrawKeyAddress)
+    const parsedSig = await getParsedSignatureOfAddressForTest(receiver, withdrawKeyAddress)
 
     await federatedAttestations
       .registerAttestationAsIssuer(identifier, receiver, TIMESTAMP)
@@ -99,7 +108,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
     const receiver: string = accounts[2]
     const withdrawKeyAddress: string = accounts[3]
     const oneDayInSecs: number = 86400
-    const parsedSig = await getParsedSignatureOfAddress(web3, receiver, withdrawKeyAddress)
+    const parsedSig = await getParsedSignatureOfAddressForTest(receiver, withdrawKeyAddress)
 
     await stableTokenContract
       .approve(escrow.address, TEN_CUSD)
@@ -128,7 +137,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
     const receiver: string = accounts[2]
     const withdrawKeyAddress: string = accounts[3]
     const oneDayInSecs: number = 86400
-    const parsedSig = await getParsedSignatureOfAddress(web3, receiver, withdrawKeyAddress)
+    const parsedSig = await getParsedSignatureOfAddressForTest(receiver, withdrawKeyAddress)
 
     await federatedAttestations
       .registerAttestationAsIssuer(identifier, receiver, TIMESTAMP)

--- a/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
@@ -10,7 +10,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
   const TEN_CUSD = kit.web3.utils.toWei('10', 'ether')
   const TIMESTAMP = 1665080820
 
-  function getParsedSignatureOfAddressForTest(address, signer) {
+  function getParsedSignatureOfAddressForTest(address: string, signer: string) {
     return getParsedSignatureOfAddress(
       web3.utils.soliditySha3,
       kit.connection.sign,

--- a/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
@@ -1,6 +1,6 @@
-import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { newKitFromWeb3 } from '../kit'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import { EscrowWrapper } from './Escrow'
 import { FederatedAttestationsWrapper } from './FederatedAttestations'
 import { StableTokenWrapper } from './StableTokenWrapper'

--- a/packages/sdk/contractkit/src/wrappers/MetaTransactionWallet.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/MetaTransactionWallet.test.ts
@@ -14,7 +14,10 @@ import {
   RawTransaction,
   toRawTransaction,
 } from './MetaTransactionWallet'
-const MetaTransactionWallet = contract(MTWContract)
+const MetaTransactionWallet = contract({
+  contractName: 'MetaTransactionWallet',
+  abi: MTWContract,
+})
 
 testWithGanache('MetaTransactionWallet Wrapper', (web3) => {
   MetaTransactionWallet.setProvider(web3.currentProvider)

--- a/packages/sdk/contractkit/src/wrappers/MetaTransactionWallet.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/MetaTransactionWallet.test.ts
@@ -1,10 +1,10 @@
 import { Address } from '@celo/base/lib/address'
 import { Signature } from '@celo/base/lib/signatureUtils'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import MTWContract from '@celo/protocol/build/contracts/MetaTransactionWallet.json'
 import { generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
 import { bufferToHex } from '@ethereumjs/util'
 import BigNumber from 'bignumber.js'
+import { ABI as MTWContract } from '../generated/MetaTransactionWallet'
 import { newKitFromWeb3 } from '../kit'
 import { GoldTokenWrapper } from './GoldTokenWrapper'
 import {

--- a/packages/sdk/contractkit/src/wrappers/MetaTransactionWallet.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/MetaTransactionWallet.test.ts
@@ -3,6 +3,7 @@ import { Signature } from '@celo/base/lib/signatureUtils'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
 import { bufferToHex } from '@ethereumjs/util'
+import contract from '@truffle/contract'
 import BigNumber from 'bignumber.js'
 import { ABI as MTWContract } from '../generated/MetaTransactionWallet'
 import { newKitFromWeb3 } from '../kit'
@@ -13,8 +14,6 @@ import {
   RawTransaction,
   toRawTransaction,
 } from './MetaTransactionWallet'
-
-const contract = require('@truffle/contract')
 const MetaTransactionWallet = contract(MTWContract)
 
 testWithGanache('MetaTransactionWallet Wrapper', (web3) => {

--- a/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.test.ts
@@ -12,8 +12,14 @@ import { newKitFromWeb3 } from '../kit'
 import { MetaTransactionWalletDeployerWrapper } from './MetaTransactionWalletDeployer'
 
 import contract from '@truffle/contract'
-const MetaTransactionWalletDeployer = contract(MTWDeployerContract)
-const MetaTransactionWallet = contract(MTWContract)
+const MetaTransactionWalletDeployer = contract({
+  abi: MTWDeployerContract,
+  name: 'MetaTransactionWalletDeployer',
+})
+const MetaTransactionWallet = contract({
+  abi: MTWContract,
+  name: 'MetaTransactionWallet',
+})
 
 testWithGanache('MetaTransactionWallet Wrapper', (web3) => {
   MetaTransactionWalletDeployer.setProvider(web3.currentProvider)

--- a/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.test.ts
@@ -11,7 +11,7 @@ import { newProxy } from '../generated/Proxy'
 import { newKitFromWeb3 } from '../kit'
 import { MetaTransactionWalletDeployerWrapper } from './MetaTransactionWalletDeployer'
 
-const contract = require('@truffle/contract')
+import contract from '@truffle/contract'
 const MetaTransactionWalletDeployer = contract(MTWDeployerContract)
 const MetaTransactionWallet = contract(MTWContract)
 

--- a/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/MetaTransactionWalletDeployer.test.ts
@@ -1,9 +1,12 @@
 import { Address, normalizeAddress } from '@celo/base'
 import { CeloTxReceipt, EventLog } from '@celo/connect'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import MTWContract from '@celo/protocol/build/contracts/MetaTransactionWallet.json'
-import MTWDeployerContract from '@celo/protocol/build/contracts/MetaTransactionWalletDeployer.json'
-import { MetaTransactionWallet, newMetaTransactionWallet } from '../generated/MetaTransactionWallet'
+import {
+  ABI as MTWContract,
+  MetaTransactionWallet,
+  newMetaTransactionWallet,
+} from '../generated/MetaTransactionWallet'
+import { ABI as MTWDeployerContract } from '../generated/MetaTransactionWalletDeployer'
 import { newProxy } from '../generated/Proxy'
 import { newKitFromWeb3 } from '../kit'
 import { MetaTransactionWalletDeployerWrapper } from './MetaTransactionWalletDeployer'

--- a/packages/sdk/contractkit/src/wrappers/SortedOracles.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/SortedOracles.test.ts
@@ -1,12 +1,12 @@
 import { Address } from '@celo/connect'
 import { describeEach } from '@celo/dev-utils/lib/describeEach'
 import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
-import { ABI as SortedOraclesABI } from '../generated/SortedOracles'
+import truffleContract from '@truffle/contract'
 import { CeloContract } from '../base'
 import { StableToken } from '../celo-tokens'
+import { ABI as SortedOraclesABI } from '../generated/SortedOracles'
 import { newKitFromWeb3 } from '../kit'
 import { OracleRate, ReportTarget, SortedOraclesWrapper } from './SortedOracles'
-import truffleContract from '@truffle/contract'
 // set timeout to 10 seconds
 jest.setTimeout(10 * 1000)
 
@@ -17,7 +17,10 @@ TEST NOTES:
 
 testWithGanache('SortedOracles Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
-  const SortedOracles = truffleContract(SortedOraclesABI)
+  const SortedOracles = truffleContract({
+    abi: SortedOraclesABI,
+    contractName: 'SortedOracles',
+  })
   SortedOracles.setProvider(web3.currentProvider)
 
   async function reportAsOracles(

--- a/packages/sdk/contractkit/src/wrappers/SortedOracles.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/SortedOracles.test.ts
@@ -6,9 +6,7 @@ import { CeloContract } from '../base'
 import { StableToken } from '../celo-tokens'
 import { newKitFromWeb3 } from '../kit'
 import { OracleRate, ReportTarget, SortedOraclesWrapper } from './SortedOracles'
-
-const truffleContract = require('@truffle/contract')
-
+import truffleContract from '@truffle/contract'
 // set timeout to 10 seconds
 jest.setTimeout(10 * 1000)
 

--- a/packages/sdk/contractkit/src/wrappers/SortedOracles.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/SortedOracles.test.ts
@@ -1,7 +1,7 @@
 import { Address } from '@celo/connect'
 import { describeEach } from '@celo/dev-utils/lib/describeEach'
 import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
-import SortedOraclesABI from '@celo/protocol/build/contracts/SortedOracles.json'
+import { ABI as SortedOraclesABI } from '../generated/SortedOracles'
 import { CeloContract } from '../base'
 import { StableToken } from '../celo-tokens'
 import { newKitFromWeb3 } from '../kit'


### PR DESCRIPTION
### Description

in preparation of moving /sdks to a new repo here the usage of '@celo/protocol' is removed from "@celo/contractkit" it was only used in tests. 

### Other changes

getParsedSignature was implemented twice in ck, once in a test file once in a wrapper. this creates a function where logic lives in once places and uses that as a base for creating some simpiler functions in tests. 

### Tested

pass

### Related issues

- Fixes #10718 

- part of https://github.com/celo-org/celo-labs/issues/1022

### Backwards compatibility

absolutely

### Documentation

n/a