### PR TITLE
FeeAdapter debit round up

### DIFF
--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -161,6 +161,16 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
     return value * digitDifference;
   }
 
+  /**
+   * @notice Downscales value to the adapted token's native digits.
+   * @dev Downscale is rounding up in favour of protocol. User possibly can pay a bit more than expected (up to 1 unit of a token).
+   * Example:
+   * USDC has 6 decimals and in such case user can pay up to 0.000001 USDC more than expected.
+   * WBTC (currently not supported by Celo chain as fee currency) has 8 decimals and in such case user can pay up to 0.00000001 WBTC more than expected.
+   * Considering the current price of WBTC, it's less than 0.0005 USD. Even when WBTC price would be 1 mil USD, it's still would be only 0.01 USD.
+   * In general it is a very small amount and it is acceptable to round up in favor of the protocol.
+   * @param value The value to downscale. 
+   */
   function downscale(uint256 value) internal view returns (uint256) {
     return (value + digitDifference - 1) / digitDifference;
   }

--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -162,7 +162,7 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
   }
 
   function downscale(uint256 value) internal view returns (uint256) {
-    return value / digitDifference;
+    return (value + digitDifference - 1) / digitDifference;
   }
 
   function _setAdaptedToken(address _adaptedToken) internal virtual {

--- a/packages/protocol/test-sol/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/stability/FeeCurrencyAdapter.t.sol
@@ -372,7 +372,7 @@ contract FeeCurrencyAdapter_UpscaleAndDownScaleTests is FeeCurrencyAdapterTest {
     assertEq(feeCurrencyAdapter.downscaleVisible(1e24), 1e12);
   }
 
-  function test_ShouldReturn0_WhenSmallEnough() public {
+  function test_ShouldReturn1_WhenSmallEnoughAndRoundingUp() public {
     assertEq(feeCurrencyAdapter.downscaleVisible(1), 1);
     assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 1);
     assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 1);

--- a/packages/protocol/test-sol/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/stability/FeeCurrencyAdapter.t.sol
@@ -183,7 +183,7 @@ contract FeeCurrencyAdapter_DebitGasFees is FeeCurrencyAdapterTest {
   function test_ShouldRevert_WhenScaledDebitValueIs0() public {
     vm.expectRevert("Scaled debit value must be > 0.");
     vm.prank(address(0));
-    feeCurrencyAdapter.debitGasFees(address(this), 1e7);
+    feeCurrencyAdapter.debitGasFees(address(this), 0);
   }
 
   function test_ShouldDebitCorrectAmount_WhenExpectedDigitsOnlyOneBigger() public {
@@ -373,9 +373,9 @@ contract FeeCurrencyAdapter_UpscaleAndDownScaleTests is FeeCurrencyAdapterTest {
   }
 
   function test_ShouldReturn0_WhenSmallEnough() public {
-    assertEq(feeCurrencyAdapter.downscaleVisible(1), 0);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 0);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 0);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1), 1);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 1);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 1);
   }
 }
 


### PR DESCRIPTION
### Description

In case that downscale would round down it would be possible for some fee currency tokens not to be usable since value would be downscaled to 0 and then call would be reverted.

Addresses https://github.com/celo-org/audit-a-findings/issues/9


### Tested

Unit tests