### PR TITLE
Fixes typo in package.json "beta-enter" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "keys:encrypt": "bash scripts/key_placer.sh encrypt",
     "check:packages": "node ./scripts/check-packages.js",
     "release": "yarn build && yarn cs publish",
-    "beta-enter": "bash scripts/beta-enter.sh",
+    "beta-enter": "bash scripts/beta-mode.sh",
     "beta-exit": "yarn changeset pre exit && git commit -am 'Complete beta mode'",
     "version-and-reinstall": "yarn changeset version && yarn install",
     "celotool": "yarn --cwd packages/celotool run --silent cli",


### PR DESCRIPTION


### Description

The script "beta-enter" should run the script `scripts/beta-mode.sh` not `scripts/beta-enter.sh` (since that file doesn't exist). This PR simply corrects a typo in `package.json`.

### Other changes

N/A

### Tested

Tested by running `yarn beta-enter` before and after fixing the typo to make this pre-release: 
- https://github.com/celo-org/celo-monorepo/pull/10764/

### Related issues

N/A

### Backwards compatibility

Yes, fixes a bug that meant the script never worked before (was only recently introduced).

### Documentation

N/A