### PR TITLE
Anvil migrations: use stable symbols

### DIFF
--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -465,7 +465,7 @@ contract Migration is Script, UsingRegistry, Constants {
 
   function migrateStableToken(string memory json) public {
     string[] memory names = abi.decode(json.parseRaw(".stableTokens.names"), (string[]));
-    string[] memory symbols = abi.decode(json.parseRaw(".stableTokens.names"), (string[]));
+    string[] memory symbols = abi.decode(json.parseRaw(".stableTokens.symbols"), (string[]));
     string[] memory contractSufixs = abi.decode(
       json.parseRaw(".stableTokens.contractSufixs"),
       (string[])


### PR DESCRIPTION
### Description

This PR changes anvil migration script to use stable tokens' symbols instead of names.

### Other changes

None.

### Tested

TBD