### PR TITLE
Send validator payment on actions that would modify reward distribution

### DIFF
--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -245,6 +245,60 @@ contract EpochManager is
     epochProcessing.status = EpochProcessStatus.NotStarted;
   }
 
+  /**
+   * @notice Sends the allocated epoch payment to a validator, their group, and
+   *   delegation beneficiary.
+   * @param validator Account of the validator.
+   */
+  function sendValidatorPayment(address validator) external {
+    IAccounts accounts = IAccounts(getAccounts());
+    address signer = accounts.getValidatorSigner(validator);
+
+    FixidityLib.Fraction memory totalPayment = FixidityLib.newFixed(
+      validatorPendingPayments[signer]
+    );
+    validatorPendingPayments[signer] = 0;
+
+    IValidators validators = getValidators();
+    address group = validators.getValidatorsGroup(validator);
+    (, uint256 commissionUnwrapped, , , , , ) = validators.getValidatorGroup(group);
+
+    uint256 groupPayment = totalPayment.multiply(FixidityLib.wrap(commissionUnwrapped)).fromFixed();
+    FixidityLib.Fraction memory remainingPayment = FixidityLib.newFixed(
+      totalPayment.fromFixed() - groupPayment
+    );
+    (address beneficiary, uint256 delegatedFraction) = getAccounts().getPaymentDelegation(
+      validator
+    );
+    uint256 delegatedPayment = remainingPayment
+      .multiply(FixidityLib.wrap(delegatedFraction))
+      .fromFixed();
+    uint256 validatorPayment = remainingPayment.fromFixed() - delegatedPayment;
+
+    IStableToken stableToken = IStableToken(getStableToken());
+
+    if (validatorPayment > 0) {
+      require(stableToken.transfer(validator, validatorPayment), "transfer failed to validator");
+    }
+
+    if (groupPayment > 0) {
+      require(stableToken.transfer(group, groupPayment), "transfer failed to validator group");
+    }
+
+    if (delegatedPayment > 0) {
+      require(stableToken.transfer(beneficiary, delegatedPayment), "transfer failed to delegatee");
+    }
+
+    emit ValidatorEpochPaymentDistributed(
+      validator,
+      validatorPayment,
+      group,
+      groupPayment,
+      beneficiary,
+      delegatedPayment
+    );
+  }
+
   /// returns the current epoch Info
   function getCurrentEpoch() external view returns (uint256, uint256, uint256, uint256) {
     Epoch storage _epoch = epochs[currentEpochNumber];
@@ -355,60 +409,6 @@ contract EpochManager is
     getCeloUnreleasedTreasure().release(
       registry.getAddressForOrDie(RESERVE_REGISTRY_ID),
       CELOequivalent
-    );
-  }
-
-  /**
-   * @notice Sends the allocated epoch payment to a validator, their group, and
-   *   delegation beneficiary.
-   * @param validator Account of the validator.
-   */
-  function sendValidatorPayment(address validator) external {
-    IAccounts accounts = IAccounts(getAccounts());
-    address signer = accounts.getValidatorSigner(validator);
-
-    FixidityLib.Fraction memory totalPayment = FixidityLib.newFixed(
-      validatorPendingPayments[signer]
-    );
-    validatorPendingPayments[signer] = 0;
-
-    IValidators validators = getValidators();
-    address group = validators.getValidatorsGroup(validator);
-    (, uint256 commissionUnwrapped, , , , , ) = validators.getValidatorGroup(group);
-
-    uint256 groupPayment = totalPayment.multiply(FixidityLib.wrap(commissionUnwrapped)).fromFixed();
-    FixidityLib.Fraction memory remainingPayment = FixidityLib.newFixed(
-      totalPayment.fromFixed() - groupPayment
-    );
-    (address beneficiary, uint256 delegatedFraction) = getAccounts().getPaymentDelegation(
-      validator
-    );
-    uint256 delegatedPayment = remainingPayment
-      .multiply(FixidityLib.wrap(delegatedFraction))
-      .fromFixed();
-    uint256 validatorPayment = remainingPayment.fromFixed() - delegatedPayment;
-
-    IStableToken stableToken = IStableToken(getStableToken());
-
-    if (validatorPayment > 0) {
-      require(stableToken.transfer(validator, validatorPayment), "transfer failed to validator");
-    }
-
-    if (groupPayment > 0) {
-      require(stableToken.transfer(group, groupPayment), "transfer failed to validator group");
-    }
-
-    if (delegatedPayment > 0) {
-      require(stableToken.transfer(beneficiary, delegatedPayment), "transfer failed to delegatee");
-    }
-
-    emit ValidatorEpochPaymentDistributed(
-      validator,
-      validatorPayment,
-      group,
-      groupPayment,
-      beneficiary,
-      delegatedPayment
     );
   }
 }

--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -270,7 +270,7 @@ contract EpochManager is
       .fromFixed();
     uint256 validatorPayment = remainingPayment.fromFixed() - delegatedPayment;
 
-    IStableToken stableToken = IStableToken(getStableToken());
+    IERC20 stableToken = IERC20(getStableToken());
 
     if (validatorPayment > 0) {
       require(stableToken.transfer(validator, validatorPayment), "transfer failed to validator");

--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -107,6 +107,11 @@ contract EpochManager is
    */
   constructor(bool test) public Initializable(test) {}
 
+  modifier onlySystemAlreadyInitialized() {
+    require(systemAlreadyInitialized(), "Epoch system not initialized");
+    _;
+  }
+
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.
    * @param registryAddress The address of the registry core smart contract.
@@ -154,8 +159,7 @@ contract EpochManager is
   /// start next epoch process.
   /// it freezes the epochrewards at the time of execution,
   /// and starts the distribution of the rewards.
-  function startNextEpochProcess() external nonReentrant {
-    require(systemAlreadyInitialized(), "Epoch system not initialized");
+  function startNextEpochProcess() external nonReentrant onlySystemAlreadyInitialized {
     require(isTimeForNextEpoch(), "Epoch is not ready to start");
     require(!isOnEpochProcess(), "Epoch process is already started");
     epochProcessing.status = EpochProcessStatus.Started;
@@ -248,7 +252,7 @@ contract EpochManager is
    *   delegation beneficiary.
    * @param validator Account of the validator.
    */
-  function sendValidatorPayment(address validator) external {
+  function sendValidatorPayment(address validator) external onlySystemAlreadyInitialized {
     FixidityLib.Fraction memory totalPayment = FixidityLib.newFixed(
       validatorPendingPayments[validator]
     );
@@ -301,8 +305,7 @@ contract EpochManager is
   }
 
   /// returns the current epoch number.
-  function getCurrentEpochNumber() external view returns (uint256) {
-    require(systemAlreadyInitialized(), "EpochManager system not yet initialized.");
+  function getCurrentEpochNumber() external view onlySystemAlreadyInitialized returns (uint256) {
     return currentEpochNumber;
   }
 

--- a/packages/protocol/contracts-0.8/common/mocks/MockAccounts.sol
+++ b/packages/protocol/contracts-0.8/common/mocks/MockAccounts.sol
@@ -16,6 +16,19 @@ contract MockAccounts {
   mapping(address => PaymentDelegation) delegations;
   mapping(address => address) accountToSigner;
 
+  function setValidatorSigner(address account, address signer) external {
+    accountToSigner[account] = signer;
+  }
+
+  function getValidatorSigner(address account) external returns (address) {
+    return accountToSigner[account];
+  }
+
+  function getPaymentDelegation(address account) external view returns (address, uint256) {
+    PaymentDelegation storage delegation = delegations[account];
+    return (delegation.beneficiary, delegation.fraction.unwrap());
+  }
+
   function setPaymentDelegationFor(
     address validator,
     address beneficiary,
@@ -26,18 +39,5 @@ contract MockAccounts {
 
   function deletePaymentDelegationFor(address validator) public {
     delete delegations[validator];
-  }
-
-  function getPaymentDelegation(address account) external view returns (address, uint256) {
-    PaymentDelegation storage delegation = delegations[account];
-    return (delegation.beneficiary, delegation.fraction.unwrap());
-  }
-
-  function setValidatorSigner(address account, address signer) external {
-    accountToSigner[account] = signer;
-  }
-
-  function getValidatorSigner(address account) external returns (address) {
-    return accountToSigner[account];
   }
 }

--- a/packages/protocol/contracts-0.8/common/test/MockEpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/test/MockEpochManager.sol
@@ -26,6 +26,8 @@ contract MockEpochManager is IEpochManager {
   bool initialized;
   mapping(uint256 => Epoch) private epochs;
 
+  event SendValidatorPaymentCalled(address validator);
+
   function setCurrentEpochNumber(uint256 _newEpochNumber) external {
     currentEpochNumber = _newEpochNumber;
   }
@@ -74,5 +76,9 @@ contract MockEpochManager is IEpochManager {
     returns (uint256, uint256, uint256, uint256, uint256)
   {
     return (0, 0, 0, 0, 0);
+  }
+
+  function sendValidatorPayment(address validator) public {
+    emit SendValidatorPaymentCalled(validator);
   }
 }

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -1498,6 +1498,17 @@ contract Validators is
     return true;
   }
 
+  function _sendValidatorPaymentIfNecessary(address validator) private {
+    getEpochManager().sendValidatorPayment(validator);
+  }
+
+  function _sendValidatorPaymentsIfNecessary(ValidatorGroup storage group) private {
+    address[] memory members = group.members.getKeys();
+    for (uint256 i = 0; i < members.length; i++) {
+      _sendValidatorPaymentIfNecessary(members[i]);
+    }
+  }
+
   /**
    * @notice Returns the epoch number.
    * @return Current epoch number.
@@ -1507,17 +1518,6 @@ contract Validators is
       return getEpochManager().getCurrentEpochNumber();
     } else {
       return getEpochNumber();
-    }
-  }
-
-  function _sendValidatorPaymentIfNecessary(address validator) private {
-    getEpochManager().sendValidatorPayment(validator);
-  }
-
-  function _sendValidatorPaymentsIfNecessary(ValidatorGroup storage group) private {
-    address[] memory members = group.members.getKeys();
-    for (uint256 i = 0; i < members.length; i++) {
-      _sendValidatorPaymentIfNecessary(members[i]);
     }
   }
 }

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -577,7 +577,6 @@ contract Validators is
    *   payments made to its members. Must be in the range [0, 1.0].
    */
   function setNextCommissionUpdate(uint256 commission) external {
-    allowOnlyL1();
     address account = getAccounts().validatorSignerToAccount(msg.sender);
     require(isValidatorGroup(account), "Not a validator group");
     ValidatorGroup storage group = groups[account];
@@ -593,7 +592,6 @@ contract Validators is
    * @notice Updates a validator group's commission based on the previously queued update
    */
   function updateCommission() external {
-    allowOnlyL1();
     address account = getAccounts().validatorSignerToAccount(msg.sender);
     require(isValidatorGroup(account), "Not a validator group");
     ValidatorGroup storage group = groups[account];

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -596,6 +596,8 @@ contract Validators is
     require(isValidatorGroup(account), "Not a validator group");
     ValidatorGroup storage group = groups[account];
 
+    _sendValidatorPayments(group);
+
     require(group.nextCommissionBlock != 0, "No commission update queued");
     require(group.nextCommissionBlock <= block.number, "Can't apply commission update yet");
 
@@ -1510,5 +1512,12 @@ contract Validators is
 
   function _sendValidatorPayment(address validator) private {
     getEpochManager().sendValidatorPayment(validator);
+  }
+
+  function _sendValidatorPayments(ValidatorGroup storage group) private {
+    address[] memory members = group.members.getKeys();
+    for (uint256 i = 0; i < members.length; i++) {
+      _sendValidatorPayment(members[i]);
+    }
   }
 }

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -19,7 +19,6 @@ import "../../contracts/common/libraries/ReentrancyGuard.sol";
 import "../common/interfaces/IStableToken.sol";
 
 import "../../contracts/common/interfaces/IAccounts.sol";
-import { console } from "forge-std/console.sol";
 
 /**
  * @title A contract for registering and electing Validator Groups and Validators.
@@ -1511,7 +1510,6 @@ contract Validators is
   }
 
   function _sendValidatorPaymentIfNecessary(address validator) private {
-    console.log("Is L2?", isL2());
     if (isL2()) {
       getEpochManager().sendValidatorPayment(validator);
     }

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -598,7 +598,7 @@ contract Validators is
     require(isValidatorGroup(account), "Not a validator group");
     ValidatorGroup storage group = groups[account];
 
-    _sendValidatorPaymentsIfNecessary(group);
+    _sendValidatorGroupPaymentsIfNecessary(group);
 
     require(group.nextCommissionBlock != 0, "No commission update queued");
     require(group.nextCommissionBlock <= block.number, "Can't apply commission update yet");
@@ -1513,10 +1513,12 @@ contract Validators is
   }
 
   function _sendValidatorPaymentIfNecessary(address validator) private {
-    getEpochManager().sendValidatorPayment(validator);
+    if (isL2()) {
+      getEpochManager().sendValidatorPayment(validator);
+    }
   }
 
-  function _sendValidatorPaymentsIfNecessary(ValidatorGroup storage group) private {
+  function _sendValidatorGroupPaymentsIfNecessary(ValidatorGroup storage group) private {
     address[] memory members = group.members.getKeys();
     for (uint256 i = 0; i < members.length; i++) {
       _sendValidatorPaymentIfNecessary(members[i]);

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -596,7 +596,7 @@ contract Validators is
     require(isValidatorGroup(account), "Not a validator group");
     ValidatorGroup storage group = groups[account];
 
-    _sendValidatorPayments(group);
+    _sendValidatorPaymentsIfNecessary(group);
 
     require(group.nextCommissionBlock != 0, "No commission update queued");
     require(group.nextCommissionBlock <= block.number, "Can't apply commission update yet");
@@ -1487,7 +1487,7 @@ contract Validators is
     Validator storage validator,
     address validatorAccount
   ) private returns (bool) {
-    _sendValidatorPayment(validatorAccount);
+    _sendValidatorPaymentIfNecessary(validatorAccount);
     address affiliation = validator.affiliation;
     ValidatorGroup storage group = groups[affiliation];
     if (group.members.contains(validatorAccount)) {
@@ -1510,14 +1510,14 @@ contract Validators is
     }
   }
 
-  function _sendValidatorPayment(address validator) private {
+  function _sendValidatorPaymentIfNecessary(address validator) private {
     getEpochManager().sendValidatorPayment(validator);
   }
 
-  function _sendValidatorPayments(ValidatorGroup storage group) private {
+  function _sendValidatorPaymentsIfNecessary(ValidatorGroup storage group) private {
     address[] memory members = group.members.getKeys();
     for (uint256 i = 0; i < members.length; i++) {
-      _sendValidatorPayment(members[i]);
+      _sendValidatorPaymentIfNecessary(members[i]);
     }
   }
 }

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -19,6 +19,7 @@ import "../../contracts/common/libraries/ReentrancyGuard.sol";
 import "../common/interfaces/IStableToken.sol";
 
 import "../../contracts/common/interfaces/IAccounts.sol";
+import { console } from "forge-std/console.sol";
 
 /**
  * @title A contract for registering and electing Validator Groups and Validators.
@@ -1513,6 +1514,7 @@ contract Validators is
   }
 
   function _sendValidatorPaymentIfNecessary(address validator) private {
+    console.log("Is L2?", isL2());
     if (isL2()) {
       getEpochManager().sendValidatorPayment(validator);
     }

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -1487,6 +1487,7 @@ contract Validators is
     Validator storage validator,
     address validatorAccount
   ) private returns (bool) {
+    _sendValidatorPayment(validatorAccount);
     address affiliation = validator.affiliation;
     ValidatorGroup storage group = groups[affiliation];
     if (group.members.contains(validatorAccount)) {
@@ -1507,5 +1508,9 @@ contract Validators is
     } else {
       return getEpochNumber();
     }
+  }
+
+  function _sendValidatorPayment(address validator) private {
+    getEpochManager().sendValidatorPayment(validator);
   }
 }

--- a/packages/protocol/contracts/common/interfaces/IEpochManager.sol
+++ b/packages/protocol/contracts/common/interfaces/IEpochManager.sol
@@ -22,4 +22,6 @@ interface IEpochManager {
     external
     view
     returns (uint256, uint256, uint256, uint256, uint256);
+
+  function sendValidatorPayment(address) external;
 }

--- a/packages/protocol/contracts/common/interfaces/IEpochManager.sol
+++ b/packages/protocol/contracts/common/interfaces/IEpochManager.sol
@@ -13,6 +13,7 @@ interface IEpochManager {
     address[] calldata lessers,
     address[] calldata greaters
   ) external;
+  function sendValidatorPayment(address) external;
   function getCurrentEpoch() external view returns (uint256, uint256, uint256, uint256);
   function getCurrentEpochNumber() external view returns (uint256);
   function getElected() external view returns (address[] memory);
@@ -22,6 +23,4 @@ interface IEpochManager {
     external
     view
     returns (uint256, uint256, uint256, uint256, uint256);
-
-  function sendValidatorPayment(address) external;
 }

--- a/packages/protocol/contracts/governance/test/MockValidators.sol
+++ b/packages/protocol/contracts/governance/test/MockValidators.sol
@@ -84,11 +84,11 @@ contract MockValidators is IValidators, IsL2Check {
   }
 
   function halveSlashingMultiplier(address) external {
-    allowOnlyL1();
+    allowOnlyL1(); // TODO remove
   }
 
   function forceDeaffiliateIfValidator(address validator) external {
-    allowOnlyL1();
+    allowOnlyL1(); // TODO remove
   }
 
   function getTopGroupValidators(address group, uint256 n) public view returns (address[] memory) {

--- a/packages/protocol/scripts/foundry/run_integration_tests_in_anvil.sh
+++ b/packages/protocol/scripts/foundry/run_integration_tests_in_anvil.sh
@@ -15,8 +15,6 @@ time FOUNDRY_PROFILE=devchain forge test \
 --match-path "test-sol/devchain/migration/*" \
 --fork-url $ANVIL_RPC_URL
 
-exit 1
-
 # Stop devchain
 echo "Stopping devchain..."
 source $PWD/scripts/foundry/stop_anvil.sh

--- a/packages/protocol/scripts/foundry/run_integration_tests_in_anvil.sh
+++ b/packages/protocol/scripts/foundry/run_integration_tests_in_anvil.sh
@@ -10,10 +10,12 @@ source $PWD/scripts/foundry/create_and_migrate_anvil_devchain.sh
 
 # Run integration tests
 echo "Running integration tests..."
-forge test \
+time FOUNDRY_PROFILE=devchain forge test \
 -vvv \
---match-contract RegistryIntegrationTest \
+--match-path "test-sol/devchain/migration/*" \
 --fork-url $ANVIL_RPC_URL
+
+exit 1
 
 # Stop devchain
 echo "Stopping devchain..."

--- a/packages/protocol/test-sol/devchain/e2e/common/EpochManager.t.sol
+++ b/packages/protocol/test-sol/devchain/e2e/common/EpochManager.t.sol
@@ -12,6 +12,16 @@ import "@test-sol/utils/ECDSAHelper08.sol";
 import "@openzeppelin/contracts8/utils/structs/EnumerableSet.sol";
 
 contract E2E_EpochManager is Test, Devchain, Utils08, ECDSAHelper08 {
+  struct VoterWithPK {
+    address voter;
+    uint256 privateKey;
+  }
+
+  struct GroupWithVotes {
+    address group;
+    uint256 votes;
+  }
+
   address epochManagerOwner;
   address epochManagerEnabler;
   address[] firstElected;
@@ -23,16 +33,6 @@ contract E2E_EpochManager is Test, Devchain, Utils08, ECDSAHelper08 {
 
   uint256[] groupScore = [5e23, 7e23, 1e24];
   uint256[] validatorScore = [1e23, 1e23, 1e23, 1e23, 1e23, 1e23];
-
-  struct VoterWithPK {
-    address voter;
-    uint256 privateKey;
-  }
-
-  struct GroupWithVotes {
-    address group;
-    uint256 votes;
-  }
 
   mapping(address => uint256) addressToPrivateKeys;
   mapping(address => VoterWithPK) validatorToVoter;

--- a/packages/protocol/test-sol/devchain/migration/IntegrationValidators.t.sol
+++ b/packages/protocol/test-sol/devchain/migration/IntegrationValidators.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.7 <0.8.20;
+
+import "celo-foundry-8/Test.sol";
+import { Devchain } from "@test-sol/devchain/e2e/utils.sol";
+
+contract IntegrationsValidators is Test, Devchain {
+  function test_deaffiliateWorskWithEpochManager() public {
+    // address of an allowed validator
+    vm.prank(address(0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65));
+    validators.deaffiliate();
+  }
+}

--- a/packages/protocol/test-sol/devchain/migration/IntegrationValidators.t.sol
+++ b/packages/protocol/test-sol/devchain/migration/IntegrationValidators.t.sol
@@ -6,8 +6,7 @@ import { Devchain } from "@test-sol/devchain/e2e/utils.sol";
 
 contract IntegrationsValidators is Test, Devchain {
   function test_deaffiliateWorskWithEpochManager() public {
-    // address of an allowed validator
-    vm.prank(address(0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65));
+    vm.prank(election.electValidatorAccounts()[0]);
     validators.deaffiliate();
   }
 }

--- a/packages/protocol/test-sol/unit/common/EpochManager.t.sol
+++ b/packages/protocol/test-sol/unit/common/EpochManager.t.sol
@@ -288,6 +288,9 @@ contract EpochManagerTest_sendValidatorPayment is EpochManagerTest {
     members[1] = validator2;
     mockValidators.setMembers(group, members);
 
+    vm.prank(epochManagerEnabler);
+    epochManager.initializeSystem(firstEpochNumber, firstEpochBlock, firstElected);
+
     stableToken.mint(address(epochManager), paymentAmount * 2);
     epochManagerBalanceBefore = stableToken.balanceOf(address(epochManager));
     epochManager._setPaymentAllocation(validator1, paymentAmount);

--- a/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
@@ -1383,7 +1383,7 @@ contract ValidatorsTest_Affiliate_WhenValidatorIsAlreadyAffiliatedWithValidatorG
     assertTrue(election.isIneligible(group));
   }
 
-  function test_ShouldSendValidatorPayment_WhenUnclaimed_WhenL2() public {
+  function test_ShouldSendValidatorPayment() public {
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.prank(validator);
@@ -1515,7 +1515,7 @@ contract ValidatorsTest_Deaffiliate is ValidatorsTest {
     assertTrue(election.isIneligible(group));
   }
 
-  function test_ShouldSendValidatorPayment_WhenUnclaimed_WhenL2() public {
+  function test_ShouldSendValidatorPayment() public {
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.prank(validator);
@@ -2595,7 +2595,7 @@ contract ValidatorsTest_UpdateCommission is ValidatorsTest {
     validators.updateCommission();
   }
 
-  function test_ShouldSendMultipleValidatorPayments_WhenUnclaimed_WhenL2() public {
+  function test_ShouldSendMultipleValidatorPayments() public {
     vm.prank(group);
     validators.addFirstMember(validator, address(0), address(0));
     vm.prank(group);
@@ -3537,7 +3537,7 @@ contract ValidatorsTest_ForceDeaffiliateIfValidator is ValidatorsTest {
     validators.forceDeaffiliateIfValidator(validator);
   }
 
-  function test_ShouldSendValidatorPayment_WhenUnclaimed_WhenL2() public {
+  function test_ShouldSendValidatorPayment() public {
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.prank(paymentDelegatee);

--- a/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
@@ -2481,13 +2481,6 @@ contract ValidatorsTest_SetNextCommissionUpdate is ValidatorsTest {
     assertEq(_commission, commission.unwrap());
   }
 
-  function test_Reverts_SetValidatorGroupCommission_WhenL2() public {
-    _whenL2();
-    vm.prank(group);
-    vm.expectRevert("This method is no longer supported in L2.");
-    validators.setNextCommissionUpdate(newCommission);
-  }
-
   function test_ShouldSetValidatorGroupNextCommission() public {
     vm.prank(group);
     validators.setNextCommissionUpdate(newCommission);
@@ -2543,13 +2536,6 @@ contract ValidatorsTest_UpdateCommission is ValidatorsTest {
     (, uint256 _commission, , , , , ) = validators.getValidatorGroup(group);
 
     assertEq(_commission, newCommission);
-  }
-
-  function test_Reverts_SetValidatorGroupCommission_WhenL2() public {
-    _whenL2();
-    vm.prank(group);
-    vm.expectRevert("This method is no longer supported in L2.");
-    validators.setNextCommissionUpdate(newCommission);
   }
 
   function test_Emits_ValidatorGroupCommissionUpdated() public {

--- a/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
@@ -138,6 +138,8 @@ contract ValidatorsTest is Test, TestConstants, Utils, ECDSAHelper {
     uint256 groupPayment
   );
 
+  event SendValidatorPaymentCalled(address validator);
+
   function setUp() public {
     owner = address(this);
     group = actor("group");
@@ -1380,6 +1382,13 @@ contract ValidatorsTest_Affiliate_WhenValidatorIsAlreadyAffiliatedWithValidatorG
 
     assertTrue(election.isIneligible(group));
   }
+
+  function test_ShouldSendValidatorPayment_WhenUnclaimed_WhenL2() public {
+    vm.expectEmit(true, true, true, true);
+    emit SendValidatorPaymentCalled(validator);
+    vm.prank(validator);
+    validators.affiliate(group);
+  }
 }
 
 contract ValidatorsTest_Deaffiliate is ValidatorsTest {
@@ -1504,6 +1513,13 @@ contract ValidatorsTest_Deaffiliate is ValidatorsTest {
     vm.prank(validator);
     validators.deaffiliate();
     assertTrue(election.isIneligible(group));
+  }
+
+  function test_ShouldSendValidatorPayment_WhenUnclaimed_WhenL2() public {
+    vm.expectEmit(true, true, true, true);
+    emit SendValidatorPaymentCalled(validator);
+    vm.prank(validator);
+    validators.deaffiliate();
   }
 }
 
@@ -3501,6 +3517,13 @@ contract ValidatorsTest_ForceDeaffiliateIfValidator is ValidatorsTest {
 
   function test_Reverts_WhenSenderNotApprovedAddress() public {
     vm.expectRevert("Only registered slasher can call");
+    validators.forceDeaffiliateIfValidator(validator);
+  }
+
+  function test_ShouldSendValidatorPayment_WhenUnclaimed_WhenL2() public {
+    vm.expectEmit(true, true, true, true);
+    emit SendValidatorPaymentCalled(validator);
+    vm.prank(paymentDelegatee);
     validators.forceDeaffiliateIfValidator(validator);
   }
 }

--- a/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
@@ -2596,16 +2596,10 @@ contract ValidatorsTest_UpdateCommission is ValidatorsTest {
   }
 
   function test_ShouldSendMultipleValidatorPayments_WhenUnclaimed_WhenL2() public {
-    vm.startPrank(group);
+    vm.prank(group);
     validators.addFirstMember(validator, address(0), address(0));
+    vm.prank(group);
     validators.addMember(otherValidator);
-    vm.stopPrank();
-
-    address[] memory members = validators.getTopGroupValidators(group, 2);
-    for (uint i = 0; i < members.length; i++) {
-      console2.log("member", i);
-      console2.log(members[i]);
-    }
     vm.prank(group);
     validators.setNextCommissionUpdate(newCommission);
     blockTravel(commissionUpdateDelay);

--- a/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
@@ -1429,7 +1429,16 @@ contract ValidatorsTest_Affiliate_WhenValidatorIsAlreadyAffiliatedWithValidatorG
     assertTrue(election.isIneligible(group));
   }
 
-  function test_ShouldSendValidatorPayment() public {
+  function test_ShouldNotTryToSendValidatorPayment() public {
+    vm.prank(validator);
+    validators.affiliate(group);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    assertEq(entries.length, 0);
+  }
+
+  function test_ShouldSendValidatorPayment_WhenL2() public {
+    _whenL2();
+    // assertTrue(validators.isL2());
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.prank(validator);

--- a/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
@@ -1415,7 +1415,7 @@ contract ValidatorsTest_Affiliate_WhenValidatorIsAlreadyAffiliatedWithValidatorG
     assertTrue(election.isIneligible(group));
   }
 
-  function test_ShouldNotTryToSendValidatorPayment() public {
+  function test_ShouldNotTryToSendValidatorPayment_WhenL1() public {
     vm.prank(validator);
     validators.affiliate(group);
     Vm.Log[] memory entries = vm.getRecordedLogs();
@@ -1424,7 +1424,6 @@ contract ValidatorsTest_Affiliate_WhenValidatorIsAlreadyAffiliatedWithValidatorG
 
   function test_ShouldSendValidatorPayment_WhenL2() public {
     _whenL2();
-    // assertTrue(validators.isL2());
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.prank(validator);
@@ -1556,7 +1555,15 @@ contract ValidatorsTest_Deaffiliate is ValidatorsTest {
     assertTrue(election.isIneligible(group));
   }
 
-  function test_ShouldSendValidatorPayment() public {
+  function test_ShouldNotTryToSendValidatorPayment_WhenL1() public {
+    vm.prank(validator);
+    validators.affiliate(group);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    assertEq(entries.length, 0);
+  }
+
+  function test_ShouldSendValidatorPayment_WhenL2() public {
+    _whenL2();
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.prank(validator);
@@ -2626,7 +2633,14 @@ contract ValidatorsTest_UpdateCommission is ValidatorsTest {
     validators.updateCommission();
   }
 
-  function test_ShouldSendMultipleValidatorPayments() public {
+  function test_ShouldNotTryTodSendMultipleValidatorPayments_WhenL1() public {
+    vm.prank(validator);
+    validators.affiliate(group);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    assertEq(entries.length, 0);
+  }
+
+  function test_ShouldSendMultipleValidatorPayments_WhenL2() public {
     vm.prank(group);
     validators.addFirstMember(validator, address(0), address(0));
     vm.prank(group);
@@ -2635,6 +2649,7 @@ contract ValidatorsTest_UpdateCommission is ValidatorsTest {
     validators.setNextCommissionUpdate(newCommission);
     blockTravel(commissionUpdateDelay);
 
+    _whenL2();
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.expectEmit(true, true, true, true);
@@ -3611,7 +3626,15 @@ contract ValidatorsTest_ForceDeaffiliateIfValidator is ValidatorsTest {
     validators.forceDeaffiliateIfValidator(validator);
   }
 
-  function test_ShouldSendValidatorPayment() public {
+  function test_ShouldNotTryToSendValidatorPayment_WhenL1() public {
+    vm.prank(validator);
+    validators.affiliate(group);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    assertEq(entries.length, 0);
+  }
+
+  function test_ShouldSendValidatorPayment_WhenL2() public {
+    _whenL2();
     vm.expectEmit(true, true, true, true);
     emit SendValidatorPaymentCalled(validator);
     vm.prank(paymentDelegatee);


### PR DESCRIPTION
### Description

Some functions would modify the amount or payment split in `EpochManager.sendValidatorPayment`. This PR adds a call to `sendValidatorPayment` before such modifications occur to ensure the payment split is deterministic after epoch processing.

The functions are:
* `Validators._deaffiliate` (called by `affiliate`, `deaffiliate`, and `forceDeaffiliateIfValidator`), which would change the group the validator is associated with, thus the group that would receive the group portion of the payment
* `Validators.updateCommission`, which would change the split between validators and group. 
* `Accounts.setPaymentDelegation`, which would change the split between validator and beneficiary (and/or who the beneficiary is). However, since this is a voluntary payment from the validator, the protocol does not need to ensure this stays the same, so we can choose not to use this mechanism here.

TODO:
- [x] Do this for `Validators.setPaymentDelegation`

### Other changes

- Removed `allowOnlyL1` from a few functions
- Function ordering for linter

### Tested

Unit tests.

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/552