### PR TITLE
chore: downgrade foundry version to match across workflows

### DIFF
--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: "nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9"
 
       - name: Install forge dependencies
         run: forge install


### PR DESCRIPTION
### Description

Small follow-on PR to downgrade the foundry version in `protocol-devchain-anvil.yml` to match the version in `protocol_tests.yml`. 

https://github.com/celo-org/celo-monorepo/pull/11002 downgraded the foundry version, but CI didn't catch the [failing `protocol-devchain-anvil.yml` workflow](https://github.com/celo-org/celo-monorepo/actions/runs/9383432703/job/25837023823) on that branch, because the workflow only runs on `master`.

### Other changes

None

### Tested

No, we'll know this works when we merge this PR to `master` and run the workflow.

### Related issues

None

### Backwards compatibility

Yes

### Documentation

No