### PR TITLE
Added Check to CeloDistributionSchedule `activate` function

### DIFF
--- a/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
+++ b/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
@@ -72,10 +72,14 @@ contract CeloDistributionSchedule is UsingRegistry, ReentrancyGuard, Initializab
     require(address(this).balance > 0, "Contract does not have CELO balance.");
     require(!areDependenciesSet, "Contract has already been activated.");
     require(block.timestamp > _l2StartTime, "L2 start time cannot be set to a future date.");
+    ICeloToken celoToken = ICeloToken(address(getCeloToken()));
+    require(
+      celoToken.getCeloTokenDistributionSchedule() != address(0),
+      "CeloDistributionSchedule address has not been set in CELO token contract."
+    );
     areDependenciesSet = true;
     l2StartTime = _l2StartTime;
     communityRewardFund = address(getGovernance());
-    ICeloToken celoToken = ICeloToken(address(getCeloToken()));
     totalAllocatedAtL2Start = celoToken.allocatedSupply();
     setCommunityRewardFraction(_communityRewardFraction);
     setCarbonOffsettingFund(_carbonOffsettingPartner, _carbonOffsettingFraction);

--- a/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
+++ b/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
@@ -74,8 +74,8 @@ contract CeloDistributionSchedule is UsingRegistry, ReentrancyGuard, Initializab
     require(block.timestamp > _l2StartTime, "L2 start time cannot be set to a future date.");
     ICeloToken celoToken = ICeloToken(address(getCeloToken()));
     require(
-      celoToken.getCeloTokenDistributionScheduleAddress() == address(this),
-      "CeloDistributionSchedule address has not been set in CELO token contract."
+      registry.getAddressForOrDie(CELO_DISTRIBUTION_SCHEDULE_ID) == address(this),
+      "CeloDistributionSchedule address is incorrectly set in Registry."
     );
     areDependenciesSet = true;
     l2StartTime = _l2StartTime;

--- a/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
+++ b/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
@@ -74,7 +74,7 @@ contract CeloDistributionSchedule is UsingRegistry, ReentrancyGuard, Initializab
     require(block.timestamp > _l2StartTime, "L2 start time cannot be set to a future date.");
     ICeloToken celoToken = ICeloToken(address(getCeloToken()));
     require(
-      celoToken.getCeloTokenDistributionScheduleAddress() != address(0),
+      celoToken.getCeloTokenDistributionScheduleAddress() == address(this),
       "CeloDistributionSchedule address has not been set in CELO token contract."
     );
     areDependenciesSet = true;

--- a/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
+++ b/packages/protocol/contracts-0.8/common/CeloDistributionSchedule.sol
@@ -74,7 +74,7 @@ contract CeloDistributionSchedule is UsingRegistry, ReentrancyGuard, Initializab
     require(block.timestamp > _l2StartTime, "L2 start time cannot be set to a future date.");
     ICeloToken celoToken = ICeloToken(address(getCeloToken()));
     require(
-      celoToken.getCeloTokenDistributionSchedule() != address(0),
+      celoToken.getCeloTokenDistributionScheduleAddress() != address(0),
       "CeloDistributionSchedule address has not been set in CELO token contract."
     );
     areDependenciesSet = true;

--- a/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
+++ b/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
@@ -28,7 +28,10 @@ interface ICeloToken is IERC20 {
     address celoTokenDistributionScheduleAddress
   ) external;
 
-  function getCeloTokenDistributionSchedule() external returns (address);
+  /**
+   * @return The address of the CeloTokenDistributionSchedule contract.
+   */
+  function getCeloTokenDistributionScheduleAddress() external returns (address);
 
   /**
    * @dev Mints a new token.

--- a/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
+++ b/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
@@ -21,11 +21,6 @@ interface ICeloToken is IERC20 {
   function setRegistry(address registryAddress) external;
 
   /**
-   * @return The address of the CeloTokenDistributionSchedule contract.
-   */
-  function getCeloTokenDistributionScheduleAddress() external returns (address);
-
-  /**
    * @dev Mints a new token.
    * @param to The address that will own the minted token.
    * @param value The amount of token to be minted.

--- a/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
+++ b/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
@@ -21,14 +21,6 @@ interface ICeloToken is IERC20 {
   function setRegistry(address registryAddress) external;
 
   /**
-   * @notice Used set the address of the CeloDistributionSchedule contract.
-   * @param celoTokenDistributionScheduleAddress The address of the CeloDistributionSchedule contract.
-   */
-  function setCeloTokenDistributionScheduleAddress(
-    address celoTokenDistributionScheduleAddress
-  ) external;
-
-  /**
    * @return The address of the CeloTokenDistributionSchedule contract.
    */
   function getCeloTokenDistributionScheduleAddress() external returns (address);

--- a/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
+++ b/packages/protocol/contracts-0.8/common/interfaces/ICeloToken.sol
@@ -28,6 +28,8 @@ interface ICeloToken is IERC20 {
     address celoTokenDistributionScheduleAddress
   ) external;
 
+  function getCeloTokenDistributionSchedule() external returns (address);
+
   /**
    * @dev Mints a new token.
    * @param to The address that will own the minted token.

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -249,13 +249,6 @@ contract GoldToken is
   }
 
   /**
-   * @return The address of the CeloTokenDistributionSchedule contract.
-   */
-  function getCeloTokenDistributionScheduleAddress() external view returns (address) {
-    return registry.getAddressForOrDie(CELO_DISTRIBUTION_SCHEDULE_ID);
-  }
-
-  /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @return Storage version of the contract.
    * @return Major version of the contract.

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -270,6 +270,13 @@ contract GoldToken is
   }
 
   /**
+   * @return The address of the CeloTokenDistributionSchedule contract.
+   */
+  function getCeloTokenDistributionSchedule() external view returns (address) {
+    return address(celoTokenDistributionSchedule);
+  }
+
+  /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @return Storage version of the contract.
    * @return Major version of the contract.

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -40,15 +40,11 @@ contract GoldToken is
   // Burn address is 0xdEaD because truffle is having buggy behaviour with the zero address
   address constant BURN_ADDRESS = address(0x000000000000000000000000000000000000dEaD);
 
-  ICeloDistributionSchedule public celoTokenDistributionSchedule;
-
   event Transfer(address indexed from, address indexed to, uint256 value);
 
   event TransferComment(string comment);
 
   event Approval(address indexed owner, address indexed spender, uint256 value);
-
-  event SetCeloTokenDistributionScheduleAddress(address indexed newScheduleAddress);
 
   /**
    * @notice Sets initialized == true on implementation contracts
@@ -64,23 +60,6 @@ contract GoldToken is
     totalSupply_ = 0;
     _transferOwnership(msg.sender);
     setRegistry(registryAddress);
-  }
-
-  /**
-   * @notice Used set the address of the CeloDistributionSchedule contract.
-   * @param celoTokenDistributionScheduleAddress The address of the CeloDistributionSchedule contract.
-   */
-  function setCeloTokenDistributionScheduleAddress(
-    address celoTokenDistributionScheduleAddress
-  ) external onlyOwner {
-    require(
-      celoTokenDistributionScheduleAddress != address(0) ||
-        celoTokenDistributionScheduleAddress != address(celoTokenDistributionSchedule),
-      "Invalid address."
-    );
-    celoTokenDistributionSchedule = ICeloDistributionSchedule(celoTokenDistributionScheduleAddress);
-
-    emit SetCeloTokenDistributionScheduleAddress(celoTokenDistributionScheduleAddress);
   }
 
   /**
@@ -174,8 +153,8 @@ contract GoldToken is
   function transferFrom(address from, address to, uint256 value) external returns (bool) {
     require(to != address(0), "transfer attempted to reserved address 0x0");
     require(
-      to != address(celoTokenDistributionSchedule),
-      "transfer attempted to reserved celoTokenDistributionSchedule address"
+      to != registry.getAddressForOrDie(CELO_DISTRIBUTION_SCHEDULE_ID),
+      "transfer attempted to reserved CeloDistributionSchedule address"
     );
     require(value <= balanceOf(from), "transfer value exceeded balance of sender");
     require(
@@ -249,7 +228,7 @@ contract GoldToken is
    * @return The total amount of allocated CELO.
    */
   function allocatedSupply() external view onlyL2 returns (uint256) {
-    return CELO_SUPPLY_CAP - address(celoTokenDistributionSchedule).balance;
+    return CELO_SUPPLY_CAP - registry.getAddressForOrDie(CELO_DISTRIBUTION_SCHEDULE_ID).balance;
   }
 
   /**
@@ -273,7 +252,7 @@ contract GoldToken is
    * @return The address of the CeloTokenDistributionSchedule contract.
    */
   function getCeloTokenDistributionScheduleAddress() external view returns (address) {
-    return address(celoTokenDistributionSchedule);
+    return registry.getAddressForOrDie(CELO_DISTRIBUTION_SCHEDULE_ID);
   }
 
   /**
@@ -323,8 +302,8 @@ contract GoldToken is
    */
   function _transfer(address to, uint256 value) internal returns (bool) {
     require(
-      to != address(celoTokenDistributionSchedule),
-      "transfer attempted to reserved celoTokenDistributionSchedule address"
+      to != registry.getAddressForOrDie(CELO_DISTRIBUTION_SCHEDULE_ID),
+      "transfer attempted to reserved CeloDistributionSchedule address"
     );
     require(value <= balanceOf(msg.sender), "transfer value exceeded balance of sender");
 

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -272,7 +272,7 @@ contract GoldToken is
   /**
    * @return The address of the CeloTokenDistributionSchedule contract.
    */
-  function getCeloTokenDistributionSchedule() external view returns (address) {
+  function getCeloTokenDistributionScheduleAddress() external view returns (address) {
     return address(celoTokenDistributionSchedule);
   }
 

--- a/packages/protocol/contracts/common/UsingRegistry.sol
+++ b/packages/protocol/contracts/common/UsingRegistry.sol
@@ -8,6 +8,7 @@ import "./interfaces/IAccounts.sol";
 import "./interfaces/IFeeCurrencyWhitelist.sol";
 import "./interfaces/IFreezer.sol";
 import "./interfaces/IRegistry.sol";
+import "./interfaces/ICeloDistributionSchedule.sol";
 
 import "../governance/interfaces/IElection.sol";
 import "../governance/interfaces/IGovernance.sol";
@@ -48,6 +49,8 @@ contract UsingRegistry is Ownable {
 
   bytes32 constant CELO_TOKEN_REGISTRY_ID = keccak256(abi.encodePacked("CeloToken"));
   bytes32 constant LOCKED_CELO_REGISTRY_ID = keccak256(abi.encodePacked("LockedCelo"));
+  bytes32 constant CELO_DISTRIBUTION_SCHEDULE_ID =
+    keccak256(abi.encodePacked("CeloDistributionSchedule"));
   // solhint-enable state-visibility
 
   IRegistry public registry;
@@ -134,5 +137,9 @@ contract UsingRegistry is Ownable {
 
   function getValidators() internal view returns (IValidators) {
     return IValidators(registry.getAddressForOrDie(VALIDATORS_REGISTRY_ID));
+  }
+
+  function getCeloDistributionSchedule() internal view returns (ICeloDistributionSchedule) {
+    return ICeloDistributionSchedule(registry.getAddressForOrDie(CELO_DISTRIBUTION_SCHEDULE_ID));
   }
 }

--- a/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
+++ b/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
@@ -307,7 +307,6 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
   }
 
   function test_Reverts_WhenCeloDistributionAddressNotSetInCeloTokenContract() public {
-    //setUp
     vm.warp(block.timestamp + l2StartTime);
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);

--- a/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
+++ b/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
@@ -323,7 +323,7 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     vm.warp(block.timestamp + l2StartTime);
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-    registry.setAddressFor("CeloDistributionSchedule", celoTokenAddress);
+    registry.setAddressFor("CeloDistributionSchedule", randomAddress);
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
 
     vm.prank(celoDistributionOwner);

--- a/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
+++ b/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
@@ -69,14 +69,8 @@ contract CeloDistributionScheduleTest is Test, Constants, IsL2Check {
     setUpL1();
 
     // Setup L2 after minting L1 supply.
-    registryAddress = proxyAdminAddress;
-    deployCodeTo("Registry.sol", abi.encode(false), registryAddress);
-    registry = IRegistry(registryAddress);
 
-    registry.setAddressFor("CeloToken", address(celoToken));
-    registry.setAddressFor("Governance", address(governance));
-
-    celoToken.setRegistry(registryAddress);
+    deployCodeTo("Registry.sol", abi.encode(false), proxyAdminAddress);
   }
 
   function setUpL1() public {
@@ -87,7 +81,7 @@ contract CeloDistributionScheduleTest is Test, Constants, IsL2Check {
 
     deployCodeTo("GoldToken.sol", abi.encode(false), celoTokenAddress);
     celoToken = ICeloToken(celoTokenAddress);
-
+    celoToken.setRegistry(registryAddress);
     // Using a mock contract, as foundry does not allow for library linking when using deployCodeTo
     governance = new MockGovernance();
 
@@ -107,10 +101,9 @@ contract CeloDistributionScheduleTest is Test, Constants, IsL2Check {
     vm.warp(block.timestamp + l2StartTime);
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
 
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
-
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
 
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule.initialize(registryAddress);
@@ -133,19 +126,17 @@ contract CeloDistributionScheduleTest_initialize is CeloDistributionScheduleTest
 
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
-
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule.initialize(registryAddress);
   }
 
-  function test_ShouldSetAOwnerToCeloDistributionScheduleInstance() public {
+  function test_ShouldSetAnOwnerToCeloDistributionScheduleInstance() public {
     assertEq(celoDistributionSchedule.owner(), celoDistributionOwner);
   }
 
   function test_ShouldSetRegistryAddressToCeloDistributionScheduleInstance() public {
-    assertEq(address(celoDistributionSchedule.registry()), proxyAdminAddress);
+    assertEq(address(celoDistributionSchedule.registry()), l1RegistryAddress);
   }
 
   function test_ShouldNotSetBeneficiariesToCeloDistributionScheduleInstance() public {
@@ -163,7 +154,7 @@ contract CeloDistributionScheduleTest_initialize is CeloDistributionScheduleTest
 
   function test_Reverts_WhenRegistryIsTheNullAddress() public {
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     vm.expectRevert("Cannot register the null address");
     celoDistributionSchedule.initialize(address(0));
   }
@@ -187,6 +178,7 @@ contract CeloDistributionScheduleTest_activate_L1 is CeloDistributionScheduleTes
     super.setUpL1();
 
     celoDistributionSchedule = new CeloDistributionSchedule(true);
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
   }
 
@@ -221,9 +213,10 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
   function test_Reverts_WhenCommunityFractionIsZero() public {
     vm.warp(block.timestamp + l2StartTime);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
+
     vm.expectRevert(
       "Value must be different from existing community reward fraction and less than 1."
     );
@@ -238,9 +231,9 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
   function test_Reverts_WhenCarbonOffsettingPartnerIsNullAddress() public {
     vm.warp(block.timestamp + l2StartTime);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
 
     vm.expectRevert("Partner cannot be the zero address.");
     celoDistributionSchedule.activate(
@@ -255,8 +248,8 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     vm.warp(block.timestamp + l2StartTime);
     registry.setAddressFor("Governance", address(0));
     celoDistributionSchedule = new CeloDistributionSchedule(true);
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
 
     vm.expectRevert("identifier has no registry entry");
@@ -286,10 +279,8 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     vm.warp(block.timestamp + l2StartTime);
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
-
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
 
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule.initialize(registryAddress);
@@ -306,7 +297,7 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     );
   }
 
-  function test_Reverts_WhenCeloDistributionAddressNotSetInCeloTokenContract() public {
+  function test_Reverts_WhenCeloDistributionAddressNotSetInRegistry() public {
     vm.warp(block.timestamp + l2StartTime);
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
@@ -316,7 +307,29 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule.initialize(registryAddress);
 
-    vm.expectRevert("CeloDistributionSchedule address has not been set in CELO token contract.");
+    vm.expectRevert("identifier has no registry entry");
+
+    vm.prank(celoDistributionOwner);
+
+    celoDistributionSchedule.activate(
+      l2StartTime,
+      communityRewardFraction,
+      carbonOffsettingPartner,
+      carbonOffsettingFraction
+    );
+  }
+
+  function test_Reverts_WhenCeloDistributionAddressIncorrectlySetInRegistry() public {
+    vm.warp(block.timestamp + l2StartTime);
+    vm.prank(celoDistributionOwner);
+    celoDistributionSchedule = new CeloDistributionSchedule(true);
+    registry.setAddressFor("CeloDistributionSchedule", celoTokenAddress);
+    vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
+
+    vm.prank(celoDistributionOwner);
+    celoDistributionSchedule.initialize(registryAddress);
+
+    vm.expectRevert("CeloDistributionSchedule address is incorrectly set in Registry.");
 
     vm.prank(celoDistributionOwner);
 
@@ -365,9 +378,7 @@ contract CeloDistributionScheduleTest_setCommunityRewardFraction is CeloDistribu
   function test_Reverts_WhenDependenciesNotSet() public {
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
-
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule.initialize(registryAddress);
 
@@ -449,9 +460,7 @@ contract CeloDistributionScheduleTest_setCarbonOffsettingFund is CeloDistributio
   function test_Reverts_WhenDependenciesNotSet() public {
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-
-    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
-
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     vm.prank(celoDistributionOwner);
     celoDistributionSchedule.initialize(registryAddress);
 
@@ -493,6 +502,7 @@ contract CeloDistributionScheduleTest_distributeAccordingToSchedule_L1 is
     super.setUpL1();
 
     celoDistributionSchedule = new CeloDistributionSchedule(true);
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
   }
 
@@ -516,7 +526,7 @@ contract CeloDistributionScheduleTest_distributeAccordingToSchedule is
 
   function test_Reverts_WhenDependenciesAreNotSet() public {
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
 
     vm.expectRevert("Distribution schedule has not been activated.");
@@ -728,7 +738,7 @@ contract CeloDistributionScheduleTest_getDistributableAmount is CeloDistribution
 
   function test_Reverts_WhenDependenciesNotSet() public {
     celoDistributionSchedule = new CeloDistributionSchedule(true);
-
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
 
     vm.expectRevert("Distribution schedule has not been activated.");

--- a/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
+++ b/packages/protocol/test-sol/unit/common/CeloDistributionSchedule.t.sol
@@ -223,6 +223,7 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     celoDistributionSchedule = new CeloDistributionSchedule(true);
     celoDistributionSchedule.initialize(registryAddress);
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
+    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
     vm.expectRevert(
       "Value must be different from existing community reward fraction and less than 1."
     );
@@ -239,6 +240,7 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     celoDistributionSchedule = new CeloDistributionSchedule(true);
     celoDistributionSchedule.initialize(registryAddress);
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
+    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
 
     vm.expectRevert("Partner cannot be the zero address.");
     celoDistributionSchedule.activate(
@@ -254,6 +256,7 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
     registry.setAddressFor("Governance", address(0));
     celoDistributionSchedule = new CeloDistributionSchedule(true);
     vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
+    celoToken.setCeloTokenDistributionScheduleAddress(address(celoDistributionSchedule));
     celoDistributionSchedule.initialize(registryAddress);
 
     vm.expectRevert("identifier has no registry entry");
@@ -295,6 +298,29 @@ contract CeloDistributionScheduleTest_activate is CeloDistributionScheduleTest {
 
     vm.expectRevert("Contract does not have CELO balance.");
     vm.prank(celoDistributionOwner);
+    celoDistributionSchedule.activate(
+      l2StartTime,
+      communityRewardFraction,
+      carbonOffsettingPartner,
+      carbonOffsettingFraction
+    );
+  }
+
+  function test_Reverts_WhenCeloDistributionAddressNotSetInCeloTokenContract() public {
+    //setUp
+    vm.warp(block.timestamp + l2StartTime);
+    vm.prank(celoDistributionOwner);
+    celoDistributionSchedule = new CeloDistributionSchedule(true);
+
+    vm.deal(address(celoDistributionSchedule), L2_INITIAL_STASH_BALANCE);
+
+    vm.prank(celoDistributionOwner);
+    celoDistributionSchedule.initialize(registryAddress);
+
+    vm.expectRevert("CeloDistributionSchedule address has not been set in CELO token contract.");
+
+    vm.prank(celoDistributionOwner);
+
     celoDistributionSchedule.activate(
       l2StartTime,
       communityRewardFraction,

--- a/packages/protocol/test-sol/unit/common/FeeHandler.t.sol
+++ b/packages/protocol/test-sol/unit/common/FeeHandler.t.sol
@@ -52,6 +52,7 @@ contract FeeHandlerTest is Test, Constants {
   address registryAddress = 0x000000000000000000000000000000000000ce10;
   address owner = address(this);
   address user = actor("user");
+  address celoDistributionSchedule = actor("CeloDistributionSchedule");
 
   uint256 celoAmountForRate = 1e24;
   uint256 stableAmountForRate = 2 * celoAmountForRate;
@@ -102,6 +103,7 @@ contract FeeHandlerTest is Test, Constants {
     registry.setAddressFor("GoldToken", address(celoToken));
     registry.setAddressFor("CeloToken", address(celoToken));
     registry.setAddressFor("Reserve", address(mockReserve));
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
 
     mockReserve.setGoldToken(address(celoToken));
     mockReserve.addToken(address(stableToken));

--- a/packages/protocol/test-sol/unit/common/FeeHandler.t.sol
+++ b/packages/protocol/test-sol/unit/common/FeeHandler.t.sol
@@ -103,7 +103,7 @@ contract FeeHandlerTest is Test, Constants {
     registry.setAddressFor("GoldToken", address(celoToken));
     registry.setAddressFor("CeloToken", address(celoToken));
     registry.setAddressFor("Reserve", address(mockReserve));
-    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
+    registry.setAddressFor("CeloDistributionSchedule", celoDistributionSchedule);
 
     mockReserve.setGoldToken(address(celoToken));
     mockReserve.addToken(address(stableToken));

--- a/packages/protocol/test-sol/unit/common/GoldToken.t.sol
+++ b/packages/protocol/test-sol/unit/common/GoldToken.t.sol
@@ -7,7 +7,9 @@ import "@test-sol/unit/common/GoldTokenMock.sol";
 
 contract GoldTokenTest is Test, IsL2Check {
   GoldToken celoToken;
+  IRegistry registry;
 
+  address constant registryAddress = 0x000000000000000000000000000000000000ce10;
   uint256 constant ONE_CELOTOKEN = 1000000000000000000;
   address receiver;
   address sender;
@@ -16,7 +18,6 @@ contract GoldTokenTest is Test, IsL2Check {
 
   event Transfer(address indexed from, address indexed to, uint256 value);
   event TransferComment(string comment);
-  event SetCeloTokenDistributionScheduleAddress(address indexed newScheduleAddress);
 
   modifier _whenL2() {
     deployCodeTo("Registry.sol", abi.encode(false), proxyAdminAddress);
@@ -24,11 +25,16 @@ contract GoldTokenTest is Test, IsL2Check {
   }
 
   function setUp() public {
+    deployCodeTo("Registry.sol", abi.encode(false), registryAddress);
+    registry = IRegistry(registryAddress);
+
     celoTokenOwner = actor("celoTokenOwner");
     celoTokenDistributionSchedule = actor("celoTokenDistributionSchedule");
     vm.prank(celoTokenOwner);
     celoToken = new GoldToken(true);
-    deployCodeTo("CeloDistributionSchedule.sol", abi.encode(false), celoTokenDistributionSchedule);
+    vm.prank(celoTokenOwner);
+    celoToken.setRegistry(registryAddress);
+    registry.setAddressFor("CeloDistributionSchedule", celoTokenDistributionSchedule);
     receiver = actor("receiver");
     sender = actor("sender");
     vm.deal(receiver, ONE_CELOTOKEN);
@@ -89,8 +95,6 @@ contract GoldTokenTest_general is GoldTokenTest {
 contract GoldTokenTest_transfer is GoldTokenTest {
   function setUp() public {
     super.setUp();
-    vm.prank(celoTokenOwner);
-    celoToken.setCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
   }
 
   function test_ShouldTransferBalanceFromOneUserToAnother() public {
@@ -123,7 +127,7 @@ contract GoldTokenTest_transfer is GoldTokenTest {
   }
   function test_Reverts_WhenTransferingToCeloDistributionSchedule() public {
     vm.prank(sender);
-    vm.expectRevert("transfer attempted to reserved celoTokenDistributionSchedule address");
+    vm.expectRevert("transfer attempted to reserved CeloDistributionSchedule address");
     celoToken.transfer(celoTokenDistributionSchedule, ONE_CELOTOKEN);
   }
 }
@@ -131,8 +135,6 @@ contract GoldTokenTest_transfer is GoldTokenTest {
 contract GoldTokenTest_transferFrom is GoldTokenTest {
   function setUp() public {
     super.setUp();
-    vm.prank(celoTokenOwner);
-    celoToken.setCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
     vm.prank(sender);
     celoToken.approve(receiver, ONE_CELOTOKEN);
   }
@@ -148,7 +150,7 @@ contract GoldTokenTest_transferFrom is GoldTokenTest {
 
   function test_Reverts_WhenTransferingToCeloDistributionSchedule() public {
     vm.prank(receiver);
-    vm.expectRevert("transfer attempted to reserved celoTokenDistributionSchedule address");
+    vm.expectRevert("transfer attempted to reserved CeloDistributionSchedule address");
     celoToken.transferFrom(sender, celoTokenDistributionSchedule, ONE_CELOTOKEN);
   }
 
@@ -236,35 +238,6 @@ contract GoldTokenTest_mint is GoldTokenTest {
   }
 }
 
-contract GoldTokenTest_setCeloTokenDistributionScheduleAddress is GoldTokenTest {
-  function test_Reverts_whenCalledByOtherThanL2Governance() public _whenL2 {
-    vm.expectRevert("Ownable: caller is not the owner");
-    vm.prank(address(0));
-    celoToken.setCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
-  }
-
-  function test_ShouldSucceedWhenCalledByOwner() public {
-    vm.prank(celoTokenOwner);
-    celoToken.setCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
-
-    assertEq(address(celoToken.celoTokenDistributionSchedule()), celoTokenDistributionSchedule);
-  }
-
-  function test_ShouldSucceedWhenCalledByL2Governance() public _whenL2 {
-    vm.prank(celoTokenOwner);
-    celoToken.setCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
-
-    assertEq(address(celoToken.celoTokenDistributionSchedule()), celoTokenDistributionSchedule);
-  }
-
-  function test_Emits_SetCeloTokenDistributionScheduleAddressEvent() public {
-    vm.expectEmit(true, true, true, true);
-    emit SetCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
-    vm.prank(celoTokenOwner);
-    celoToken.setCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
-  }
-}
-
 contract GoldTokenTest_increaseSupply is GoldTokenTest {
   function test_ShouldIncreaseTotalSupply() public {
     uint256 celoTokenSupplyBefore = celoToken.totalSupply();
@@ -282,9 +255,11 @@ contract GoldTokenTest_increaseSupply is GoldTokenTest {
 }
 
 contract CeloTokenMockTest is Test {
+  IRegistry registry;
   GoldTokenMock mockCeloToken;
   uint256 ONE_CELOTOKEN = 1000000000000000000;
   address burnAddress = address(0x000000000000000000000000000000000000dEaD);
+  address constant registryAddress = 0x000000000000000000000000000000000000ce10;
   address constant proxyAdminAddress = 0x4200000000000000000000000000000000000018;
   address celoTokenDistributionSchedule;
 
@@ -294,10 +269,14 @@ contract CeloTokenMockTest is Test {
   }
 
   function setUp() public {
+    deployCodeTo("Registry.sol", abi.encode(false), registryAddress);
+    registry = IRegistry(registryAddress);
+
     mockCeloToken = new GoldTokenMock();
+    mockCeloToken.setRegistry(registryAddress);
     mockCeloToken.setTotalSupply(ONE_CELOTOKEN * 1000);
     celoTokenDistributionSchedule = actor("celoTokenDistributionSchedule");
-    mockCeloToken.setCeloTokenDistributionScheduleAddress(celoTokenDistributionSchedule);
+    registry.setAddressFor("CeloDistributionSchedule", celoTokenDistributionSchedule);
   }
 }
 
@@ -328,7 +307,7 @@ contract CeloTokenMock_circulatingSupply is CeloTokenMockTest {
   }
 }
 
-contract CeloToken_AllocatedSupply is CeloTokenMockTest {
+contract GoldTokenTest_AllocatedSupply is CeloTokenMockTest {
   function test_ShouldRevert_WhenL1() public {
     vm.expectRevert("This method is not supported in L1.");
     mockCeloToken.allocatedSupply();
@@ -344,7 +323,7 @@ contract CeloToken_AllocatedSupply is CeloTokenMockTest {
   }
 }
 
-contract CeloToken_TotalSupply is CeloTokenMockTest {
+contract GoldTokenTest_TotalSupply is CeloTokenMockTest {
   uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
 
   function test_TotalSupply_ShouldReturnTotalSupply_WhenL2() public _whenL2 {

--- a/packages/protocol/test-sol/unit/governance/voting/ReleaseGold.t.sol
+++ b/packages/protocol/test-sol/unit/governance/voting/ReleaseGold.t.sol
@@ -45,6 +45,7 @@ contract ReleaseGoldTest is Test, ECDSAHelper {
   address refundAddress = actor("refundAddress");
   address newBeneficiary = actor("newBeneficiary");
   address randomAddress = actor("randomAddress");
+  address celoDistributionSchedule = actor("CeloDistributionSchedule");
 
   uint256 constant TOTAL_AMOUNT = 1 ether * 10;
 
@@ -68,19 +69,6 @@ contract ReleaseGoldTest is Test, ECDSAHelper {
   address constant proxyAdminAddress = 0x4200000000000000000000000000000000000018;
   function _whenL2() public {
     deployCodeTo("Registry.sol", abi.encode(false), proxyAdminAddress);
-    registry = Registry(proxyAdminAddress);
-    registry.setAddressFor("Accounts", address(accounts));
-    registry.setAddressFor("Election", address(election));
-    registry.setAddressFor("Freezer", address(freezer));
-    registry.setAddressFor("CeloToken", address(goldToken));
-    registry.setAddressFor("Governance", address(governance));
-    registry.setAddressFor("LockedGold", address(lockedGold));
-    registry.setAddressFor("Validators", address(validators));
-    registry.setAddressFor("StableToken", address(stableToken));
-
-    lockedGold.setRegistry(proxyAdminAddress);
-    goldToken.setRegistry(proxyAdminAddress);
-    accounts.setRegistry(proxyAdminAddress);
   }
 
   function newReleaseGold(bool prefund, bool startReleasing) internal returns (ReleaseGold) {
@@ -136,6 +124,7 @@ contract ReleaseGoldTest is Test, ECDSAHelper {
     registry.setAddressFor("LockedGold", address(lockedGold));
     registry.setAddressFor("Validators", address(validators));
     registry.setAddressFor("StableToken", address(stableToken));
+    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
 
     lockedGold.initialize(registryAddress, UNLOCKING_PERIOD);
     goldToken.initialize(registryAddress);

--- a/packages/protocol/test-sol/unit/governance/voting/ReleaseGold.t.sol
+++ b/packages/protocol/test-sol/unit/governance/voting/ReleaseGold.t.sol
@@ -124,7 +124,7 @@ contract ReleaseGoldTest is Test, ECDSAHelper {
     registry.setAddressFor("LockedGold", address(lockedGold));
     registry.setAddressFor("Validators", address(validators));
     registry.setAddressFor("StableToken", address(stableToken));
-    registry.setAddressFor("CeloDistributionSchedule", address(celoDistributionSchedule));
+    registry.setAddressFor("CeloDistributionSchedule", celoDistributionSchedule);
 
     lockedGold.initialize(registryAddress, UNLOCKING_PERIOD);
     goldToken.initialize(registryAddress);

--- a/packages/protocol/test/common/feehandlerseller.ts
+++ b/packages/protocol/test/common/feehandlerseller.ts
@@ -51,7 +51,7 @@ contract('FeeHandlerSeller', (accounts: string[]) => {
     await registry.setAddressFor(
       CeloContractName.CeloDistributionSchedule,
       celoDistributionSchedule.address
-    )
+    ) // Added because the CeloToken `_transfer` prevents transfers to the celoDistributionSchedule.
 
     uniswapFeeHandlerSeller = await UniswapFeeHandlerSeller.new(true)
     mentoFeeHandlerSeller = await MentoFeeHandlerSeller.new(true)

--- a/packages/protocol/test/common/feehandlerseller.ts
+++ b/packages/protocol/test/common/feehandlerseller.ts
@@ -14,6 +14,7 @@ import {
   UniswapFeeHandlerSellerContract,
   UniswapFeeHandlerSellerInstance,
 } from 'types'
+import { CeloDistributionScheduleContract, CeloDistributionScheduleInstance } from 'types/08'
 
 const MentoFeeHandlerSeller: MentoFeeHandlerSellerContract =
   artifacts.require('MentoFeeHandlerSeller')
@@ -23,7 +24,9 @@ const UniswapFeeHandlerSeller: UniswapFeeHandlerSellerContract =
 
 const GoldToken: GoldTokenContract = artifacts.require('GoldToken')
 const Registry: RegistryContract = artifacts.require('Registry')
-
+const CeloDistributionSchedule: CeloDistributionScheduleContract = artifacts.require(
+  'CeloDistributionSchedule'
+)
 const oneCelo = new BigNumber('1e18')
 
 contract('FeeHandlerSeller', (accounts: string[]) => {
@@ -31,16 +34,22 @@ contract('FeeHandlerSeller', (accounts: string[]) => {
   let mentoFeeHandlerSeller: MentoFeeHandlerSellerInstance
   let goldToken: GoldTokenInstance
   let registry: RegistryInstance
+  let celoDistributionSchedule: CeloDistributionScheduleInstance
 
   let contractsToTest
   const user = accounts[1]
 
   beforeEach(async () => {
     registry = await Registry.new(true)
+    celoDistributionSchedule = await CeloDistributionSchedule.new(true)
 
     goldToken = await GoldToken.new(true)
     await goldToken.initialize(registry.address)
     await registry.setAddressFor(CeloContractName.GoldToken, goldToken.address)
+    await registry.setAddressFor(
+      CeloContractName.CeloDistributionSchedule,
+      celoDistributionSchedule.address
+    )
 
     uniswapFeeHandlerSeller = await UniswapFeeHandlerSeller.new(true)
     mentoFeeHandlerSeller = await MentoFeeHandlerSeller.new(true)

--- a/packages/protocol/test/common/feehandlerseller.ts
+++ b/packages/protocol/test/common/feehandlerseller.ts
@@ -15,6 +15,8 @@ import {
   UniswapFeeHandlerSellerInstance,
 } from 'types'
 import { CeloDistributionScheduleContract, CeloDistributionScheduleInstance } from 'types/08'
+import { SOLIDITY_08_PACKAGE } from '../../contractPackages'
+import { ArtifactsSingleton } from '../../lib/artifactsSingleton'
 
 const MentoFeeHandlerSeller: MentoFeeHandlerSellerContract =
   artifacts.require('MentoFeeHandlerSeller')
@@ -24,9 +26,9 @@ const UniswapFeeHandlerSeller: UniswapFeeHandlerSellerContract =
 
 const GoldToken: GoldTokenContract = artifacts.require('GoldToken')
 const Registry: RegistryContract = artifacts.require('Registry')
-const CeloDistributionSchedule: CeloDistributionScheduleContract = artifacts.require(
-  'CeloDistributionSchedule'
-)
+const CeloDistributionSchedule: CeloDistributionScheduleContract = ArtifactsSingleton.getInstance(
+  SOLIDITY_08_PACKAGE
+).require('CeloDistributionSchedule')
 const oneCelo = new BigNumber('1e18')
 
 contract('FeeHandlerSeller', (accounts: string[]) => {

--- a/packages/protocol/test/common/recoverFunds.ts
+++ b/packages/protocol/test/common/recoverFunds.ts
@@ -38,7 +38,7 @@ contract('Proxy', (accounts: string[]) => {
       const Freezer: FreezerContract = artifacts.require('Freezer')
       const GoldToken: GoldTokenContract = artifacts.require('GoldToken')
       const CeloDistributionSchedule: CeloDistributionScheduleContract =
-        ArtifactsSingleton.getInstance(SOLIDITY_08_PACKAGE).require('CeloDistributionSchedule')
+        ArtifactsSingleton.getInstance(SOLIDITY_08_PACKAGE).require('CeloDistributionSchedule') // Added because the CeloToken `_transfer` prevents transfers to the celoDistributionSchedule.
       // @ts-ignore
       GoldToken.numberFormat = 'BigNumber'
       const Registry: RegistryContract = artifacts.require('Registry')

--- a/packages/protocol/test/common/recoverFunds.ts
+++ b/packages/protocol/test/common/recoverFunds.ts
@@ -12,6 +12,8 @@ import {
   RegistryContract,
 } from 'types'
 import { CeloDistributionScheduleContract } from 'types/08'
+import { SOLIDITY_08_PACKAGE } from '../../contractPackages'
+import { ArtifactsSingleton } from '../../lib/artifactsSingleton'
 
 const GetSetV0: Truffle.Contract<GetSetV0Instance> = artifacts.require('GetSetV0')
 const Proxy: Truffle.Contract<ProxyInstance> = artifacts.require('Proxy')
@@ -35,9 +37,8 @@ contract('Proxy', (accounts: string[]) => {
     it('recovers funds from an incorrectly intialized implementation', async () => {
       const Freezer: FreezerContract = artifacts.require('Freezer')
       const GoldToken: GoldTokenContract = artifacts.require('GoldToken')
-      const CeloDistributionSchedule: CeloDistributionScheduleContract = artifacts.require(
-        'CeloDistributionSchedule'
-      )
+      const CeloDistributionSchedule: CeloDistributionScheduleContract =
+        ArtifactsSingleton.getInstance(SOLIDITY_08_PACKAGE).require('CeloDistributionSchedule')
       // @ts-ignore
       GoldToken.numberFormat = 'BigNumber'
       const Registry: RegistryContract = artifacts.require('Registry')

--- a/packages/protocol/test/common/recoverFunds.ts
+++ b/packages/protocol/test/common/recoverFunds.ts
@@ -3,6 +3,7 @@
 import { recoverFunds } from '@celo/protocol/lib/recover-funds'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { expectBigNumberInRange } from '@celo/protocol/lib/test-utils'
+import { CeloDistributionScheduleContract } from '@celo/protocol/types/08'
 import { BigNumber } from 'bignumber.js'
 import {
   FreezerContract,
@@ -34,14 +35,23 @@ contract('Proxy', (accounts: string[]) => {
     it('recovers funds from an incorrectly intialized implementation', async () => {
       const Freezer: FreezerContract = artifacts.require('Freezer')
       const GoldToken: GoldTokenContract = artifacts.require('GoldToken')
+      const CeloDistributionSchedule: CeloDistributionScheduleContract = artifacts.require(
+        'CeloDistributionSchedule'
+      )
       // @ts-ignore
       GoldToken.numberFormat = 'BigNumber'
       const Registry: RegistryContract = artifacts.require('Registry')
 
       const freezer = await Freezer.new(true)
       const goldToken = await GoldToken.new(true)
+      const celoDistributionSchedule = await CeloDistributionSchedule.new(true)
+
       const registry = await Registry.new(true)
       await registry.setAddressFor(CeloContractName.Freezer, freezer.address)
+      await registry.setAddressFor(
+        CeloContractName.CeloDistributionSchedule,
+        celoDistributionSchedule.address
+      )
       await goldToken.initialize(registry.address)
 
       const amount = new BigNumber(10)

--- a/packages/protocol/test/common/recoverFunds.ts
+++ b/packages/protocol/test/common/recoverFunds.ts
@@ -3,7 +3,6 @@
 import { recoverFunds } from '@celo/protocol/lib/recover-funds'
 import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import { expectBigNumberInRange } from '@celo/protocol/lib/test-utils'
-import { CeloDistributionScheduleContract } from '@celo/protocol/types/08'
 import { BigNumber } from 'bignumber.js'
 import {
   FreezerContract,
@@ -12,6 +11,7 @@ import {
   ProxyInstance,
   RegistryContract,
 } from 'types'
+import { CeloDistributionScheduleContract } from 'types/08'
 
 const GetSetV0: Truffle.Contract<GetSetV0Instance> = artifacts.require('GetSetV0')
 const Proxy: Truffle.Contract<ProxyInstance> = artifacts.require('Proxy')


### PR DESCRIPTION
### Description

~~Added a check that prevents activating the `CeloDistributionSchedule` contract if the distributionSchedule contract address if not set in CELO token contract.~~

Previously, it was expected that the `CeloDistributionSchedule` address would be manually set in the `GoldToken` contract by calling `setCeloTokenDistributionSchedule()`. This was expected to be done before calling `activate()` in the `CeloDistributionSchedule`. However, the `CeloDistributionSchedule` contract did not verify that the `CeloDistributionSchedule` address was set in the `GoldToken` contract, allowing for the `CeloDistributionSchedule` to be incorrectly activated.

These new changes get the `CeloDistributionSchedule` address from the registry, instead of setting it in the `GoldToken` contract. Hence, no longer requiring that the `CeloDistributionSchedule` address be manually set in the `GoldToken` contract before activating the `CeloDistributionSchedule` contract.



### Tested

unit tested

