### PR TITLE
Fix mistaken revert

### DIFF
--- a/.changeset/clean-dragons-tan.md
+++ b/.changeset/clean-dragons-tan.md
@@ -1,0 +1,5 @@
+---
+'@celo/connect': patch
+---
+
+Add back setFeeMarket function and re remove fillGasPrice which were accidentally reverted in beta 0

--- a/packages/cli/src/commands/identity/get-attestations.ts
+++ b/packages/cli/src/commands/identity/get-attestations.ts
@@ -88,7 +88,7 @@ export default class GetAttestations extends BaseCommand {
     console.log('Using network: ' + network)
     const authSigner: AuthSigner = {
       authenticationMethod: OdisUtils.Query.AuthenticationMethod.WALLET_KEY,
-      // @ts-ignore
+      // @ts-ignore -- TODO: if identity depends on diff version of ck which has a slightly different type this complains
       contractKit: kit,
     }
 

--- a/packages/cli/src/commands/identity/identifier.ts
+++ b/packages/cli/src/commands/identity/identifier.ts
@@ -42,7 +42,7 @@ export default class IdentifierQuery extends BaseCommand {
 
     const authSigner: AuthSigner = {
       authenticationMethod: OdisUtils.Query.AuthenticationMethod.WALLET_KEY,
-      // @ts-ignore fails when identity brings in different version of ck than is specified in dependencies
+      // @ts-ignore -- TODO: if identity depends on diff version of ck which has a slightly differnt type this complains
       contractKit: this.kit,
     }
 

--- a/packages/cli/src/utils/off-chain-data.ts
+++ b/packages/cli/src/utils/off-chain-data.ts
@@ -46,7 +46,7 @@ export abstract class OffchainDataCommand extends BaseCommand {
     }: ParserOutput<any, any> = this.parse()
 
     const from = privateKeyToAddress(privateKey)
-    // @ts-ignore
+    // @ts-ignore -- TODO: if identity depends on diff version of ck which has a slightly differnt type this complains
     this.offchainDataWrapper = new BasicDataWrapper(from, this.kit)
 
     this.offchainDataWrapper.storageWriter =

--- a/packages/sdk/connect/src/connection.test.ts
+++ b/packages/sdk/connect/src/connection.test.ts
@@ -1,0 +1,59 @@
+import Web3 from 'web3'
+import { Connection } from './connection'
+
+describe('Connection', () => {
+  let connection: Connection
+  beforeEach(() => {
+    const web3 = new Web3('http://localhost:8545')
+    connection = new Connection(web3)
+  })
+
+  describe('#setFeeMarketGas', () => {
+    describe('when fee market gas is set', () => {
+      it('returns with gasPrice undefined and feeMarketGas set', async () => {
+        const result = await connection.setFeeMarketGas({
+          maxFeePerGas: '1',
+          maxPriorityFeePerGas: '2',
+        })
+        expect(result).toEqual({
+          gasPrice: undefined,
+          maxFeePerGas: '1',
+          maxPriorityFeePerGas: '2',
+        })
+      })
+    })
+
+    describe('when fee market gas is not set', () => {
+      beforeEach(() => {
+        connection.rpcCaller.call = jest.fn(async (method) => {
+          if (method === 'eth_gasPrice') {
+            return {
+              result: '300000',
+              id: 22,
+              jsonrpc: '2.0',
+            }
+          }
+          if (method === 'eth_maxPriorityFeePerGas') {
+            return {
+              result: '200000',
+              id: 23,
+              jsonrpc: '2.0',
+            }
+          }
+          return {
+            result: 0,
+            id: 24,
+            jsonrpc: '2.0',
+          }
+        })
+      })
+      it('asked the rpc what they should be', () => {
+        connection.setFeeMarketGas({ feeCurrency: '0x000000' })
+        expect(connection.rpcCaller.call).toHaveBeenCalledWith('eth_gasPrice', ['0x000000'])
+        expect(connection.rpcCaller.call).toHaveBeenCalledWith('eth_maxPriorityFeePerGas', [
+          '0x000000',
+        ])
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Description

Sometime after release of @celo/connect 5.1.0 (t[he latest release](https://www.npmjs.com/package/@celo/connect?activeTab=code)) there was a commit or series of commits which removed setFeeMarketGas and added back fillGasPice ([removed in 5.0](https://github.com/celo-org/celo-monorepo/releases/tag/v5.0)) 

this reverts 

### Other changes


### Tested

added to ensure this doesnt happen this way again

### Related issues


### Backwards compatibility

matches what is released in 5.1

### Documentation

n/a