### PR TITLE
Equivalent tokens on top of updated sorted oracles 

### DIFF
--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -331,8 +331,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @notice Returns the median of the currently stored rates for a specified rateFeedId.
    * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId of the rates for which the median value is being retrieved.
-   * @return uint256 The median exchange rate for rateFeedId.
-   * @return fixidity
+   * @return uint256 The median exchange rate for rateFeedId (fixidity).
+   * @return uint256 num of rates
    */
   function medianRateWithoutEquivalentMapping(address token)
     public
@@ -347,8 +347,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @dev Please note that this function respects the equivalentToken mapping, and so may
    * return the median identified as an equivalent to the supplied rateFeedId.
    * @param token The rateFeedId of the rates for which the median value is being retrieved.
-   * @return uint256 The median exchange rate for rateFeedId.
-   * @return fixidity
+   * @return uint256 The median exchange rate for rateFeedId (fixidity).
+   * @return uint256 num of rates
    */
   function medianRate(address token) external view returns (uint256, uint256) {
     EquivalentToken storage equivalentToken = equivalentTokens[token];

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -42,11 +42,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   using AddressSortedLinkedListWithMedian for SortedLinkedListWithMedian.List;
   using FixidityLib for FixidityLib.Fraction;
 
-  struct EquivalentToken {
-    address token;
-    uint256 multiplier;
-  }
-
   uint256 private constant FIXED1_UINT = 1e24;
 
   // Maps a rateFeedID to a sorted list of report values.
@@ -66,9 +61,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   mapping(address => uint256) public tokenReportExpirySeconds;
 
   IBreakerBox public breakerBox;
-  // Maps a token address to its equivalent token address.
-  // Original token will return the median value same as the value of equivalent token.
-  mapping(address => EquivalentToken) public equivalentTokens;
 
   event OracleAdded(address indexed token, address indexed oracleAddress);
   event OracleRemoved(address indexed token, address indexed oracleAddress);
@@ -83,7 +75,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   event ReportExpirySet(uint256 reportExpiry);
   event TokenReportExpirySet(address token, uint256 reportExpiry);
   event BreakerBoxUpdated(address indexed newBreakerBox);
-  event EquivalentTokenSet(address indexed token, address indexed equivalentToken);
 
   modifier onlyOracle(address token) {
     require(isOracle[token][msg.sender], "sender was not an oracle for token addr");
@@ -98,7 +89,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 3, 0);
+    return (1, 1, 2, 1);
   }
 
   /**
@@ -231,44 +222,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   }
 
   /**
-   * @notice Sets the equivalent token for a token.
-   * @param token The address of the token.
-   * @param equivalentToken The address of the equivalent token.
-   * @param multiplier The multiplier to convert the equivalent token median value to the token value (fixidity).
-   * @dev For tokens with 6 decimals multiplier is 1e18 / 1e6 = 1e12
-   */
-  function setEquivalentToken(address token, address equivalentToken, uint256 multiplier)
-    external
-    onlyOwner
-  {
-    require(token != address(0), "token address cannot be 0");
-    require(equivalentToken != address(0), "equivalentToken address cannot be 0");
-    require(multiplier > 0, "multiplier must be > 0");
-    equivalentTokens[token] = EquivalentToken(equivalentToken, multiplier);
-    emit EquivalentTokenSet(token, equivalentToken);
-  }
-
-  /**
-   * @notice Sets the equivalent token for a token.
-   * @param token The address of the token.
-   */
-  function deleteEquivalentToken(address token) external onlyOwner {
-    require(token != address(0), "token address cannot be 0");
-    delete equivalentTokens[token];
-    emit EquivalentTokenSet(token, address(0));
-  }
-
-  /**
-   * @notice Gets the equivalent token for a token.
-   * @param token The address of the token.
-   * @return The address of the equivalent token.
-   * @return The multiplier to convert the equivalent token median value to the token value (fixidity).
-   */
-  function getEquivalentToken(address token) external view returns (address, uint256) {
-    return (equivalentTokens[token].token, equivalentTokens[token].multiplier);
-  }
-
-  /**
    * @notice Updates an oracle value and the median.
    * @param token The rateFeedId for the rate that is being reported.
    * @param value The number of stable asset that equate to one unit of collateral asset, for the
@@ -319,7 +272,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the number of rates that are currently stored for a specifed rateFeedId.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId for which to retrieve the number of rates.
    * @return uint256 The number of reported oracle rates stored for the given rateFeedId.
    */
@@ -329,48 +281,16 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the median of the currently stored rates for a specified rateFeedId.
-   * @dev Does not take account of equivalentTokens mapping.
-   * @param token The rateFeedId of the rates for which the median value is being retrieved.
-   * @return uint256 The median exchange rate for rateFeedId.
-   * @return fixidity
-   */
-  function medianRateWithoutEquivalentMapping(address token)
-    public
-    view
-    returns (uint256, uint256)
-  {
-    return (rates[token].getMedianValue(), numRates(token) == 0 ? 0 : FIXED1_UINT);
-  }
-
-  /**
-   * @notice Returns the median of the currently stored rates for a specified rateFeedId.
-   * @dev Please note that this function respects the equivalentToken mapping, and so may
-   * return the median identified as an equivalent to the supplied rateFeedId.
    * @param token The rateFeedId of the rates for which the median value is being retrieved.
    * @return uint256 The median exchange rate for rateFeedId.
    * @return fixidity
    */
   function medianRate(address token) external view returns (uint256, uint256) {
-    EquivalentToken storage equivalentToken = equivalentTokens[token];
-    if (equivalentToken.token != address(0)) {
-      (uint256 equivalentMedianRate, uint256 numRates) = medianRateWithoutEquivalentMapping(
-        equivalentToken.token
-      );
-      return (
-        FixidityLib
-          .wrap(equivalentMedianRate)
-          .multiply(FixidityLib.wrap(equivalentToken.multiplier))
-          .unwrap(),
-        numRates
-      );
-    }
-
-    return medianRateWithoutEquivalentMapping(token);
+    return (rates[token].getMedianValue(), numRates(token) == 0 ? 0 : FIXED1_UINT);
   }
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
    * @return keys Keys of an unpacked list of elements from largest to smallest.
    * @return values Values of an unpacked list of elements from largest to smallest.
@@ -386,7 +306,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the number of timestamps.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
    * @return uint256 The number of oracle report timestamps for the specified rateFeedId.
    */
@@ -396,7 +315,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the median timestamp.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
    * @return uint256 The median report timestamp for the specified rateFeedId.
    */
@@ -406,7 +324,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
    * @return keys Keys of nn unpacked list of elements from largest to smallest.
    * @return values Values of an unpacked list of elements from largest to smallest.
@@ -422,7 +339,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Checks if a report exists for a specified rateFeedId from a given oracle.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId to be checked.
    * @param oracle The oracle whose report should be checked.
    * @return bool True if a report exists, false otherwise.
@@ -433,7 +349,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the list of oracles for a speficied rateFeedId.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId whose oracles should be returned.
    * @return address[] A list of oracles for the given rateFeedId.
    */
@@ -443,7 +358,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the expiry for specified rateFeedId if it exists, if not the default is returned.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId.
    * @return The report expiry in seconds.
    */
@@ -457,7 +371,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Removes an oracle value and updates the median.
-   * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
    * @param oracle The oracle whose value should be removed.
    * @dev This can be used to delete elements for oracles that have been removed.

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -5,6 +6,7 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 import "./interfaces/ISortedOracles.sol";
 import "../common/interfaces/ICeloVersionedContract.sol";
+import "./interfaces/IBreakerBox.sol";
 
 import "../common/FixidityLib.sol";
 import "../common/Initializable.sol";
@@ -12,18 +14,39 @@ import "../common/linkedlists/AddressSortedLinkedListWithMedian.sol";
 import "../common/linkedlists/SortedLinkedListWithMedian.sol";
 
 /**
- * @title Maintains a sorted list of oracle exchange rates between CELO and other currencies.
+ * @title   SortedOracles
+ *
+ * @notice  This contract stores a collection of exchange rate reports between mento
+ *          collateral assets and other currencies. The most recent exchange rates
+ *          are gathered off-chain by oracles, who then use the `report` function to
+ *          submit the rates to this contract. Before submitting a rate report, an
+ *          oracle's address must be added to the `isOracle` mapping for a specific
+ *          rateFeedId, with the flag set to true. While submitting a report requires
+ *          an address to be added to the mapping, no additional permissions are needed
+ *          to read the reports, the calculated median rate, or the list of oracles.
+ *
+ * @dev     A unique rateFeedId identifies each exchange rate. In the initial implementation
+ *          of this contract, the rateFeedId was set as the address of the mento stable
+ *          asset contract that used the rate. However, this implementation has since
+ *          been updated, and the rateFeedId now refers to an address derived from the
+ *          concatenation of the mento collateral asset and the currency symbols' hash.
+ *          This change enables the contract to store multiple exchange rates for a
+ *          single stable asset. As a result of this change, there may be instances
+ *          where the term "token" is used in the contract code. These useages of the term
+ *          "token" are actually referring to the rateFeedId. You can refer to the Mento
+ *          protocol documentation to learn more about the rateFeedId and how it is derived.
+ *
  */
 contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initializable {
   using SafeMath for uint256;
   using AddressSortedLinkedListWithMedian for SortedLinkedListWithMedian.List;
   using FixidityLib for FixidityLib.Fraction;
 
-  uint256 private constant FIXED1_UINT = 1000000000000000000000000;
+  uint256 private constant FIXED1_UINT = 1e24;
 
-  // Maps a token address to a sorted list of report values.
+  // Maps a rateFeedID to a sorted list of report values.
   mapping(address => SortedLinkedListWithMedian.List) private rates;
-  // Maps a token address to a sorted list of report timestamps.
+  // Maps a rateFeedID to a sorted list of report timestamps.
   mapping(address => SortedLinkedListWithMedian.List) private timestamps;
   mapping(address => mapping(address => bool)) public isOracle;
   mapping(address => address[]) public oracles;
@@ -34,7 +57,10 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   // doesn't have a value in the mapping (i.e. it's 0), the fallback is used.
   // See: #getTokenReportExpirySeconds
   uint256 public reportExpirySeconds;
+  // Maps a rateFeedId to its report expiry time in seconds.
   mapping(address => uint256) public tokenReportExpirySeconds;
+
+  IBreakerBox public breakerBox;
 
   event OracleAdded(address indexed token, address indexed oracleAddress);
   event OracleRemoved(address indexed token, address indexed oracleAddress);
@@ -48,6 +74,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   event MedianUpdated(address indexed token, uint256 value);
   event ReportExpirySet(uint256 reportExpiry);
   event TokenReportExpirySet(address token, uint256 reportExpiry);
+  event BreakerBoxUpdated(address indexed newBreakerBox);
 
   modifier onlyOracle(address token) {
     require(isOracle[token][msg.sender], "sender was not an oracle for token addr");
@@ -62,7 +89,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 2, 3);
+    return (1, 1, 2, 1);
   }
 
   /**
@@ -92,8 +119,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   }
 
   /**
-   * @notice Sets the report expiry parameter for a token.
-   * @param _token The address of the token to set expiry for.
+   * @notice Sets the report expiry parameter for a rateFeedId.
+   * @param _token The rateFeedId for which the expiry is to be set.
    * @param _reportExpirySeconds The number of seconds before a report is considered expired.
    */
   function setTokenReportExpiry(address _token, uint256 _reportExpirySeconds) external onlyOwner {
@@ -107,26 +134,39 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   }
 
   /**
-   * @notice Adds a new Oracle.
-   * @param token The address of the token.
+   * @notice Sets the address of the BreakerBox.
+   * @param newBreakerBox The new BreakerBox address.
+   */
+  function setBreakerBox(IBreakerBox newBreakerBox) public onlyOwner {
+    require(address(newBreakerBox) != address(0), "BreakerBox address must be set");
+    breakerBox = newBreakerBox;
+    emit BreakerBoxUpdated(address(newBreakerBox));
+  }
+
+  /**
+   * @notice Adds a new Oracle for a specified rate feed.
+   * @param token The rateFeedId that the specified oracle is permitted to report.
    * @param oracleAddress The address of the oracle.
    */
   function addOracle(address token, address oracleAddress) external onlyOwner {
-    require(token != address(0), "token addr was null");
-    require(oracleAddress != address(0), "oracle addr was null");
-    require(!isOracle[token][oracleAddress], "oracle addr is not an oracle for token addr");
+    // solhint-disable-next-line reason-string
+    require(
+      token != address(0) && oracleAddress != address(0) && !isOracle[token][oracleAddress],
+      "token addr was null or oracle addr was null or oracle addr is already an oracle for token addr"
+    );
     isOracle[token][oracleAddress] = true;
     oracles[token].push(oracleAddress);
     emit OracleAdded(token, oracleAddress);
   }
 
   /**
-   * @notice Removes an Oracle.
-   * @param token The address of the token.
+   * @notice Removes an Oracle from a specified rate feed.
+   * @param token The rateFeedId that the specified oracle is no longer permitted to report.
    * @param oracleAddress The address of the oracle.
    * @param index The index of `oracleAddress` in the list of oracles.
    */
   function removeOracle(address token, address oracleAddress, uint256 index) external onlyOwner {
+    // solhint-disable-next-line reason-string
     require(
       token != address(0) &&
         oracleAddress != address(0) &&
@@ -145,7 +185,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Removes a report that is expired.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
+   * @param token The rateFeedId of the report to be removed.
    * @param n The number of expired reports to remove, at most (deterministic upper gas bound).
    */
   function removeExpiredReports(address token, uint256 n) external {
@@ -165,12 +205,13 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Check if last report is expired.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return isExpired
-   * @return The address of the last report.
+   * @param token The rateFeedId of the reports to be checked.
+   * @return bool A bool indicating if the last report is expired.
+   * @return address Oracle address of the last report.
    */
   function isOldestReportExpired(address token) public view returns (bool, address) {
-    require(token != address(0), "token address cannot be null");
+    // solhint-disable-next-line reason-string
+    require(token != address(0));
     address oldest = timestamps[token].getTail();
     uint256 timestamp = timestamps[token].getValue(oldest);
     // solhint-disable-next-line not-rely-on-time
@@ -182,8 +223,9 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Updates an oracle value and the median.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @param value The amount of `token` equal to one CELO, expressed as a fixidity value.
+   * @param token The rateFeedId for the rate that is being reported.
+   * @param value The number of stable asset that equate to one unit of collateral asset, for the
+   *              specified rateFeedId, expressed as a fixidity value.
    * @param lesserKey The element which should be just left of the new oracle value.
    * @param greaterKey The element which should be just right of the new oracle value.
    * @dev Note that only one of `lesserKey` or `greaterKey` needs to be correct to reduce friction.
@@ -222,21 +264,25 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
     if (newMedian != originalMedian) {
       emit MedianUpdated(token, newMedian);
     }
+
+    if (address(breakerBox) != address(0)) {
+      breakerBox.checkAndSetBreakers(token);
+    }
   }
 
   /**
-   * @notice Returns the number of rates.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return The number of reported oracle rates for `token`.
+   * @notice Returns the number of rates that are currently stored for a specifed rateFeedId.
+   * @param token The rateFeedId for which to retrieve the number of rates.
+   * @return uint256 The number of reported oracle rates stored for the given rateFeedId.
    */
   function numRates(address token) public view returns (uint256) {
     return rates[token].getNumElements();
   }
 
   /**
-   * @notice Returns the median rate.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return The median exchange rate for `token`.
+   * @notice Returns the median of the currently stored rates for a specified rateFeedId.
+   * @param token The rateFeedId of the rates for which the median value is being retrieved.
+   * @return uint256 The median exchange rate for rateFeedId.
    * @return fixidity
    */
   function medianRate(address token) external view returns (uint256, uint256) {
@@ -245,8 +291,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return keys Keys of nn unpacked list of elements from largest to smallest.
+   * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
+   * @return keys Keys of an unpacked list of elements from largest to smallest.
    * @return values Values of an unpacked list of elements from largest to smallest.
    * @return relations Relations of an unpacked list of elements from largest to smallest.
    */
@@ -260,8 +306,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the number of timestamps.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return The number of oracle report timestamps for `token`.
+   * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
+   * @return uint256 The number of oracle report timestamps for the specified rateFeedId.
    */
   function numTimestamps(address token) public view returns (uint256) {
     return timestamps[token].getNumElements();
@@ -269,8 +315,8 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Returns the median timestamp.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
-   * @return The median report timestamp for `token`.
+   * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
+   * @return uint256 The median report timestamp for the specified rateFeedId.
    */
   function medianTimestamp(address token) external view returns (uint256) {
     return timestamps[token].getMedianValue();
@@ -278,7 +324,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Gets all elements from the doubly linked list.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
+   * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
    * @return keys Keys of nn unpacked list of elements from largest to smallest.
    * @return values Values of an unpacked list of elements from largest to smallest.
    * @return relations Relations of an unpacked list of elements from largest to smallest.
@@ -292,26 +338,27 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
   }
 
   /**
-   * @notice Returns whether a report exists on token from oracle.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
+   * @notice Checks if a report exists for a specified rateFeedId from a given oracle.
+   * @param token The rateFeedId to be checked.
    * @param oracle The oracle whose report should be checked.
+   * @return bool True if a report exists, false otherwise.
    */
   function reportExists(address token, address oracle) internal view returns (bool) {
     return rates[token].contains(oracle) && timestamps[token].contains(oracle);
   }
 
   /**
-   * @notice Returns the list of oracles for a particular token.
-   * @param token The address of the token whose oracles should be returned.
-   * @return The list of oracles for a particular token.
+   * @notice Returns the list of oracles for a speficied rateFeedId.
+   * @param token The rateFeedId whose oracles should be returned.
+   * @return address[] A list of oracles for the given rateFeedId.
    */
   function getOracles(address token) external view returns (address[] memory) {
     return oracles[token];
   }
 
   /**
-   * @notice Returns the expiry for the token if exists, if not the default.
-   * @param token The address of the token.
+   * @notice Returns the expiry for specified rateFeedId if it exists, if not the default is returned.
+   * @param token The rateFeedId.
    * @return The report expiry in seconds.
    */
   function getTokenReportExpirySeconds(address token) public view returns (uint256) {
@@ -324,7 +371,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
 
   /**
    * @notice Removes an oracle value and updates the median.
-   * @param token The address of the token for which the CELO exchange rate is being reported.
+   * @param token The rateFeedId for which the collateral asset exchange rate is being reported.
    * @param oracle The oracle whose value should be removed.
    * @dev This can be used to delete elements for oracles that have been removed.
    * However, a > 1 elements reports list should always be maintained
@@ -338,6 +385,9 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
     uint256 newMedian = rates[token].getMedianValue();
     if (newMedian != originalMedian) {
       emit MedianUpdated(token, newMedian);
+      if (address(breakerBox) != address(0)) {
+        breakerBox.checkAndSetBreakers(token);
+      }
     }
   }
 }

--- a/packages/protocol/contracts/stability/interfaces/IBreakerBox.sol
+++ b/packages/protocol/contracts/stability/interfaces/IBreakerBox.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+
+/**
+ * @title Breaker Box Interface
+ * @notice Defines the basic interface for the Breaker Box
+ */
+interface IBreakerBox {
+  /**
+   * @dev Used to keep track of the status of a breaker for a specific rate feed.
+   *
+   * - TradingMode: Represents the trading mode the breaker is in for a rate feed.
+   *                This uses a bitmask approach, meaning each bit represents a
+   *                different trading mode. The final trading mode of the rate feed
+   *                is obtained by applying a logical OR operation to the TradingMode
+   *                of all breakers associated with that rate feed. This allows multiple
+   *                breakers to contribute to the final trading mode simultaneously.
+   *                Possible values:
+   *                0: bidirectional trading.
+   *                1: inflow only.
+   *                2: outflow only.
+   *                3: trading halted.
+   *
+   * - LastUpdatedTime: Records the last time the breaker status was updated. This is
+   *                    used to manage cooldown periods before the breaker can be reset.
+   *
+   * - Enabled:     Indicates whether the breaker is enabled for the associated rate feed.
+   */
+  struct BreakerStatus {
+    uint8 tradingMode;
+    uint64 lastUpdatedTime;
+    bool enabled;
+  }
+
+  /**
+   * @notice Emitted when a new breaker is added to the breaker box.
+   * @param breaker The address of the breaker.
+   */
+  event BreakerAdded(address indexed breaker);
+
+  /**
+   * @notice Emitted when a breaker is removed from the breaker box.
+   * @param breaker The address of the breaker.
+   */
+  event BreakerRemoved(address indexed breaker);
+
+  /**
+   * @notice Emitted when a breaker is tripped by a rate feed.
+   * @param breaker The address of the breaker.
+   * @param rateFeedID The address of the rate feed.
+   */
+  event BreakerTripped(address indexed breaker, address indexed rateFeedID);
+
+  /**
+   * @notice Emitted when a new rate feed is added to the breaker box.
+   * @param rateFeedID The address of the rate feed.
+   */
+  event RateFeedAdded(address indexed rateFeedID);
+
+  /**
+   * @notice Emitted when dependencies for a rate feed are set.
+   * @param rateFeedID The address of the rate feed.
+   * @param dependencies The addresses of the dependendent rate feeds.
+   */
+  event RateFeedDependenciesSet(address indexed rateFeedID, address[] indexed dependencies);
+
+  /**
+   * @notice Emitted when a rate feed is removed from the breaker box.
+   * @param rateFeedID The address of the rate feed.
+   */
+  event RateFeedRemoved(address indexed rateFeedID);
+
+  /**
+   * @notice Emitted when the trading mode for a rate feed is updated
+   * @param rateFeedID The address of the rate feed.
+   * @param tradingMode The new trading mode.
+   */
+  event TradingModeUpdated(address indexed rateFeedID, uint256 tradingMode);
+
+  /**
+   * @notice Emitted after a reset attempt is successful.
+   * @param rateFeedID The address of the rate feed.
+   * @param breaker The address of the breaker.
+   */
+  event ResetSuccessful(address indexed rateFeedID, address indexed breaker);
+
+  /**
+   * @notice  Emitted after a reset attempt fails when the
+   *          rate feed fails the breakers reset criteria.
+   * @param rateFeedID The address of the rate feed.
+   * @param breaker The address of the breaker.
+   */
+  event ResetAttemptCriteriaFail(address indexed rateFeedID, address indexed breaker);
+
+  /**
+   * @notice Emitted after a reset attempt fails when cooldown time has not elapsed.
+   * @param rateFeedID The address of the rate feed.
+   * @param breaker The address of the breaker.
+   */
+  event ResetAttemptNotCool(address indexed rateFeedID, address indexed breaker);
+
+  /**
+   * @notice Emitted when the sortedOracles address is updated.
+   * @param newSortedOracles The address of the new sortedOracles.
+   */
+  event SortedOraclesUpdated(address indexed newSortedOracles);
+
+  /**
+   * @notice Emitted when the breaker is enabled or disabled for a rate feed.
+   * @param breaker The address of the breaker.
+   * @param rateFeedID The address of the rate feed.
+   * @param status Indicating the status.
+   */
+  event BreakerStatusUpdated(address breaker, address rateFeedID, bool status);
+
+  /**
+   * @notice Retrives an array of all breaker addresses.
+   */
+  function getBreakers() external view returns (address[] memory);
+
+  /**
+   * @notice Checks if a breaker with the specified address has been added to the breaker box.
+   * @param breaker The address of the breaker to check;
+   * @return A bool indicating whether or not the breaker has been added.
+   */
+  function isBreaker(address breaker) external view returns (bool);
+
+  /**
+   * @notice Checks breakers for the rateFeedID and sets correct trading mode
+   * if any breakers are tripped or need to be reset.
+   * @param rateFeedID The address of the rate feed to run checks for.
+   */
+  function checkAndSetBreakers(address rateFeedID) external;
+
+  /**
+   * @notice Gets the trading mode for the specified rateFeedID.
+   * @param rateFeedID The address of the rate feed to retrieve the trading mode for.
+   */
+  function getRateFeedTradingMode(address rateFeedID) external view returns (uint8 tradingMode);
+}

--- a/packages/protocol/test-sol/stability/SortedOracles.mento.t.sol
+++ b/packages/protocol/test-sol/stability/SortedOracles.mento.t.sol
@@ -1,0 +1,659 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, var-name-mixedcase, state-visibility
+// solhint-disable const-name-snakecase, max-states-count, contract-name-camelcase
+pragma solidity ^0.5.13;
+
+import { Test, console2 as console } from "celo-foundry/Test.sol";
+
+import {
+  SortedLinkedListWithMedian
+} from "contracts/common/linkedlists/SortedLinkedListWithMedian.sol";
+import { FixidityLib } from "contracts/common/FixidityLib.sol";
+
+import { IBreakerBox } from "../../contracts/stability/interfaces/IBreakerBox.sol";
+import { SortedOracles } from "../../contracts/stability/SortedOracles.sol";
+
+contract MockBreakerBox is IBreakerBox {
+  uint256 public tradingMode;
+
+  function setTradingMode(uint256 _tradingMode) external {
+    tradingMode = _tradingMode;
+  }
+
+  function getBreakers() external view returns (address[] memory) {
+    return new address[](0);
+  }
+
+  function isBreaker(address) external view returns (bool) {
+    return true;
+  }
+
+  function getRateFeedTradingMode(address) external view returns (uint8) {
+    return 0;
+  }
+
+  function checkAndSetBreakers(address) external {}
+}
+
+contract SortedOraclesTest is Test {
+  // Declare SortedOracles events for matching
+  event ReportExpirySet(uint256 reportExpiry);
+  event TokenReportExpirySet(address token, uint256 reportExpiry);
+  event OracleAdded(address indexed token, address indexed oracleAddress);
+  event OracleRemoved(address indexed token, address indexed oracleAddress);
+  event OracleReportRemoved(address indexed token, address indexed oracle);
+  event MedianUpdated(address indexed token, uint256 value);
+  event OracleReported(
+    address indexed token,
+    address indexed oracle,
+    uint256 timestamp,
+    uint256 value
+  );
+  event BreakerBoxUpdated(address indexed newBreakerBox);
+
+  SortedOracles sortedOracles;
+  address owner;
+  address notOwner;
+  address rando;
+  address token;
+  uint256 aReportExpiry = 3600;
+  uint256 fixed1 = FixidityLib.unwrap(FixidityLib.fixed1());
+
+  address oracle;
+
+  bytes32 constant MOCK_EXCHANGE_ID = keccak256(abi.encodePacked("mockExchange"));
+
+  MockBreakerBox mockBreakerBox;
+
+  function setUp() public {
+    sortedOracles = new SortedOracles(true);
+    sortedOracles.initialize(aReportExpiry);
+
+    owner = address(this);
+    notOwner = address(10);
+    rando = address(2);
+    token = address(3);
+    oracle = address(4);
+
+    mockBreakerBox = new MockBreakerBox();
+    sortedOracles.setBreakerBox(IBreakerBox(mockBreakerBox));
+    vm.startPrank(owner);
+    currentPrank = owner;
+  }
+
+  /**
+   * @notice Test helper function. Submits n Reports for a token from n different Oracles.
+   */
+
+  function submitNReports(uint256 n) public {
+    sortedOracles.addOracle(token, oracle);
+    changePrank(oracle);
+    sortedOracles.report(token, fixed1 * 10, address(0), address(0));
+    for (uint256 i = 5; i < 5 + n - 1; i++) {
+      address anotherOracle = address(i);
+      changePrank(owner);
+      sortedOracles.addOracle(token, anotherOracle);
+      changePrank(address(i));
+      sortedOracles.report(token, fixed1 * 10, oracle, address(0));
+    }
+    changePrank(owner);
+  }
+}
+
+/**
+ * @notice Tests
+ */
+contract SortedOracles_initialize is SortedOraclesTest {
+  function test_initialize_shouldHaveSetTheOwner() public {
+    assertEq(sortedOracles.owner(), owner);
+  }
+
+  function test_initialize_shouldHaveSetReportExpiryToAReportExpiry() public {
+    assertEq(sortedOracles.reportExpirySeconds(), aReportExpiry);
+  }
+
+  function test_initialize_whenCalledAgain_shouldRevert() public {
+    vm.expectRevert("contract already initialized");
+    sortedOracles.initialize(aReportExpiry);
+  }
+}
+
+contract SortedOracles_setReportExpiry is SortedOraclesTest {
+  function test_setReportExpiry_shouldUpdateReportExpiry() public {
+    sortedOracles.setReportExpiry(aReportExpiry + 1);
+    assertEq(sortedOracles.reportExpirySeconds(), aReportExpiry + 1);
+  }
+
+  function test_setReportExpiry_shouldEmitEvent() public {
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit ReportExpirySet(aReportExpiry + 1);
+    sortedOracles.setReportExpiry(aReportExpiry + 1);
+  }
+
+  function test_setReportExpiry_whenCalledByNonOwner_shouldRevert() public {
+    vm.expectRevert("Ownable: caller is not the owner");
+    changePrank(rando);
+    sortedOracles.setReportExpiry(aReportExpiry + 1);
+  }
+}
+
+contract SortedOracles_setTokenReportExpiry is SortedOraclesTest {
+  uint256 aNewReportExpiry = aReportExpiry + 1;
+
+  function test_setTokenReportExpiry_shouldUpdateTokenReportExpiry() public {
+    sortedOracles.setTokenReportExpiry(token, aNewReportExpiry);
+    assertEq(sortedOracles.tokenReportExpirySeconds(token), aNewReportExpiry);
+  }
+
+  function test_setTokenReportExpiry_shouldEmitTokenReportExpirySetEvent() public {
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit TokenReportExpirySet(token, aNewReportExpiry);
+    sortedOracles.setTokenReportExpiry(token, aNewReportExpiry);
+  }
+
+  function test_setTokenReportExpiry_whenCalledByNonOwner_shouldRevert() public {
+    vm.expectRevert("Ownable: caller is not the owner");
+    changePrank(rando);
+    sortedOracles.setTokenReportExpiry(token, aNewReportExpiry);
+  }
+}
+
+contract SortedOracles_getTokenReportExpiry is SortedOraclesTest {
+  function test_getTokenReportExpirySeconds_whenNoTokenLevelExpiryIsSet_shouldReturnContractLevel()
+    public
+  {
+    assertEq(sortedOracles.getTokenReportExpirySeconds(token), aReportExpiry);
+  }
+
+  function test_getTokenReportExpirySeconds_whenTokenLevelExpiryIsSet_shouldReturnTokenLevel()
+    public
+  {
+    sortedOracles.setTokenReportExpiry(token, aReportExpiry + 1);
+    assertEq(sortedOracles.getTokenReportExpirySeconds(token), aReportExpiry + 1);
+  }
+}
+
+contract SortedOracles_addOracles is SortedOraclesTest {
+  function test_addOracle_shouldAddAnOracle() public {
+    sortedOracles.addOracle(token, oracle);
+    assertTrue(sortedOracles.isOracle(token, oracle));
+  }
+
+  function test_addOracle_shouldEmitEvent() public {
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit OracleAdded(token, oracle);
+    sortedOracles.addOracle(token, oracle);
+  }
+
+  function test_addOracle_whenTokenIsTheNullAddress_shouldRevert() public {
+    vm.expectRevert(
+      "token addr was null or oracle addr was null or oracle addr is already an oracle for token addr"
+    );
+    sortedOracles.addOracle(address(0), oracle);
+  }
+
+  function test_addOracle_whenOracleIsTheNullAddress_shouldRevert() public {
+    vm.expectRevert(
+      "token addr was null or oracle addr was null or oracle addr is already an oracle for token addr"
+    );
+    sortedOracles.addOracle(token, address(0));
+  }
+
+  function test_addOracle_whenOracleHasBeenAdded_shouldRevert() public {
+    sortedOracles.addOracle(token, oracle);
+    vm.expectRevert(
+      "token addr was null or oracle addr was null or oracle addr is already an oracle for token addr"
+    );
+    sortedOracles.addOracle(token, oracle);
+  }
+
+  function test_addOracle_whenCalledByNonOwner_shouldRevert() public {
+    vm.expectRevert("Ownable: caller is not the owner");
+    changePrank(rando);
+    sortedOracles.addOracle(token, oracle);
+  }
+}
+
+contract SortedOracles_breakerBox is SortedOraclesTest {
+  function test_setBreakerBox_whenCalledByNonOwner_shouldRevert() public {
+    changePrank(notOwner);
+    vm.expectRevert("Ownable: caller is not the owner");
+    sortedOracles.setBreakerBox(MockBreakerBox(address(0)));
+  }
+
+  function test_setBreakerBox_whenGivenAddressIsNull_shouldRevert() public {
+    vm.expectRevert("BreakerBox address must be set");
+    sortedOracles.setBreakerBox(MockBreakerBox(address(0)));
+  }
+
+  function test_setBreakerBox_shouldUpdateAndEmit() public {
+    sortedOracles = new SortedOracles(true);
+    assertEq(address(sortedOracles.breakerBox()), address(0));
+    vm.expectEmit(true, true, true, true);
+    emit BreakerBoxUpdated(address(mockBreakerBox));
+
+    sortedOracles.setBreakerBox(mockBreakerBox);
+    assertEq(address(sortedOracles.breakerBox()), address(mockBreakerBox));
+  }
+}
+
+contract SortedOracles_RemoveOracles is SortedOraclesTest {
+  function test_removeOracle_shouldRemoveAnOracle() public {
+    sortedOracles.addOracle(token, oracle);
+    sortedOracles.removeOracle(token, oracle, 0);
+    assertFalse(sortedOracles.isOracle(token, oracle));
+  }
+
+  function test_removeOracle_whenMoreThanOneReportExists_shouldDecreaseNumberOfRates() public {
+    submitNReports(2);
+    sortedOracles.removeOracle(token, oracle, 0);
+    assertEq(sortedOracles.numRates(token), 1);
+  }
+
+  function test_removeOracle_whenMoreThanOneReportExists_shouldDecreaseNumberOfTimestamps() public {
+    submitNReports(2);
+    sortedOracles.removeOracle(token, oracle, 0);
+    assertEq(sortedOracles.numTimestamps(token), 1);
+  }
+
+  function test_removeOracle_whenMoreThanOneReportExists_shouldEmitOracleRemovedOracleReportRemovedMedianUpdatedEvent()
+    public
+  {
+    submitNReports(1);
+    sortedOracles.addOracle(token, address(6));
+    changePrank(address(6));
+    sortedOracles.report(token, fixed1 * 12, oracle, address(0));
+
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit OracleReportRemoved(token, address(6));
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit MedianUpdated(token, fixed1 * 10);
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit OracleRemoved(token, address(6));
+
+    changePrank(owner);
+    sortedOracles.removeOracle(token, address(6), 1);
+  }
+
+  function test_removeOracle_whenOneReportExists_shouldNotDecreaseNumberOfRates() public {
+    submitNReports(1);
+    sortedOracles.removeOracle(token, oracle, 0);
+    assertEq(sortedOracles.numRates(token), 1);
+  }
+
+  function test_removeOracle_whenOneReportExists_shouldNotResetTheMedianRate() public {
+    submitNReports(1);
+    (uint256 numeratorBefore, ) = sortedOracles.medianRate(token);
+    sortedOracles.removeOracle(token, oracle, 0);
+    (uint256 numeratorAfter, ) = sortedOracles.medianRate(token);
+    assertEq(numeratorBefore, numeratorAfter);
+  }
+
+  function test_removeOracle_whenOneReportExists_shouldNotDecreaseNumberOfTimestamps() public {
+    submitNReports(1);
+    sortedOracles.removeOracle(token, oracle, 0);
+    assertEq(sortedOracles.numTimestamps(token), 1);
+  }
+
+  function test_removeOracle_whenOneReportExists_shouldNotResetTheMedianTimestamp() public {
+    submitNReports(1);
+    uint256 medianTimestampBefore = sortedOracles.medianTimestamp(token);
+    sortedOracles.removeOracle(token, oracle, 0);
+    uint256 medianTimestampAfter = sortedOracles.medianTimestamp(token);
+    assertEq(medianTimestampBefore, medianTimestampAfter);
+  }
+
+  function testFail_removeOracle_whenOneReportExists_shouldNotEmitTheOracleReportedAndMedianUpdatedEvent()
+    public
+  {
+    // testFail feals impricise here.
+    // TODO: Better way of testing this case :)
+    submitNReports(1);
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit OracleReportRemoved(token, oracle);
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit MedianUpdated(token, 0);
+    sortedOracles.removeOracle(token, oracle, 0);
+  }
+
+  function test_removeOracle_whenOneReportExists_shouldEmitTheOracleRemovedEvent() public {
+    submitNReports(1);
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit OracleRemoved(token, oracle);
+    sortedOracles.removeOracle(token, oracle, 0);
+  }
+
+  function test_removeOracle_whenIndexIsWrong_shouldRevert() public {
+    submitNReports(1);
+    vm.expectRevert(
+      "token addr null or oracle addr null or index of token oracle not mapped to oracle addr"
+    );
+    sortedOracles.removeOracle(token, oracle, 1);
+  }
+
+  function test_removeOracle_whenAddressIsWrong_shouldRevert() public {
+    submitNReports(1);
+    vm.expectRevert(
+      "token addr null or oracle addr null or index of token oracle not mapped to oracle addr"
+    );
+    sortedOracles.removeOracle(token, address(15), 0);
+  }
+
+  function test_removeOracle_whenCalledByNonOwner_shouldRevert() public {
+    submitNReports(1);
+    vm.expectRevert("Ownable: caller is not the owner");
+    changePrank(rando);
+    sortedOracles.removeOracle(token, address(15), 0);
+  }
+}
+
+contract SortedOracles_removeExpiredReports is SortedOraclesTest {
+  function test_removeExpiredReports_whenNoReportExists_shouldRevert() public {
+    sortedOracles.addOracle(token, oracle);
+    vm.expectRevert("token addr null or trying to remove too many reports");
+    sortedOracles.removeExpiredReports(token, 1);
+  }
+
+  function test_removeExpiredReports_whenOnlyOneReportExists_shouldRevert() public {
+    sortedOracles.addOracle(token, oracle);
+    changePrank(oracle);
+    sortedOracles.report(token, fixed1, address(0), address(0));
+    vm.expectRevert("token addr null or trying to remove too many reports");
+    sortedOracles.removeExpiredReports(token, 1);
+  }
+
+  function test_removeExpiredReports_whenOldestReportIsNotExpired_shouldDoNothing() public {
+    submitNReports(5);
+    sortedOracles.removeExpiredReports(token, 3);
+    assertEq(sortedOracles.numTimestamps(token), 5);
+  }
+
+  function test_removeExpiredReports_whenLessThanNReportsAreExpired_shouldRemoveAllExpiredAndStop()
+    public
+  {
+    //first 5 expired reports
+    submitNReports(5);
+    skip(aReportExpiry);
+    //two reports that aren't expired
+    sortedOracles.addOracle(token, address(10));
+    changePrank(address(10));
+    sortedOracles.report(token, fixed1 * 10, oracle, address(0));
+    changePrank(owner);
+    sortedOracles.addOracle(token, address(11));
+    changePrank(address(11));
+    sortedOracles.report(token, fixed1 * 10, oracle, address(0));
+
+    changePrank(owner);
+    sortedOracles.removeExpiredReports(token, 6);
+    assertEq(sortedOracles.numTimestamps(token), 2);
+  }
+
+  function test_removeExpiredReports_whenNLargerThanNumberOfTimestamps_shouldRevert() public {
+    submitNReports(5);
+    vm.expectRevert("token addr null or trying to remove too many reports");
+    sortedOracles.removeExpiredReports(token, 7);
+  }
+
+  function test_removeExpiredReports_whenNReportsAreExpired_shouldRemoveNReports() public {
+    submitNReports(6);
+    skip(aReportExpiry);
+    sortedOracles.removeExpiredReports(token, 5);
+    assertEq(sortedOracles.numTimestamps(token), 1);
+  }
+
+  function test_removeExpiredReports_whenMoreThanOneReportExistsAndMedianUpdated_shouldCallCheckAndSetBreakers()
+    public
+  {
+    submitNReports(2);
+    sortedOracles.addOracle(token, address(6));
+    changePrank(address(6));
+
+    vm.warp(now + aReportExpiry);
+    sortedOracles.report(token, fixed1 * 12, oracle, address(0));
+
+    vm.expectEmit(false, false, false, false, address(sortedOracles));
+    emit OracleReportRemoved(token, rando);
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit MedianUpdated(token, fixed1 * 12);
+    vm.expectCall(
+      address(mockBreakerBox),
+      abi.encodeWithSelector(mockBreakerBox.checkAndSetBreakers.selector)
+    );
+
+    sortedOracles.removeExpiredReports(token, 2);
+  }
+}
+
+contract SortedOracles_isOldestReportExpired is SortedOraclesTest {
+  function test_isOldestReportExpired_whenNoReportsExist_shouldReturnTrue() public {
+    //added this skip because foundry starts at a block time of 0
+    //without the skip isOldestReortExpired would return false when no reports exist
+    skip(aReportExpiry);
+    sortedOracles.addOracle(token, oracle);
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertTrue(isReportExpired);
+  }
+
+  function test_isOldestReportExpired_whenReportIsExpired_shouldReturnTrue() public {
+    submitNReports(1);
+    skip(aReportExpiry);
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertTrue(isReportExpired);
+  }
+
+  function test_isOldestReportExpired_whenReportIsntExpired_shouldReturnFalse() public {
+    submitNReports(1);
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertFalse(isReportExpired);
+  }
+
+  function test_isOldestReportExpired_whenTokenSpecificExpiryIsntExceeded_shoulReturnFalse()
+    public
+  {
+    submitNReports(1);
+    sortedOracles.setTokenReportExpiry(token, aReportExpiry * 2);
+    //neither general nor specific Expiry expired
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertFalse(isReportExpired);
+    //general Expiry expired but not specific
+    skip(aReportExpiry);
+    (isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertFalse(isReportExpired);
+  }
+
+  function test_isOldestReportExpired_whenSpecificTokenExpiryIsExceeded_shouldReturnTrue() public {
+    submitNReports(1);
+    sortedOracles.setTokenReportExpiry(token, aReportExpiry * 2);
+    skip(aReportExpiry * 2);
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertTrue(isReportExpired);
+  }
+
+  function test_isOldestReportExpired_whenSpecificExpiryIsLowerButNotExpired_shouldReturnFalse()
+    public
+  {
+    submitNReports(1);
+    sortedOracles.setTokenReportExpiry(token, (aReportExpiry * 1) / 2);
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertFalse(isReportExpired);
+  }
+
+  function test_isOldestReportExpired_whenSpecificExpiryIsLowerAndGeneralExpiryIsExceeded_shouldReturnTrue()
+    public
+  {
+    submitNReports(1);
+    sortedOracles.setTokenReportExpiry(token, (aReportExpiry * 1) / 2);
+    skip(aReportExpiry);
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertTrue(isReportExpired);
+  }
+
+  function test_isOldestReportExpired_whenSpecificExpiryIsLowerAndSpecificExpiryIsExceeded_shouldReturnTrue()
+    public
+  {
+    submitNReports(1);
+    sortedOracles.setTokenReportExpiry(token, (aReportExpiry * 1) / 2);
+    skip((aReportExpiry * 1) / 2);
+    (bool isReportExpired, ) = sortedOracles.isOldestReportExpired(token);
+    assertTrue(isReportExpired);
+  }
+}
+
+contract SortedOracles_report is SortedOraclesTest {
+  address oracleB = actor("oracleB");
+  address oracleC = actor("oracleC");
+
+  function test_report_shouldIncreaseTheNumberOfRates() public {
+    assertEq(sortedOracles.numRates(token), 0);
+    submitNReports(1);
+    assertEq(sortedOracles.numRates(token), 1);
+  }
+
+  function test_report_shouldSetTheMedianRate() public {
+    sortedOracles.addOracle(token, oracle);
+    changePrank(oracle);
+    sortedOracles.report(token, fixed1 * 10, address(0), address(0));
+    (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(token);
+    assertEq(numerator, fixed1 * 10);
+    assertEq(denominator, fixed1);
+  }
+
+  function test_report_shouldIncreaseTheNumberOfTimestamps() public {
+    assertEq(sortedOracles.numTimestamps(token), 0);
+    submitNReports(1);
+    assertEq(sortedOracles.numTimestamps(token), 1);
+  }
+
+  function test_report_shouldSetTheMedianTimestamp() public {
+    submitNReports(1);
+    assertEq(block.timestamp, sortedOracles.medianTimestamp(token));
+  }
+
+  function test_report_shouldEmitTheOracleReportedAndMedianUpdatedEvent() public {
+    sortedOracles.addOracle(token, oracle);
+    vm.expectEmit(true, true, true, true, address(sortedOracles));
+    emit OracleReported(token, oracle, block.timestamp, fixed1 * 10);
+    emit MedianUpdated(token, fixed1 * 10);
+    changePrank(oracle);
+    sortedOracles.report(token, fixed1 * 10, address(0), address(0));
+  }
+
+  function test_report_whenCalledByNonOracle_shouldRevert() public {
+    changePrank(rando);
+    vm.expectRevert("sender was not an oracle for token addr");
+    sortedOracles.report(token, fixed1, address(0), address(0));
+  }
+
+  function test_report_whenOneReportBySameOracleExists_shouldResetMedianRate() public {
+    submitNReports(1);
+    (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(token);
+    assertEq(numerator, fixed1 * 10);
+    assertEq(denominator, fixed1);
+
+    changePrank(oracle);
+    sortedOracles.report(token, fixed1 * 20, address(0), address(0));
+    (numerator, denominator) = sortedOracles.medianRate(token);
+    assertEq(numerator, fixed1 * 20);
+    assertEq(denominator, fixed1);
+  }
+
+  function test_report_whenOneReportBySameOracleExists_shouldNotChangeNumberOfTotalReports()
+    public
+  {
+    submitNReports(1);
+    uint256 initialNumberOfReports = sortedOracles.numRates(token);
+    changePrank(oracle);
+    sortedOracles.report(token, fixed1 * 20, address(0), address(0));
+    assertEq(initialNumberOfReports, sortedOracles.numRates(token));
+  }
+
+  function test_report_whenMultipleReportsExistTheMostRecent_shouldUpdateListOfRatesCorrectly()
+    public
+  {
+    address anotherOracle = address(5);
+    uint256 oracleValue1 = fixed1;
+    uint256 oracleValue2 = fixed1 * 2;
+    uint256 oracleValue3 = fixed1 * 3;
+    sortedOracles.addOracle(token, anotherOracle);
+    sortedOracles.addOracle(token, oracle);
+
+    changePrank(anotherOracle);
+    sortedOracles.report(token, oracleValue1, address(0), address(0));
+    changePrank(oracle);
+    sortedOracles.report(token, oracleValue2, anotherOracle, address(0));
+
+    //confirm correct setUp
+    changePrank(owner);
+    (address[] memory oracles, uint256[] memory rates, ) = sortedOracles.getRates(token);
+    assertEq(oracle, oracles[0]);
+    assertEq(oracleValue2, rates[0]);
+    assertEq(anotherOracle, oracles[1]);
+    assertEq(oracleValue1, rates[1]);
+
+    changePrank(oracle);
+    sortedOracles.report(token, oracleValue3, anotherOracle, address(0));
+
+    changePrank(owner);
+    (oracles, rates, ) = sortedOracles.getRates(token);
+    assertEq(oracle, oracles[0]);
+    assertEq(oracleValue3, rates[0]);
+    assertEq(anotherOracle, oracles[1]);
+    assertEq(oracleValue1, rates[1]);
+  }
+
+  function test_report_whenMultipleReportsExistTheMostRecent_shouldUpdateTimestampsCorrectly()
+    public
+  {
+    address anotherOracle = address(5);
+    uint256 oracleValue1 = fixed1;
+    uint256 oracleValue2 = fixed1 * 2;
+    uint256 oracleValue3 = fixed1 * 3;
+    sortedOracles.addOracle(token, anotherOracle);
+    sortedOracles.addOracle(token, oracle);
+
+    changePrank(anotherOracle);
+    uint256 timestamp0 = block.timestamp;
+    sortedOracles.report(token, oracleValue1, address(0), address(0));
+    skip(5);
+
+    uint256 timestamp1 = block.timestamp;
+    changePrank(oracle);
+    sortedOracles.report(token, oracleValue2, anotherOracle, address(0));
+    skip(5);
+
+    //confirm correct setUp
+    changePrank(owner);
+    (address[] memory oracles, uint256[] memory timestamps, ) = sortedOracles.getTimestamps(token);
+    assertEq(oracle, oracles[0]);
+    assertEq(timestamp1, timestamps[0]);
+    assertEq(anotherOracle, oracles[1]);
+    assertEq(timestamp0, timestamps[1]);
+
+    changePrank(oracle);
+    uint256 timestamp3 = block.timestamp;
+    sortedOracles.report(token, oracleValue3, anotherOracle, address(0));
+
+    changePrank(owner);
+    (oracles, timestamps, ) = sortedOracles.getTimestamps(token);
+    assertEq(oracle, oracles[0]);
+    assertEq(timestamp3, timestamps[0]);
+
+    assertEq(anotherOracle, oracles[1]);
+    assertEq(timestamp0, timestamps[1]);
+  }
+
+  function test_report_shouldCallBreakerBoxWithRateFeedID() public {
+    // token is a legacy reference of rateFeedID
+    sortedOracles.addOracle(token, oracle);
+    sortedOracles.setBreakerBox(mockBreakerBox);
+
+    vm.expectCall(
+      address(mockBreakerBox),
+      abi.encodeWithSelector(mockBreakerBox.checkAndSetBreakers.selector, token)
+    );
+
+    changePrank(oracle);
+
+    sortedOracles.report(token, 9999, address(0), address(0));
+  }
+}

--- a/packages/protocol/test-sol/stability/SortedOracles.t.sol
+++ b/packages/protocol/test-sol/stability/SortedOracles.t.sol
@@ -121,17 +121,23 @@ contract AddOracle is SortedOraclesTest {
 
   function test_ShouldRevertWhenAlreadyOracle() public {
     sortedOracle.addOracle(aToken, oracleAccount);
-    vm.expectRevert("oracle addr is not an oracle for token addr");
+    vm.expectRevert(
+      "token addr was null or oracle addr was null or oracle addr is already an oracle for token addr"
+    );
     sortedOracle.addOracle(aToken, oracleAccount);
   }
 
   function test_ShouldRevertWhenOracleIsZeroAddress() public {
-    vm.expectRevert("oracle addr was null");
+    vm.expectRevert(
+      "token addr was null or oracle addr was null or oracle addr is already an oracle for token addr"
+    );
     sortedOracle.addOracle(aToken, address(0));
   }
 
   function test_ShouldRevertWhenTokenIsZeroAddress() public {
-    vm.expectRevert("token addr was null");
+    vm.expectRevert(
+      "token addr was null or oracle addr was null or oracle addr is already an oracle for token addr"
+    );
     sortedOracle.addOracle(address(0), oracleAccount);
   }
 }

--- a/packages/protocol/test-sol/stability/SortedOracles.t.sol
+++ b/packages/protocol/test-sol/stability/SortedOracles.t.sol
@@ -8,6 +8,7 @@ import "../../contracts/common/FixidityLib.sol";
 import "../../contracts/common/linkedlists/AddressSortedLinkedListWithMedian.sol";
 import "../../contracts/common/linkedlists/SortedLinkedListWithMedian.sol";
 import { Constants } from "../constants.sol";
+import "forge-std/console.sol";
 
 contract SortedOraclesTest is Test, Constants {
   using FixidityLib for FixidityLib.Fraction;
@@ -31,6 +32,7 @@ contract SortedOraclesTest is Test, Constants {
   event MedianUpdated(address indexed token, uint256 value);
   event ReportExpirySet(uint256 reportExpiry);
   event TokenReportExpirySet(address token, uint256 reportExpiry);
+  event EquivalentTokenSet(address indexed token, address indexed equivalentToken);
 
   function setUp() public {
     warp(0);
@@ -77,6 +79,69 @@ contract SetReportExpiry is SortedOraclesTest {
     vm.expectRevert("Ownable: caller is not the owner");
     vm.prank(oracleAccount);
     sortedOracle.setReportExpiry(7200);
+  }
+}
+
+contract SortedOracles_SetEquivalentToken is SortedOraclesTest {
+  address bToken = actor("bToken");
+
+  function test_ShouldSetReportExpiry() public {
+    sortedOracle.setEquivalentToken(aToken, bToken, FIXED1);
+    (address equivalentToken, uint256 multiplier) = sortedOracle.getEquivalentToken(aToken);
+    assertEq(equivalentToken, bToken);
+    assertEq(multiplier, FIXED1);
+  }
+
+  function test_ShouldRevert_WhenToken0() public {
+    vm.expectRevert("token address cannot be 0");
+    sortedOracle.setEquivalentToken(address(0), bToken, FIXED1);
+  }
+
+  function test_ShouldRevert_WhenEquivalentToken0() public {
+    vm.expectRevert("equivalentToken address cannot be 0");
+    sortedOracle.setEquivalentToken(aToken, address(0), FIXED1);
+  }
+
+  function test_ShouldEmitEquivalentTokenSet() public {
+    vm.expectEmit(true, true, true, true);
+    emit EquivalentTokenSet(aToken, bToken);
+    sortedOracle.setEquivalentToken(aToken, bToken, FIXED1);
+  }
+
+  function test_ShouldRevertWhenNotOwner() public {
+    vm.expectRevert("Ownable: caller is not the owner");
+    vm.prank(oracleAccount);
+    sortedOracle.setEquivalentToken(aToken, bToken, FIXED1);
+  }
+}
+
+contract SortedOracles_DeleteEquivalentToken is SortedOraclesTest {
+  address bToken = actor("bToken");
+
+  function test_ShouldDeleteEquivalentToken() public {
+    sortedOracle.setEquivalentToken(aToken, bToken, FIXED1);
+    sortedOracle.deleteEquivalentToken(aToken);
+    (address equivalentToken, uint256 multiplier) = sortedOracle.getEquivalentToken(aToken);
+    assertEq(equivalentToken, address(0));
+    assertEq(multiplier, 0);
+  }
+
+  function test_ShouldRevert_WhenEquivalentToken0() public {
+    vm.expectRevert("token address cannot be 0");
+    sortedOracle.deleteEquivalentToken(address(0));
+  }
+
+  function test_ShouldEmitEquivalentTokenSet() public {
+    sortedOracle.setEquivalentToken(aToken, bToken, FIXED1);
+    vm.expectEmit(true, true, true, true);
+    emit EquivalentTokenSet(aToken, address(0));
+    sortedOracle.deleteEquivalentToken(aToken);
+  }
+
+  function test_ShouldRevertWhenNotOwner() public {
+    vm.expectRevert("Ownable: caller is not the owner");
+    vm.prank(oracleAccount);
+    sortedOracle.deleteEquivalentToken(aToken);
   }
 }
 
@@ -479,6 +544,8 @@ contract Report is SortedOraclesTest {
   uint256 oracleValue2 = FixidityLib.newFixedFraction(3, 1).unwrap();
   uint256 anotherOracleValue = FIXED1;
 
+  address bToken = actor("bToken");
+
   function setUp() public {
     super.setUp();
     sortedOracle.addOracle(aToken, oracleAccount);
@@ -496,6 +563,69 @@ contract Report is SortedOraclesTest {
     (uint256 medianRate, uint256 denominator) = sortedOracle.medianRate(aToken);
     assertEq(medianRate, value);
     assertEq(denominator, FIXED1);
+  }
+
+  function test_ShouldReturnTheMedianRate_WhenEquivalentTokenIsSet() public {
+    vm.prank(oracleAccount);
+    sortedOracle.report(aToken, value, address(0), address(0));
+    sortedOracle.setEquivalentToken(bToken, aToken, FIXED1);
+    (uint256 medianRate, uint256 denominator) = sortedOracle.medianRate(bToken);
+    assertEq(medianRate, value);
+    assertEq(denominator, FIXED1);
+  }
+
+  function test_ShouldReturnTheMedianRateWithDifferentMultiplier_WhenEquivalentTokenIsSet() public {
+    uint256 cUSDRate = 700000000000000000000000;
+
+    uint256 oneCELO = 1e18;
+    uint256 oneUSD = 1e6;
+    uint256 oncecUSD = 1e18;
+
+    uint256 celoFromcUSD = FixidityLib
+      .wrap(cUSDRate)
+      .multiply(FixidityLib.newFixed(oncecUSD))
+      .fromFixed();
+
+    vm.prank(oracleAccount);
+    sortedOracle.report(aToken, cUSDRate, address(0), address(0));
+    uint256 usdMultiplier = FixidityLib.newFixedFraction(1e12, 1).unwrap();
+    sortedOracle.setEquivalentToken(bToken, aToken, usdMultiplier);
+    (uint256 medianRate, uint256 denominator) = sortedOracle.medianRate(bToken);
+    assertEq(medianRate, cUSDRate * 1e12);
+    assertEq(denominator, FIXED1);
+    uint256 celoFromUSD = FixidityLib
+      .wrap(medianRate)
+      .multiply(FixidityLib.newFixed(oneUSD))
+      .fromFixed();
+    assertEq(celoFromUSD, celoFromcUSD);
+  }
+
+  function test_ShouldNotReturnTheMedianRate_WhenEquivalentTokenIsSet() public {
+    vm.prank(oracleAccount);
+    sortedOracle.report(aToken, value, address(0), address(0));
+    sortedOracle.setEquivalentToken(bToken, aToken, FIXED1);
+    (uint256 medianRate, uint256 denominator) = sortedOracle.medianRateWithoutEquivalentMapping(
+      bToken
+    );
+    assertEq(medianRate, 0);
+    assertEq(denominator, 0);
+  }
+
+  function test_ShouldNotReturnTheMedianRateOfEquivalentToken_WhenEquivalentTokenIsSetAndDeleted()
+    public
+  {
+    vm.prank(oracleAccount);
+    sortedOracle.report(aToken, value, address(0), address(0));
+    sortedOracle.setEquivalentToken(bToken, aToken, FIXED1);
+    uint256 medianRate;
+    uint256 denominator;
+    (medianRate, denominator) = sortedOracle.medianRate(bToken);
+    assertEq(medianRate, value);
+    assertEq(denominator, FIXED1);
+    sortedOracle.deleteEquivalentToken(bToken);
+    (medianRate, denominator) = sortedOracle.medianRate(bToken);
+    assertEq(medianRate, 0);
+    assertEq(denominator, 0);
   }
 
   function test_ShouldIncreaseTheNumberOfTimestamps() public {

--- a/packages/protocol/test/common/integration.ts
+++ b/packages/protocol/test/common/integration.ts
@@ -665,18 +665,12 @@ contract('Integration: Adding StableToken', (accounts: string[]) => {
 
     it(`should be impossible to sell CELO`, async () => {
       await goldToken.approve(exchangeAbc.address, sellAmount)
-      await assertTransactionRevertWithReason(
-        exchangeAbc.sell(sellAmount, minBuyAmount, true),
-        'token address cannot be null'
-      )
+      await assertTransactionRevertWithReason(exchangeAbc.sell(sellAmount, minBuyAmount, true))
     })
 
     it(`should be impossible to sell stable token`, async () => {
       await stableTokenAbc.approve(exchangeAbc.address, sellAmount)
-      await assertTransactionRevertWithReason(
-        exchangeAbc.sell(sellAmount, minBuyAmount, false),
-        'token address cannot be null'
-      )
+      await assertTransactionRevertWithReason(exchangeAbc.sell(sellAmount, minBuyAmount, false))
     })
   })
 


### PR DESCRIPTION
### Description

Introduction of equivalent tokens in Sorted Oracles. With this change it is possible for function medianRate called with  tokenA argument to return value of tokenB when equivalent token mapping is set between tokenA and tokenB.

Since some tokens have only 6 digits compared to cUSD with 18, multiplier was introduces for equivalent token mapping.

### Other changes

No other changes

### Tested

Unit tests added

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/10894

### Backwards compatibility

Yes