### PR TITLE
getGasPriceMinimum reverts when there is no rate

### DIFF
--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -165,6 +165,7 @@ contract GasPriceMinimum is
       uint256 rateNumerator;
       uint256 rateDenominator;
       (rateNumerator, rateDenominator) = sortedOracles.medianRate(tokenAddress);
+      require(rateDenominator > 0, "Token has no rate");
       return ((gasPriceMinimum() * rateNumerator) / rateDenominator);
     }
   }
@@ -175,7 +176,7 @@ contract GasPriceMinimum is
    * For other addresses it returns gasPriceMinimum() mutiplied by 
    * the SortedOracles median of the token. It does not check tokenAddress is a valid fee currency.
    * this function will never returns values less than ABSOLUTE_MINIMAL_GAS_PRICE.
-   * If Oracle rate doesn't exist, it returns ABSOLUTE_MINIMAL_GAS_PRICE.
+   * If Oracle rate doesn't exist, it reverts.
    * @dev This functions assumes one unit of token has 18 digits.
    * @param tokenAddress The currency the gas price should be in (defaults to Celo).
    * @return current gas price minimum in the requested currency

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -162,11 +162,8 @@ contract GasPriceMinimum is
       ISortedOracles sortedOracles = ISortedOracles(
         registry.getAddressForOrDie(SORTED_ORACLES_REGISTRY_ID)
       );
-      uint256 rateNumerator;
-      uint256 rateDenominator;
-      (rateNumerator, rateDenominator) = sortedOracles.medianRate(tokenAddress);
-      require(rateDenominator > 0, "Token has no rate");
-      return ((gasPriceMinimum() * rateNumerator) / rateDenominator);
+      (uint256 medianRate, uint256 denominator) = sortedOracles.medianRate(tokenAddress);
+      return ((gasPriceMinimum() * medianRate) / denominator);
     }
   }
 

--- a/packages/protocol/contracts/stability/test/MockSortedOracles.sol
+++ b/packages/protocol/contracts/stability/test/MockSortedOracles.sol
@@ -33,10 +33,9 @@ contract MockSortedOracles {
   }
 
   function medianRate(address token) external view returns (uint256, uint256) {
-    if (numerators[token] > 0) {
-      return (numerators[token], DENOMINATOR);
-    }
-    return (0, 0);
+    uint256 numerator = numerators[token];
+    require(numerator > 0, "Token has no rate");
+    return (numerator, DENOMINATOR);
   }
 
   function isOldestReportExpired(address token) public view returns (bool, address) {

--- a/packages/protocol/test-sol/common/GasPriceMinimum.t.sol
+++ b/packages/protocol/test-sol/common/GasPriceMinimum.t.sol
@@ -110,6 +110,11 @@ contract GasPriceMinimumTest_getGasPriceMinimum is GasPriceMinimumTest {
     assertEq(gasPriceMinimum.getGasPriceMinimum(whateverAddress), ABSOLUTE_MINIMAL_GAS_PRICE);
   }
 
+  function test_ShouldRevert_WhenNoMedianRate() public {
+    vm.expectRevert("Token has no rate");
+    gasPriceMinimum.getGasPriceMinimum(whateverAddress);
+  }
+
   function test_shouldReturnTheRightRateForToken() public {
     sortedOracles.setMedianRate(whateverAddress, 2e24);
     assertEq(gasPriceMinimum.getGasPriceMinimum(whateverAddress), initialGasPriceMinimum * 2);

--- a/packages/protocol/test-sol/stability/SortedOracles.t.sol
+++ b/packages/protocol/test-sol/stability/SortedOracles.t.sol
@@ -625,11 +625,8 @@ contract Report is SortedOraclesTest {
     vm.prank(oracleAccount);
     sortedOracle.report(aToken, value, address(0), address(0));
     sortedOracle.setEquivalentToken(bToken, aToken, FIXED1);
-    (uint256 medianRate, uint256 denominator) = sortedOracle.medianRateWithoutEquivalentMapping(
-      bToken
-    );
-    assertEq(medianRate, 0);
-    assertEq(denominator, 0);
+    vm.expectRevert("Token has no rate");
+    sortedOracle.medianRateWithoutEquivalentMapping(bToken);
   }
 
   function test_ShouldNotReturnTheMedianRateOfEquivalentToken_WhenEquivalentTokenIsSetAndDeleted()
@@ -644,9 +641,8 @@ contract Report is SortedOraclesTest {
     assertEq(medianRate, value);
     assertEq(denominator, FIXED1);
     sortedOracle.deleteEquivalentToken(bToken);
+    vm.expectRevert("Token has no rate");
     (medianRate, denominator) = sortedOracle.medianRate(bToken);
-    assertEq(medianRate, 0);
-    assertEq(denominator, 0);
   }
 
   function test_ShouldIncreaseTheNumberOfTimestamps() public {

--- a/packages/protocol/test-sol/stability/SortedOracles.t.sol
+++ b/packages/protocol/test-sol/stability/SortedOracles.t.sol
@@ -576,11 +576,8 @@ contract Report is SortedOraclesTest {
     vm.prank(oracleAccount);
     sortedOracle.report(aToken, value, address(0), address(0));
     sortedOracle.setEquivalentToken(bToken, aToken);
-    (uint256 medianRate, uint256 denominator) = sortedOracle.medianRateWithoutEquivalentMapping(
-      bToken
-    );
-    assertEq(medianRate, 0);
-    assertEq(denominator, 0);
+    vm.expectRevert("Token has no rate");
+    sortedOracle.medianRateWithoutEquivalentMapping(bToken);
   }
 
   function test_ShouldNotReturnTheMedianRateOfEquivalentToken_WhenEquivalentTokenIsSetAndDeleted()


### PR DESCRIPTION
### Description

Readable error message instead of panic when no medianRate for token exists

Addresses: https://github.com/celo-org/audit-a-findings/issues/8