### PR TITLE
updated base branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>celo-org/.github:renovate-config"]
+  "extends": ["local>celo-org/.github:renovate-config"],
+  "baseBranches": ["/^release\/core-contracts\\/.*/"]
 }


### PR DESCRIPTION
### Description

Primitive has transitioned from using `master` as the base branch, to using `release/core-contract/<VERSION>` 

This PR updates the Renovate configs to reflect this change and only use the latest release branch.

One concern I have, and couldn't find a reference in the docs, is wether or not there will be a conflict when `master` and `release/core-contract/<VERSION>` have different configs.