### PR TITLE
Shell scripts to calculate smart contract sizes

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -180,3 +180,87 @@ yarn truffle-verify MentoFeeHandlerSeller@0x4efa274b7e33476c961065000d58ee09f792
           }
     }
     ```
+
+## Calculate smart contract sizes
+
+Sometimes it's useful to know the bytecode size of core contracts.
+We can calculate that in two ways:
+
+1. Using the bytecode of actually deployed smart contracts.
+2. Using the build artifacts of locally built smart contracts.
+
+### Using build artifacts
+
+Usage:
+
+```sh
+$ yarn size:artifacts
+```
+
+Description: This command uses a script ([`get_smart_contract_size_from_build_artifacts.sh`](./scripts/bash/get_smart_contract_size_from_build_artifacts.sh)) to calculate the size of smart contracts from Truffle build artifacts. It extracts the bytecode of each contract, calculates its size in kilobytes, and outputs the results to a CSV file in the `scripts/bash/out/` directory.
+
+> [!NOTE]  
+> The script requires Truffle build artifacts to be located in the `packages/protocol/build/` directory.
+
+For example:
+
+```sh
+$ yarn size:artifacts
+
+# ...
+ReleaseGold,31.721
+OdisPaymentsProxy,2.868
+Data extraction complete. Results saved to /Users/arthur/Documents/celo-org/celo-monorepo/packages/protocol/scripts/bash/out/build_artefact_bytecode_sizes_20240509_151111.csv
+✨  Done in 9.57s.
+```
+
+How it works:
+
+1.  The script first creates an output directory named `out` in the current directory if it doesn't exist.
+2.  It then generates a timestamp and uses it to create a unique output file in the `out` directory.
+3.  The script searches for all JSON files in the `protocol/build/contracts`, `protocol/build/contracts-0.8`, and `protocol/build/contracts-mento` directories.
+4.  For each JSON file found, it extracts the contract name and bytecode using the `jq` command-line JSON processor.
+5.  It calculates the size of the bytecode in kilobytes and appends the contract name and size to a temporary file.
+6.  The script then sorts the data in the temporary file by size in descending order and appends it to the output file.
+7.  Finally, it removes the temporary file and prints a completion message with the location of the output file.
+
+Output: The output is a CSV file named `build_artefact_bytecode_sizes_<timestamp>.csv` in the `out` directory. Each line in the file contains a contract name and its size in kilobytes, sorted in descending order by size.
+
+Requirements: This script requires the `jq` and `bc` command-line tools to be installed on your system.
+
+### Using contracts deployed on-chain
+
+Usage:
+
+```sh
+$ yarn size:onchain
+```
+
+Description: This command uses a script ([`get_smart_contract_size_from_onchain_address.sh`](./scripts/bash/get_smart_contract_size_from_onchain_address.sh)) to calculate the size of smart contracts deployed on Celo Mainnet. It uses the Celo CLI to fetch the addresses of all core contracts, and Foundry to get the bytecode deployed at each address. The size of the bytecode is then calculated and the results are output to a CSV file.
+
+> [!NOTE]  
+> The script requires the Celo CLI and Foundry to be installed on your system.
+
+For example:
+
+```sh
+$ yarn size:onchain
+
+# ...
+StableTokenEUR,0x434563B0604BE100F04B7Ae485BcafE3c9D8850E,9.180
+Validators,0xe52EaC18fB3C1e1713e73d4A5b7dCb12a2f2C697,58.228
+Data extraction complete. Results saved to /Users/arthur/Documents/celo-org/celo-monorepo/packages/protocol/out/onchain_bytecode_sizes_20240509_145556.csv
+✨  Done in 19.15s.
+```
+
+How it works:
+
+1.  The script first creates an output directory named `out` in the current directory if it doesn't exist.
+2.  It then generates a timestamp and uses it to create a unique output file in the `out` directory.
+3.  The script sets the RPC URL for the Celo blockchain to `https://forno.celo.org`.
+4.  It initializes a temporary file and the output file with headers.
+5.  The script uses the `celocli network:contracts` command to fetch the addresses of all core contracts.
+6.  For each contract address, it uses Foundry to get the deployed bytecode.
+7.  It calculates the size of the bytecode in kilobytes and appends the contract name, address, and size to the output file.
+
+Output: The output is a CSV file named `onchain_bytecode_sizes_<timestamp>.csv` in the `out` directory. Each line in the file contains a contract name, its implementation address, and its size in kilobytes.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -230,9 +230,16 @@ Requirements: This script requires the `jq` and `bc` command-line tools to b
 
 ### Using contracts deployed on-chain
 
-Usage:
+Default usage (Celo Mainnet):
 
 ```sh
+$ yarn size:onchain
+```
+
+Custom usage (any Celo RPC URL)
+
+```sh
+$ export RPC_URL=https://alfajores-forno.celo-testnet.org
 $ yarn size:onchain
 ```
 
@@ -246,6 +253,7 @@ For example:
 ```sh
 $ yarn size:onchain
 
+No custom RPC URL provided. Using default RPC URL: https://forno.celo.org
 # ...
 StableTokenEUR,0x434563B0604BE100F04B7Ae485BcafE3c9D8850E,9.180
 Validators,0xe52EaC18fB3C1e1713e73d4A5b7dCb12a2f2C697,58.228
@@ -253,11 +261,25 @@ Data extraction complete. Results saved to /Users/arthur/Documents/celo-org/celo
 ✨  Done in 19.15s.
 ```
 
+Or with custom RPC URL:
+
+```sh
+$ export RPC_URL=https://alfajores-forno.celo-testnet.org
+$ yarn size:onchain
+
+Using custom RPC URL: https://alfajores-forno.celo-testnet.org
+# ...
+StableTokenEUR,0x3Bd899048f4f6951fFeB5474205B79FDB09D6212,9.180
+Validators,0xF17D8624e0c3402D02b6F8D5870Fff0Dd35e4f0B,58.228
+Data extraction complete. Results saved to /Users/arthur/Documents/celo-org/celo-monorepo/packages/protocol/scripts/bash/out/onchain_bytecode_sizes_20240510_122254.csv
+✨  Done in 38.59s.
+```
+
 How it works:
 
 1.  The script first creates an output directory named `out` in the current directory if it doesn't exist.
 2.  It then generates a timestamp and uses it to create a unique output file in the `out` directory.
-3.  The script sets the RPC URL for the Celo blockchain to `https://forno.celo.org`.
+3.  The script sets the RPC URL to `https://forno.celo.org` (default), or uses the user-specific RPC URL.
 4.  It initializes a temporary file and the output file with headers.
 5.  The script uses the `celocli network:contracts` command to fetch the addresses of all core contracts.
 6.  For each contract address, it uses Foundry to get the deployed bytecode.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -70,11 +70,13 @@ By default, `NAME` will be set as `RELEASE_NAME`, `NAMESPACE_NAME`, `TESTNET_NAM
 ### Console
 
 To start a truffle console run:
+
 ```
 yarn console -f -n rc1
 ```
 
 Options:
+
 - "-f" for Forno mode, otherwise there needs to be a node running at localhost:8585
 - "-n <network>" possible values are: "rc1", "alfajores", "baklava"
 
@@ -83,6 +85,7 @@ All compiled assets from `build/contracts` are injected in scope so for example 
 ```
 truffle(rc1)> let exchange = await ExchangeEUR.at("0xE383394B913d7302c49F794C7d3243c429d53D1d")
 ```
+
 To instantiate a contract at a known address, and then interact with it:
 
 ```
@@ -112,19 +115,22 @@ yarn run test
 
 Adding the optional `--gas` flag will print out a report of contract gas usage.
 
-
 To test a single smart contract, run:
+
 ```bash
 yarn run test ${contract name}
 ```
+
 Adding the optional `--gas` flag will print out a report of contract gas usage.
 
 For quick test iterations run:
+
 ```bash
 yarn run quicktest
 ```
 
 or for a single contract:
+
 ```bash
 yarn run quicktest ${contract name}
 ```
@@ -132,10 +138,12 @@ yarn run quicktest ${contract name}
 For `quicktest` to work correctly a contract's migration dependencies have to be uncommented in `scripts/bash/backupmigrations.sh`.
 
 Compared to the normal test command, quicktest will:
+
 1. Not run the pretest script of building solidity (will still be run as part of truffle test) and compiling typescript. This works because truffle can run typescript "natively".
 2. Only migrate selected migrations as set in `backupmigrations.sh` (you'll likely need at least one compilation step since truffle seems to only run compiled migrations)
 
 ## Verify released smart contracts
+
 1. Update CeloScanApi in env.json file
 2. Run verification command
 
@@ -144,27 +152,31 @@ yarn truffle-verify [ContractName]@[Contract address]  --network [network] --for
 ```
 
 example:
+
 ```bash
 yarn truffle-verify MentoFeeHandlerSeller@0x4efa274b7e33476c961065000d58ee09f7921a74 --network mainnet --forno https://forno.celo.org
 ```
 
 ### Possible problems
- 1. Some of old smart contracts have slightly different bytecode when verified (it is usually just few bytes difference). Some of the smart contracts were originally deployed with version 0.5.8 instead of 0.5.13 even though there is no history trace about this in our monorepo.
- 2. Bytecode differs because of missing library addresses on CeloScan. Json file that will be manually uploaded to CeloScan needs to have libraries root element updated. Library addresses is possible to get either manually or with command which will generate libraries.json.
-  ```bash
-   yarn verify-deployed -n $NETWORK -b $PREVIOUS_RELEASE -f
-   ```
-    
-  ```javascript
-  {
-    "libraries": {
-            "/contracts/governance/Governance.sol": {
-                "Proposals": "0x38afc0dc55415ae27b81c24b5a5fbfe433ebfba8",
-                "IntegerSortedLinkedList": "0x411b40a81a07fcd3542ce5b3d7e215178c4ca2ef",
-                "AddressLinkedList": "0xd26d896d258e258eba71ff0873a878ec36538f8d",
-                "Signatures": "0x69baecd458e7c08b13a18e11887dbb078fb3cbb4",
-                "AddressSortedLinkedList": "0x4819ad0a0eb1304b1d7bc3afd7818017b52a87ab"
-            }
-        }
-  }
-```
+
+1.  Some of old smart contracts have slightly different bytecode when verified (it is usually just few bytes difference). Some of the smart contracts were originally deployed with version 0.5.8 instead of 0.5.13 even though there is no history trace about this in our monorepo.
+
+2.  Bytecode differs because of missing library addresses on CeloScan. Json file that will be manually uploaded to CeloScan needs to have libraries root element updated. Library addresses is possible to get either manually or with command which will generate libraries.json.
+
+    ```bash
+    yarn verify-deployed -n $NETWORK -b $PREVIOUS_RELEASE -f
+    ```
+
+    ```javascript
+    {
+      "libraries": {
+              "/contracts/governance/Governance.sol": {
+                  "Proposals": "0x38afc0dc55415ae27b81c24b5a5fbfe433ebfba8",
+                  "IntegerSortedLinkedList": "0x411b40a81a07fcd3542ce5b3d7e215178c4ca2ef",
+                  "AddressLinkedList": "0xd26d896d258e258eba71ff0873a878ec36538f8d",
+                  "Signatures": "0x69baecd458e7c08b13a18e11887dbb078fb3cbb4",
+                  "AddressSortedLinkedList": "0x4819ad0a0eb1304b1d7bc3afd7818017b52a87ab"
+              }
+          }
+    }
+    ```

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -197,7 +197,7 @@ Usage:
 $ yarn size:artifacts
 ```
 
-Description: This command uses a script ([`get_smart_contract_size_from_build_artifacts.sh`](./scripts/bash/get_smart_contract_size_from_build_artifacts.sh)) to calculate the size of smart contracts from Truffle build artifacts. It extracts the bytecode of each contract, calculates its size in kilobytes, and outputs the results to a CSV file in the `scripts/bash/out/` directory.
+Description: This command uses a script ([`get_smart_contract_size_from_build_artifacts.sh`](./scripts/bash/get_smart_contract_size_from_build_artifacts.sh)) to calculate the size of smart contracts from Truffle build artifacts. It extracts the `deployedBytecode` of each contract, calculates its size in kilobytes, and outputs the results to a CSV file in the `scripts/bash/out/` directory.
 
 > [!NOTE]  
 > The script requires Truffle build artifacts to be located in the `packages/protocol/build/` directory.
@@ -219,8 +219,8 @@ How it works:
 1.  The script first creates an output directory named `out` in the current directory if it doesn't exist.
 2.  It then generates a timestamp and uses it to create a unique output file in the `out` directory.
 3.  The script searches for all JSON files in the `protocol/build/contracts`, `protocol/build/contracts-0.8`, and `protocol/build/contracts-mento` directories.
-4.  For each JSON file found, it extracts the contract name and bytecode using the `jq` command-line JSON processor.
-5.  It calculates the size of the bytecode in kilobytes and appends the contract name and size to a temporary file.
+4.  For each JSON file found, it extracts the contract name and `deployedBytecode` using the `jq` command-line JSON processor.
+5.  It calculates the size of the `deployedBytecode` in kilobytes and appends the contract name and size to a temporary file.
 6.  The script then sorts the data in the temporary file by size in descending order and appends it to the output file.
 7.  Finally, it removes the temporary file and prints a completion message with the location of the output file.
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -43,6 +43,8 @@
     "make-release": "./scripts/bash/make-release.sh",
     "verify-deployed": "./scripts/bash/verify-deployed.sh",
     "verify-release": "./scripts/bash/verify-release.sh",
+    "size:onchain": "./scripts/bash/get_smart_contract_size_from_onchain_address.sh",
+    "size:artifacts": "./scripts/bash/get_smart_contract_size_from_build_artifacts.sh",
     "ganache-dev": "./scripts/bash/ganache.sh",
     "ganache-devchain": "./scripts/bash/ganache_devchain.sh",
     "truffle:migrate": "truffle migrate",

--- a/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artefacts.sh
+++ b/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artefacts.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+: '
+  Uses:
+    1. Truffle build artefacts located in the packages/protocol/build/ directory
+
+  Requirements:
+  1. Have the Truffle build artefacts in the packages/protocol/build/ directory
+  '
+
+# Get the current date and time for the filename
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+
+# Create the output directory if it doesn't exist
+OUTPUT_DIRECTORY="$(pwd)/out"
+mkdir -p "$OUTPUT_DIRECTORY"
+OUTPUT_FILE="$OUTPUT_DIRECTORY/build_artefact_bytecode_sizes_$TIMESTAMP.csv"
+
+# Temporary file to collect data before sorting
+TEMP_FILE=$(mktemp)
+
+# Write the header to the output file
+echo "Contract,Size (KB)" > "$OUTPUT_FILE"
+
+# Find all JSON files in the subdirectories and process them
+find "../../../protocol/build/contracts" \
+     "../../../protocol/build/contracts-0.8" \
+     "../../../protocol/build/contracts-mento" -name '*.json' | while read -r file
+do
+    # Extract the contract name and bytecode using jq
+    contract=$(jq -r '.contractName' "$file")
+    bytecode=$(jq -r '.bytecode' "$file")
+    
+    : '
+      Converts the hexadecimal string to bytes, to measure the size in kilobytes.
+      The size can be calculated by counting the number of characters, dividing by two 
+      (since each byte is represented by two characters), and then converting to kilobytes.
+      Subtracts 2 characters to account for the "0x" prefix.
+      '
+    # Calculate the size in bytes (hex chars / 2)
+    size_bytes=$(((${#bytecode} - 2) / 2))
+
+    # Calculate size in kilobytes with scale 3 precision
+    size_kb=$(echo "scale=3; $size_bytes / 1024" | bc)
+
+    # Append the data to the temporary file
+    echo "$contract,$size_kb" >> "$TEMP_FILE"
+
+    # Print progress to the console
+    echo "$contract,$size_kb"
+done
+
+# Sort the temporary file by size in descending order and append to the output file
+sort -t',' -k2,2nr "$TEMP_FILE" >> "$OUTPUT_FILE"
+
+# Clean up the temporary file
+rm "$TEMP_FILE"
+
+# Output completion message
+echo "Data extraction complete. Results saved to $OUTPUT_FILE"

--- a/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artifacts.sh
+++ b/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artifacts.sh
@@ -10,8 +10,17 @@
 # Get the current date and time for the filename
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 
+# Get the directory where the script is located, assuming the script is in the root or a subdirectory of the repo
+BASE_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Get the root of the repo based on the known structure
+REPO_ROOT_DIRECTORY="$BASE_DIRECTORY/../../../"
+
+# Get the directory with build artifacts
+BUILD_ARTIFACT_DIRECTORY="${REPO_ROOT_DIRECTORY}protocol/build/contracts"
+
 # Create the output directory if it doesn't exist
-OUTPUT_DIRECTORY="$(pwd)/out"
+OUTPUT_DIRECTORY="$BASE_DIRECTORY/out"
 mkdir -p "$OUTPUT_DIRECTORY"
 OUTPUT_FILE="$OUTPUT_DIRECTORY/build_artefact_bytecode_sizes_$TIMESTAMP.csv"
 
@@ -22,9 +31,9 @@ TEMP_FILE=$(mktemp)
 echo "Contract,Size (KB)" > "$OUTPUT_FILE"
 
 # Find all JSON files in the subdirectories and process them
-find "../../../protocol/build/contracts" \
-     "../../../protocol/build/contracts-0.8" \
-     "../../../protocol/build/contracts-mento" -name '*.json' | while read -r file
+find "$BUILD_ARTIFACT_DIRECTORY" \
+     "${BUILD_ARTIFACT_DIRECTORY}-0.8" \
+     "${BUILD_ARTIFACT_DIRECTORY}-mento" -name '*.json' | while read -r file
 do
     # Extract the contract name and bytecode using jq
     contract=$(jq -r '.contractName' "$file")

--- a/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artifacts.sh
+++ b/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artifacts.sh
@@ -37,7 +37,7 @@ find "$BUILD_ARTIFACT_DIRECTORY" \
 do
     # Extract the contract name and bytecode using jq
     contract=$(jq -r '.contractName' "$file")
-    bytecode=$(jq -r '.bytecode' "$file")
+    bytecode=$(jq -r '.deployedBytecode' "$file")
     
     : '
       Converts the hexadecimal string to bytes, to measure the size in kilobytes.

--- a/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artifacts.sh
+++ b/packages/protocol/scripts/bash/get_smart_contract_size_from_build_artifacts.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 : '
   Uses:
-    1. Truffle build artefacts located in the packages/protocol/build/ directory
+    1. Truffle build artifacts located in the packages/protocol/build/ directory
 
   Requirements:
-  1. Have the Truffle build artefacts in the packages/protocol/build/ directory
+  1. Have the Truffle build artifacts in the packages/protocol/build/ directory
   '
 
 # Get the current date and time for the filename

--- a/packages/protocol/scripts/bash/get_smart_contract_size_from_onchain_address.sh
+++ b/packages/protocol/scripts/bash/get_smart_contract_size_from_onchain_address.sh
@@ -20,8 +20,13 @@ mkdir -p "$OUTPUT_DIRECTORY"
 OUTPUT_FILE="$OUTPUT_DIRECTORY/onchain_bytecode_sizes_$TIMESTAMP.csv"
 TEMP_FILE="temp_$TIMESTAMP.txt"
 
-# Set the RPC URL for the blockchain
-RPC_URL="https://forno.celo.org"
+# Set the RPC URL using environment variable or fallback to the default value
+RPC_URL="${RPC_URL:-https://forno.celo.org}"
+if [ "$RPC_URL" == "https://forno.celo.org" ]; then
+  echo "No custom RPC URL provided. Using default RPC URL: $RPC_URL."
+else
+  echo "Using custom RPC URL: $RPC_URL"
+fi
 
 # Initialize the temporary file
 echo "" > $TEMP_FILE

--- a/packages/protocol/scripts/bash/get_smart_contract_size_from_onchain_address.sh
+++ b/packages/protocol/scripts/bash/get_smart_contract_size_from_onchain_address.sh
@@ -11,8 +11,11 @@
 # Get the current date and time for the filename
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 
+# Get the directory where the script is located, assuming the script is in the root or a subdirectory of the repo
+BASE_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 # Create the output directory if it doesn't exist
-OUTPUT_DIRECTORY="$(pwd)/out"
+OUTPUT_DIRECTORY="$BASE_DIRECTORY/out"
 mkdir -p "$OUTPUT_DIRECTORY"
 OUTPUT_FILE="$OUTPUT_DIRECTORY/onchain_bytecode_sizes_$TIMESTAMP.csv"
 TEMP_FILE="temp_$TIMESTAMP.txt"

--- a/packages/protocol/scripts/bash/get_smart_contract_size_from_onchain_address.sh
+++ b/packages/protocol/scripts/bash/get_smart_contract_size_from_onchain_address.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+: '
+  Uses Celo CLI ("network:contracts") to get all core contracts and their implementation addresses.
+  Uses Foundry ("cast code") to get the bytecode deployed at each core contract implementation address.
+
+  Requirements:
+  1. Have Foundry installed
+  2. Have celocli installed
+  '
+
+# Get the current date and time for the filename
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+
+# Create the output directory if it doesn't exist
+OUTPUT_DIRECTORY="$(pwd)/out"
+mkdir -p "$OUTPUT_DIRECTORY"
+OUTPUT_FILE="$OUTPUT_DIRECTORY/onchain_bytecode_sizes_$TIMESTAMP.csv"
+TEMP_FILE="temp_$TIMESTAMP.txt"
+
+# Set the RPC URL for the blockchain
+RPC_URL="https://forno.celo.org"
+
+# Initialize the temporary file
+echo "" > $TEMP_FILE
+
+# Initialize the CSV output file with headers
+echo "Contract,Implementation Address,Size (KB)" > $OUTPUT_FILE
+
+# Fetch contract information from celocli and process the output
+celocli network:contracts --node $RPC_URL | grep -E '0x[a-fA-F0-9]{40}' | while IFS=" " read -ra line
+do
+  # Extract contract name and implementation address from the output
+  contract="${line[0]}"
+  implementation_address="${line[2]}"
+
+  # Ensure address is not empty or undefined
+  if [ -z "$implementation_address" ] || [ "$implementation_address" == "NONE" ]; then
+    echo "No implementation address available for $contract"
+    echo "$contract,NONE,0" >> $TEMP_FILE
+    echo "$contract,NONE,0"
+    continue
+  fi
+
+  # Fetch bytecode using cast with the specified flag order
+  bytecode=$(cast code $implementation_address --rpc-url $RPC_URL 2>/dev/null) # Redirect stderr to null to handle any errors gracefully
+
+  # Check if bytecode was successfully fetched; handle cases where the contract might not have bytecode (e.g., non-contract addresses)
+  if [[ -z "$bytecode" || "$bytecode" == "0x" ]]; then
+    echo "No bytecode found for $contract at $implementation_address"
+    echo "$contract,$implementation_address,0" >> $TEMP_FILE
+    echo "$contract,$implementation_address,0"
+    continue
+  fi
+
+  : '
+    Converts the hexadecimal string to bytes, to measure the size in kilobytes.
+    The size can be calculated by counting the number of characters, dividing by two 
+    (since each byte is represented by two characters), and then converting to kilobytes.
+    Subtracts 2 characters to account for the "0x" prefix.
+    '
+  # Calculate size in bytes (hex chars / 2)
+  size_bytes=$(((${#bytecode} - 2) / 2))
+
+  # Calculate size in kilobytes
+  size_kb=$(echo "scale=3; $size_bytes / 1024" | bc)
+
+  # Output to the temporary file and console
+  echo "$contract,$implementation_address,$size_kb" >> $TEMP_FILE
+  echo "$contract,$implementation_address,$size_kb"
+done
+
+# Sort the temporary file by size in descending order and append to the final CSV
+sort -t, -k3,3nr $TEMP_FILE >> $OUTPUT_FILE
+
+# Cleanup temporary file
+rm $TEMP_FILE
+
+
+# Output completion message
+echo "Data extraction complete. Results saved to $OUTPUT_FILE"


### PR DESCRIPTION
### Description

Sometimes it's useful to know the bytecode size of core contracts. This PR adds scripts calculate that in two ways:

1. Using the bytecode of actually deployed smart contracts.
2. Using the build artifacts of locally built smart contracts.

Writes the output to the console and to csv files in the `scripts/bash/out/` directory (which is gitignored).

### Changes

1. Adds two shell scripts
2. Adds commands to `package.json`
3. Adds documentation to `README.md`

### Other changes

Nit: Linting in `README.md` file

### Tested

- [x] Example run `size:onchain`

    ```sh
    $ yarn size:onchain
    
    # ...
    StableTokenEUR,0x434563B0604BE100F04B7Ae485BcafE3c9D8850E,9.180
    Validators,0xe52EaC18fB3C1e1713e73d4A5b7dCb12a2f2C697,58.228
    Data extraction complete. Results saved to /Users/arthur/Documents/celo-org/celo-monorepo/packages/protocol/out/onchain_bytecode_sizes_20240509_145556.csv
    ✨  Done in 19.15s.
    ```

- [x] Example run `size:artifacts`

    ```sh
    $ yarn size:artifacts
    
    # ...
    ReleaseGold,31.721
    OdisPaymentsProxy,2.868
    Data extraction complete. Results saved to /Users/arthur/Documents/celo-org/celo-monorepo/packages/protocol/scripts/bash/out/build_artefact_bytecode_sizes_20240509_151111.csv
    ✨  Done in 9.57s.
    ```

- [x] CSV output for both scripts looks good 👍 
- [x] Output in `out/` is gitignored

### Related issues

- Fixes #10988 

### Backwards compatibility

Yes, backwards compatible. The new scripts can be used on-demand, but don't interfere with any existing flows. 

### Documentation

Yes, added documentation to the `README.md` file.