### PR TITLE
SortedOracles sourced from Mento core for CR10

### DIFF
--- a/packages/protocol/lib/compatibility/ignored-contracts-v9.ts
+++ b/packages/protocol/lib/compatibility/ignored-contracts-v9.ts
@@ -10,19 +10,18 @@ export const ignoredContractsV9 = [
   'StableTokenRegistry',
   'Reserve',
   'ReserveSpenderMultiSig',
+]
 
-  'SortedOracles' 
- // Note: Sorted Oracles is a Celo Core Contract
-  // but as it has also been modified and deployed but the Mento team.
-  // We currently need work to be able to upgrade it again:
-  // https://github.com/celo-org/celo-monorepo/issues/10435
+export const ignoredContractsV9Only = [
+  'SortedOracles'
+  // In CR9 the SortedOracles contract was deployed by Mento team, in CR10 we redeployed it ourselves
 ]
 
 export function getReleaseVersion(tag: string) {
   const regexp = /core-contracts.v(?<version>.*[0-9])/gm
   const matches = regexp.exec(tag)
   const version = parseInt(matches?.groups?.version ?? '0', 10)
-  if ((version) == 0){
+  if ((version) == 0) {
     throw `Tag doesn't have the correct format ${tag}`
   }
   return version

--- a/packages/protocol/lib/compatibility/ignored-contracts-v9.ts
+++ b/packages/protocol/lib/compatibility/ignored-contracts-v9.ts
@@ -14,7 +14,7 @@ export const ignoredContractsV9 = [
 
 export const ignoredContractsV9Only = [
   'SortedOracles'
-  // In CR9 the SortedOracles contract was deployed by Mento team, in CR10 we redeployed it ourselves
+  // Between CR9 and CR10, a Mento upgrade MU03 also upgraded SortedOracles. For the purposes of our compatibility tests, we use the Mento version of the contract in CR10, so that we're comparing the most recent pre-CR10 contracts with the CR10 versions.
 ]
 
 export function getReleaseVersion(tag: string) {

--- a/packages/protocol/lib/compatibility/verify-bytecode.ts
+++ b/packages/protocol/lib/compatibility/verify-bytecode.ts
@@ -1,18 +1,18 @@
 /* eslint-disable no-console: 0 */
 import { ensureLeading0x } from '@celo/base/lib/address'
 import {
-    LibraryAddresses,
-    LibraryPositions,
-    linkLibraries,
-    stripMetadata,
-    verifyAndStripLibraryPrefix,
+  LibraryAddresses,
+  LibraryPositions,
+  linkLibraries,
+  stripMetadata,
+  verifyAndStripLibraryPrefix,
 } from '@celo/protocol/lib/bytecode'
 import { verifyProxyStorageProof } from '@celo/protocol/lib/proxy-utils'
 import { ProposalTx } from '@celo/protocol/scripts/truffle/make-release'
 import { BuildArtifacts } from '@openzeppelin/upgrades'
 import { ProxyInstance, RegistryInstance } from 'types'
 import Web3 from 'web3'
-import { ignoredContractsV9 } from './ignored-contracts-v9'
+import { ignoredContractsV9, ignoredContractsV9Only } from './ignored-contracts-v9'
 
 let ignoredContracts = [
   // This contract is not proxied
@@ -143,8 +143,7 @@ const dfsStep = async (queue: string[], visited: Set<string>, context: Verificat
     throw new Error(`${contract}'s onchain and compiled bytecodes do not match`)
   } else {
     console.log(
-      `${
-        isLibrary(contract, context) ? 'Library' : 'Contract'
+      `${isLibrary(contract, context) ? 'Library' : 'Contract'
       } deployed at ${implementationAddress} matches ${contract}`
     )
   }
@@ -231,15 +230,17 @@ export const verifyBytecodes = async (
 
   const compiledContracts = artifacts.listArtifacts().map((a) => a.contractName)
 
-  if (version >= 9) {
+  if (version > 9) {
     ignoredContracts = [...ignoredContracts, ...ignoredContractsV9]
+  } else if (version == 9) {
+    ignoredContracts = [...ignoredContracts, ...ignoredContractsV9, ...ignoredContractsV9Only]
   }
 
   const queue = contracts.filter(
     (contract) => !ignoredContracts.includes(contract)
-    ).filter(
-      (contract) => compiledContracts.includes(contract)
-      )
+  ).filter(
+    (contract) => compiledContracts.includes(contract)
+  )
 
   const visited: Set<string> = new Set(queue)
 

--- a/packages/protocol/scripts/bash/contract-exclusion-regex.sh
+++ b/packages/protocol/scripts/bash/contract-exclusion-regex.sh
@@ -18,10 +18,8 @@ if [ $VERSION_NUMBER -gt 8 ]
   CONTRACT_EXCLUSION_REGEX="$CONTRACT_EXCLUSION_REGEX|^Ownable|Initializable|BLS12_377Passthrough|BLS12_381Passthrough]UniswapV2ERC20"
 fi
 
-  # https://github.com/celo-org/celo-monorepo/issues/10435
-  # SortedOracles is currently not deployable
-  # after fixing that this should be modified to VERSION_NUMBER==10
-if [ $VERSION_NUMBER -gt 9 ]
+# In CR9 the SortedOracles contract was deployed by Mento team, in CR10 we redeployed it ourselves
+if [ $VERSION_NUMBER -eq 9 ]
   then
   CONTRACT_EXCLUSION_REGEX="$CONTRACT_EXCLUSION_REGEX|SortedOracles"
 fi

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -32,4 +32,31 @@ done
 source scripts/bash/release-lib.sh
 build_tag $BRANCH $LOG_FILE
 
+if [ "$BRANCH" = "core-contracts.v10" ]; then
+  if [ ! -d "build/mento" ]; then
+    mkdir -p build/mento
+    cd build/mento
+    git clone --depth 1 --branch v2.2.1 https://github.com/mento-protocol/mento-core.git
+    cd mento-core
+    yarn 
+    forge install
+    forge build
+  else 
+    cd build/mento/mento-core
+  fi
+
+  # Replace the bytecode of the SortedOracles contracts with the bytecode from Mento core v2.2.1
+  orig_value_SortedOracles=$(jq -r '.deployedBytecode.object' out/SortedOracles.sol/SortedOracles.json)
+  substring_to_replace='__$e9f4a9f9de32ce6d7070252f1b707ecbd2$__'
+  replacement='__AddressSortedLinkedListWithMedian_____'
+  value_SortedOracles="${orig_value_SortedOracles//$substring_to_replace/$replacement}"
+  jq --arg value "$value_SortedOracles" '.deployedBytecode = $value' ../../../$BUILD_DIR/contracts/SortedOracles.json > "temp.json" && mv "temp.json" ../../../$BUILD_DIR/contracts/SortedOracles.json
+
+  # Replace the bytecode of the AddressSortedLinkedListWithMedian contract with the bytecode from Mento core v2.2.1
+  value_AddressSortedLinkedListWithMedian=$(jq -r '.deployedBytecode.object' out/AddressSortedLinkedListWithMedian.sol/AddressSortedLinkedListWithMedian.json)
+  jq --arg value "$value_AddressSortedLinkedListWithMedian" '.deployedBytecode = $value' ../../../$BUILD_DIR/contracts/AddressSortedLinkedListWithMedian.json > temp.json && mv temp.json ../../../$BUILD_DIR/contracts/AddressSortedLinkedListWithMedian.json
+
+  cd ../../../
+fi
+
 yarn run truffle exec ./scripts/truffle/verify-bytecode.js --network $NETWORK --build_artifacts $BUILD_DIR/contracts  --branch $BRANCH --librariesFile "libraries.json" $FORNO

--- a/packages/protocol/scripts/bash/verify-deployed.sh
+++ b/packages/protocol/scripts/bash/verify-deployed.sh
@@ -47,8 +47,8 @@ if [ "$BRANCH" = "core-contracts.v10" ]; then
 
   # Replace the bytecode of the SortedOracles contracts with the bytecode from Mento core v2.2.1
   orig_value_SortedOracles=$(jq -r '.deployedBytecode.object' out/SortedOracles.sol/SortedOracles.json)
-  substring_to_replace='__$e9f4a9f9de32ce6d7070252f1b707ecbd2$__'
-  replacement='__AddressSortedLinkedListWithMedian_____'
+  substring_to_replace='__$e9f4a9f9de32ce6d7070252f1b707ecbd2$__' # Foundry artifact bytecode differs for linked libraries, instead of library name it inserts a hashed value of library name in-place
+  replacement='__AddressSortedLinkedListWithMedian_____' # Replace with Truffle specific library placeholder
   value_SortedOracles="${orig_value_SortedOracles//$substring_to_replace/$replacement}"
   jq --arg value "$value_SortedOracles" '.deployedBytecode = $value' ../../../$BUILD_DIR/contracts/SortedOracles.json > "temp.json" && mv "temp.json" ../../../$BUILD_DIR/contracts/SortedOracles.json
 


### PR DESCRIPTION
### Description

During CR10 Mento team redeployed SortedOracles. This change clones&builds Mento source code and then uses generated bytecode of SortedOracles for CR10 release.