### PR TITLE
ReleaseGold L2 Compatibility Check

### DIFF
--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -20,6 +20,10 @@ jobs:
     name: Run tests
     runs-on: ubuntu-20.04
     steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
+        with:
+          swap-size-gb: 16
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
         with:
-          swap-size-gb: 16
+          swap-size-gb: 32
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 env:
   # Increment these to force cache rebuilding
-  FOUNDRY_CACHE_KEY: 1
+  FOUNDRY_CACHE_KEY: 2
 
 jobs:
   check:

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run tests common
         # can't use gas limit because some setUp function use more than the limit
-        run: forge test -vvv --match-path "test-sol/common/*" # --block-gas-limit 50000000 
+        run: forge test -vvv --match-path "test-sol/common/*" # --block-gas-limit 50000000
 
       - name: Run tests governance/network
         if: success() || failure()
@@ -59,7 +59,7 @@ jobs:
       - name: Run tests governance/validators
         if: success() || failure()
         run: forge test -vvv --block-gas-limit 50000000 --match-path "test-sol/governance/validators/*"
-      
+
       - name: Run tests governance/voting
         # can't use gas limit because some setUp function use more than the limit
         if: success() || failure()
@@ -80,7 +80,8 @@ jobs:
             echo "All tests should be in a folder"
             exit 1
           fi
-
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Run Everything just in case something was missed
         # can't use gas limit because some setUp function use more than the limit
         run: forge test -vvv #TODO this should ignore integration tests

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: packages/protocol
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -90,7 +90,7 @@ jobs:
           fi
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -18,8 +18,8 @@ jobs:
       run:
         working-directory: packages/protocol
     name: Run tests
-    # runs-on: ubuntu-latest
-    runs-on: ['self-hosted', 'monorepo-node18']
+    runs-on: ubuntu-20.04
+    # runs-on: ['self-hosted', 'monorepo-node18']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -11,7 +11,8 @@ jobs:
       run:
         working-directory: packages/protocol
     name: Run tests
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'monorepo-node18']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,8 +81,6 @@ jobs:
             echo "All tests should be in a folder"
             exit 1
           fi
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Run Everything just in case something was missed
         # can't use gas limit because some setUp function use more than the limit
         run: forge test -vvv #TODO this should ignore integration tests

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -19,7 +19,6 @@ jobs:
         working-directory: packages/protocol
     name: Run tests
     runs-on: ubuntu-20.04
-    # runs-on: ['self-hosted', 'monorepo-node18']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -88,11 +87,6 @@ jobs:
             echo "All tests should be in a folder"
             exit 1
           fi
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 30
-        with:
-          limit-access-to-actor: true
 
       - name: Run Everything just in case something was missed
         # can't use gas limit because some setUp function use more than the limit

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -88,6 +88,12 @@ jobs:
             echo "All tests should be in a folder"
             exit 1
           fi
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
       - name: Run Everything just in case something was missed
         # can't use gas limit because some setUp function use more than the limit
         run: forge test -vvv #TODO this should ignore integration tests

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -1,5 +1,12 @@
 name: Protocol Foundry tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+      - 'release/**'
 
 env:
   # Increment these to force cache rebuilding

--- a/packages/protocol/contracts/governance/ReleaseGold.sol
+++ b/packages/protocol/contracts/governance/ReleaseGold.sol
@@ -451,6 +451,7 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
    * @param ecdsaPublicKey The ECDSA public key corresponding to `signer`.
    * @dev The v,r and s signature should be signed by the authorized signer
    *      key, with the ReleaseGold contract address as the message.
+   * @dev Function is deprecated on L2.
    */
   function authorizeValidatorSignerWithPublicKey(
     address payable signer,
@@ -479,6 +480,7 @@ contract ReleaseGold is UsingRegistry, ReentrancyGuard, IReleaseGold, Initializa
    *   account address. 48 bytes.
    * @dev The v,r and s signature should be signed by the authorized signer
    *      key, with the ReleaseGold contract address as the message.
+   * @dev Function is deprecated on L2.
    */
   function authorizeValidatorSignerWithKeys(
     address payable signer,

--- a/packages/protocol/contracts/governance/test/MockValidators.sol
+++ b/packages/protocol/contracts/governance/test/MockValidators.sol
@@ -2,10 +2,12 @@ pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+import "../../../contracts-0.8/common/IsL2Check.sol";
+
 /**
  * @title Holds a list of addresses of validators
  */
-contract MockValidators {
+contract MockValidators is IsL2Check {
   using SafeMath for uint256;
 
   uint256 private constant FIXED1_UINT = 1000000000000000000000000;
@@ -20,6 +22,7 @@ contract MockValidators {
   uint256 private numRegisteredValidators;
 
   function updateEcdsaPublicKey(address, address, bytes calldata) external returns (bool) {
+    allowOnlyL1();
     return true;
   }
 
@@ -30,6 +33,7 @@ contract MockValidators {
     bytes calldata,
     bytes calldata
   ) external returns (bool) {
+    allowOnlyL1();
     return true;
   }
 
@@ -42,6 +46,7 @@ contract MockValidators {
   }
 
   function affiliate(address group) external returns (bool) {
+    allowOnlyL1();
     affiliations[msg.sender] = group;
     return true;
   }
@@ -62,9 +67,13 @@ contract MockValidators {
     lockedGoldRequirements[account] = value;
   }
 
-  function halveSlashingMultiplier(address) external {}
+  function halveSlashingMultiplier(address) external {
+    allowOnlyL1();
+  }
 
-  function forceDeaffiliateIfValidator(address validator) external {}
+  function forceDeaffiliateIfValidator(address validator) external {
+    allowOnlyL1();
+  }
 
   function getTopGroupValidators(
     address group,
@@ -79,6 +88,7 @@ contract MockValidators {
   }
 
   function getValidatorGroupSlashingMultiplier(address) external view returns (uint256) {
+    allowOnlyL1();
     return FIXED1_UINT;
   }
 
@@ -107,6 +117,7 @@ contract MockValidators {
   }
 
   function groupMembershipInEpoch(address addr, uint256, uint256) external view returns (address) {
+    allowOnlyL1();
     return affiliations[addr];
   }
 

--- a/packages/protocol/test-sol/governance/voting/ReleaseGold.t.sol
+++ b/packages/protocol/test-sol/governance/voting/ReleaseGold.t.sol
@@ -37,14 +37,6 @@ contract ReleaseGoldTest is Test, ECDSAHelper {
   ReleaseGold releaseGold;
   ReleaseGold releaseGold2;
 
-  event ReleaseGoldInstanceCreated(address indexed beneficiary, address indexed atAddress);
-  event ReleaseScheduleRevoked(uint256 revokeTimestamp, uint256 releasedBalanceAtRevoke);
-  event ReleaseGoldInstanceDestroyed(address indexed beneficiary, address indexed atAddress);
-  event DistributionLimitSet(address indexed beneficiary, uint256 maxDistribution);
-  event LiquidityProvisionSet(address indexed beneficiary);
-  event CanExpireSet(bool canExpire);
-  event BeneficiarySet(address indexed beneficiary);
-
   address owner = address(this);
   address beneficiary;
   uint256 beneficiaryPrivateKey;
@@ -64,6 +56,14 @@ contract ReleaseGoldTest is Test, ECDSAHelper {
 
   ReleaseGoldMockTunnel.InitParams initParams;
   ReleaseGoldMockTunnel.InitParams2 initParams2;
+
+  event ReleaseGoldInstanceCreated(address indexed beneficiary, address indexed atAddress);
+  event ReleaseScheduleRevoked(uint256 revokeTimestamp, uint256 releasedBalanceAtRevoke);
+  event ReleaseGoldInstanceDestroyed(address indexed beneficiary, address indexed atAddress);
+  event DistributionLimitSet(address indexed beneficiary, uint256 maxDistribution);
+  event LiquidityProvisionSet(address indexed beneficiary);
+  event CanExpireSet(bool canExpire);
+  event BeneficiarySet(address indexed beneficiary);
 
   function newReleaseGold(bool prefund, bool startReleasing) internal returns (ReleaseGold) {
     releaseGold = new ReleaseGold(true);
@@ -149,7 +149,7 @@ contract ReleaseGoldTest is Test, ECDSAHelper {
   }
 }
 
-contract ReleaseGoldInitialize is ReleaseGoldTest {
+contract ReleaseGoldTest_ReleaseGoldInitialize is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
   }
@@ -165,7 +165,7 @@ contract ReleaseGoldInitialize is ReleaseGoldTest {
   }
 }
 
-contract Payable is ReleaseGoldTest {
+contract ReleaseGoldTest_Payable is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
   }
@@ -204,7 +204,7 @@ contract Payable is ReleaseGoldTest {
   }
 }
 
-contract Transfer is ReleaseGoldTest {
+contract ReleaseGoldTest_Transfer is ReleaseGoldTest {
   address receiver = actor("receiver");
   uint256 transferAmount = 10;
 
@@ -222,7 +222,7 @@ contract Transfer is ReleaseGoldTest {
   }
 }
 
-contract GenericTransfer is ReleaseGoldTest {
+contract ReleaseGoldTest_GenericTransfer is ReleaseGoldTest {
   address receiver = actor("receiver");
   uint256 transferAmount = 10;
 
@@ -255,7 +255,7 @@ contract GenericTransfer is ReleaseGoldTest {
   }
 }
 
-contract Creation is ReleaseGoldTest {
+contract ReleaseGoldTest_Creation is ReleaseGoldTest {
   uint256 public maxUint256 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
   function setUp() public {
@@ -380,7 +380,7 @@ contract Creation is ReleaseGoldTest {
   }
 }
 
-contract SetBeneficiary is ReleaseGoldTest {
+contract ReleaseGoldTest_SetBeneficiary is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     newReleaseGold(true, false);
@@ -404,7 +404,7 @@ contract SetBeneficiary is ReleaseGoldTest {
   }
 }
 
-contract CreateAccount is ReleaseGoldTest {
+contract ReleaseGoldTest_CreateAccount is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     newReleaseGold(true, false);
@@ -478,7 +478,7 @@ contract SetAccount is ReleaseGoldTest {
   }
 }
 
-contract SetAccountName is ReleaseGoldTest {
+contract ReleaseGoldTest_SetAccountName is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     newReleaseGold(true, false);
@@ -519,7 +519,7 @@ contract SetAccountName is ReleaseGoldTest {
   }
 }
 
-contract SetAccountWalletAddress is ReleaseGoldTest {
+contract ReleaseGoldTest_SetAccountWalletAddress is ReleaseGoldTest {
   uint8 v;
   bytes32 r;
   bytes32 s;
@@ -577,7 +577,7 @@ contract SetAccountWalletAddress is ReleaseGoldTest {
   }
 }
 
-contract SetAccountMetadataURL is ReleaseGoldTest {
+contract ReleaseGoldTest_SetAccountMetadataURL is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     newReleaseGold(true, false);
@@ -622,7 +622,7 @@ contract SetAccountMetadataURL is ReleaseGoldTest {
   }
 }
 
-contract SetAccountDataEncryptionKey is ReleaseGoldTest {
+contract ReleaseGoldTest_SetAccountDataEncryptionKey is ReleaseGoldTest {
   bytes dataEncryptionKey = hex"02f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e01611111111";
   bytes longDataEncryptionKey =
     hex"04f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0161111111102f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e01611111111";
@@ -672,7 +672,7 @@ contract SetAccountDataEncryptionKey is ReleaseGoldTest {
   }
 }
 
-contract SetMaxDistribution is ReleaseGoldTest {
+contract ReleaseGoldTest_SetMaxDistribution is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     initParams2.initialDistributionRatio = 0;
@@ -702,7 +702,7 @@ contract SetMaxDistribution is ReleaseGoldTest {
   }
 }
 
-contract AuthorizationTests is ReleaseGoldTest {
+contract ReleaseGoldTest_AuthorizationTests is ReleaseGoldTest {
   uint256 initialReleaseGoldAmount;
 
   uint8 v;
@@ -1021,7 +1021,7 @@ contract AuthorizationTests is ReleaseGoldTest {
   }
 }
 
-contract AuthorizeWithPublicKeys is ReleaseGoldTest {
+contract ReleaseGoldTest_AuthorizeWithPublicKeys is ReleaseGoldTest {
   uint8 v;
   bytes32 r;
   bytes32 s;
@@ -1108,7 +1108,7 @@ contract AuthorizeWithPublicKeys is ReleaseGoldTest {
   }
 }
 
-contract Revoke is ReleaseGoldTest {
+contract ReleaseGoldTest_Revoke is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
   }
@@ -1150,7 +1150,7 @@ contract Revoke is ReleaseGoldTest {
   }
 }
 
-contract Expire is ReleaseGoldTest {
+contract ReleaseGoldTest_Expire is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     newReleaseGold(true, false);
@@ -1285,7 +1285,7 @@ contract Expire is ReleaseGoldTest {
   }
 }
 
-contract RefundAndFinalize is ReleaseGoldTest {
+contract ReleaseGoldTest_RefundAndFinalize is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     newReleaseGold(true, false);
@@ -1341,7 +1341,7 @@ contract RefundAndFinalize is ReleaseGoldTest {
   }
 }
 
-contract ExpireSelfDestructTest is ReleaseGoldTest {
+contract ReleaseGoldTest_ExpireSelfDestructTest is ReleaseGoldTest {
   function setUp() public {
     super.setUp();
     newReleaseGold(true, false);
@@ -1361,7 +1361,7 @@ contract ExpireSelfDestructTest is ReleaseGoldTest {
   }
 }
 
-contract LockGold is ReleaseGoldTest {
+contract ReleaseGoldTest_LockGold is ReleaseGoldTest {
   uint256 lockAmount;
   function setUp() public {
     super.setUp();
@@ -1403,7 +1403,7 @@ contract LockGold is ReleaseGoldTest {
   }
 }
 
-contract UnlockGold is ReleaseGoldTest {
+contract ReleaseGoldTest_UnlockGold is ReleaseGoldTest {
   uint256 lockAmount;
   function setUp() public {
     super.setUp();
@@ -1466,7 +1466,7 @@ contract UnlockGold is ReleaseGoldTest {
   }
 }
 
-contract WithdrawLockedGold is ReleaseGoldTest {
+contract ReleaseGoldTest_WithdrawLockedGold is ReleaseGoldTest {
   uint256 value = 1000;
   uint256 index = 0;
 
@@ -1536,7 +1536,7 @@ contract WithdrawLockedGold is ReleaseGoldTest {
   }
 }
 
-contract RelockGold is ReleaseGoldTest {
+contract ReleaseGoldTest_RelockGold is ReleaseGoldTest {
   uint256 pendingWithdrawalValue = 1000;
   uint256 index = 0;
 
@@ -1642,7 +1642,7 @@ contract RelockGold is ReleaseGoldTest {
   }
 }
 
-contract Withdraw is ReleaseGoldTest {
+contract ReleaseGoldTest_Withdraw is ReleaseGoldTest {
   uint256 initialReleaseGoldAmount;
 
   function setUp() public {
@@ -1938,7 +1938,7 @@ contract Withdraw is ReleaseGoldTest {
   }
 }
 
-contract WithdrawSelfDestruct_WhenNotRevoked is ReleaseGoldTest {
+contract ReleaseGoldTest_WithdrawSelfDestruct_WhenNotRevoked is ReleaseGoldTest {
   uint256 initialReleaseGoldAmount;
 
   function setUp() public {
@@ -1964,7 +1964,7 @@ contract WithdrawSelfDestruct_WhenNotRevoked is ReleaseGoldTest {
   }
 }
 
-contract WithdrawSelfDestruct_WhenRevoked is ReleaseGoldTest {
+contract ReleaseGoldTest_WithdrawSelfDestruct_WhenRevoked is ReleaseGoldTest {
   uint256 initialReleaseGoldAmount;
 
   function setUp() public {
@@ -1992,7 +1992,7 @@ contract WithdrawSelfDestruct_WhenRevoked is ReleaseGoldTest {
   }
 }
 
-contract GetCurrentReleasedTotalAmount is ReleaseGoldTest {
+contract ReleaseGoldTest_GetCurrentReleasedTotalAmount is ReleaseGoldTest {
   uint256 initialReleaseGoldAmount;
 
   function setUp() public {
@@ -2035,7 +2035,7 @@ contract GetCurrentReleasedTotalAmount is ReleaseGoldTest {
   }
 }
 
-contract GetWithdrawableAmount is ReleaseGoldTest {
+contract ReleaseGoldTest_GetWithdrawableAmount is ReleaseGoldTest {
   uint256 initialReleaseGoldAmount;
 
   function setUp() public {


### PR DESCRIPTION
### Description

Updated the ReleaseGold test to include L2 Compatibility Check.

### Other changes

Added L2 check to MockValidator contract

### Tested

Unit tested

### Related issues

https://github.com/celo-org/celo-blockchain-planning/issues/209

### Backwards compatibility

`authorizeValidatorSignerWithPublicKey` and `authorizeValidatorSignerWithKeys` will be deprecated once transitionned to L2.

These functions are not critical to the ReleaseGold Contract as ReleaseGold beneficiaries can continue to use `authorizeVoteSigner`. 

Any beneficiaries that have already used these functions to authorize signers will not encounter any issues.

