### PR TITLE
feat: add ReserveSpenderMultiSig to anvil migrations

### DIFF
--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -16,7 +16,8 @@ remappings = [
     '@openzeppelin/contracts8/=lib/openzeppelin-contracts8/contracts/',
     '@celo-contracts/=contracts/',
     '@celo-migrations/=migrations_sol/',
-    '@test-sol/=test-sol/'
+    '@test-sol/=test-sol/',
+    '@mento-core/=lib/mento-core/'
 ]
 
 no_match_test = "skip"

--- a/packages/protocol/migrations_sol/HelperInterFaces.sol
+++ b/packages/protocol/migrations_sol/HelperInterFaces.sol
@@ -58,8 +58,8 @@ interface IReserveSpenderMultiSig {
     @param _internalRequired Number of required confirmations for internal transactions. 
   */
   function initialize(
-      address[] calldata _owners,
-      uint256 _required,
-      uint256 _internalRequired
+    address[] calldata _owners,
+    uint256 _required,
+    uint256 _internalRequired
   ) external;
 }

--- a/packages/protocol/migrations_sol/HelperInterFaces.sol
+++ b/packages/protocol/migrations_sol/HelperInterFaces.sol
@@ -49,3 +49,17 @@ interface IExchangeInitializer {
 interface IExchange {
   function activateStable() external;
 }
+
+interface IReserveSpenderMultiSig {
+  /**
+    @dev Contract constructor sets initial owners and required number of confirmations.
+    @param _owners List of initial owners.
+    @param _required Number of required confirmations for external transactions.
+    @param _internalRequired Number of required confirmations for internal transactions. 
+  */
+  function initialize(
+      address[] calldata _owners,
+      uint256 _required,
+      uint256 _internalRequired
+  ) external;
+}

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -342,9 +342,8 @@ contract Migration is Script, UsingRegistry, Constants {
     );
 
     // Deploys and adds the ReserveSpenderMultiSig to the Registry for ease of reference.
-    // The ReserveSpenderMultiSig is not in the Registry on Mainnet, but 
-    // it's useful to keep a reference of the deployed contract, so it's in the Registry
-    // in the devchain.
+    // The ReserveSpenderMultiSig is not in the Registry on Mainnet, but it's useful to keep a 
+    // reference of the deployed contract, so it's in the Registry on the devchain.
     deployProxiedContract(
       "ReserveSpenderMultiSig",
       abi.encodeWithSelector(

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -43,10 +43,8 @@ import "@celo-contracts/stability/interfaces/ISortedOracles.sol";
 import "@celo-contracts-8/common/interfaces/IGasPriceMinimumInitializer.sol";
 import "@celo-contracts-8/common/interfaces/IMintGoldScheduleInitializer.sol";
 
-// TODO(Arthur): refactor to use @mento-core remapping. Waiting to merge PR from `master` that has this.
-import "../../lib/mento-core/contracts/ReserveSpenderMultiSig.sol";
 
-import "./HelperInterFaces.sol";
+import "@celo-migrations/HelperInterFaces.sol";
 import "@openzeppelin/contracts8/utils/math/Math.sol";
 
 import "@celo-contracts-8/common/UsingRegistry.sol";
@@ -383,7 +381,7 @@ contract Migration is Script, UsingRegistry, Constants {
       : deployerAccount;
 
     IReserve(reserveProxyAddress).addSpender(spender);
-    console.log("reserveSpenderMultiSig set to:", spender);
+    console.log("reserveSpenderMultiSig added as Reserve spender");
   }
 
   function deployStable(
@@ -807,7 +805,7 @@ contract Migration is Script, UsingRegistry, Constants {
     deployProxiedContract(
       "ReserveSpenderMultiSig",
       abi.encodeWithSelector(
-        ReserveSpenderMultiSig.initialize.selector,
+        IReserveSpenderMultiSig.initialize.selector,
         owners,
         required,
         internalRequired

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -43,7 +43,6 @@ import "@celo-contracts/stability/interfaces/ISortedOracles.sol";
 import "@celo-contracts-8/common/interfaces/IGasPriceMinimumInitializer.sol";
 import "@celo-contracts-8/common/interfaces/IMintGoldScheduleInitializer.sol";
 
-
 import "@celo-migrations/HelperInterFaces.sol";
 import "@openzeppelin/contracts8/utils/math/Math.sol";
 
@@ -342,7 +341,7 @@ contract Migration is Script, UsingRegistry, Constants {
     );
 
     // Deploys and adds the ReserveSpenderMultiSig to the Registry for ease of reference.
-    // The ReserveSpenderMultiSig is not in the Registry on Mainnet, but it's useful to keep a 
+    // The ReserveSpenderMultiSig is not in the Registry on Mainnet, but it's useful to keep a
     // reference of the deployed contract, so it's in the Registry on the devchain.
     deployProxiedContract(
       "ReserveSpenderMultiSig",

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -374,7 +374,7 @@ contract Migration is Script, UsingRegistry, Constants {
     // TODO this should be a transfer from the deployer rather than a deal
     vm.deal(reserveProxyAddress, initialBalance);
 
-    // Reserve spend multisig not migrated
+    // Adds ReserveSpenderMultiSig to Reserve
     bool useSpender = abi.decode(json.parseRaw(".reserveSpenderMultiSig.required"), (bool));
     address spender = useSpender
       ? registry.getAddressForString("ReserveSpenderMultiSig")

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -331,6 +331,31 @@ contract Migration is Script, UsingRegistry, Constants {
     );
   }
 
+  function migrateReserveSpenderMultiSig(string memory json) public {
+    address[] memory owners = new address[](1);
+    owners[0] = deployerAccount;
+
+    uint256 required = abi.decode(json.parseRaw(".reserveSpenderMultiSig.required"), (uint256));
+    uint256 internalRequired = abi.decode(
+      json.parseRaw(".reserveSpenderMultiSig.internalRequired"),
+      (uint256)
+    );
+
+    // Deploys and adds the ReserveSpenderMultiSig to the Registry for ease of reference.
+    // The ReserveSpenderMultiSig is not in the Registry on Mainnet, but 
+    // it's useful to keep a reference of the deployed contract, so it's in the Registry
+    // in the devchain.
+    deployProxiedContract(
+      "ReserveSpenderMultiSig",
+      abi.encodeWithSelector(
+        IReserveSpenderMultiSig.initialize.selector,
+        owners,
+        required,
+        internalRequired
+      )
+    );
+  }
+
   function migrateReserve(string memory json) public {
     uint256 tobinTaxStalenessThreshold = abi.decode(
       json.parseRaw(".reserve.tobinTaxStalenessThreshold"),
@@ -787,30 +812,6 @@ contract Migration is Script, UsingRegistry, Constants {
     );
 
     getLockedGold().addSlasher("DowntimeSlasher");
-  }
-
-  // TODO(Arthur): Move this up to line 337-ish where `migrateReserve()` is defined.
-  function migrateReserveSpenderMultiSig(string memory json) public {
-    address[] memory owners = new address[](1);
-    owners[0] = deployerAccount;
-
-    uint256 required = abi.decode(json.parseRaw(".reserveSpenderMultiSig.required"), (uint256));
-    uint256 internalRequired = abi.decode(
-      json.parseRaw(".reserveSpenderMultiSig.internalRequired"),
-      (uint256)
-    );
-
-    // This adds the multisig to the registry, which is not a case in mainnet but it's useful to keep a reference
-    // of the deployed contract
-    deployProxiedContract(
-      "ReserveSpenderMultiSig",
-      abi.encodeWithSelector(
-        IReserveSpenderMultiSig.initialize.selector,
-        owners,
-        required,
-        internalRequired
-      )
-    );
   }
 
   function migrateGovernanceApproverMultiSig(string memory json) public {

--- a/packages/protocol/migrations_sol/migrationsConfig.json
+++ b/packages/protocol/migrations_sol/migrationsConfig.json
@@ -134,6 +134,10 @@
     "internalRequired": 1,
     "governanceApproverMultiSig": true
   },
+  "reserveSpenderMultiSig": {
+    "required": 1,
+    "internalRequired": 1
+  },
   "feeHandler": {
     "beneficiary": "0x2A486910DBC72cACcbb8d0e1439C96b03B2A4699",
     "burnFraction": 800000000000000000000000

--- a/packages/protocol/test-sol/utils/ReserveSpenderMultiSig.t.sol
+++ b/packages/protocol/test-sol/utils/ReserveSpenderMultiSig.t.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.13;
+
+import "@mento-core/contracts/ReserveSpenderMultiSig.sol";
+
+/**
+  The purpose of this file is not to provide test coverage for `ReserveSpenderMultiSig.sol`.
+  This is an empty test to force foundry to compile `ReserveSpenderMultiSig.sol`, and include its
+  artifacts in the `/out` directory. `ReserveSpenderMultiSig.sol` is needed in the migrations
+  script, but because it's on Solidity 0.5 it can't be imported there directly.
+  If there is a better way to force foundry to compile `ReserveSpenderMultiSig.sol` without
+  this file, this file can confidently be deleted.
+ */
+contract ReserveSpenderMultiSigTest {}


### PR DESCRIPTION
### Description

1. adds `ReserveSpenderMultiSig` configs in `migrationsConfig.json`.
1. proxies and deploys `ReserveSpenderMultiSig.sol`.
1. sets `ReserveSpenderMultiSig.sol` as a spender on the `Reserve` contract.
1. adds `ReserveSpenderMultiSig.sol` to the `Registry`. 

### Other changes

1. adds empty `ReserveSpenderMultiSig.t.sol` test as a workaround to force foundry to compile the contract and adds its artifacts to the `out/` directory.
1. adds `IReserveSpenderMultiSig` to the `HelperInterFaces.sol`

### Tested

Yes, locally. 

<details>
<summary>Steps to reproduce tests locally</summary>

1. generate migrations and run anvil devchain (in separate terminal)
1. get address of `ReserveSpenderMultiSig` from `Registry` ✅ 

    ```sh
    cast call \
    "0x000000000000000000000000000000000000ce10" \
    "getAddressForStringOrDie(string calldata identifier)(address)" \
    "ReserveSpenderMultiSig" \
    --rpc-url=http://127.0.0.1:8546
    0x1A888D93eeAcF683c68E07Ad58Aa43f2A5742490
    ```

1. Check that the `ReserveSpenderMultiSig` address is in the `isSpender` mapping on the `Reserve` ✅ 

    Context:
    
    ```sol
    mapping(address => bool) public isSpender;
    ```

    Source: `mento-core/contracts/Reserve.sol`

    Get `Reserve` address from `Registry`

    ```sh
    cast call \
    "0x000000000000000000000000000000000000ce10" \
    "getAddressForStringOrDie(string calldata identifier)(address)" \
    "Reserve" \
    --rpc-url=http://127.0.0.1:8546
    0x0a887500E327375378edF7b7d0E85F0378b8677a
    ```

    ```
    cast call \
    "0x0a887500E327375378edF7b7d0E85F0378b8677a" \
    "isSpender(address)(bool)" \
    "0x1A888D93eeAcF683c68E07Ad58Aa43f2A5742490" \
    --rpc-url=http://127.0.0.1:8546
    true
    ```

</details>


### Related issues

- Fixes #11025 

### Backwards compatibility

Yes, backwards compatible. All existing features on the devchain are unchanged.

### Documentation

Yes with detailed code comments.