### PR TITLE
feat: increase EUROCEUR bidAskSpread from 0.0075 to 0.0125

### DIFF
--- a/packages/helm-charts/oracle/EUROCEUR.yaml
+++ b/packages/helm-charts/oracle/EUROCEUR.yaml
@@ -4,7 +4,7 @@ oracle:
     mid:
       maxExchangeVolumeShare: 1
       maxPercentageDeviation: 0.01
-      maxPercentageBidAskSpread: 0.0075
+      maxPercentageBidAskSpread: 0.0125
   metrics:
     enabled: true
     prometheusPort: 9090


### PR DESCRIPTION
### Description

This Pr increases the max bid ask spread for EUROCEUR from 0.0075 to 0.0125 due to not enough liquidity on EUROC pairs 

### Other changes



### Tested

- deployed new EUROCEUR config on all networks 
- oracles run fine and report again

### Related issues



### Backwards compatibility



### Documentation

