### PR TITLE
refactor: reads supported Foundry version from an environment variable

### DIFF
--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -20,6 +20,8 @@ on:
 env:
   # Increment these to force cache rebuilding
   FOUNDRY_CACHE_KEY: 1
+  # Supported Foundry version defined at celo-org (GitHub organisation) level, for consistency across workflows.
+  SUPPORTED_FOUNDRY_VERSION: ${{ vars.SUPPORTED_FOUNDRY_VERSION }}
   ANVIL_PORT: 8546
 
 jobs:
@@ -91,7 +93,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: 'nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9'
+          version: ${{ env.SUPPORTED_FOUNDRY_VERSION }}
 
       - name: Install forge dependencies
         run: forge install

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -12,6 +12,8 @@ on:
 env:
   # Increment these to force cache rebuilding
   FOUNDRY_CACHE_KEY: 2
+  # Supported Foundry version defined at celo-org (GitHub organisation) level, for consistency across workflows.
+  SUPPORTED_FOUNDRY_VERSION: ${{ vars.SUPPORTED_FOUNDRY_VERSION }}
   ANVIL_PORT: 8546
 
 jobs:
@@ -53,7 +55,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9"
+          version: ${{ env.SUPPORTED_FOUNDRY_VERSION }}
 
       - name: Install forge dependencies
         run: forge install


### PR DESCRIPTION
### Description

1. reads an environment variable (`SUPPORTED_FOUNDRY_VERSION`) defined at the [celo-org](https://github.com/celo-org) (GitHub org) level. 
2. updates the Foundry installation version to use the defined variable for consistency across workflows in [celo-org/celo-monorepo](https://github.com/celo-org/celo-monorepo/blob/b10b77a5b3b1ac9e8750b246e786a649548a2556/.github/workflows/protocol-devchain-anvil.yml#L77-L80) and [celo-org/developer-tooling](https://github.com/celo-org/developer-tooling/blob/ccc5cbb6c46a7f9f74c5b3fdfb1c3fd9fcee257d/.github/workflows/ci.yml#L221-L224).

The overall objective is to update Foundry versions in lock-steps. See more context on pros and cons in: 
- https://github.com/celo-org/celo-monorepo/issues/11032

### Other changes

None.

### Tested

Tested on CI. This only changes CI workflows.

### Related issues

- Fixes #11032

### Backwards compatibility

Yes.

### Documentation

Yes in code comments and this PR description.