### PR TITLE
Anvil migrations: use stable symbols

### DIFF
--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -466,7 +466,7 @@ contract Migration is Script, UsingRegistry, MigrationsConstants {
 
   function migrateStableToken(string memory json) public {
     string[] memory names = abi.decode(json.parseRaw(".stableTokens.names"), (string[]));
-    string[] memory symbols = abi.decode(json.parseRaw(".stableTokens.names"), (string[]));
+    string[] memory symbols = abi.decode(json.parseRaw(".stableTokens.symbols"), (string[]));
     string[] memory contractSufixs = abi.decode(
       json.parseRaw(".stableTokens.contractSufixs"),
       (string[])


### PR DESCRIPTION
This PR just brings https://github.com/celo-org/celo-monorepo/pull/11188 to the release branch.