### PR TITLE
fix: celocli network:contracts command post Mento upgrade 04 

### DIFF
--- a/.changeset/new-queens-smoke.md
+++ b/.changeset/new-queens-smoke.md
@@ -1,5 +1,5 @@
 ---
-'@celo/celocli': minor
+'@celo/celocli': patch
 ---
 
 network:contracts command fix added StableTokens to unversioned contracts list

--- a/.changeset/new-queens-smoke.md
+++ b/.changeset/new-queens-smoke.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+network:contracts command fix added StableTokens to unversioned contracts list

--- a/packages/cli/src/commands/network/contracts.ts
+++ b/packages/cli/src/commands/network/contracts.ts
@@ -10,6 +10,9 @@ const UNVERSIONED_CONTRACTS = [
   CeloContract.Registry,
   CeloContract.FeeCurrencyWhitelist,
   CeloContract.Freezer,
+  CeloContract.StableToken,
+  CeloContract.StableTokenBRL,
+  CeloContract.StableTokenEUR,
 ]
 const UNPROXIED_CONTRACTS: CeloContract[] = []
 


### PR DESCRIPTION
### Description

As part of MU04 the mento team is upgrading the StableToken implementation. The new [StableToken](https://github.com/mento-protocol/mento-core/blob/develop/contracts/tokens/StableTokenV2.sol) implementation is not going to have a version therefore we need to add the StableToken contracts to the ```UNVERSIONED_CONTRACTS``` List. 

### Other changes
Even with these changes the command still fails on baklava. While debugging we noticed that the registry entry for the FeeHandler on baklava is pointing to the address(1) and is no proxy as expected by the code :/

### Tested

currently on baklava the new implementation is deployed and when removing the FeeHandler problem(as described above) the command works 

