### PR TITLE
Add FeeCurrencyDirectory to Anvil migrations

### DIFF
--- a/packages/protocol/contracts/stability/SortedOracles.sol
+++ b/packages/protocol/contracts/stability/SortedOracles.sol
@@ -36,7 +36,7 @@ import "../../contracts-0.8/common/interfaces/IOracle.sol";
  *          "token" are actually referring to the rateFeedId.
  *
  */
-contract SortedOracles is ISortedOracles, ICeloVersionedContract, Ownable, Initializable {
+contract SortedOracles is ISortedOracles, IOracle, ICeloVersionedContract, Ownable, Initializable {
   using SafeMath for uint256;
   using AddressSortedLinkedListWithMedian for SortedLinkedListWithMedian.List;
   using FixidityLib for FixidityLib.Fraction;

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -425,14 +425,10 @@ contract Migration is Script, UsingRegistry {
     Source: https://github.com/celo-org/celo-monorepo/blob/2cec07d43328cf4216c62491a35eacc4960fffb6/packages/protocol/test-sol/common/FeeCurrencyDirectory.t.sol#L27 
     */
     uint256 mockIntrinsicGas = 21000;
-    
-    FeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory")).setCurrencyConfig(
-      stableTokenProxyAddress,
-      address(getSortedOracles()), 
-      mockIntrinsicGas
-    );
+
+    FeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory"))
+      .setCurrencyConfig(stableTokenProxyAddress, address(getSortedOracles()), mockIntrinsicGas);
   }
-  
 
   function migrateStableToken(string memory json) public {
     string[] memory names = abi.decode(json.parseRaw(".stableTokens.names"), (string[]));

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -49,6 +49,8 @@ import "@openzeppelin/contracts8/utils/math/Math.sol";
 import "@celo-contracts-8/common/UsingRegistry.sol";
 import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol"; // TODO(Arthur): Is this a duplicate?
 
+import "@celo-contracts-8/common/mocks/MockOracle.sol";
+
 contract ForceTx {
   // event to trigger so a tx can be processed
   event VanillaEvent(string);
@@ -434,7 +436,10 @@ contract Migration is Script, UsingRegistry {
     This is an arbitrary hex address I took from celoscan.
     For now, I only want to test if I can set a currency config.
     */
-    address mockOracleAddress = 0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33;
+    MockOracle mockOracle = new MockOracle();
+    address mockOracleAddress = address(mockOracle);
+    mockOracle.setExchangeRate(stableTokenProxyAddress, 10, 5); // TODO(Arthur): These are arbitrary numerator and denumerators.
+
     /*
     Arbitrary intrinsic gas number take from existing `FeeCurrencyDirectory.t.sol` tests
     Source: https://github.com/celo-org/celo-monorepo/blob/2cec07d43328cf4216c62491a35eacc4960fffb6/packages/protocol/test-sol/common/FeeCurrencyDirectory.t.sol#L27 
@@ -442,7 +447,7 @@ contract Migration is Script, UsingRegistry {
     uint256 mockIntrinsicGas = 21000;
     FeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory")).setCurrencyConfig(
       stableTokenProxyAddress,
-      mockOracleAddress,
+      mockOracleAddress, 
       mockIntrinsicGas
     );
   }

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -423,7 +423,17 @@ contract Migration is Script, UsingRegistry {
     IReserve(registry.getAddressForStringOrDie("Reserve")).addToken(stableTokenProxyAddress);
 
     getFeeCurrencyWhitelist().addToken(stableTokenProxyAddress);
-    // TODO(Arthur): Add stabletoken to FeeCurrencyDirectory
+    /* 
+    TODO(Arthur): Add stabletoken to FeeCurrencyDirectory 
+    1. Check that the syntax below is correct to .setCurrencyCongif
+    2. Set oracle address (is this sortedOracle?)
+    3. Set intrinsic gas value
+    */
+    IFeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory")).setCurrencyConfig(
+      stableTokenProxyAddress,
+      , // TODO(Arthur): add oracle address
+      , // TODO(Arthur): add intrinsice gas value
+    )
   }
 
   function migrateStableToken(string memory json) public {

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -12,6 +12,7 @@ import "@celo-contracts/common/interfaces/IRegistry.sol";
 import "@celo-contracts/common/interfaces/IFreezer.sol";
 import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol";
 // TODO(Arthur): import FeeCurrencyDirectory interface?
+import "@celo-contracts-8/common/interfaces/IFeeCurrencyDirectory.sol";
 import "@celo-contracts/common/interfaces/ICeloToken.sol"; // TODO move these to Initializer
 import "@celo-contracts/common/interfaces/IAccountsInitializer.sol";
 import "@celo-contracts/common/interfaces/IAccounts.sol";
@@ -206,6 +207,7 @@ contract Migration is Script, UsingRegistry {
     migrateFreezer();
     migrateFeeCurrencyWhitelist();
     // TODO(Arthur): Add FeeCurrencyDirectory here
+    migrateFeeCurrencyDirectory();
     migrateGoldToken(json);
     migrateSortedOracles(json);
     migrateGasPriceMinimum(json);
@@ -266,6 +268,13 @@ contract Migration is Script, UsingRegistry {
   }
 
   // TODO(Arthur): Add FeeCurrencyDirectory function
+  function migrateFeeCurrencyDirectory() public {
+    // TODO migrate the initializations interface
+    deployProxiedContract(
+      "FeeCurrencyDirectory",
+      abi.encodeWithSelector(IFeeCurrencyDirectory.initialize.selector)
+    );
+  }
 
   function migrateGoldToken(string memory json) public {
     // TODO change pre-funded addresses to make it match circulation supply
@@ -414,6 +423,7 @@ contract Migration is Script, UsingRegistry {
     IReserve(registry.getAddressForStringOrDie("Reserve")).addToken(stableTokenProxyAddress);
 
     getFeeCurrencyWhitelist().addToken(stableTokenProxyAddress);
+    // TODO(Arthur): Add stabletoken to FeeCurrencyDirectory
   }
 
   function migrateStableToken(string memory json) public {
@@ -940,7 +950,8 @@ contract Migration is Script, UsingRegistry {
         "EpochRewards",
         "Escrow",
         "FederatedAttestations",
-        "FeeCurrencyWhitelist",
+        "FeeCurrencyWhitelist", // TODO(Arthur): Add FeeCurrencyDirectory
+        "FeeCurrencyDirectory",
         "Freezer",
         "FeeHandler",
         "GoldToken",

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -13,6 +13,7 @@ import "@celo-contracts/common/interfaces/IFreezer.sol";
 import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol";
 // TODO(Arthur): import FeeCurrencyDirectory interface?
 import "@celo-contracts-8/common/interfaces/IFeeCurrencyDirectory.sol";
+import "@celo-contracts-8/common/FeeCurrencyDirectory.sol";
 import "@celo-contracts/common/interfaces/ICeloToken.sol"; // TODO move these to Initializer
 import "@celo-contracts/common/interfaces/IAccountsInitializer.sol";
 import "@celo-contracts/common/interfaces/IAccounts.sol";
@@ -272,7 +273,7 @@ contract Migration is Script, UsingRegistry {
     // TODO migrate the initializations interface
     deployProxiedContract(
       "FeeCurrencyDirectory",
-      abi.encodeWithSelector(IFeeCurrencyDirectory.initialize.selector)
+      abi.encodeWithSelector(FeeCurrencyDirectory.initialize.selector)
     );
   }
 
@@ -439,7 +440,7 @@ contract Migration is Script, UsingRegistry {
     Source: https://github.com/celo-org/celo-monorepo/blob/2cec07d43328cf4216c62491a35eacc4960fffb6/packages/protocol/test-sol/common/FeeCurrencyDirectory.t.sol#L27 
     */
     uint256 mockIntrinsicGas = 21000;
-    IFeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory")).setCurrencyConfig(
+    FeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory")).setCurrencyConfig(
       stableTokenProxyAddress,
       mockOracleAddress,
       mockIntrinsicGas
@@ -960,7 +961,7 @@ contract Migration is Script, UsingRegistry {
     if (!skipTransferOwnership) {
       // TODO move this list somewhere else
 
-      string[22] memory fixedStringArray = [
+      string[23] memory fixedStringArray = [
         "Accounts",
         // 'Attestations',
         // BlockchainParameters ownership transitioned to governance in a follow-up script.?

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -429,12 +429,23 @@ contract Migration is Script, UsingRegistry {
     2. Set oracle address (is this sortedOracle?)
     3. Set intrinsic gas value
     */
+    /*
+    This is an arbitrary hex address I took from celoscan.
+    For now, I only want to test if I can set a currency config.
+    */
+    address mockOracleAddress = 0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33;
+    /*
+    Arbitrary intrinsic gas number take from existing `FeeCurrencyDirectory.t.sol` tests
+    Source: https://github.com/celo-org/celo-monorepo/blob/2cec07d43328cf4216c62491a35eacc4960fffb6/packages/protocol/test-sol/common/FeeCurrencyDirectory.t.sol#L27 
+    */
+    uint256 mockIntrinsicGas = 21000;
     IFeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory")).setCurrencyConfig(
       stableTokenProxyAddress,
-      , // TODO(Arthur): add oracle address
-      , // TODO(Arthur): add intrinsice gas value
-    )
+      mockOracleAddress,
+      mockIntrinsicGas
+    );
   }
+  
 
   function migrateStableToken(string memory json) public {
     string[] memory names = abi.decode(json.parseRaw(".stableTokens.names"), (string[]));

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -422,19 +422,16 @@ contract Migration is Script, UsingRegistry {
     IReserve(registry.getAddressForStringOrDie("Reserve")).addToken(stableTokenProxyAddress);
 
     getFeeCurrencyWhitelist().addToken(stableTokenProxyAddress);
-    
-    MockOracle mockOracle = new MockOracle();
-    address mockOracleAddress = address(mockOracle);
-    mockOracle.setExchangeRate(stableTokenProxyAddress, 10, 5); // TODO(Arthur): These are arbitrary numerator and denumerators.
 
     /*
     Arbitrary intrinsic gas number take from existing `FeeCurrencyDirectory.t.sol` tests
     Source: https://github.com/celo-org/celo-monorepo/blob/2cec07d43328cf4216c62491a35eacc4960fffb6/packages/protocol/test-sol/common/FeeCurrencyDirectory.t.sol#L27 
     */
     uint256 mockIntrinsicGas = 21000;
+    
     FeeCurrencyDirectory(registry.getAddressForStringOrDie("FeeCurrencyDirectory")).setCurrencyConfig(
       stableTokenProxyAddress,
-      mockOracleAddress, 
+      address(getSortedOracles()), 
       mockIntrinsicGas
     );
   }

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -205,6 +205,7 @@ contract Migration is Script, UsingRegistry {
 
     migrateFreezer();
     migrateFeeCurrencyWhitelist();
+    // TODO(Arthur): Add FeeCurrencyDirectory here
     migrateGoldToken(json);
     migrateSortedOracles(json);
     migrateGasPriceMinimum(json);
@@ -263,6 +264,8 @@ contract Migration is Script, UsingRegistry {
       abi.encodeWithSelector(IFeeCurrencyWhitelist.initialize.selector)
     );
   }
+
+  // TODO(Arthur): Add FeeCurrencyDirectory function
 
   function migrateGoldToken(string memory json) public {
     // TODO change pre-funded addresses to make it match circulation supply

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -45,9 +45,6 @@ import "./HelperInterFaces.sol";
 import "@openzeppelin/contracts8/utils/math/Math.sol";
 
 import "@celo-contracts-8/common/UsingRegistry.sol";
-import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol"; // TODO(Arthur): Is this a duplicate?
-
-import "@celo-contracts-8/common/mocks/MockOracle.sol";
 
 contract ForceTx {
   // event to trigger so a tx can be processed

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -11,8 +11,6 @@ import "@celo-contracts/common/interfaces/IProxy.sol";
 import "@celo-contracts/common/interfaces/IRegistry.sol";
 import "@celo-contracts/common/interfaces/IFreezer.sol";
 import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol";
-// TODO(Arthur): import FeeCurrencyDirectory interface?
-import "@celo-contracts-8/common/interfaces/IFeeCurrencyDirectory.sol";
 import "@celo-contracts-8/common/FeeCurrencyDirectory.sol";
 import "@celo-contracts/common/interfaces/ICeloToken.sol"; // TODO move these to Initializer
 import "@celo-contracts/common/interfaces/IAccountsInitializer.sol";
@@ -209,7 +207,6 @@ contract Migration is Script, UsingRegistry {
 
     migrateFreezer();
     migrateFeeCurrencyWhitelist();
-    // TODO(Arthur): Add FeeCurrencyDirectory here
     migrateFeeCurrencyDirectory();
     migrateGoldToken(json);
     migrateSortedOracles(json);
@@ -270,7 +267,6 @@ contract Migration is Script, UsingRegistry {
     );
   }
 
-  // TODO(Arthur): Add FeeCurrencyDirectory function
   function migrateFeeCurrencyDirectory() public {
     // TODO migrate the initializations interface
     deployProxiedContract(
@@ -426,16 +422,7 @@ contract Migration is Script, UsingRegistry {
     IReserve(registry.getAddressForStringOrDie("Reserve")).addToken(stableTokenProxyAddress);
 
     getFeeCurrencyWhitelist().addToken(stableTokenProxyAddress);
-    /* 
-    TODO(Arthur): Add stabletoken to FeeCurrencyDirectory 
-    1. Check that the syntax below is correct to .setCurrencyCongif
-    2. Set oracle address (is this sortedOracle?)
-    3. Set intrinsic gas value
-    */
-    /*
-    This is an arbitrary hex address I took from celoscan.
-    For now, I only want to test if I can set a currency config.
-    */
+    
     MockOracle mockOracle = new MockOracle();
     address mockOracleAddress = address(mockOracle);
     mockOracle.setExchangeRate(stableTokenProxyAddress, 10, 5); // TODO(Arthur): These are arbitrary numerator and denumerators.
@@ -977,7 +964,7 @@ contract Migration is Script, UsingRegistry {
         "EpochRewards",
         "Escrow",
         "FederatedAttestations",
-        "FeeCurrencyWhitelist", // TODO(Arthur): Add FeeCurrencyDirectory
+        "FeeCurrencyWhitelist",
         "FeeCurrencyDirectory",
         "Freezer",
         "FeeHandler",

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -11,6 +11,7 @@ import "@celo-contracts/common/interfaces/IProxy.sol";
 import "@celo-contracts/common/interfaces/IRegistry.sol";
 import "@celo-contracts/common/interfaces/IFreezer.sol";
 import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol";
+// TODO(Arthur): import FeeCurrencyDirectory interface?
 import "@celo-contracts/common/interfaces/ICeloToken.sol"; // TODO move these to Initializer
 import "@celo-contracts/common/interfaces/IAccountsInitializer.sol";
 import "@celo-contracts/common/interfaces/IAccounts.sol";
@@ -44,7 +45,7 @@ import "./HelperInterFaces.sol";
 import "@openzeppelin/contracts8/utils/math/Math.sol";
 
 import "@celo-contracts-8/common/UsingRegistry.sol";
-import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol";
+import "@celo-contracts/common/interfaces/IFeeCurrencyWhitelist.sol"; // TODO(Arthur): Is this a duplicate?
 
 contract ForceTx {
   // event to trigger so a tx can be processed
@@ -60,6 +61,9 @@ contract ForceTx {
 contract Migration is Script, UsingRegistry {
   using stdJson for string;
 
+  /**
+   * This is Anvil's default account
+   */
   address constant deployerAccount = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
   IProxyFactory proxyFactory;
@@ -177,6 +181,9 @@ contract Migration is Script, UsingRegistry {
     console.log("------------------------------");
   }
 
+  /**
+   * Entry point of the script
+   */
   function run() external {
     // TODO check that this matches deployerAccount and the pK can be avoided with --unlock
     vm.startBroadcast(deployerAccount);

--- a/packages/protocol/migrations_sol/create_and_migrate_anvil_devchain.sh
+++ b/packages/protocol/migrations_sol/create_and_migrate_anvil_devchain.sh
@@ -7,7 +7,7 @@ forge build
 export ANVIL_PORT=8546
 
 # TODO make this configurable
-FROM_ACCOUNT_NO_ZERO="f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FROM_ACCOUNT_NO_ZERO="f39Fd6e51aad88F6F4ce6aB8827279cffFb92266" # This is Anvil's default account (1)
 FROM_ACCOUNT="0x$FROM_ACCOUNT_NO_ZERO"
 TEMP_FOLDER="$PWD/.tmp"
 

--- a/packages/protocol/migrations_sol/start_anvil.sh
+++ b/packages/protocol/migrations_sol/start_anvil.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 timestamp=`date -Iseconds`
-ANVI_FILE="$TEMP_FOLDER/anvil_state-$timestamp"
+ANVIL_FILE="$TEMP_FOLDER/anvil_state-$timestamp"
 
 if nc -z localhost $ANVIL_PORT; then
   echo "Port already used"
@@ -12,7 +12,7 @@ fi
 
 
 
-anvil --port $ANVIL_PORT --gas-limit 50000000 --steps-tracing --code-size-limit 245760 --balance 60000 --dump-state $ANVI_FILE &
+anvil --port $ANVIL_PORT --gas-limit 50000000 --steps-tracing --code-size-limit 245760 --balance 60000 --dump-state $ANVIL_FILE &
 
 # alternatively:
 # ANVIL_PID=`lsof -i tcp:8545 | tail -n 1 | awk '{print $2}'`

--- a/packages/protocol/test-sol/governance/validators/DoubleSigningSlasher.t.sol
+++ b/packages/protocol/test-sol/governance/validators/DoubleSigningSlasher.t.sol
@@ -408,7 +408,7 @@ contract DoubleSigningSlasherSlash is DoubleSigningSlasherBaseTest {
       groupElectionGreaters: groupElectionGreaters,
       groupElectionIndices: groupElectionIndices
     });
-    vm.expectRevert("This method is not supported in L2 anymore.");
+    vm.expectRevert("This method is no longer supported in L2.");
     slasher.mockSlash(params);
   }
 }


### PR DESCRIPTION
### Description

Adds the new `FeeCurrencyDirectory` contract to the Anvil migration script.

### Changes

1. deploys and proxies the `FeeCurrencyDirectory` contract
2. registers `FeeCurrencyDirectory` in the `Registry`
3. adds three existing cStables (cUSD, cEUR, and cREAL) to the `FeeCurrencyDirectory`

### Other changes

1. adds `is IOracle` to the class definition in `SortedOracles`
4. removes a duplicate import in `Migrations.s.sol`

### Tested

Yes, tested locally:
- [x] get the `FeeCurrencyDirectory` address from the `Registry`
- [x] get registered currencies from the `FeeCurrencyDirectory` contract
- [x] get the exchange rate for a currency from the `FeeCurrencyDirectory` contract

<details>
  <summary>Steps to reproduce tests locally</summary>

Requirement:
1. Have foundry installed
2. Be in the `packages/protocol` directory

Tests:

1. Run migration script (in a different Terminal)

    ```sh
    $ ./migrations_sol/create_and_migrate_anvil_devchain.sh
    ```

1. Check that Anvil is running

    ```sh
    $ nc -z localhost 8546
    Connection to localhost port 8546 [tcp/*] succeeded!
    ```
    
    Source: [start_anvil.sh](https://github.com/celo-org/celo-monorepo/blob/a36eae5bc2c9c2071fb942199b1ba265f3937c17/packages/protocol/migrations_sol/start_anvil.sh#L7)

    Anvil is running ✅

1. get the `FeeCurrencyDirectory` address from the `Registry`:

    ```sh
    export REGISTRY_ADDRESS="0x000000000000000000000000000000000000ce10"
    export ANVIL_PORT=8546
    cast call \
    $REGISTRY_ADDRESS \
    "getAddressForStringOrDie(string calldata identifier)" \
    "FeeCurrencyDirectory" \
    --rpc-url=http://127.0.0.1:$ANVIL_PORT
    
    0x00000000000000000000000042fe5a2a61ed9705eb2f08a04a58ceb606d22f6a
    ```
    
    ```sh
    cast abi-decode \
    "getAddressForStringOrDie(string calldata identifier)(address)" \
    "0x00000000000000000000000042fe5a2a61ed9705eb2f08a04a58ceb606d22f6a"
    
    0x42Fe5a2A61ed9705eb2F08a04A58CEB606D22f6a
    ```

    `FeeCurrencyDirectory` is registered in the `Registry` ✅

1. get registered currencies from the `FeeCurrencyDirectory` contract

    ```sh
    export FEECURRENCYDIRECTORY_PROXY_ADDRESS=0x42Fe5a2A61ed9705eb2F08a04A58CEB606D22f6a
    export ANVIL_PORT=8546
    
    cast call \
    $FEECURRENCYDIRECTORY_PROXY_ADDRESS \
    "getCurrencies()" \
    --rpc-url=http://127.0.0.1:$ANVIL_PORT
    
    0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000e6774be4e5f97db10cafb4c00c74cfbdcdc434d9000000000000000000000000b7a33b4ad2b1f6b0a944232f5c71798d27ad92720000000000000000000000002a3733dbc31980f02b12135c809b5da33bf3a1e9
    ```
    
    ```sh
    cast abi-decode \
    "getCurrencies()(address[] memory)" \
    "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000e6774be4e5f97db10cafb4c00c74cfbdcdc434d9000000000000000000000000b7a33b4ad2b1f6b0a944232f5c71798d27ad92720000000000000000000000002a3733dbc31980f02b12135c809b5da33bf3a1e9"
    
    [0xe6774BE4E5f97dB10cAFB4c00C74cFbdCDc434D9, 0xb7a33b4ad2B1f6b0a944232F5c71798d27Ad9272, 0x2A3733dBc31980f02b12135C809b5da33BF3a1e9]
    ```

    3 currencies are registered in the `FeeCurrencyDirectory` ✅ As expected, the registered currencies are:

    cUSD ✅
    
    ```sh
    cast call \
    0xe6774BE4E5f97dB10cAFB4c00C74cFbdCDc434D9 \
    "name()" \
    --rpc-url=http://127.0.0.1:8546
    0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b43656c6f20446f6c6c6172000000000000000000000000000000000000000000
    ```
    
    ```sh
    cast abi-decode \
    "name()(string memory)" \
    "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b43656c6f20446f6c6c6172000000000000000000000000000000000000000000"
    "Celo Dollar"
    ```
    
    cEUR ✅
    
    ```sh
    cast call \
    0xb7a33b4ad2B1f6b0a944232F5c71798d27Ad9272 \
    "name()" \
    --rpc-url=http://127.0.0.1:8546
    0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000943656c6f204575726f0000000000000000000000000000000000000000000000
    ```
    
    ```sh
    cast abi-decode \
    "name()(string memory)" \
    "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000943656c6f204575726f0000000000000000000000000000000000000000000000"
    "Celo Euro"
    ```
    
    cREAL ✅
    
    ```sh
    cast call \
    0x2A3733dBc31980f02b12135C809b5da33BF3a1e9 \
    "name()" \
    --rpc-url=http://127.0.0.1:8546
    0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001343656c6f204272617a696c69616e205265616c00000000000000000000000000
    ```
    
    ```sh
    cast abi-decode \
    "name()(string memory)" \
    "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001343656c6f204272617a696c69616e205265616c00000000000000000000000000"
    "Celo Brazilian Real"
    ```

1. Get exchange rate for a currency:

    ```sh
    $ cast call \
    0x42Fe5a2A61ed9705eb2F08a04A58CEB606D22f6a \
    "getExchangeRate(address)(uint256, uint256)" \
    0xb7a33b4ad2B1f6b0a944232F5c71798d27Ad9272 \
    --rpc-url=http://127.0.0.1:8546
    1000000000000000000000000 [1e24]
    1000000000000000000000000 [1e24]
    ```
    
    Calling the `getExchangeRate` function on a registered currency returns an exchange rate ✅

1. Terminate Anvil:

    ```sh
    $ kill $(lsof -i tcp:8546 | tail -n 1 | awk '{print $2}')
    ```
    
    Source: [start_anvil.sh](https://github.com/celo-org/celo-monorepo/blob/a36eae5bc2c9c2071fb942199b1ba265f3937c17/packages/protocol/migrations_sol/start_anvil.sh#L9)

</details>


### Related issues

- Fixes #10991

### Backwards compatibility

Yes, only adds to the migration script, doesn't alter existing expectations and behaviour.

### Documentation

No docs changes