### PR TITLE
Split initEpochManager Function

### DIFF
--- a/packages/protocol/contracts-0.8/common/EpochManagerInitializer.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManagerInitializer.sol
@@ -51,6 +51,7 @@ contract EpochManagerInitializer is Initializable, UsingPrecompiles, UsingRegist
     lastKnownElectedAccounts = new address[](numberElectedValidators);
 
     for (uint256 i = 0; i < numberElectedValidators; i++) {
+      // TODO: document how much gas this takes for 110 signers
       address validatorAccountAddress = getAccounts().validatorSignerToAccount(
         validatorSignerAddressFromCurrentSet(i)
       );

--- a/packages/protocol/contracts-0.8/common/EpochManagerInitializer.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManagerInitializer.sol
@@ -9,6 +9,9 @@ import "../../contracts/common/interfaces/ICeloVersionedContract.sol";
 import "../../contracts/governance/interfaces/IEpochRewards.sol";
 
 contract EpochManagerInitializer is Initializable, UsingPrecompiles, UsingRegistry {
+  uint256 public lastKnownEpochNumber;
+  address[] public lastKnownElectedAccounts;
+
   /**
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
@@ -27,22 +30,32 @@ contract EpochManagerInitializer is Initializable, UsingPrecompiles, UsingRegist
   /**
    * @notice initializes the epochManager contract during L2 transition.
    */
-  function initEpochManager() external onlyOwner {
-    uint256 currentEpoch = getEpochNumber();
+  function initEpochManager() external onlyL2 {
+    require(lastKnownEpochNumber != 0, "lastKnownEpochNumber not set.");
+    require(lastKnownElectedAccounts.length > 0, "lastKnownElectedAccounts not set.");
+    getEpochManager().initializeSystem(
+      lastKnownEpochNumber,
+      _getFirstBlockOfEpoch(lastKnownEpochNumber),
+      lastKnownElectedAccounts
+    );
+  }
+
+  /**
+   * @notice Stores the last known epochNumber and the related elected validator accounts.
+   */
+  function captureEpochAndValidators() external onlyL1 {
+    lastKnownEpochNumber = getEpochNumber();
 
     uint256 numberElectedValidators = numberValidatorsInCurrentSet();
 
-    address[] memory electedValidatorAddresses = new address[](numberElectedValidators);
+    lastKnownElectedAccounts = new address[](numberElectedValidators);
 
     for (uint256 i = 0; i < numberElectedValidators; i++) {
-      address validatorAddress = validatorSignerAddressFromCurrentSet(i);
-      electedValidatorAddresses[i] = validatorAddress;
+      address validatorAccountAddress = getAccounts().validatorSignerToAccount(
+        validatorSignerAddressFromCurrentSet(i)
+      );
+      lastKnownElectedAccounts[i] = validatorAccountAddress;
     }
-    getEpochManager().initializeSystem(
-      currentEpoch,
-      _getFirstBlockOfEpoch(currentEpoch),
-      electedValidatorAddresses
-    );
   }
 
   function getFirstBlockOfEpoch(uint256 currentEpoch) external view returns (uint256) {


### PR DESCRIPTION
### Description

Split initEpochManager function into two separate permisionnless functions
### Tested

Not yet tested, as other PRs have boiler plate code pending to be merged. Created an [issue](https://github.com/celo-org/celo-blockchain-planning/issues/593) to track the test progress

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/591
- related: https://github.com/celo-org/celo-blockchain-planning/issues/575

