### PR TITLE
Debit 0 value check

### DIFF
--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -63,6 +63,7 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
    */
   function debitGasFees(address from, uint256 value) external onlyVm {
     uint256 valueScaled = downscale(value);
+    require(valueScaled > 0, "Scaled debit value must be > 0.");
     debited = valueScaled;
     adaptedToken.debitGasFees(from, valueScaled);
   }

--- a/packages/protocol/test-sol/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/stability/FeeCurrencyAdapter.t.sol
@@ -180,6 +180,12 @@ contract FeeCurrencyAdapter_DebitGasFees is FeeCurrencyAdapterTest {
     feeCurrencyAdapter.debitGasFees(address(this), 1000);
   }
 
+  function test_ShouldRevert_WhenScaledDebitValueIs0() public {
+    vm.expectRevert("Scaled debit value must be > 0.");
+    vm.prank(address(0));
+    feeCurrencyAdapter.debitGasFees(address(this), 1e7);
+  }
+
   function test_ShouldDebitCorrectAmount_WhenExpectedDigitsOnlyOneBigger() public {
     debitFuzzyHelper(7, 1e1);
   }


### PR DESCRIPTION
### Description

In case of really low gas fee (Celo should be 0.01 USD) adapter allowed 0 value during downscaling. 

Addresses https://github.com/celo-org/audit-a-findings/issues/9
Addresses https://github.com/celo-org/audit-a-findings/issues/10

### Tested

Unit test added