### PR TITLE
Bring back some functions removed since CR11

### DIFF
--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -894,6 +894,14 @@ contract Validators is
   }
 
   /**
+   * @notice Returns the maximum number of members a group can add.
+   * @return The maximum number of members a group can add.
+   */
+  function getMaxGroupSize() external view returns (uint256) {
+    return maxGroupSize;
+  }
+
+  /**
    * @notice Returns the block delay for a ValidatorGroup's commission udpdate.
    * @return The block delay for a ValidatorGroup's commission udpdate.
    */

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -782,6 +782,19 @@ contract Validators is
   }
 
   /**
+   * @notice Returns the list of signers for the registered validator accounts.
+   * @return The list of signers for registered validator accounts.
+   */
+  function getRegisteredValidatorSigners() external view returns (address[] memory) {
+    IAccounts accounts = getAccounts();
+    address[] memory signers = new address[](registeredValidators.length);
+    for (uint256 i = 0; i < signers.length; i = i.add(1)) {
+      signers[i] = accounts.getValidatorSigner(registeredValidators[i]);
+    }
+    return signers;
+  }
+
+  /**
    * @notice Returns the list of registered validator accounts.
    * @return The list of registered validator accounts.
    */

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -1028,7 +1028,7 @@ contract Governance is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 5, 0, 0);
+    return (1, 4, 2, 0);
   }
 
   /**

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -1315,6 +1315,19 @@ contract Governance is
   }
 
   /**
+   * @notice Gets information about a L1 hotfix.
+   * @param hash The abi encoded keccak256 hash of the hotfix transaction.
+   * @return Hotfix approved.
+   * @return Hotfix executed.
+   * @return Hotfix preparedEpoch.
+   * @dev Provided for API backwards compatibility. Prefer the explicitly named
+   * `getL1HotfixRecord`/`getL2HotfixRecord` functions.
+   */
+  function getHotfixRecord(bytes32 hash) public view returns (bool, bool, uint256) {
+    return getL1HotfixRecord(hash);
+  }
+
+  /**
    * @notice Gets information about a L2 hotfix.
    * @param hash The abi encoded keccak256 hash of the hotfix transaction.
    * @return Hotfix approved by approver.


### PR DESCRIPTION
### Description

Some functions were removed unnecessarily since CR12, this PR brings them back.

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/652/