### PR TITLE
removes moment.js from the repo completely

### DIFF
--- a/.changeset/hot-lamps-grin.md
+++ b/.changeset/hot-lamps-grin.md
@@ -1,0 +1,7 @@
+---
+'@celo/env-tests': patch
+'@celo/celotool': patch
+'@celo/celocli': patch
+---
+
+Remove moment.js dependency

--- a/packages/celotool/package.json
+++ b/packages/celotool/package.json
@@ -33,7 +33,6 @@
     "generate-password": "^1.5.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.21",
-    "moment": "^2.29.0",
     "node-fetch": "^2.6.7",
     "prompts": "1.2.0",
     "read-last-lines": "^1.7.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,6 @@
     "events": "^3.0.0",
     "fs-extra": "^8.1.0",
     "humanize-duration": "^3.29.0",
-    "moment": "^2.29.0",
     "path": "^0.12.7",
     "prompts": "^2.0.1",
     "randombytes": "^2.0.1",

--- a/packages/cli/src/utils/identity.ts
+++ b/packages/cli/src/utils/identity.ts
@@ -1,7 +1,7 @@
 import { ContractKit } from '@celo/contractkit'
 import { ClaimTypes, IdentityMetadataWrapper } from '@celo/contractkit/lib/identity'
 import { Claim } from '@celo/contractkit/lib/identity/claims/claim'
-import { VERIFIABLE_CLAIM_TYPES, now } from '@celo/contractkit/lib/identity/claims/types'
+import { now, VERIFIABLE_CLAIM_TYPES } from '@celo/contractkit/lib/identity/claims/types'
 import { verifyClaim } from '@celo/contractkit/lib/identity/claims/verify'
 import { eqAddress } from '@celo/utils/lib/address'
 import { concurrentMap } from '@celo/utils/lib/async'

--- a/packages/cli/src/utils/identity.ts
+++ b/packages/cli/src/utils/identity.ts
@@ -1,7 +1,7 @@
 import { ContractKit } from '@celo/contractkit'
 import { ClaimTypes, IdentityMetadataWrapper } from '@celo/contractkit/lib/identity'
 import { Claim } from '@celo/contractkit/lib/identity/claims/claim'
-import { VERIFIABLE_CLAIM_TYPES } from '@celo/contractkit/lib/identity/claims/types'
+import { VERIFIABLE_CLAIM_TYPES, now } from '@celo/contractkit/lib/identity/claims/types'
 import { verifyClaim } from '@celo/contractkit/lib/identity/claims/verify'
 import { eqAddress } from '@celo/utils/lib/address'
 import { concurrentMap } from '@celo/utils/lib/async'
@@ -9,7 +9,7 @@ import { NativeSigner } from '@celo/utils/lib/signatureUtils'
 import { toChecksumAddress } from '@ethereumjs/util'
 import { cli } from 'cli-ux'
 import { writeFileSync } from 'fs'
-import moment from 'moment'
+import humanizeDuration from 'humanize-duration'
 import { BaseCommand } from '../base'
 import { Args, Flags } from './command'
 
@@ -23,7 +23,7 @@ export abstract class ClaimCommand extends BaseCommand {
     }),
   }
   static args = [Args.file('file', { description: 'Path of the metadata file' })]
-  public requireSynced: boolean = false
+  public requireSynced = false
   // We need this to properly parse flags for subclasses
   protected self = ClaimCommand
 
@@ -93,6 +93,10 @@ export abstract class ClaimCommand extends BaseCommand {
 
 export const claimArgs = [Args.file('file', { description: 'Path of the metadata file' })]
 
+const fromNow = (timeInSeconds: number) => {
+  return `${humanizeDuration((now() - timeInSeconds) * 1000)} ago`
+}
+
 export const displayMetadata = async (
   metadata: IdentityMetadataWrapper,
   kit: ContractKit,
@@ -123,7 +127,8 @@ export const displayMetadata = async (
       type: claim.type,
       extra,
       status: verifiable ? (status ? `Could not verify: ${status}` : 'Verified!') : 'N/A',
-      createdAt: moment.unix(claim.timestamp).fromNow(),
+      // timestamp is in seconds see packages/sdk/contractkit/src/identity/claims/types.ts#now
+      createdAt: fromNow(claim.timestamp), // or //new Date(claim.timestamp * 1000).toUTCString(),
     }
   })
 

--- a/packages/env-tests/package.json
+++ b/packages/env-tests/package.json
@@ -18,7 +18,6 @@
     "bunyan-debug-stream": "2.0.0",
     "dotenv": "8.2.0",
     "jest": "^29.0.2",
-    "moment": "^2.29.0",
     "web3": "1.10.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17512,7 +17512,7 @@ module-not-found-error@^1.0.1:
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
   integrity sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==
 
-moment@^2.10.6, moment@^2.19.3, moment@^2.22.1, moment@^2.29.0:
+moment@^2.10.6, moment@^2.19.3, moment@^2.22.1:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
### Description

moment was listed as a dep but not used and the one place it was used was easily replaced with other code. 

### other changes

prettier made one small change automaticlly removing the explicit `boolean`

### Tested

### Related issues

### backwards compatiblity

the fromNow based on duration may have slightly different output but this is for human eyes so its ok.

### Documentation
 n/a
