### PR TITLE
Reset pending payment to 0 after sending

### DIFF
--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -367,6 +367,7 @@ contract EpochManager is
     FixidityLib.Fraction memory totalPayment = FixidityLib.newFixed(
       validatorPendingPayments[signer]
     );
+    validatorPendingPayments[signer] = 0;
 
     IValidators validators = getValidators();
     address group = validators.getValidatorsGroup(validator);

--- a/packages/protocol/test-sol/unit/common/EpochManager.t.sol
+++ b/packages/protocol/test-sol/unit/common/EpochManager.t.sol
@@ -380,4 +380,15 @@ contract EpochManagerTest_sendValidatorPayment is EpochManagerTest {
     assertEq(beneficiaryBalanceAfter, 0);
     assertEq(epochManagerBalanceAfter, epochManagerBalanceBefore);
   }
+
+  function test_doesntAllowDoubleSending() public {
+    epochManager.sendValidatorPayment(validator1);
+    epochManager.sendValidatorPayment(validator1);
+
+    uint256 validatorBalanceAfter = stableToken.balanceOf(validator1);
+    uint256 epochManagerBalanceAfter = stableToken.balanceOf(address(epochManager));
+
+    assertEq(validatorBalanceAfter, paymentAmount);
+    assertEq(epochManagerBalanceAfter, epochManagerBalanceBefore - paymentAmount);
+  }
 }


### PR DESCRIPTION
### Description

Small but important change: need to reset the pending payments mapping value to 0 when sending the payment.

### Tested

Added a regression unit test.
