### PR TITLE
Deactivate BlochainParameters Contract on L2

### DIFF
--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -5,10 +5,12 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "../common/Initializable.sol";
 import "../common/UsingPrecompiles.sol";
 
+import "../../contracts-0.8/common/IsL2Check.sol";
+
 /**
  * @title Contract for storing blockchain parameters that can be set by governance.
  */
-contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
+contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles, IsL2Check {
   using SafeMath for uint256;
 
   // obsolete
@@ -92,7 +94,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @notice Sets the uptime lookback window.
    * @param window New window.
    */
-  function setUptimeLookbackWindow(uint256 window) public onlyOwner {
+  function setUptimeLookbackWindow(uint256 window) public onlyL1 onlyOwner {
     require(window >= 3 && window <= 720, "UptimeLookbackWindow must be within safe range");
     require(
       window <= getEpochSize().sub(2),
@@ -119,7 +121,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   /**
    * @notice Gets the uptime lookback window.
    */
-  function _getUptimeLookbackWindow() internal view returns (uint256 lookbackWindow) {
+  function _getUptimeLookbackWindow() internal view onlyL1 returns (uint256 lookbackWindow) {
     if (getEpochNumber() >= uptimeLookbackWindow.nextValueActivationEpoch) {
       return uptimeLookbackWindow.nextValue;
     } else {

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -76,7 +76,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles, IsL2C
    * @notice Sets the block gas limit.
    * @param gasLimit New block gas limit.
    */
-  function setBlockGasLimit(uint256 gasLimit) public onlyOwner {
+  function setBlockGasLimit(uint256 gasLimit) public onlyOwner onlyL1 {
     blockGasLimit = gasLimit;
     emit BlockGasLimitSet(gasLimit);
   }
@@ -85,7 +85,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles, IsL2C
    * @notice Sets the intrinsic gas for non-gold gas currencies.
    * @param gas Intrinsic gas for non-gold gas currencies.
    */
-  function setIntrinsicGasForAlternativeFeeCurrency(uint256 gas) public onlyOwner {
+  function setIntrinsicGasForAlternativeFeeCurrency(uint256 gas) public onlyOwner onlyL1 {
     intrinsicGasForAlternativeFeeCurrency = gas;
     emit IntrinsicGasForAlternativeFeeCurrencySet(gas);
   }

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -69,7 +69,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles, IsL2C
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 3, 0, 1);
+    return (1, 3, 1, 0);
   }
 
   /**

--- a/packages/protocol/test-sol/governance/network/BlockchainParameters.t.sol
+++ b/packages/protocol/test-sol/governance/network/BlockchainParameters.t.sol
@@ -76,9 +76,14 @@ contract BlockchainParametersTest_setBlockGasLimit is BlockchainParametersTest {
     vm.expectRevert("Ownable: caller is not the owner");
     blockchainParameters.setBlockGasLimit(gasLimit);
   }
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    blockchainParameters.setBlockGasLimit(gasLimit);
+  }
 }
 
-contract BlockchainParametersTestSet_intrinsicGasForAlternativeFeeCurrency is
+contract BlockchainParametersTest_setIntrinsicGasForAlternativeFeeCurrency is
   BlockchainParametersTest
 {
   function test_ShouldSetTheVariable() public {
@@ -95,6 +100,12 @@ contract BlockchainParametersTestSet_intrinsicGasForAlternativeFeeCurrency is
   function test_Revert_WhenCalledByNonOwner() public {
     vm.prank(nonOwner);
     vm.expectRevert("Ownable: caller is not the owner");
+    blockchainParameters.setIntrinsicGasForAlternativeFeeCurrency(gasForNonGoldCurrencies);
+  }
+
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
     blockchainParameters.setIntrinsicGasForAlternativeFeeCurrency(gasForNonGoldCurrencies);
   }
 }

--- a/packages/protocol/test-sol/governance/network/BlockchainParameters.t.sol
+++ b/packages/protocol/test-sol/governance/network/BlockchainParameters.t.sol
@@ -8,11 +8,10 @@ import { Constants } from "@test-sol/constants.sol";
 import { Utils } from "@test-sol/utils.sol";
 
 contract BlockchainParametersTest is Test, Constants, Utils {
-  // using the mainnet epoch size would not allow to test an edge case
-  uint256 constant EPOCH_SIZE = 100;
   uint256 constant gasLimit = 7000000;
   uint256 constant gasForNonGoldCurrencies = 50000;
   address nonOwner;
+  address constant proxyAdminAddress = 0x4200000000000000000000000000000000000018;
 
   BlockchainParameters blockchainParameters;
 
@@ -25,6 +24,9 @@ contract BlockchainParametersTest is Test, Constants, Utils {
     nonOwner = actor("nonOwner");
     ph.setEpochSize(EPOCH_SIZE);
     blockchainParameters = new BlockchainParameters(true);
+  }
+  function _whenL2() public {
+    deployCodeTo("Registry.sol", abi.encode(false), proxyAdminAddress);
   }
 }
 
@@ -108,6 +110,12 @@ contract BlockchainParametersTest_getUptimeLookbackWindow is BlockchainParameter
     vm.expectRevert("UptimeLookbackWindow is not initialized");
     blockchainParameters.getUptimeLookbackWindow();
   }
+
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    blockchainParameters.getUptimeLookbackWindow();
+  }
 }
 
 contract BlockchainParametersTest_setUptimeLookbackWindow is BlockchainParametersTest {
@@ -139,7 +147,7 @@ contract BlockchainParametersTest_setUptimeLookbackWindow is BlockchainParameter
     blockchainParameters.setUptimeLookbackWindow(newValue);
   }
 
-  function test_Revert_ShouldFail_WhenUsingValueLowerThanSafeMinimum() public {
+  function test_Revert_WhenUsingValueLowerThanSafeMinimum() public {
     vm.expectRevert("UptimeLookbackWindow must be within safe range");
     blockchainParameters.setUptimeLookbackWindow(2);
   }
@@ -149,9 +157,9 @@ contract BlockchainParametersTest_setUptimeLookbackWindow is BlockchainParameter
     blockchainParameters.setUptimeLookbackWindow(721);
   }
 
-  function test_Revert_WhenUsingValueGreaterThanEpochsizeminus2() public {
-    vm.expectRevert("UptimeLookbackWindow must be smaller or equal to epochSize - 2");
-    // 720 is harcoded as maximum in the code
-    blockchainParameters.setUptimeLookbackWindow(EPOCH_SIZE - 1);
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    blockchainParameters.setUptimeLookbackWindow(100);
   }
 }


### PR DESCRIPTION
### Description

Functions that call precompiles now revert on L2.

### Other changes

Removed an edge-case test that was only relevant when running test on Ganache, where the epoch size was set to 100

### Tested

Unit testes

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/192

