### PR TITLE
updating apps tooling path to NPM

### DIFF
--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/apps-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/dev-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/dev-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/apps-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/dev-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/dev-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### Description

Updating path to the npm publish token folder in akeyless.  Backwards compatible since the old folder still exists for now.