### PR TITLE
Add ContractCall mode

### DIFF
--- a/packages/celotool/src/cmds/geth/simulate_client.ts
+++ b/packages/celotool/src/cmds/geth/simulate_client.ts
@@ -2,10 +2,10 @@
 import BigNumber from 'bignumber.js'
 import { AccountType, generateAddress, generatePrivateKey } from 'src/lib/generate_utils'
 import {
-  MAX_LOADTEST_THREAD_COUNT,
-  TestMode,
   getIndexForLoadTestThread,
+  MAX_LOADTEST_THREAD_COUNT,
   simulateClient,
+  TestMode,
 } from 'src/lib/geth'
 import * as yargs from 'yargs'
 export const command = 'simulate-client'

--- a/packages/celotool/src/cmds/geth/simulate_client.ts
+++ b/packages/celotool/src/cmds/geth/simulate_client.ts
@@ -1,6 +1,12 @@
 /* tslint:disable no-console */
-import { AccountType, generateAddress } from 'src/lib/generate_utils'
-import { getIndexForLoadTestThread, simulateClient, TestMode } from 'src/lib/geth'
+import BigNumber from 'bignumber.js'
+import { AccountType, generateAddress, generatePrivateKey } from 'src/lib/generate_utils'
+import {
+  MAX_LOADTEST_THREAD_COUNT,
+  TestMode,
+  getIndexForLoadTestThread,
+  simulateClient,
+} from 'src/lib/geth'
 import * as yargs from 'yargs'
 export const command = 'simulate-client'
 
@@ -13,8 +19,12 @@ interface SimulateClientArgv extends yargs.Argv {
   index: number
   mnemonic: string
   recipientIndex: number
+  contractAddress: string
+  contractData: string
   clientCount: number
   reuseClient: boolean
+  maxGasPrice: number
+  totalTxGas: number
   testMode: string
 }
 
@@ -47,6 +57,16 @@ export const builder = () => {
         'Index of the load test account to send transactions to. Used to generate account address',
       default: 0,
     })
+    .options('contract-address', {
+      type: 'string',
+      description: `Contract Address to send to when using test mode: ${TestMode.ContractCall}`,
+      default: '',
+    })
+    .options('contract-data', {
+      type: 'string',
+      description: `Data to send to when using test mode: ${TestMode.ContractCall}`,
+      default: '',
+    })
     .options('mnemonic', {
       type: 'string',
       description: 'Mnemonic used to generate account addresses',
@@ -54,19 +74,36 @@ export const builder = () => {
     })
     .options('client-count', {
       type: 'number',
-      description: 'Number of clients to simulate',
+      description: `Number of clients to simulate, must not exceed ${MAX_LOADTEST_THREAD_COUNT}`,
       default: 1,
     })
+    .check((argv) => argv['client-count'] <= MAX_LOADTEST_THREAD_COUNT)
     .options('reuse-client', {
       type: 'boolean',
       description: 'Use the same client for all the threads/accounts',
       default: false,
     })
+    .options('max-gas-price', {
+      type: 'number',
+      description: 'Max gasPrice to use for transactions',
+      default: 0,
+    })
+    .options('total-tx-gas', {
+      type: 'number',
+      description: 'Gas Target when using data transfers',
+      default: 500000,
+    })
     .options('test-mode', {
       type: 'string',
       description:
-        'Load test mode: mixed transaction types, big calldatas, simple transfers paid in CELO or transfers paid in cUSD',
-      choices: [TestMode.Mixed, TestMode.Data, TestMode.Transfer, TestMode.StableTransfer],
+        'Load test mode: mixed transaction types, big calldatas, simple transfers paid in CELO, transfers paid in cUSD, or contract calls',
+      choices: [
+        TestMode.Mixed,
+        TestMode.Data,
+        TestMode.Transfer,
+        TestMode.StableTransfer,
+        TestMode.ContractCall,
+      ],
       default: TestMode.Mixed,
     })
 }
@@ -75,7 +112,7 @@ export const handler = async (argv: SimulateClientArgv) => {
   for (let thread = 0; thread < argv.clientCount; thread++) {
     const senderIndex = getIndexForLoadTestThread(argv.index, thread)
     const recipientIndex = getIndexForLoadTestThread(argv.recipientIndex, thread)
-    const senderAddress = generateAddress(
+    const senderPK = generatePrivateKey(
       argv.mnemonic,
       AccountType.LOAD_TESTING_ACCOUNT,
       senderIndex
@@ -89,7 +126,7 @@ export const handler = async (argv: SimulateClientArgv) => {
     const web3ProviderPort = argv.reuseClient ? 8545 : 8545 + thread
 
     console.log(
-      `Account for sender index ${argv.index} thread ${thread}, final index ${senderIndex}: ${senderAddress}`
+      `PK for sender index ${argv.index} thread ${thread}, final index ${senderIndex}: ${senderPK}`
     )
     console.log(
       `Account for recipient index ${argv.recipientIndex} thread ${thread}, final index ${recipientIndex}: ${recipientAddress}`
@@ -98,15 +135,19 @@ export const handler = async (argv: SimulateClientArgv) => {
 
     // tslint:disable-next-line: no-floating-promises
     simulateClient(
-      senderAddress,
+      senderPK,
       recipientAddress,
+      argv.contractAddress,
+      argv.contractData,
       argv.delay,
       argv.blockscoutUrl,
       argv.blockscoutMeasurePercent,
       argv.index,
       argv.testMode as TestMode,
       thread,
-      `http://localhost:${web3ProviderPort}`
+      new BigNumber(argv.maxGasPrice),
+      argv.totalTxGas,
+      `http://127.0.0.1:${web3ProviderPort}`
     )
   }
 }

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -541,7 +541,7 @@ export enum TestMode {
   Data = 'data',
   Transfer = 'transfer',
   StableTransfer = 'stable_transfer',
-  ContractCall = 'contract-call',
+  ContractCall = 'contract_call',
 }
 
 export const simulateClient = async (

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -19,12 +19,12 @@ import { convertToContractDecimals } from './contract-utils'
 import { envVar, fetchEnv, fetchEnvOrFallback } from './env-utils'
 import {
   AccountType,
-  Validator,
   generateGenesis,
   generateGenesisWithMigrations,
   generatePrivateKey,
   privateKeyToAddress,
   privateKeyToPublicKey,
+  Validator,
 } from './generate_utils'
 import { retrieveClusterIPAddress, retrieveIPAddress } from './helm_deploy'
 import { GethInstanceConfig } from './interfaces/geth-instance-config'

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -16,14 +16,15 @@ import Web3 from 'web3'
 import { Admin } from 'web3-eth-admin'
 import { spawnCmd, spawnCmdWithExitOnFailure } from './cmd-utils'
 import { convertToContractDecimals } from './contract-utils'
-import { envVar, fetchEnv } from './env-utils'
+import { envVar, fetchEnv, fetchEnvOrFallback } from './env-utils'
 import {
   AccountType,
+  Validator,
   generateGenesis,
   generateGenesisWithMigrations,
   generatePrivateKey,
+  privateKeyToAddress,
   privateKeyToPublicKey,
-  Validator,
 } from './generate_utils'
 import { retrieveClusterIPAddress, retrieveIPAddress } from './helm_deploy'
 import { GethInstanceConfig } from './interfaces/geth-instance-config'
@@ -77,6 +78,8 @@ export const LOG_TAG_TRANSACTION_VALIDATION_ERROR = 'validate_transaction_error'
 // for log messages which show time needed to receive the receipt after
 // the transaction has been sent
 export const LOG_TAG_TX_TIME_MEASUREMENT = 'tx_time_measurement'
+// max number of threads used for load testing
+export const MAX_LOADTEST_THREAD_COUNT = 100
 
 export const getEnodeAddress = (nodeId: string, ipAddress: string, port: number) => {
   return `enode://${nodeId}@${ipAddress}:${port}`
@@ -538,30 +541,36 @@ export enum TestMode {
   Data = 'data',
   Transfer = 'transfer',
   StableTransfer = 'stable_transfer',
+  ContractCall = 'contract-call',
 }
 
 export const simulateClient = async (
-  senderAddress: string,
+  senderPK: string,
   recipientAddress: string,
+  contractAddress: string,
+  contractData: string,
   txPeriodMs: number, // time between new transactions in ms
   blockscoutUrl: string,
   blockscoutMeasurePercent: number, // percent of time in range [0, 100] to measure blockscout for a tx
   index: number,
   testMode: TestMode,
   thread: number,
-  web3Provider: string = 'http://localhost:8545'
+  maxGasPrice: BigNumber = new BigNumber(0),
+  totalTxGas: number = 500000, // aim for half million gas txs
+  web3Provider: string = 'http://127.0.0.1:8545'
 ) => {
   // Assume the node is accessible via localhost with senderAddress unlocked
   const kit = newKitFromWeb3(new Web3(web3Provider))
-  const password = fetchEnv('PASSWORD')
 
   let lastNonce: number = -1
   let lastTx: string = ''
   let lastGasPriceMinimum: BigNumber = new BigNumber(0)
   let nonce: number = 0
-  let unlockNeeded: boolean = true
   let recipientAddressFinal: string = recipientAddress
-  const useRandomRecipient = fetchEnv(envVar.LOAD_TEST_USE_RANDOM_RECIPIENT)
+  const useRandomRecipient = fetchEnvOrFallback(envVar.LOAD_TEST_USE_RANDOM_RECIPIENT, 'false')
+
+  kit.connection.addAccount(senderPK)
+  kit.defaultAccount = privateKeyToAddress(senderPK)
 
   const sleepTime = 5000
   while (await kit.connection.isSyncing()) {
@@ -570,7 +579,6 @@ export const simulateClient = async (
     )
     await sleep(sleepTime)
   }
-  kit.defaultAccount = senderAddress
 
   // sleep a random amount of time in the range [0, txPeriodMs) before starting so
   // that if multiple simulations are started at the same time, they don't all
@@ -579,23 +587,35 @@ export const simulateClient = async (
   console.info(`Sleeping for ${randomSleep} ms`)
   await sleep(randomSleep)
 
+  const txConf = await getTxConf(testMode)
+  const intrinsicGas = txConf.feeCurrencyGold ? 21000 : 71000
+  const calldataGas = totalTxGas - intrinsicGas
+  const calldataSize = calldataGas / 4 // 119750 < tx pool size limit (128k)
+  let dataStr = testMode === TestMode.Data ? getBigData(calldataSize) : undefined // aim for half million gas txs
+  // Also running below the 128kb limit from the tx pool
+  let transferAmount = LOAD_TEST_TRANSFER_WEI
+
+  if (testMode === TestMode.ContractCall) {
+    if (!contractData || !contractAddress) {
+      throw new Error('Contract address and data must be provided for TestMode.ContractCall')
+    }
+    dataStr = contractData
+    recipientAddressFinal = contractAddress
+    transferAmount = new BigNumber(0)
+  }
+
   const baseLogMessage: any = {
     loadTestID: index,
     threadID: thread,
-    sender: senderAddress,
+    sender: kit.defaultAccount,
     recipient: recipientAddressFinal,
     feeCurrency: '',
     txHash: '',
+    tokenName: txConf.tokenName,
   }
 
   while (true) {
     const sendTransactionTime = Date.now()
-    if (unlockNeeded) {
-      await unlock(kit, kit.defaultAccount, password, 9223372036)
-      unlockNeeded = false
-    }
-    const txConf = await getTxConf(testMode)
-    baseLogMessage.tokenName = txConf.tokenName
 
     // randomly choose the recipientAddress if configured
     if (useRandomRecipient === 'true') {
@@ -621,6 +641,9 @@ export const simulateClient = async (
       )
       nonce = nonceResult.nonce
       gasPrice = nonceResult.newPrice
+      if (maxGasPrice.isGreaterThan(0)) {
+        gasPrice = BigNumber.min(gasPrice, maxGasPrice)
+      }
       lastGasPriceMinimum = gasPrice
       txOptions = {
         gasPrice: gasPrice.toString(),
@@ -634,19 +657,21 @@ export const simulateClient = async (
         ...baseLogMessage,
       })
     }
-    const intrinsicGas = txConf.feeCurrencyGold ? 21000 : 71000
-    const totalTxGas = 500000 // aim for half million gas txs
-    const calldataGas = totalTxGas - intrinsicGas
-    const calldataSize = calldataGas / 4 // 119750 < tx pool size limit (128k)
-    const dataStr = testMode === TestMode.Data ? getBigData(calldataSize) : undefined // aim for half million gas txs
-    // Also running below the 128kb limit from the tx pool
+
+    if (testMode === TestMode.ContractCall) {
+      if (!contractData || !contractAddress) {
+        throw new Error('Contract address and data must be provided for TestMode.ContractCall')
+      }
+      dataStr = contractData
+      recipientAddressFinal = contractAddress
+    }
 
     await txConf
       .transferFn(
         kit,
-        senderAddress,
+        kit.defaultAccount,
         recipientAddressFinal,
-        LOAD_TEST_TRANSFER_WEI,
+        transferAmount,
         dataStr,
         txOptions
       )
@@ -655,7 +680,7 @@ export const simulateClient = async (
         lastNonce = (await kit.web3.eth.getTransaction(lastTx)).nonce
         await onLoadTestTxResult(
           kit,
-          senderAddress,
+          kit.defaultAccount!,
           txResult,
           sendTransactionTime,
           baseLogMessage,
@@ -664,9 +689,11 @@ export const simulateClient = async (
         )
       })
       .catch((error: any) => {
-        if (catchNeedUnlock(error, baseLogMessage)) {
-          unlockNeeded = true
-        }
+        tracerLog({
+          tag: LOG_TAG_TRANSACTION_ERROR,
+          error: error.toString(),
+          ...baseLogMessage,
+        })
       })
     if (sendTransactionTime + txPeriodMs > Date.now()) {
       await sleep(sendTransactionTime + txPeriodMs - Date.now())
@@ -679,39 +706,46 @@ const getBigData = (size: number) => {
 }
 
 const getTxConf = async (testMode: TestMode) => {
-  if (testMode === TestMode.Data) {
-    return {
-      feeCurrencyGold: true,
-      tokenName: 'cGLD.L',
-      transferFn: transferCalldata,
-    }
-  }
-  if (testMode === TestMode.Transfer) {
-    return {
-      feeCurrencyGold: true,
-      tokenName: 'cGLD',
-      transferFn: transferCeloGold,
-    }
-  }
-  if (testMode === TestMode.StableTransfer) {
-    return {
-      feeCurrencyGold: false,
-      tokenName: 'cUSD',
-      transferFn: transferCeloDollars,
-    }
-  }
+  switch (testMode) {
+    case TestMode.Data:
+      return {
+        feeCurrencyGold: true,
+        tokenName: 'cGLD.L',
+        transferFn: transferCalldata,
+      }
+    case TestMode.Transfer:
+      return {
+        feeCurrencyGold: true,
+        tokenName: 'cGLD',
+        transferFn: transferCeloGold,
+      }
+    case TestMode.StableTransfer:
+      return {
+        feeCurrencyGold: false,
+        tokenName: 'cUSD',
+        transferFn: transferCeloDollars,
+      }
+    case TestMode.Mixed:
+      // randomly choose which token to use
+      const useGold = Boolean(Math.round(Math.random()))
+      const _transferFn = useGold ? transferCeloGold : transferCeloDollars
+      const _tokenName = useGold ? 'cGLD' : 'cUSD'
 
-  // randomly choose which token to use
-  const useGold = Boolean(Math.round(Math.random()))
-  const _transferFn = useGold ? transferCeloGold : transferCeloDollars
-  const _tokenName = useGold ? 'cGLD' : 'cUSD'
-
-  // randomly choose which gas currency to use
-  const _feeCurrencyGold = Boolean(Math.round(Math.random()))
-  return {
-    feeCurrencyGold: _feeCurrencyGold,
-    tokenName: _tokenName,
-    transferFn: _transferFn,
+      // randomly choose which gas currency to use
+      const _feeCurrencyGold = Boolean(Math.round(Math.random()))
+      return {
+        feeCurrencyGold: _feeCurrencyGold,
+        tokenName: _tokenName,
+        transferFn: _transferFn,
+      }
+    case TestMode.ContractCall:
+      return {
+        feeCurrencyGold: true,
+        tokenName: 'contract', // For logging
+        transferFn: transferCalldata,
+      }
+    default:
+      throw new Error(`Unimplemented TestMode: ${testMode}`)
   }
 }
 
@@ -740,27 +774,6 @@ const getNonce = async (
     newPrice: _newPrice,
     nonce: _nonce,
   }
-}
-
-// Catch errors from the transfer Fn, and returns if an account unlock
-// is needed.
-const catchNeedUnlock = (error: any, baseLogMessage: any) => {
-  let unlockNeeded = false
-  if (
-    typeof error === 'string' &&
-    error.includes('Error: authentication needed: password or unlock')
-  ) {
-    console.warn('Load test transaction failed with locked account:', error)
-    unlockNeeded = true
-  } else {
-    console.error('Load test transaction failed with error:', error)
-    tracerLog({
-      tag: LOG_TAG_TRANSACTION_ERROR,
-      error: error.toString(),
-      ...baseLogMessage,
-    })
-  }
-  return unlockNeeded
 }
 
 const getFeeCurrency = async (kit: ContractKit, feeCurrencyGold: boolean, baseLogMessage: any) => {
@@ -842,9 +855,11 @@ export const onLoadTestTxResult = async (
  * @param thread the thread number inside the pod
  */
 export function getIndexForLoadTestThread(pod: number, thread: number) {
-  // max number of threads to avoid overlap is [0, base)
-  const base = 10000
-  return pod * base + thread
+  if (thread > MAX_LOADTEST_THREAD_COUNT) {
+    throw new Error(`thread count must be smaller than ${MAX_LOADTEST_THREAD_COUNT}`)
+  }
+  // max number of threads to avoid overlap is [0, MAX_LOADTEST_THREAD_COUNT)
+  return pod * MAX_LOADTEST_THREAD_COUNT + thread
 }
 
 /**


### PR DESCRIPTION
### Description

Based on @eelanagaraj's [PR](https://github.com/celo-org/celo-monorepo/pull/10354/files)

New mode that simulates contract calls.

### Other changes

Additionally:
- cleans up some obsolete code
- provides additional informational context for the --client-count parameter
- refactors the simulateClient method and extracts some shared parameters of the load test from the main loop

### Tested

Tested on a local devnet.

### Related issues

- Needed for testing https://github.com/celo-org/celo-blockchain/pull/2203

### Backwards compatibility

Yes.