### PR TITLE
Fix publish failing due to tag push fail

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Prepare Release
+    name: Prepare or Publish
     runs-on: ['self-hosted', 'org', 'npm-publish']
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Release to NPM
+    name: Prepare Release
     runs-on: ['self-hosted', 'org', 'npm-publish']
     permissions:
       contents: write

--- a/scripts/hooks/pre-push.js
+++ b/scripts/hooks/pre-push.js
@@ -60,7 +60,13 @@ function getDateFromFirstCommit(fromSHA, toSHA) {
 ////////////////////////////////////////////////////////////////
 
 // must trim otherwise the name will be 'origin\n'
+
 const remoteName = execSync('git remote').toString().trim()
+// create remote tracking branches to ensure we can compare current to origin/master
+const remoteTrackingMasterBranches = execSync('git ls-remote --heads origin master')
+if (remoteTrackingMasterBranches.toString().trim() === '') {
+  execSync('git fetch origin')
+}
 const changes = process.env.HUSKY_GIT_STDIN.split('\n')
   .filter((line) => line !== '')
   .map((line) => {


### PR DESCRIPTION
### Description

ensure origin master is tracked so pre push script works.

fixes 
```
/usr/bin/git push origin --tags
fatal: Not a valid object name origin/master
node:child_process:965
    throw err;

```

### Other changes


### Tested

Made the same change to prerelease branch and it succeeded https://github.com/celo-org/celo-monorepo/actions/runs/6943730052/job/18889421546

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/actions/runs/6942106852/job/18884367766#step:9:972

