### PR TITLE
feat: increase maxPercentageBidAskSpread to 75bps

### DIFF
--- a/packages/helm-charts/oracle/EUROCEUR.yaml
+++ b/packages/helm-charts/oracle/EUROCEUR.yaml
@@ -4,7 +4,7 @@ oracle:
     mid:
       maxExchangeVolumeShare: 1
       maxPercentageDeviation: 0.01
-      maxPercentageBidAskSpread: 0.005
+      maxPercentageBidAskSpread: 0.0075
   metrics:
     enabled: true
     prometheusPort: 9090

--- a/packages/helm-charts/oracle/EUROCXOF.yaml
+++ b/packages/helm-charts/oracle/EUROCXOF.yaml
@@ -5,7 +5,7 @@ oracle:
     mid:
       maxExchangeVolumeShare: 1
       maxPercentageDeviation: 0.01
-      maxPercentageBidAskSpread: 0.005
+      maxPercentageBidAskSpread: 0.0075
   metrics:
     enabled: true
     prometheusPort: 9090


### PR DESCRIPTION
### Description

- this pr increases the maxPercentageBidAskSpread to 75bps this decision was made because of the current EUROC liquidity on CEX

### Other changes

- n/a

### Tested

- n/a

### Related issues

- n/a

### Backwards compatibility

- n/a

### Documentation

- n/a