### PR TITLE
Implement new loadtest case

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -5,11 +5,13 @@ on:
   push:
     paths:
       - 'dockerfiles/**'
+      - 'packages/celotool/**'
     branches:
       - master
   pull_request:
     paths:
       - 'dockerfiles/**'
+      - 'packages/celotool/**'
   workflow_dispatch:
 
 jobs:
@@ -34,8 +36,11 @@ jobs:
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/celotool:${{ github.sha }}
     needs: changed-files
     if: |
-      github.ref != 'refs/heads/master' &&
-      contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/celotool/Dockerfile')
+      github.ref != 'refs/heads/master' && (
+        contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/celotool/Dockerfile') ||
+        contains(needs.changed-files.outputs.all_modified_files, ',packages/celotool') ||
+        github.event_name == 'workflow_dispatch'
+      )
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo/providers/github-by-repos
       service-account: 'celo-monorepo-dev@devopsre.iam.gserviceaccount.com'
@@ -44,14 +49,17 @@ jobs:
       platforms: linux/amd64
       context: .
       file: dockerfiles/celotool/Dockerfile
-      trivy: true
+      trivy: false
   celotool-build:
     uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0.1
     name: Build us-west1-docker.pkg.dev/devopsre/celo-monorepo/celotool:${{ github.sha }}
     needs: changed-files
     if: |
-      github.ref == 'refs/heads/master' &&
-      contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/celotool/Dockerfile')
+      github.ref == 'refs/heads/master' && (
+        contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/celotool/Dockerfile') ||
+        contains(needs.changed-files.outputs.all_modified_files, ',packages/celotool') ||
+        github.event_name == 'workflow_dispatch'
+      )
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo-master/providers/github-by-repos
       service-account: 'celo-monorepo@devopsre.iam.gserviceaccount.com'
@@ -60,7 +68,7 @@ jobs:
       platforms: linux/amd64
       context: .
       file: dockerfiles/celotool/Dockerfile
-      trivy: true
+      trivy: false
 
   # All monorepo
   celomonorepo-build-dev:
@@ -68,8 +76,9 @@ jobs:
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/monorepo:${{ github.sha }}
     needs: changed-files
     if: |
-      github.ref != 'refs/heads/master' &&
-      contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/all-monorepo/Dockerfile')
+      github.ref != 'refs/heads/master' && (
+        contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/all-monorepo/Dockerfile')
+      )
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo/providers/github-by-repos
       service-account: 'celo-monorepo-dev@devopsre.iam.gserviceaccount.com'
@@ -77,14 +86,15 @@ jobs:
       tags: ${{ github.sha }}
       context: .
       file: dockerfiles/all-monorepo/Dockerfile
-      trivy: true
+      trivy: false
   celomonorepo-build:
     uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0.1
     name: Build us-west1-docker.pkg.dev/devopsre/celo-monorepo/monorepo:${{ github.sha }}
     needs: changed-files
     if: |
-      github.ref == 'refs/heads/master' &&
-      contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/all-monorepo/Dockerfile')
+      github.ref == 'refs/heads/master' && (
+        contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/all-monorepo/Dockerfile')
+      )
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo-master/providers/github-by-repos
       service-account: 'celo-monorepo@devopsre.iam.gserviceaccount.com'
@@ -92,7 +102,7 @@ jobs:
       tags: ${{ github.sha }}
       context: .
       file: dockerfiles/all-monorepo/Dockerfile
-      trivy: true
+      trivy: false
 
   # Blockscout Metadata crawler images
   metadata-crawler-build-dev:
@@ -100,8 +110,9 @@ jobs:
     needs: changed-files
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/blockscout-metadata-crawler:testing
     if: |
-      github.ref != 'refs/heads/master' &&
-      contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/metadata-crawler')
+      github.ref != 'refs/heads/master' && (
+        contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/metadata-crawler')
+      )
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo/providers/github-by-repos
       service-account: 'celo-monorepo-dev@devopsre.iam.gserviceaccount.com'
@@ -109,14 +120,15 @@ jobs:
       tags: testing
       context: .
       file: dockerfiles/metadata-crawler/Dockerfile
-      trivy: true
+      trivy: false
   metadata-crawler-build:
     uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0.1
     needs: changed-files
     name: Build us-west1-docker.pkg.dev/devopsre/celo-monorepo/blockscout-metadata-crawler:latest
     if: |
-      github.ref == 'refs/heads/master' &&
-      contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/metadata-crawler')
+      github.ref == 'refs/heads/master' && (
+        contains(needs.changed-files.outputs.all_modified_files, ',dockerfiles/metadata-crawler')
+      )
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-monorepo-master/providers/github-by-repos
       service-account: 'celo-monorepo@devopsre.iam.gserviceaccount.com'
@@ -124,4 +136,4 @@ jobs:
       tags: latest
       context: .
       file: dockerfiles/metadata-crawler/Dockerfile
-      trivy: true
+      trivy: false

--- a/packages/celotool/src/cmds/generate/prepare-load-test-client.ts
+++ b/packages/celotool/src/cmds/generate/prepare-load-test-client.ts
@@ -1,6 +1,7 @@
 /* tslint:disable no-console */
 import * as fs from 'fs'
 import { AccountType, generatePrivateKey, privateKeyToAddress } from 'src/lib/generate_utils'
+import { getIndexForLoadTestThread } from 'src/lib/geth'
 import yargs from 'yargs'
 
 interface Bip32Argv {
@@ -39,7 +40,8 @@ export const builder = (argv: yargs.Argv) => {
 export const handler = (argv: Bip32Argv) => {
   const accountType = AccountType.LOAD_TESTING_ACCOUNT
   for (let t = 0; t < argv.threads; t++) {
-    const index = argv.index * 10000 + t
+    const index = getIndexForLoadTestThread(argv.index, t)
+    console.info(`Index for thread ${t} --> ${index}`)
 
     const privateKey = generatePrivateKey(argv.mnemonic, accountType, index)
     const address = privateKeyToAddress(privateKey)

--- a/packages/celotool/src/cmds/generate/prepare-load-test-client.ts
+++ b/packages/celotool/src/cmds/generate/prepare-load-test-client.ts
@@ -39,6 +39,9 @@ export const builder = (argv: yargs.Argv) => {
 
 export const handler = (argv: Bip32Argv) => {
   const accountType = AccountType.LOAD_TESTING_ACCOUNT
+  // Empty address file if there is any address (i.e.: Used a snapshot with addresses already generated)
+  fs.writeFileSync(`/root/.celo/address`, ``)
+  // Generate private keys and addresses for each thread
   for (let t = 0; t < argv.threads; t++) {
     const index = getIndexForLoadTestThread(argv.index, t)
     console.info(`Index for thread ${t} --> ${index}`)

--- a/packages/celotool/src/cmds/geth/simulate_client.ts
+++ b/packages/celotool/src/cmds/geth/simulate_client.ts
@@ -1,4 +1,4 @@
-/* tslint:disable no-console */
+/* eslint-disable no-console */
 import BigNumber from 'bignumber.js'
 import {
   AccountType,
@@ -157,8 +157,7 @@ export const handler = async (argv: SimulateClientArgv) => {
     console.info(
       `Account for recipient index ${argv.recipientIndex} thread ${thread}, final index ${recipientIndex}: ${recipientAddress}`
     )
-    // tslint:disable-next-line: no-floating-promises
-    simulateClient(
+    void simulateClient(
       senderPK,
       recipientAddress,
       argv.contractAddress,

--- a/packages/celotool/src/cmds/geth/simulate_client.ts
+++ b/packages/celotool/src/cmds/geth/simulate_client.ts
@@ -1,9 +1,15 @@
 /* tslint:disable no-console */
 import BigNumber from 'bignumber.js'
-import { AccountType, generateAddress, generatePrivateKey } from 'src/lib/generate_utils'
+import {
+  AccountType,
+  generateAddress,
+  generatePrivateKey,
+  privateKeyToAddress,
+} from 'src/lib/generate_utils'
 import {
   MAX_LOADTEST_THREAD_COUNT,
   TestMode,
+  faucetLoadTestThreads,
   getIndexForLoadTestThread,
   simulateClient,
 } from 'src/lib/geth'
@@ -26,6 +32,8 @@ interface SimulateClientArgv extends yargs.Argv {
   maxGasPrice: number
   totalTxGas: number
   testMode: string
+  web3Provider: string
+  chainId: number
 }
 
 export const builder = () => {
@@ -96,19 +104,37 @@ export const builder = () => {
     .options('test-mode', {
       type: 'string',
       description:
-        'Load test mode: mixed transaction types, big calldatas, simple transfers paid in CELO, transfers paid in cUSD, or contract calls',
+        'Load test mode: mixed transaction types, big calldatas, simple transfers paid in CELO, transfers paid in cUSD, ordinals, or contract calls',
       choices: [
         TestMode.Mixed,
         TestMode.Data,
         TestMode.Transfer,
         TestMode.StableTransfer,
         TestMode.ContractCall,
+        TestMode.Ordinals,
       ],
       default: TestMode.Mixed,
+    })
+    .options('web3-provider', {
+      type: 'string',
+      description: 'web3 endpoint to use for sending transactions',
+      default: 'http://127.0.0.1:8545',
+    })
+    .options('chainId', {
+      type: 'number',
+      description: 'ChainId to use for sending transactions',
+      default: '42220',
     })
 }
 
 export const handler = async (argv: SimulateClientArgv) => {
+  await faucetLoadTestThreads(
+    argv.index,
+    argv.clientCount,
+    argv.mnemonic,
+    argv.web3Provider,
+    argv.chainId
+  )
   for (let thread = 0; thread < argv.clientCount; thread++) {
     const senderIndex = getIndexForLoadTestThread(argv.index, thread)
     const recipientIndex = getIndexForLoadTestThread(argv.recipientIndex, thread)
@@ -123,17 +149,16 @@ export const handler = async (argv: SimulateClientArgv) => {
       recipientIndex
     )
 
-    const web3ProviderPort = argv.reuseClient ? 8545 : 8545 + thread
-
-    console.info(
-      `PK for sender index ${argv.index} thread ${thread}, final index ${senderIndex}: ${senderPK}`
+    console.log(
+      `PK for sender index ${
+        argv.index
+      } thread ${thread}, final index ${senderIndex}: ${privateKeyToAddress(senderPK)}`
     )
     console.info(
       `Account for recipient index ${argv.recipientIndex} thread ${thread}, final index ${recipientIndex}: ${recipientAddress}`
     )
-    console.info(`web3ProviderPort for thread ${thread}: ${web3ProviderPort}`)
-
-    await simulateClient(
+    // tslint:disable-next-line: no-floating-promises
+    simulateClient(
       senderPK,
       recipientAddress,
       argv.contractAddress,
@@ -146,7 +171,8 @@ export const handler = async (argv: SimulateClientArgv) => {
       thread,
       new BigNumber(argv.maxGasPrice),
       argv.totalTxGas,
-      `http://127.0.0.1:${web3ProviderPort}`
+      argv.web3Provider,
+      argv.chainId
     )
   }
 }

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -498,7 +498,8 @@ export const transferOrdinals = async (
       'hex'
     ),
     gas: '40000',
-    gasPrice: txOptions.gasPrice,
+    maxFeePerGas: txOptions.gasPrice,
+    maxPriorityFeePerGas: '0',
     nonce: txOptions.nonce,
   })
 }

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -498,8 +498,8 @@ export const transferOrdinals = async (
       'hex'
     ),
     gas: '40000',
-    maxFeePerGas: txOptions.gasPrice,
-    maxPriorityFeePerGas: '0',
+    maxFeePerGas: Web3.utils.toWei('5', 'gwei'),
+    maxPriorityFeePerGas: '1',
     nonce: txOptions.nonce,
   })
 }

--- a/packages/celotool/src/lib/geth.ts
+++ b/packages/celotool/src/lib/geth.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console: 0 */
+/* eslint-disable no-console */
 import { CeloTxReceipt, TransactionResult } from '@celo/connect'
 import { CeloContract, ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper'


### PR DESCRIPTION
### Description

Add to celotool a new case for simulate-client command that emulates the load produced by ordinals/inscription scenario. That is:
- Self native-token (celo) transfers
- 0 value
- Transaction data of inscriptions type (i.e.: `data:,{"p":"cls-20","op":"mint","tick":"cels","amt":"100000000"}`)

Additionally to that, I added a few changes to help with the testing:
- Fauceting threads accounts automatically (the accounts used to faucet must be fauceted using the command `bin/celotooljs.sh generate faucet-load-test --mnemonic $MNEMONIC --replica_from 0 --replica_to 10 --threads_from 0 --threads_to 0 -e <NETWORK> --gold 50 --dollars 50`)
- Adding `chainId` to txOptions
- Unify the logic to derive the account index using `getIndexForLoadTestThread` function.