### PR TITLE
Update workload-id-provider in metadata-crawler-build job

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -118,7 +118,7 @@ jobs:
       github.ref == 'refs/heads/master' &&
       contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/metadata-crawler')
     with:
-      workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo/providers/github-by-repos
+      workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo-master/providers/github-by-repos
       service-account: 'celo-monorepo@devopsre.iam.gserviceaccount.com'
       artifact-registry: us-west1-docker.pkg.dev/devopsre/celo-monorepo/blockscout-metadata-crawler
       tags: latest


### PR DESCRIPTION
Use `master` workload-id-provider pool. Fixes https://github.com/celo-org/celo-monorepo/actions/runs/7694659919/job/20965892734