### PR TITLE
Removal of SortedOracle multiplier

### DIFF
--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -253,7 +253,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @notice Gets the equivalent token for a token.
    * @param token The address of the token.
    * @return The address of the equivalent token.
-   * @return The multiplier to convert the equivalent token median value to the token value (fixidity).
    */
   function getEquivalentToken(address token) external view returns (address) {
     return (equivalentTokens[token].token);

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -323,7 +323,7 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @dev Does not take account of equivalentTokens mapping.
    * @param token The rateFeedId of the rates for which the median value is being retrieved.
    * @return uint256 The median exchange rate for rateFeedId (fixidity).
-   * @return uint256 num of rates
+   * @return uint256 denominator
    */
   function medianRateWithoutEquivalentMapping(address token)
     public
@@ -339,15 +339,15 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * return the median identified as an equivalent to the supplied rateFeedId.
    * @param token The rateFeedId of the rates for which the median value is being retrieved.
    * @return uint256 The median exchange rate for rateFeedId (fixidity).
-   * @return uint256 num of rates
+   * @return uint256 denominator
    */
   function medianRate(address token) external view returns (uint256, uint256) {
     EquivalentToken storage equivalentToken = equivalentTokens[token];
     if (equivalentToken.token != address(0)) {
-      (uint256 equivalentMedianRate, uint256 _numRates) = medianRateWithoutEquivalentMapping(
+      (uint256 equivalentMedianRate, uint256 denominator) = medianRateWithoutEquivalentMapping(
         equivalentToken.token
       );
-      return (equivalentMedianRate, _numRates);
+      return (equivalentMedianRate, denominator);
     }
 
     return medianRateWithoutEquivalentMapping(token);

--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -231,7 +231,6 @@ contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initi
    * @notice Sets the equivalent token for a token.
    * @param token The address of the token.
    * @param equivalentToken The address of the equivalent token.
-   * @dev For tokens with 6 decimals multiplier is 1e18 / 1e6 = 1e12
    */
   function setEquivalentToken(address token, address equivalentToken) external onlyOwner {
     require(token != address(0), "token address cannot be 0");


### PR DESCRIPTION
### Description

Removal of multiplier in SortedOracles since we will not be using it. 

Addresses: https://github.com/celo-org/audit-a-findings/issues/6
Addresses: https://github.com/celo-org/audit-a-findings/issues/15