### PR TITLE
Update gap size to follow 50 rule

### DIFF
--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -25,7 +25,7 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
 
   uint8 public expectedDecimals;
 
-  uint256[48] __gap;
+  uint256[44] __gap;
 
   /**
    * @notice Sets initialized == true on implementation contracts

--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapterOwnable.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapterOwnable.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
 import "./FeeCurrencyAdapter.sol";
 
 contract FeeCurrencyAdapterOwnable is FeeCurrencyAdapter, Ownable {
-  uint256[48] __gap2;
+  uint256[49] __gap2;
 
   /**
    * @notice Sets initialized == true on implementation contracts


### PR DESCRIPTION
### Description

The gap technically does not need to have any specific value, though the standard is that the number of storage slots of a contract totals to 50. So 50 - usedSlots = gap.length.