### PR TITLE
Epoch manager enabler tests

### DIFF
--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -128,11 +128,6 @@ contract EpochManager is
       address(registry.getAddressForOrDie(CELO_UNRELEASED_TREASURE_REGISTRY_ID)).balance > 0,
       "CeloUnreleasedTreasury not yet funded."
     );
-    require(
-      getCeloToken().balanceOf(registry.getAddressForOrDie(CELO_UNRELEASED_TREASURE_REGISTRY_ID)) >
-        0,
-      "CeloUnreleasedTreasury not yet funded."
-    );
     require(!systemAlreadyInitialized(), "Epoch system already initialized");
     require(firstEpochNumber > 0, "First epoch number must be greater than 0");
     require(firstEpochBlock > 0, "First epoch block must be greater than 0");

--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -125,7 +125,8 @@ contract EpochManager is
     address[] memory firstElected
   ) external onlyEpochManagerEnabler {
     require(
-      address(registry.getAddressForOrDie(CELO_UNRELEASED_TREASURE_REGISTRY_ID)).balance > 0,
+      getCeloToken().balanceOf(registry.getAddressForOrDie(CELO_UNRELEASED_TREASURE_REGISTRY_ID)) >
+        0,
       "CeloUnreleasedTreasury not yet funded."
     );
     require(!systemAlreadyInitialized(), "Epoch system already initialized");

--- a/packages/protocol/contracts-0.8/common/EpochManagerEnabler.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManagerEnabler.sol
@@ -67,6 +67,13 @@ contract EpochManagerEnabler is Initializable, UsingPrecompiles, UsingRegistry {
   }
 
   /**
+   * @return a list of know elected validator accounts.
+   */
+  function getlastKnownElectedAccounts() external view returns (address[] memory) {
+    return lastKnownElectedAccounts;
+  }
+
+  /**
    * @notice Returns the storage, major, minor, and patch version of the contract.
    * @return Storage version of the contract.
    * @return Major version of the contract.

--- a/packages/protocol/contracts-0.8/common/UsingPrecompiles.sol
+++ b/packages/protocol/contracts-0.8/common/UsingPrecompiles.sol
@@ -89,7 +89,9 @@ contract UsingPrecompiles is IsL2Check {
    * @param index Index of requested validator in the validator set.
    * @return Address of validator at the requested index.
    */
-  function validatorSignerAddressFromCurrentSet(uint256 index) public view returns (address) {
+  function validatorSignerAddressFromCurrentSet(
+    uint256 index
+  ) public view virtual returns (address) {
     bytes memory out;
     bool success;
     (success, out) = GET_VALIDATOR.staticcall(abi.encodePacked(index, uint256(block.number)));
@@ -118,7 +120,7 @@ contract UsingPrecompiles is IsL2Check {
    * @notice Gets the size of the current elected validator set.
    * @return Size of the current elected validator set.
    */
-  function numberValidatorsInCurrentSet() public view returns (uint256) {
+  function numberValidatorsInCurrentSet() public view virtual returns (uint256) {
     bytes memory out;
     bool success;
     (success, out) = NUMBER_VALIDATORS.staticcall(abi.encodePacked(uint256(block.number)));
@@ -131,7 +133,7 @@ contract UsingPrecompiles is IsL2Check {
    * @param blockNumber Block number to retrieve the validator set from.
    * @return Size of the validator set.
    */
-  function numberValidatorsInSet(uint256 blockNumber) public view returns (uint256) {
+  function numberValidatorsInSet(uint256 blockNumber) public view virtual returns (uint256) {
     bytes memory out;
     bool success;
     (success, out) = NUMBER_VALIDATORS.staticcall(abi.encodePacked(blockNumber));

--- a/packages/protocol/contracts-0.8/common/test/MockCeloToken.sol
+++ b/packages/protocol/contracts-0.8/common/test/MockCeloToken.sol
@@ -9,19 +9,6 @@ contract MockCeloToken08 {
   uint8 public constant decimals = 18;
   mapping(address => uint256) balances;
 
-  uint256 constant L1_MINTED_CELO_SUPPLY = 692702432463315819704447326; // as of May 15 2024
-
-  uint256 constant CELO_SUPPLY_CAP = 1000000000 ether; // 1 billion Celo
-  uint256 constant GENESIS_CELO_SUPPLY = 600000000 ether; // 600 million Celo
-
-  uint256 constant FIFTEEN_YEAR_LINEAR_REWARD = (CELO_SUPPLY_CAP - GENESIS_CELO_SUPPLY) / 2; // 200 million Celo
-
-  uint256 constant FIFTEEN_YEAR_CELO_SUPPLY = GENESIS_CELO_SUPPLY + FIFTEEN_YEAR_LINEAR_REWARD; // 800 million Celo (includes GENESIS_CELO_SUPPLY)
-
-  uint256 constant MAX_L2_DISTRIBUTION = FIFTEEN_YEAR_CELO_SUPPLY - L1_MINTED_CELO_SUPPLY; // 107.2 million Celo
-
-  uint256 constant L2_INITIAL_STASH_BALANCE = FIFTEEN_YEAR_LINEAR_REWARD + MAX_L2_DISTRIBUTION; // leftover from L1 target supply plus the 2nd 15 year term.
-
   function setTotalSupply(uint256 value) external {
     totalSupply_ = value;
   }

--- a/packages/protocol/test-sol/mocks/EpochManagerEnablerMock.sol
+++ b/packages/protocol/test-sol/mocks/EpochManagerEnablerMock.sol
@@ -8,6 +8,10 @@ import "../../contracts-0.8/common/EpochManagerEnabler.sol";
 contract EpochManagerEnablerMock is EpochManagerEnabler(true) {
   address[] validatorSet;
 
+  function setFirstBlockOfEpoch() external {
+    return _setFirstBlockOfEpoch();
+  }
+
   function addValidator(address validator) external {
     validatorSet.push(validator);
   }

--- a/packages/protocol/test-sol/mocks/EpochManagerEnablerMock.sol
+++ b/packages/protocol/test-sol/mocks/EpochManagerEnablerMock.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.8.0;
+
+import "../../contracts-0.8/common/EpochManagerEnabler.sol";
+
+/**
+ * @title A wrapper around EpochManagerEnabler that exposes internal functions for testing.
+ */
+contract EpochManagerEnablerMock is EpochManagerEnabler(true) {
+  address[] validatorSet;
+
+  function addValidator(address validator) external {
+    validatorSet.push(validator);
+  }
+
+  // Minimally override core functions from UsingPrecompiles
+  function numberValidatorsInCurrentSet() public view override returns (uint256) {
+    return validatorSet.length;
+  }
+
+  function numberValidatorsInSet(uint256) public view override returns (uint256) {
+    return validatorSet.length;
+  }
+
+  function validatorSignerAddressFromCurrentSet(
+    uint256 index
+  ) public view override returns (address) {
+    return validatorSet[index];
+  }
+}

--- a/packages/protocol/test-sol/unit/common/EpochManagerEnabler.t.sol
+++ b/packages/protocol/test-sol/unit/common/EpochManagerEnabler.t.sol
@@ -97,8 +97,6 @@ contract EpochManagerEnablerTest_initialize is EpochManagerEnablerTest {
 
 contract EpochManagerEnablerTest_initEpochManager is EpochManagerEnablerTest {
   function test_CanBeCalledByAnyone() public {
-    travelEpochL1(vm);
-    travelEpochL1(vm);
     epochManagerEnabler.captureEpochAndValidators();
 
     whenL2(vm);
@@ -125,38 +123,33 @@ contract EpochManagerEnablerTest_initEpochManager is EpochManagerEnablerTest {
 
 contract EpochManagerEnablerTest_captureEpochAndValidators is EpochManagerEnablerTest {
   function test_Reverts_whenL2() public {
-    travelEpochL1(vm);
     whenL2(vm);
     vm.expectRevert("This method is no longer supported in L2.");
     epochManagerEnabler.captureEpochAndValidators();
   }
 
   function test_shouldSetLastKnownElectedAccounts() public {
-    travelEpochL1(vm);
     epochManagerEnabler.captureEpochAndValidators();
 
     assertEq(epochManagerEnabler.getlastKnownElectedAccounts().length, numberValidators);
   }
 
   function test_shouldSetLastKnownEpochNumber() public {
-    travelEpochL1(vm);
     epochManagerEnabler.captureEpochAndValidators();
 
-    assertEq(epochManagerEnabler.lastKnownEpochNumber(), 4);
+    assertEq(epochManagerEnabler.lastKnownEpochNumber(), 3);
   }
 
   function test_shouldSetLastKnownFirstBlockOfEpoch() public {
-    travelEpochL1(vm);
     epochManagerEnabler.captureEpochAndValidators();
 
-    assertEq(epochManagerEnabler.lastKnownFirstBlockOfEpoch(), 17280 * 3);
+    assertEq(epochManagerEnabler.lastKnownFirstBlockOfEpoch(), 17280 * 2);
   }
 
   function test_Emits_LastKnownEpochNumberSet() public {
     vm.expectEmit(true, true, true, true);
-    emit LastKnownEpochNumberSet(4);
+    emit LastKnownEpochNumberSet(3);
 
-    travelEpochL1(vm);
     epochManagerEnabler.captureEpochAndValidators();
   }
 
@@ -164,15 +157,13 @@ contract EpochManagerEnablerTest_captureEpochAndValidators is EpochManagerEnable
     vm.expectEmit(true, true, true, true);
     emit LastKnownElectedAccountsSet();
 
-    travelEpochL1(vm);
     epochManagerEnabler.captureEpochAndValidators();
   }
 
   function test_Emits_LastKnownFirstBlockOfEpochSet() public {
     vm.expectEmit(true, true, true, true);
-    emit LastKnownFirstBlockOfEpochSet(51840);
+    emit LastKnownFirstBlockOfEpochSet(34560);
 
-    travelEpochL1(vm);
     epochManagerEnabler.captureEpochAndValidators();
   }
 }

--- a/packages/protocol/test-sol/unit/common/EpochManagerEnabler.t.sol
+++ b/packages/protocol/test-sol/unit/common/EpochManagerEnabler.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.5.13 <0.8.20;
+pragma solidity >=0.8.0 <0.8.20;
 
 import "celo-foundry-8/Test.sol";
 import "@celo-contracts-8/common/EpochManager.sol";
@@ -37,7 +37,6 @@ contract EpochManagerEnablerTest is Test, TestConstants, Utils08 {
     epochManager = new EpochManager(true);
     epochManagerEnabler = new EpochManagerEnablerMock();
 
-    // celoToken = new MockCeloToken08();
     celoUnreleasedTreasure = new MockCeloUnreleasedTreasure();
 
     accountsAddress = actor("accountsAddress");
@@ -56,9 +55,7 @@ contract EpochManagerEnablerTest is Test, TestConstants, Utils08 {
 
     registry.setAddressFor(CeloUnreleasedTreasureContract, address(celoUnreleasedTreasure));
 
-    // celoToken.setTotalSupply(CELO_SUPPLY_CAP);
     vm.deal(address(celoUnreleasedTreasure), L2_INITIAL_STASH_BALANCE);
-    // celoToken.setBalanceOf(address(celoUnreleasedTreasure), L2_INITIAL_STASH_BALANCE);
 
     epochManagerEnabler.initialize(REGISTRY_ADDRESS);
     epochManager.initialize(REGISTRY_ADDRESS, epochDuration);

--- a/packages/protocol/test-sol/unit/common/EpochManagerEnabler.t.sol
+++ b/packages/protocol/test-sol/unit/common/EpochManagerEnabler.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.5.13 <0.8.20;
+
+import "celo-foundry-8/Test.sol";
+import "@celo-contracts-8/common/EpochManager.sol";
+
+import { EpochManagerEnablerMock } from "@test-sol/mocks/EpochManagerEnablerMock.sol";
+
+import { CeloUnreleasedTreasure } from "@celo-contracts-8/common/CeloUnreleasedTreasure.sol";
+import { ICeloUnreleasedTreasure } from "@celo-contracts/common/interfaces/ICeloUnreleasedTreasure.sol";
+import { IAccounts } from "@celo-contracts/common/interfaces/IAccounts.sol";
+
+import { TestConstants } from "@test-sol/constants.sol";
+import { Utils08 } from "@test-sol/utils08.sol";
+
+import "@celo-contracts/common/interfaces/IRegistry.sol";
+
+import { EpochRewardsMock08 } from "@celo-contracts-8/governance/test/EpochRewardsMock.sol";
+import { ValidatorsMock } from "@test-sol/unit/governance/validators/mocks/ValidatorsMock.sol";
+import { MockCeloUnreleasedTreasure } from "@celo-contracts-8/common/test/MockCeloUnreleasedTreasure.sol";
+
+contract EpochManagerEnablerTest is Test, TestConstants, Utils08 {
+  EpochManager epochManager;
+  EpochManagerEnablerMock epochManagerEnabler;
+  MockCeloUnreleasedTreasure celoUnreleasedTreasure;
+
+  IRegistry registry;
+  IAccounts accounts;
+
+  address accountsAddress;
+  address nonOwner;
+
+  uint256 epochDuration = DAY;
+  uint256 numberValidators = 100;
+
+  function setUp() public virtual {
+    epochManager = new EpochManager(true);
+    epochManagerEnabler = new EpochManagerEnablerMock();
+
+    // celoToken = new MockCeloToken08();
+    celoUnreleasedTreasure = new MockCeloUnreleasedTreasure();
+
+    accountsAddress = actor("accountsAddress");
+
+    nonOwner = actor("nonOwner");
+
+    deployCodeTo("MockRegistry.sol", abi.encode(false), REGISTRY_ADDRESS);
+    deployCodeTo("Accounts.sol", abi.encode(false), accountsAddress);
+
+    registry = IRegistry(REGISTRY_ADDRESS);
+    accounts = IAccounts(accountsAddress);
+
+    registry.setAddressFor(EpochManagerContract, address(epochManager));
+    registry.setAddressFor(EpochManagerEnablerContract, address(epochManagerEnabler));
+    registry.setAddressFor(AccountsContract, address(accounts));
+
+    registry.setAddressFor(CeloUnreleasedTreasureContract, address(celoUnreleasedTreasure));
+
+    // celoToken.setTotalSupply(CELO_SUPPLY_CAP);
+    vm.deal(address(celoUnreleasedTreasure), L2_INITIAL_STASH_BALANCE);
+    // celoToken.setBalanceOf(address(celoUnreleasedTreasure), L2_INITIAL_STASH_BALANCE);
+
+    epochManagerEnabler.initialize(REGISTRY_ADDRESS);
+    epochManager.initialize(REGISTRY_ADDRESS, epochDuration);
+
+    _setupValidators();
+    travelEpochL1(vm);
+    travelEpochL1(vm);
+  }
+
+  function _setupValidators() internal {
+    for (uint256 i = 0; i < numberValidators; i++) {
+      vm.prank(vm.addr(i + 1));
+      accounts.createAccount();
+
+      epochManagerEnabler.addValidator(vm.addr(i + 1));
+    }
+  }
+}
+
+contract EpochManagerEnablerTest_initialize is EpochManagerEnablerTest {
+  function test_initialize() public {
+    assertEq(address(epochManagerEnabler.registry()), REGISTRY_ADDRESS);
+  }
+
+  function test_Reverts_WhenAlreadyInitialized() public virtual {
+    vm.expectRevert("contract already initialized");
+    epochManagerEnabler.initialize(REGISTRY_ADDRESS);
+  }
+}
+
+contract EpochManagerEnablerTest_initEpochManager is EpochManagerEnablerTest {
+  function test_CanBeCalledByAnyone() public {
+    travelEpochL1(vm);
+    travelEpochL1(vm);
+    epochManagerEnabler.captureEpochAndValidators();
+
+    whenL2(vm);
+    vm.prank(nonOwner);
+    epochManagerEnabler.initEpochManager();
+
+    assertGt(epochManager.getElected().length, 0);
+    assertTrue(epochManager.systemAlreadyInitialized());
+  }
+
+  function test_Reverts_ifEpochAndValidatorsAreNotCaptured() public {
+    whenL2(vm);
+    vm.expectRevert("lastKnownEpochNumber not set.");
+
+    epochManagerEnabler.initEpochManager();
+  }
+
+  function test_Reverts_whenL1() public {
+    vm.expectRevert("This method is not supported in L1.");
+
+    epochManagerEnabler.initEpochManager();
+  }
+}
+
+contract EpochManagerEnablerTest_captureEpochAndValidators is EpochManagerEnablerTest {
+  function test_Reverts_whenL2() public {
+    travelEpochL1(vm);
+    whenL2(vm);
+    vm.expectRevert("This method is no longer supported in L2.");
+    epochManagerEnabler.captureEpochAndValidators();
+  }
+
+  function test_shouldSetLastKnownElectedAccounts() public {
+    travelEpochL1(vm);
+    epochManagerEnabler.captureEpochAndValidators();
+
+    assertEq(epochManagerEnabler.getlastKnownElectedAccounts().length, numberValidators);
+  }
+
+  function test_shouldSetLastKnownEpochNumber() public {
+    travelEpochL1(vm);
+    epochManagerEnabler.captureEpochAndValidators();
+
+    assertEq(epochManagerEnabler.lastKnownEpochNumber(), 4);
+  }
+
+  function test_shouldSetLastKnownFirstBlockOfEpoch() public {
+    travelEpochL1(vm);
+    epochManagerEnabler.captureEpochAndValidators();
+
+    assertEq(epochManagerEnabler.lastKnownFirstBlockOfEpoch(), 17280 * 3);
+  }
+}


### PR DESCRIPTION
### Description

Added basic unit test for epochManagerEnabler contract

### Other changes

removed extra native token balance check in `initializeSystem` of epochManager contract.

### Tested

unit tested

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/593

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_