### PR TITLE
Use getParsedSignature from ck not from protocol in ck tests

### DIFF
--- a/.changeset/strange-eels-live.md
+++ b/.changeset/strange-eels-live.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': patch
+---
+
+Refactor Accounts.getParsedSignatureOfAddress

--- a/packages/sdk/contractkit/src/utils/getParsedSignatureOfAddress.ts
+++ b/packages/sdk/contractkit/src/utils/getParsedSignatureOfAddress.ts
@@ -1,0 +1,14 @@
+import { Connection } from '@celo/connect'
+import { parseSignature } from '@celo/utils/lib/signatureUtils'
+import Web3 from 'web3'
+
+export const getParsedSignatureOfAddress = async (
+  sha3: Web3['utils']['soliditySha3'],
+  sign: Connection['sign'],
+  address: string,
+  signer: string
+) => {
+  const addressHash = sha3({ type: 'address', value: address })!
+  const signature = await sign(addressHash, signer)
+  return parseSignature(addressHash, signature, signer)
+}

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -1,4 +1,4 @@
-import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -1,12 +1,12 @@
+import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import { addressToPublicKey, parseSignature } from '@celo/utils/lib/signatureUtils'
+import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
 import { ContractKit, newKitFromWeb3 } from '../kit'
 import { AccountsWrapper } from './Accounts'
 import { valueToBigNumber, valueToFixidityString } from './BaseWrapper'
 import { LockedGoldWrapper } from './LockedGold'
 import { ValidatorsWrapper } from './Validators'
-
 jest.setTimeout(10 * 1000)
 
 /*
@@ -36,10 +36,13 @@ testWithGanache('Accounts Wrapper', (web3) => {
     await lockedGold.lock().sendAndWaitForReceipt({ from: account, value: minLockedGoldValue })
   }
 
-  const getParsedSignatureOfAddress = async (address: string, signer: string) => {
-    const addressHash = web3.utils.soliditySha3({ type: 'address', value: address })!
-    const signature = await kit.connection.sign(addressHash, signer)
-    return parseSignature(addressHash, signature, signer)
+  function getParsedSignatureOfAddressForTest(address: string, signer: string) {
+    return getParsedSignatureOfAddress(
+      web3.utils.soliditySha3,
+      kit.connection.sign,
+      address,
+      signer
+    )
   }
 
   beforeAll(async () => {
@@ -69,7 +72,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const account = accounts[0]
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeAttestationSigner(signer, sig)
     ).sendAndWaitForReceipt({
@@ -83,7 +86,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const account = accounts[0]
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeAttestationSigner(signer, sig)
     ).sendAndWaitForReceipt({
@@ -107,7 +110,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const account = accounts[0]
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeValidatorSigner(signer, sig, validators)
     ).sendAndWaitForReceipt({ from: account })
@@ -121,7 +124,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
     await setupValidator(account)
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeValidatorSigner(signer, sig, validators)
     ).sendAndWaitForReceipt({ from: account })
@@ -137,7 +140,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     const signer = accounts[1]
     await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
     await setupValidator(account)
-    const sig = await getParsedSignatureOfAddress(account, signer)
+    const sig = await getParsedSignatureOfAddressForTest(account, signer)
     await (
       await accountsInstance.authorizeValidatorSignerAndBls(signer, sig, newBlsPublicKey, newBlsPoP)
     ).sendAndWaitForReceipt({ from: account })

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -1,9 +1,8 @@
 import { NativeSigner, Signature, Signer } from '@celo/base/lib/signatureUtils'
 import { Address, CeloTransactionObject, toTransactionObject } from '@celo/connect'
-import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import {
-  LocalSigner,
   hashMessageWithPrefix,
+  LocalSigner,
   parseSignature,
   signedMessageToPublicKey,
 } from '@celo/utils/lib/signatureUtils'
@@ -11,6 +10,7 @@ import { soliditySha3 } from '@celo/utils/lib/solidity'
 import { authorizeSigner as buildAuthorizeSignerTypedData } from '@celo/utils/lib/typed-data-constructors'
 import type BN from 'bn.js' // just the types
 import { Accounts } from '../generated/Accounts'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import { newContractVersion } from '../versions'
 import {
   proxyCall,

--- a/packages/sdk/contractkit/src/wrappers/Accounts.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.ts
@@ -1,8 +1,9 @@
 import { NativeSigner, Signature, Signer } from '@celo/base/lib/signatureUtils'
 import { Address, CeloTransactionObject, toTransactionObject } from '@celo/connect'
+import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import {
-  hashMessageWithPrefix,
   LocalSigner,
+  hashMessageWithPrefix,
   parseSignature,
   signedMessageToPublicKey,
 } from '@celo/utils/lib/signatureUtils'
@@ -496,9 +497,7 @@ export class AccountsWrapper extends BaseWrapper<Accounts> {
   }
 
   private async getParsedSignatureOfAddress(address: Address, signer: string, signerFn: Signer) {
-    const hash = soliditySha3({ type: 'address', value: address })
-    const signature = await signerFn.sign(hash!)
-    return parseSignature(hash!, signature, signer)
+    return getParsedSignatureOfAddress(soliditySha3, signerFn.sign, address, signer)
   }
 
   private keccak256(value: string | BN): string {

--- a/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
@@ -1,5 +1,5 @@
+import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import { getParsedSignatureOfAddress } from '@celo/protocol/lib/signing-utils'
 import { newKitFromWeb3 } from '../kit'
 import { EscrowWrapper } from './Escrow'
 import { FederatedAttestationsWrapper } from './FederatedAttestations'
@@ -9,6 +9,15 @@ testWithGanache('Escrow Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   const TEN_CUSD = kit.web3.utils.toWei('10', 'ether')
   const TIMESTAMP = 1665080820
+
+  function getParsedSignatureOfAddressForTest(address, signer) {
+    return getParsedSignatureOfAddress(
+      web3.utils.soliditySha3,
+      kit.connection.sign,
+      address,
+      signer
+    )
+  }
 
   let accounts: string[] = []
   let escrow: EscrowWrapper
@@ -59,7 +68,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
     const receiver: string = accounts[2]
     const withdrawKeyAddress: string = accounts[3]
     const oneDayInSecs: number = 86400
-    const parsedSig = await getParsedSignatureOfAddress(web3, receiver, withdrawKeyAddress)
+    const parsedSig = await getParsedSignatureOfAddressForTest(receiver, withdrawKeyAddress)
 
     await federatedAttestations
       .registerAttestationAsIssuer(identifier, receiver, TIMESTAMP)
@@ -99,7 +108,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
     const receiver: string = accounts[2]
     const withdrawKeyAddress: string = accounts[3]
     const oneDayInSecs: number = 86400
-    const parsedSig = await getParsedSignatureOfAddress(web3, receiver, withdrawKeyAddress)
+    const parsedSig = await getParsedSignatureOfAddressForTest(receiver, withdrawKeyAddress)
 
     await stableTokenContract
       .approve(escrow.address, TEN_CUSD)
@@ -128,7 +137,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
     const receiver: string = accounts[2]
     const withdrawKeyAddress: string = accounts[3]
     const oneDayInSecs: number = 86400
-    const parsedSig = await getParsedSignatureOfAddress(web3, receiver, withdrawKeyAddress)
+    const parsedSig = await getParsedSignatureOfAddressForTest(receiver, withdrawKeyAddress)
 
     await federatedAttestations
       .registerAttestationAsIssuer(identifier, receiver, TIMESTAMP)

--- a/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Escrow.test.ts
@@ -1,6 +1,6 @@
-import { getParsedSignatureOfAddress } from '@celo/contractkit/lib/utils/getParsedSignatureOfAddress'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { newKitFromWeb3 } from '../kit'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import { EscrowWrapper } from './Escrow'
 import { FederatedAttestationsWrapper } from './FederatedAttestations'
 import { StableTokenWrapper } from './StableTokenWrapper'
@@ -10,7 +10,7 @@ testWithGanache('Escrow Wrapper', (web3) => {
   const TEN_CUSD = kit.web3.utils.toWei('10', 'ether')
   const TIMESTAMP = 1665080820
 
-  function getParsedSignatureOfAddressForTest(address, signer) {
+  function getParsedSignatureOfAddressForTest(address: string, signer: string) {
     return getParsedSignatureOfAddress(
       web3.utils.soliditySha3,
       kit.connection.sign,


### PR DESCRIPTION
### Description

A few contract kit tests were importing a getParsedSignatureFromAddress @celo/protocol/lib/signing-utils. This ends that as part of broader effort to eliminate use of protocol code in contractkit. 

### Other changes

Accounts wrapper had its own implementation of the function which now defers to the getParsedSignatureFromAddress in ck utils. 

### Tested
existing tests

### Related issues

- part of [#10718](https://github.com/celo-org/celo-monorepo/issues/10718)

### Backwards compatibility

should be

### Documentation

n/a