### PR TITLE
CR11 fix verification

### DIFF
--- a/packages/protocol/scripts/bash/check-versions.sh
+++ b/packages/protocol/scripts/bash/check-versions.sh
@@ -52,6 +52,7 @@ yarn ts-node scripts/check-backward.ts sem_check \
   --old_contracts $BRANCH_BUILD_DIR/contracts \
   --new_contracts $NEW_BRANCH_BUILD_DIR/contracts \
   --exclude $CONTRACT_EXCLUSION_REGEX \
+  --new_branch $NEW_BRANCH \
   $REPORT_FLAG
 
 git checkout $CURRENT_HASH -- migrationsConfig.js

--- a/packages/protocol/scripts/check-backward.ts
+++ b/packages/protocol/scripts/check-backward.ts
@@ -88,11 +88,15 @@ try {
     out
   )
 
-  const version = getReleaseVersion(argv.new_branch)
-  if (version === 11) {
-    // force redeploy of AddressSortedLinkedListWithMedian for CR11
-    // since it was deployed by Mento team with different settings and bytecode
-    backward.report.libraries.AddressSortedLinkedListWithMedian = {} as CategorizedChanges
+  try {
+    const version = getReleaseVersion(argv.new_branch)
+    if (version === 11) {
+      // force redeploy of AddressSortedLinkedListWithMedian for CR11
+      // since it was deployed by Mento team with different settings and bytecode
+      backward.report.libraries.AddressSortedLinkedListWithMedian = {} as CategorizedChanges
+    }
+  } catch (error) {
+    out(`Error parsing branch name: ${argv.new_branch}\n`)
   }
 
   out(`Writing compatibility report to ${outFile} ...`)

--- a/packages/protocol/scripts/check-backward.ts
+++ b/packages/protocol/scripts/check-backward.ts
@@ -46,7 +46,7 @@ const argv = yargs
     type: 'boolean',
   })
   .option('new_branch', {
-    alias: 'nb',
+    alias: 'b',
     description: 'Branch name (for versioning)',
     type: 'string',
   })


### PR DESCRIPTION
### Description

Force redeploy of AddressSortedLinkedListWithMedian for CR11 since it was deployed by Mento team with different settings and bytecode.