### PR TITLE
Make sendValidatorPayment nonReentrant

### DIFF
--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -248,7 +248,7 @@ contract EpochManager is
    *   delegation beneficiary.
    * @param validator Account of the validator.
    */
-  function sendValidatorPayment(address validator) external {
+  function sendValidatorPayment(address validator) external nonReentrant {
     IAccounts accounts = IAccounts(getAccounts());
     address signer = accounts.getValidatorSigner(validator);
 


### PR DESCRIPTION
### Description

Adds reentrancy guard to `sendValidatorPayment`.


### Tested

Tests still pass.

### Related issues

Addresses @martinvol's comment [here](https://github.com/celo-org/celo-monorepo/pull/11189#discussion_r1765511618).