### PR TITLE
updating workflows to version 2.0

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -30,7 +30,7 @@ jobs:
 
   # Celotool images
   celotool-build-dev:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.1
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/celotool:${{ github.sha }}
     needs: changed-files
     if: |
@@ -46,7 +46,7 @@ jobs:
       file: dockerfiles/celotool/Dockerfile
       trivy: true
   celotool-build:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.1
     name: Build us-west1-docker.pkg.dev/devopsre/celo-monorepo/celotool:${{ github.sha }}
     needs: changed-files
     if: |
@@ -64,7 +64,7 @@ jobs:
 
   # All monorepo
   celomonorepo-build-dev:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.1
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/monorepo:${{ github.sha }}
     needs: changed-files
     if: |
@@ -79,7 +79,7 @@ jobs:
       file: dockerfiles/all-monorepo/Dockerfile
       trivy: true
   celomonorepo-build:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.1
     name: Build us-west1-docker.pkg.dev/devopsre/celo-monorepo/monorepo:${{ github.sha }}
     needs: changed-files
     if: |
@@ -96,7 +96,7 @@ jobs:
 
   # Blockscout Metadata crawler images
   metadata-crawler-build-dev:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.1
     needs: changed-files
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/blockscout-metadata-crawler:testing
     if: |
@@ -111,7 +111,7 @@ jobs:
       file: dockerfiles/metadata-crawler/Dockerfile
       trivy: true
   metadata-crawler-build:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.1
     needs: changed-files
     name: Build us-west1-docker.pkg.dev/devopsre/celo-monorepo/blockscout-metadata-crawler:latest
     if: |


### PR DESCRIPTION
### Description

Updating workflow to version 2.1 to add in checks for container images being built with gha-credentials from workload identity federation.


### Tested

tested in other repos
### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Should cause no issues with backwards compatibility.

### Documentation

_The set of community facing docs that have been added/modified because of this change_