### PR TITLE
UsingPrecompiles fix for anvil

### DIFF
--- a/packages/protocol/contracts/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts/common/UsingPrecompiles.sol
@@ -57,7 +57,7 @@ contract UsingPrecompiles {
   function getEpochSize() public view returns (uint256) {
     bytes memory out;
     bool success;
-    (success, out) = EPOCH_SIZE.staticcall(abi.encodePacked());
+    (success, out) = EPOCH_SIZE.staticcall(abi.encodePacked(true));
     require(success, "error calling getEpochSize precompile");
     return getUint256FromBytes(out, 0);
   }

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -67,7 +67,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 3, 0, 0);
+    return (1, 3, 0, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
+++ b/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
@@ -44,7 +44,7 @@ contract DoubleSigningSlasher is ICeloVersionedContract, SlasherUtil {
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 1, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/DowntimeSlasher.sol
+++ b/packages/protocol/contracts/governance/DowntimeSlasher.sol
@@ -64,7 +64,7 @@ contract DowntimeSlasher is ICeloVersionedContract, SlasherUtil {
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (2, 0, 0, 0);
+    return (2, 0, 0, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/Election.sol
+++ b/packages/protocol/contracts/governance/Election.sol
@@ -602,7 +602,7 @@ contract Election is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 3, 0);
+    return (1, 1, 3, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/EpochRewards.sol
+++ b/packages/protocol/contracts/governance/EpochRewards.sol
@@ -265,7 +265,7 @@ contract EpochRewards is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 1, 1);
   }
 
   /**

--- a/packages/protocol/contracts/governance/Validators.sol
+++ b/packages/protocol/contracts/governance/Validators.sol
@@ -854,7 +854,7 @@ contract Validators is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 2, 0, 5);
+    return (1, 2, 0, 6);
   }
 
   /**

--- a/packages/protocol/contracts/identity/Random.sol
+++ b/packages/protocol/contracts/identity/Random.sol
@@ -93,7 +93,7 @@ contract Random is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 1, 1);
   }
 
   /**


### PR DESCRIPTION
### Description

When in Anvil we deploy code to an address with fallback function it is not possible to call it with staticcall without passing any value (it will just return empty byte array)