### PR TITLE
Deprecate unnecessary public variables in L2

### DIFF
--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -112,7 +112,7 @@ contract GasPriceMinimum is
    * @param tokenAddress The currency the gas price should be in (defaults to Celo).
    * @return current gas price minimum in the requested currency
    */
-  function getGasPriceMinimum(address tokenAddress) external view returns (uint256) {
+  function getGasPriceMinimum(address tokenAddress) external view onlyL1 returns (uint256) {
     return Math.max(_getGasPriceMinimum(tokenAddress), ABSOLUTE_MINIMAL_GAS_PRICE);
   }
   /**

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -35,7 +35,7 @@ contract GasPriceMinimum is
   // Speed of gas price minimum adjustment due to congestion.
   FixidityLib.Fraction private deprecated_adjustmentSpeed;
 
-  uint256 public baseFeeOpCodeActivationBlock;
+  uint256 private deprecated_baseFeeOpCodeActivationBlock;
   uint256 public constant ABSOLUTE_MINIMAL_GAS_PRICE = 1;
 
   event TargetDensitySet(uint256 targetDensity);
@@ -166,7 +166,10 @@ contract GasPriceMinimum is
   }
 
   function gasPriceMinimum() public view returns (uint256) {
-    if (baseFeeOpCodeActivationBlock > 0 && block.number >= baseFeeOpCodeActivationBlock) {
+    if (
+      deprecated_baseFeeOpCodeActivationBlock > 0 &&
+      block.number >= deprecated_baseFeeOpCodeActivationBlock
+    ) {
       return block.basefee;
     } else {
       return deprecated_gasPriceMinimum;
@@ -234,6 +237,14 @@ contract GasPriceMinimum is
   }
 
   /**
+   * @notice Returns the basefee opcode activation block.
+   * @return The basefee opcode activation block.
+   */
+  function baseFeeOpCodeActivationBlock() external view onlyL1 returns (uint256) {
+    return deprecated_baseFeeOpCodeActivationBlock;
+  }
+
+  /**
    * @notice Set the activation block of the baseFee opCode.
    * @param _baseFeeOpCodeActivationBlock Block number where the baseFee opCode is activated
    * @dev Value is expected to be > 0.
@@ -246,7 +257,7 @@ contract GasPriceMinimum is
       allowZero || _baseFeeOpCodeActivationBlock > 0,
       "baseFee opCode activation block must be greater than zero"
     );
-    baseFeeOpCodeActivationBlock = _baseFeeOpCodeActivationBlock;
+    deprecated_baseFeeOpCodeActivationBlock = _baseFeeOpCodeActivationBlock;
     emit BaseFeeOpCodeActivationBlockSet(_baseFeeOpCodeActivationBlock);
   }
 

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -36,7 +36,7 @@ contract GasPriceMinimum is
   FixidityLib.Fraction private deprecated_adjustmentSpeed;
 
   uint256 private deprecated_baseFeeOpCodeActivationBlock;
-  uint256 public constant ABSOLUTE_MINIMAL_GAS_PRICE = 1;
+  uint256 private constant ABSOLUTE_MINIMAL_GAS_PRICE = 1;
 
   event TargetDensitySet(uint256 targetDensity);
   event GasPriceMinimumFloorSet(uint256 gasPriceMinimumFloor);

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -26,7 +26,7 @@ contract GasPriceMinimum is
   // TODO add IGasPriceMinimum
   using FixidityLib for FixidityLib.Fraction;
 
-  uint256 public deprecated_gasPriceMinimum;
+  uint256 private deprecated_gasPriceMinimum;
   uint256 public gasPriceMinimumFloor;
 
   // Block congestion level targeted by the gas price minimum calculation.

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -123,7 +123,7 @@ contract GasPriceMinimum is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 2, 0, 2);
+    return (1, 3, 0, 0);
   }
 
   /**

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -123,7 +123,7 @@ contract GasPriceMinimum is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 3, 0, 0);
+    return (1, 2, 1, 0);
   }
 
   /**

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -30,10 +30,10 @@ contract GasPriceMinimum is
   uint256 private deprecated_gasPriceMinimumFloor;
 
   // Block congestion level targeted by the gas price minimum calculation.
-  FixidityLib.Fraction public targetDensity;
+  FixidityLib.Fraction private deprecated_targetDensity;
 
   // Speed of gas price minimum adjustment due to congestion.
-  FixidityLib.Fraction public adjustmentSpeed;
+  FixidityLib.Fraction private deprecated_adjustmentSpeed;
 
   uint256 public baseFeeOpCodeActivationBlock;
   uint256 public constant ABSOLUTE_MINIMAL_GAS_PRICE = 1;
@@ -132,8 +132,11 @@ contract GasPriceMinimum is
    * @dev Value is expected to be < 1.
    */
   function setAdjustmentSpeed(uint256 _adjustmentSpeed) public onlyOwner onlyL1 {
-    adjustmentSpeed = FixidityLib.wrap(_adjustmentSpeed);
-    require(adjustmentSpeed.lt(FixidityLib.fixed1()), "adjustment speed must be smaller than 1");
+    deprecated_adjustmentSpeed = FixidityLib.wrap(_adjustmentSpeed);
+    require(
+      deprecated_adjustmentSpeed.lt(FixidityLib.fixed1()),
+      "adjustment speed must be smaller than 1"
+    );
     emit AdjustmentSpeedSet(_adjustmentSpeed);
   }
 
@@ -143,8 +146,11 @@ contract GasPriceMinimum is
    * @dev Value is expected to be < 1.
    */
   function setTargetDensity(uint256 _targetDensity) public onlyOwner onlyL1 {
-    targetDensity = FixidityLib.wrap(_targetDensity);
-    require(targetDensity.lt(FixidityLib.fixed1()), "target density must be smaller than 1");
+    deprecated_targetDensity = FixidityLib.wrap(_targetDensity);
+    require(
+      deprecated_targetDensity.lt(FixidityLib.fixed1()),
+      "target density must be smaller than 1"
+    );
     emit TargetDensitySet(_targetDensity);
   }
 
@@ -184,13 +190,13 @@ contract GasPriceMinimum is
       blockGasTotal,
       blockGasLimit
     );
-    bool densityGreaterThanTarget = blockDensity.gt(targetDensity);
+    bool densityGreaterThanTarget = blockDensity.gt(deprecated_targetDensity);
     FixidityLib.Fraction memory densityDelta = densityGreaterThanTarget
-      ? blockDensity.subtract(targetDensity)
-      : targetDensity.subtract(blockDensity);
+      ? blockDensity.subtract(deprecated_targetDensity)
+      : deprecated_targetDensity.subtract(blockDensity);
     FixidityLib.Fraction memory adjustment = densityGreaterThanTarget
-      ? FixidityLib.fixed1().add(adjustmentSpeed.multiply(densityDelta))
-      : FixidityLib.fixed1().subtract(adjustmentSpeed.multiply(densityDelta));
+      ? FixidityLib.fixed1().add(deprecated_adjustmentSpeed.multiply(densityDelta))
+      : FixidityLib.fixed1().subtract(deprecated_adjustmentSpeed.multiply(densityDelta));
 
     uint256 newGasPriceMinimum = adjustment
       .multiply(FixidityLib.newFixed(gasPriceMinimum()))
@@ -209,6 +215,22 @@ contract GasPriceMinimum is
    */
   function gasPriceMinimumFloor() external view onlyL1 returns (uint256) {
     return deprecated_gasPriceMinimumFloor;
+  }
+
+  /**
+   * @notice Returns the target density.
+   * @return The target density.
+   */
+  function targetDensity() external view onlyL1 returns (uint256) {
+    return deprecated_targetDensity.unwrap();
+  }
+
+  /**
+   * @notice Returns the adjustment speed.
+   * @return The adjustment speed.
+   */
+  function adjustmentSpeed() external view onlyL1 returns (uint256) {
+    return deprecated_adjustmentSpeed.unwrap();
   }
 
   /**

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -27,7 +27,7 @@ contract GasPriceMinimum is
   using FixidityLib for FixidityLib.Fraction;
 
   uint256 private deprecated_gasPriceMinimum;
-  uint256 public gasPriceMinimumFloor;
+  uint256 private deprecated_gasPriceMinimumFloor;
 
   // Block congestion level targeted by the gas price minimum calculation.
   FixidityLib.Fraction public targetDensity;
@@ -155,7 +155,7 @@ contract GasPriceMinimum is
    */
   function setGasPriceMinimumFloor(uint256 _gasPriceMinimumFloor) public onlyOwner onlyL1 {
     require(_gasPriceMinimumFloor > 0, "gas price minimum floor must be greater than zero");
-    gasPriceMinimumFloor = _gasPriceMinimumFloor;
+    deprecated_gasPriceMinimumFloor = _gasPriceMinimumFloor;
     emit GasPriceMinimumFloorSet(_gasPriceMinimumFloor);
   }
 
@@ -197,7 +197,18 @@ contract GasPriceMinimum is
       .add(FixidityLib.fixed1())
       .fromFixed();
 
-    return newGasPriceMinimum >= gasPriceMinimumFloor ? newGasPriceMinimum : gasPriceMinimumFloor;
+    return
+      newGasPriceMinimum >= deprecated_gasPriceMinimumFloor
+        ? newGasPriceMinimum
+        : deprecated_gasPriceMinimumFloor;
+  }
+
+  /**
+   * @notice Returns the gas price minimum floor.
+   * @return The gas price minimum floor.
+   */
+  function gasPriceMinimumFloor() external view onlyL1 returns (uint256) {
+    return deprecated_gasPriceMinimumFloor;
   }
 
   /**

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -165,7 +165,7 @@ contract GasPriceMinimum is
     emit GasPriceMinimumFloorSet(_gasPriceMinimumFloor);
   }
 
-  function gasPriceMinimum() public view returns (uint256) {
+  function gasPriceMinimum() public view onlyL1 returns (uint256) {
     if (
       deprecated_baseFeeOpCodeActivationBlock > 0 &&
       block.number >= deprecated_baseFeeOpCodeActivationBlock

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -188,7 +188,7 @@ contract GasPriceMinimum is
   function getUpdatedGasPriceMinimum(
     uint256 blockGasTotal,
     uint256 blockGasLimit
-  ) public view returns (uint256) {
+  ) public view onlyL1 returns (uint256) {
     FixidityLib.Fraction memory blockDensity = FixidityLib.newFixedFraction(
       blockGasTotal,
       blockGasLimit

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -74,7 +74,7 @@ contract FeeCurrencyWhitelist is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 0);
+    return (1, 1, 2, 0);
   }
 
   /**

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -42,7 +42,7 @@ contract FeeCurrencyWhitelist is
    * @dev Add a token to the whitelist
    * @param tokenAddress The address of the token to add.
    */
-  function addToken(address tokenAddress) external onlyOwner {
+  function addToken(address tokenAddress) external onlyOwner onlyL1 {
     deprecated_whitelist.push(tokenAddress);
     emit FeeCurrencyWhitelisted(tokenAddress);
   }
@@ -83,7 +83,7 @@ contract FeeCurrencyWhitelist is
    * @param tokenAddress The address of the token to remove.
    * @param index The index of the token in the whitelist array.
    */
-  function removeToken(address tokenAddress, uint256 index) public onlyOwner {
+  function removeToken(address tokenAddress, uint256 index) public onlyOwner onlyL1 {
     require(deprecated_whitelist[index] == tokenAddress, "Index does not match");
     uint256 length = deprecated_whitelist.length;
     deprecated_whitelist[index] = deprecated_whitelist[length - 1];

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -3,10 +3,9 @@ pragma solidity ^0.5.13;
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 import "./interfaces/IFeeCurrencyWhitelist.sol";
-
 import "../common/Initializable.sol";
-
 import "../common/interfaces/ICeloVersionedContract.sol";
+import "../../contracts-0.8/common/IsL2Check.sol";
 
 /**
  * @title Holds a whitelist of the ERC20+ tokens that can be used to pay for gas
@@ -16,10 +15,11 @@ contract FeeCurrencyWhitelist is
   IFeeCurrencyWhitelist,
   Ownable,
   Initializable,
-  ICeloVersionedContract
+  ICeloVersionedContract,
+  IsL2Check
 {
   // Array of all the tokens enabled
-  address[] public whitelist;
+  address[] private deprecated_whitelist;
 
   event FeeCurrencyWhitelisted(address token);
 
@@ -43,7 +43,7 @@ contract FeeCurrencyWhitelist is
    * @param tokenAddress The address of the token to add.
    */
   function addToken(address tokenAddress) external onlyOwner {
-    whitelist.push(tokenAddress);
+    deprecated_whitelist.push(tokenAddress);
     emit FeeCurrencyWhitelisted(tokenAddress);
   }
 
@@ -51,7 +51,17 @@ contract FeeCurrencyWhitelist is
    * @return a list of all tokens enabled as gas fee currency.
    */
   function getWhitelist() external view returns (address[] memory) {
-    return whitelist;
+    return deprecated_whitelist;
+  }
+
+  /**
+   * @notice Gets the whitelist item at the specified index.
+   * @return Address of a token in the whitelist.
+   * @dev Once Celo becomes an L2, use the FeeCurrencyDirectory contract
+   * instead.
+   */
+  function whitelist(uint256 index) external view onlyL1 returns (address) {
+    return deprecated_whitelist[index];
   }
 
   /**
@@ -72,10 +82,10 @@ contract FeeCurrencyWhitelist is
    * @param index The index of the token in the whitelist array.
    */
   function removeToken(address tokenAddress, uint256 index) public onlyOwner {
-    require(whitelist[index] == tokenAddress, "Index does not match");
-    uint256 length = whitelist.length;
-    whitelist[index] = whitelist[length - 1];
-    whitelist.pop();
+    require(deprecated_whitelist[index] == tokenAddress, "Index does not match");
+    uint256 length = deprecated_whitelist.length;
+    deprecated_whitelist[index] = deprecated_whitelist[length - 1];
+    deprecated_whitelist.pop();
     emit FeeCurrencyWhitelistRemoved(tokenAddress);
   }
 }

--- a/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
+++ b/packages/protocol/contracts/common/FeeCurrencyWhitelist.sol
@@ -49,8 +49,10 @@ contract FeeCurrencyWhitelist is
 
   /**
    * @return a list of all tokens enabled as gas fee currency.
+   * @dev Once Celo becomes an L2, use the FeeCurrencyDirectory contract
+   * instead.
    */
-  function getWhitelist() external view returns (address[] memory) {
+  function getWhitelist() external view onlyL1 returns (address[] memory) {
     return deprecated_whitelist;
   }
 

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -29,7 +29,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
 
   ClientVersion private minimumClientVersion; // obsolete
   uint256 private deprecated_blockGasLimit;
-  uint256 public intrinsicGasForAlternativeFeeCurrency;
+  uint256 private deprecated_intrinsicGasForAlternativeFeeCurrency;
   LookbackWindow public uptimeLookbackWindow;
 
   event IntrinsicGasForAlternativeFeeCurrencySet(uint256 gas);
@@ -84,7 +84,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @param gas Intrinsic gas for non-gold gas currencies.
    */
   function setIntrinsicGasForAlternativeFeeCurrency(uint256 gas) public onlyOwner onlyL1 {
-    intrinsicGasForAlternativeFeeCurrency = gas;
+    deprecated_intrinsicGasForAlternativeFeeCurrency = gas;
     emit IntrinsicGasForAlternativeFeeCurrencySet(gas);
   }
 
@@ -124,6 +124,16 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    */
   function blockGasLimit() public view onlyL1 returns (uint256) {
     return deprecated_blockGasLimit;
+  }
+
+  /**
+   * @notice Gets the intrinsic gas paid for transactions using alternative fee
+   * currencies.
+   * @return The intrinsic gas for alternative fee currencies.
+   * @dev Once Celo becomes an L2, query the FeeCurrencyDirectory instead.
+   */
+  function intrinsicGasForAlternativeFeeCurrency() public view onlyL1 returns (uint256) {
+    return deprecated_intrinsicGasForAlternativeFeeCurrency;
   }
 
   /**

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -67,7 +67,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 3, 0, 1);
+    return (1, 3, 1, 0);
   }
 
   /**

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -28,7 +28,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   }
 
   ClientVersion private minimumClientVersion; // obsolete
-  uint256 public blockGasLimit;
+  uint256 private deprecated_blockGasLimit;
   uint256 public intrinsicGasForAlternativeFeeCurrency;
   LookbackWindow public uptimeLookbackWindow;
 
@@ -75,7 +75,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
    * @param gasLimit New block gas limit.
    */
   function setBlockGasLimit(uint256 gasLimit) public onlyOwner onlyL1 {
-    blockGasLimit = gasLimit;
+    deprecated_blockGasLimit = gasLimit;
     emit BlockGasLimitSet(gasLimit);
   }
 
@@ -114,6 +114,16 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   function getUptimeLookbackWindow() public view returns (uint256 lookbackWindow) {
     lookbackWindow = _getUptimeLookbackWindow();
     require(lookbackWindow != 0, "UptimeLookbackWindow is not initialized");
+  }
+
+  /**
+   * @notice Gets the Celo L1 block gas limit.
+   * @return The block gas limit.
+   * @dev Once Celo becomes an L2, query Optimism's L1 SystemConfig contract
+   * instead.
+   */
+  function blockGasLimit() public view onlyL1 returns (uint256) {
+    return deprecated_blockGasLimit;
   }
 
   /**

--- a/packages/protocol/contracts/governance/BlockchainParameters.sol
+++ b/packages/protocol/contracts/governance/BlockchainParameters.sol
@@ -30,7 +30,7 @@ contract BlockchainParameters is Ownable, Initializable, UsingPrecompiles {
   ClientVersion private minimumClientVersion; // obsolete
   uint256 private deprecated_blockGasLimit;
   uint256 private deprecated_intrinsicGasForAlternativeFeeCurrency;
-  LookbackWindow public uptimeLookbackWindow;
+  LookbackWindow private uptimeLookbackWindow;
 
   event IntrinsicGasForAlternativeFeeCurrencySet(uint256 gas);
   event BlockGasLimitSet(uint256 limit);

--- a/packages/protocol/contracts/identity/Random.sol
+++ b/packages/protocol/contracts/identity/Random.sol
@@ -109,7 +109,7 @@ contract Random is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 1, 1);
+    return (1, 1, 2, 0);
   }
 
   /**

--- a/packages/protocol/contracts/identity/Random.sol
+++ b/packages/protocol/contracts/identity/Random.sol
@@ -23,9 +23,9 @@ contract Random is
   using SafeMath for uint256;
 
   /* Stores most recent commitment per address */
-  mapping(address => bytes32) public commitments;
+  mapping(address => bytes32) private deprecated_commitments;
 
-  uint256 public randomnessBlockRetentionWindow;
+  uint256 private deprecated_randomnessBlockRetentionWindow;
 
   mapping(uint256 => bytes32) private history;
   uint256 private historyFirst;
@@ -78,6 +78,20 @@ contract Random is
   }
 
   /**
+   * @notice Returns the most recent commitment by a validator.
+   * @param addr Address of the validator.
+   * @return The validator's most recent commitment.
+   * @dev The Random system will be deprecated once Celo becomes an L2.
+   */
+  function commitments(address addr) external view onlyL1 returns (bytes32) {
+    return deprecated_commitments[addr];
+  }
+
+  function randomnessBlockRetentionWindow() external view onlyL1 returns (uint256) {
+    return deprecated_randomnessBlockRetentionWindow;
+  }
+
+  /**
    * @notice Get randomness values of previous blocks.
    * @param blockNumber The number of block whose randomness value we want to know.
    * @return The associated randomness value.
@@ -105,7 +119,7 @@ contract Random is
    */
   function setRandomnessBlockRetentionWindow(uint256 value) public onlyL1 onlyOwner {
     require(value > 0, "randomnessBlockRetetionWindow cannot be zero");
-    randomnessBlockRetentionWindow = value;
+    deprecated_randomnessBlockRetentionWindow = value;
     emit RandomnessBlockRetentionWindowSet(value);
   }
 
@@ -133,11 +147,11 @@ contract Random is
     require(newCommitment != computeCommitment(0), "cannot commit zero randomness");
 
     // ensure revealed randomness matches previous commitment
-    if (commitments[proposer] != 0) {
+    if (deprecated_commitments[proposer] != 0) {
       require(randomness != 0, "randomness cannot be zero if there is a previous commitment");
       bytes32 expectedCommitment = computeCommitment(randomness);
       require(
-        expectedCommitment == commitments[proposer],
+        expectedCommitment == deprecated_commitments[proposer],
         "commitment didn't match the posted randomness"
       );
     } else {
@@ -148,7 +162,7 @@ contract Random is
     uint256 blockNumber = block.number == 0 ? 0 : block.number.sub(1);
     addRandomness(block.number, keccak256(abi.encodePacked(history[blockNumber], randomness)));
 
-    commitments[proposer] = newCommitment;
+    deprecated_commitments[proposer] = newCommitment;
   }
 
   /**
@@ -170,16 +184,16 @@ contract Random is
       if (historySize == 0) {
         historyFirst = blockNumber;
         historySize = 1;
-      } else if (historySize > randomnessBlockRetentionWindow) {
+      } else if (historySize > deprecated_randomnessBlockRetentionWindow) {
         deleteHistoryIfNotLastEpochBlock(historyFirst);
         deleteHistoryIfNotLastEpochBlock(historyFirst.add(1));
         historyFirst = historyFirst.add(2);
         historySize = historySize.sub(1);
-      } else if (historySize == randomnessBlockRetentionWindow) {
+      } else if (historySize == deprecated_randomnessBlockRetentionWindow) {
         deleteHistoryIfNotLastEpochBlock(historyFirst);
         historyFirst = historyFirst.add(1);
       } else {
-        // historySize < randomnessBlockRetentionWindow
+        // historySize < deprecated_randomnessBlockRetentionWindow
         historySize = historySize.add(1);
       }
     }
@@ -206,8 +220,8 @@ contract Random is
     require(
       blockNumber == lastEpochBlock ||
         (blockNumber > cur.sub(historySize) &&
-          (randomnessBlockRetentionWindow >= cur ||
-            blockNumber > cur.sub(randomnessBlockRetentionWindow))),
+          (deprecated_randomnessBlockRetentionWindow >= cur ||
+            blockNumber > cur.sub(deprecated_randomnessBlockRetentionWindow))),
       "Cannot query randomness older than the stored history"
     );
     return history[blockNumber];

--- a/packages/protocol/test-sol/unit/common/FeeCurrencyWhitelist.t.sol
+++ b/packages/protocol/test-sol/unit/common/FeeCurrencyWhitelist.t.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.5.13;
 import "celo-foundry/Test.sol";
 import "@celo-contracts/common/FeeCurrencyWhitelist.sol";
 
-contract FeeCurrencyWhitelistTest is Test {
+import { TestConstants } from "@test-sol/constants.sol";
+
+contract FeeCurrencyWhitelistTest is Test, TestConstants {
   FeeCurrencyWhitelist feeCurrencyWhitelist;
   address nonOwner;
   address owner;
@@ -15,6 +17,10 @@ contract FeeCurrencyWhitelistTest is Test {
 
     feeCurrencyWhitelist = new FeeCurrencyWhitelist(true);
     feeCurrencyWhitelist.initialize();
+  }
+
+  function _whenL2() public {
+    deployCodeTo("Registry.sol", abi.encode(false), PROXY_ADMIN_ADDRESS);
   }
 }
 
@@ -70,5 +76,23 @@ contract FeeCurrencyWhitelistRemoveToken is FeeCurrencyWhitelistTest {
     vm.expectRevert("Ownable: caller is not the owner");
     vm.prank(nonOwner);
     feeCurrencyWhitelist.removeToken(address(2), 1);
+  }
+}
+
+contract FeeCurrencyWhitelist_whitelist is FeeCurrencyWhitelistTest {
+  function setUp() public {
+    super.setUp();
+    feeCurrencyWhitelist.addToken(address(1));
+  }
+
+  function test_ShouldRetrieveAToken() public {
+    address token = feeCurrencyWhitelist.whitelist(0);
+    assertEq(token, address(1));
+  }
+
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    feeCurrencyWhitelist.whitelist(0);
   }
 }

--- a/packages/protocol/test-sol/unit/common/FeeCurrencyWhitelist.t.sol
+++ b/packages/protocol/test-sol/unit/common/FeeCurrencyWhitelist.t.sol
@@ -96,3 +96,24 @@ contract FeeCurrencyWhitelist_whitelist is FeeCurrencyWhitelistTest {
     feeCurrencyWhitelist.whitelist(0);
   }
 }
+
+contract FeeCurrencyWhitelist_getWhitelist is FeeCurrencyWhitelistTest {
+  function setUp() public {
+    super.setUp();
+    feeCurrencyWhitelist.addToken(address(1));
+    feeCurrencyWhitelist.addToken(address(2));
+  }
+
+  function test_ShouldRetrieveAToken() public {
+    address[] memory tokens = feeCurrencyWhitelist.getWhitelist();
+    assertEq(tokens.length, 2);
+    assertEq(tokens[0], address(1));
+    assertEq(tokens[1], address(2));
+  }
+
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    feeCurrencyWhitelist.getWhitelist();
+  }
+}

--- a/packages/protocol/test-sol/unit/common/FeeCurrencyWhitelist.t.sol
+++ b/packages/protocol/test-sol/unit/common/FeeCurrencyWhitelist.t.sol
@@ -49,6 +49,12 @@ contract FeeCurrencyWhitelistAddToken is FeeCurrencyWhitelistTest {
     vm.prank(nonOwner);
     feeCurrencyWhitelist.addToken(address(1));
   }
+
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    feeCurrencyWhitelist.addToken(address(1));
+  }
 }
 
 contract FeeCurrencyWhitelistRemoveToken is FeeCurrencyWhitelistTest {
@@ -75,6 +81,12 @@ contract FeeCurrencyWhitelistRemoveToken is FeeCurrencyWhitelistTest {
   function test_ShouldRevert_WhenNonOwnerRemovesToken() public {
     vm.expectRevert("Ownable: caller is not the owner");
     vm.prank(nonOwner);
+    feeCurrencyWhitelist.removeToken(address(2), 1);
+  }
+
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
     feeCurrencyWhitelist.removeToken(address(2), 1);
   }
 }

--- a/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
@@ -363,3 +363,16 @@ contract GasPriceMinimumTest_baseFeeOpCodeActivationBlock is GasPriceMinimumTest
     gasPriceMinimum.baseFeeOpCodeActivationBlock();
   }
 }
+
+contract GasPriceMinimumTest_gasPriceMinimum is GasPriceMinimumTest {
+  function test_shouldReturnTheGasPriceMinimum() public {
+    uint256 realGasPriceMinimum = gasPriceMinimum.gasPriceMinimum();
+    assertEq(realGasPriceMinimum, 100);
+  }
+
+  function test_shouldRevert_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    gasPriceMinimum.gasPriceMinimum();
+  }
+}

--- a/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
@@ -199,7 +199,7 @@ contract GasPriceMinimumTest_setGasPriceMinimumFloor is GasPriceMinimumTest {
   }
 }
 
-contract GasPriceMinimumTest_setUpdatedGasPriceMinimum is GasPriceMinimumTest {
+contract GasPriceMinimumTest_getUpdatedGasPriceMinimum is GasPriceMinimumTest {
   using FixidityLib for FixidityLib.Fraction;
   uint256 nonce = 0;
 
@@ -296,6 +296,12 @@ contract GasPriceMinimumTest_setUpdatedGasPriceMinimum is GasPriceMinimumTest {
 
       assertEq(actualUpdatedGasPriceMinimum, expectedUpdatedGasPriceMinimum);
     }
+  }
+
+  function test_shouldRevert_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    gasPriceMinimum.getUpdatedGasPriceMinimum(0, 1);
   }
 }
 

--- a/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
@@ -376,3 +376,16 @@ contract GasPriceMinimumTest_gasPriceMinimum is GasPriceMinimumTest {
     gasPriceMinimum.gasPriceMinimum();
   }
 }
+
+contract GasPriceMinimumTest_getGasPriceMinimum is GasPriceMinimumTest {
+  function test_shouldReturnTheGasPriceMinimum() public {
+    uint256 realGasPriceMinimum = gasPriceMinimum.getGasPriceMinimum(address(0));
+    assertEq(realGasPriceMinimum, 100);
+  }
+
+  function test_shouldRevert_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    gasPriceMinimum.getGasPriceMinimum(address(0));
+  }
+}

--- a/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
@@ -311,3 +311,29 @@ contract GasPriceMinimumTest_gasPriceMinimumFloor is GasPriceMinimumTest {
     gasPriceMinimum.gasPriceMinimumFloor();
   }
 }
+
+contract GasPriceMinimumTest_targetDensity is GasPriceMinimumTest {
+  function test_shouldReturnTheTargetDensity() public {
+    uint256 realTargetDensity = gasPriceMinimum.targetDensity();
+    assertEq(realTargetDensity, targetDensity);
+  }
+
+  function test_shouldRevert_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    gasPriceMinimum.targetDensity();
+  }
+}
+
+contract GasPriceMinimumTest_adjustmentSpeed is GasPriceMinimumTest {
+  function test_shouldReturnTheAdjustementSpeed() public {
+    uint256 realAdjustementSpeed = gasPriceMinimum.adjustmentSpeed();
+    assertEq(realAdjustementSpeed, adjustmentSpeed);
+  }
+
+  function test_shouldRevert_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    gasPriceMinimum.adjustmentSpeed();
+  }
+}

--- a/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
@@ -298,3 +298,16 @@ contract GasPriceMinimumTest_setUpdatedGasPriceMinimum is GasPriceMinimumTest {
     }
   }
 }
+
+contract GasPriceMinimumTest_gasPriceMinimumFloor is GasPriceMinimumTest {
+  function test_shouldReturnTheGasPriceMinimumFloor() public {
+    uint256 gasPriceMinFloor = gasPriceMinimum.gasPriceMinimumFloor();
+    assertEq(gasPriceMinFloor, gasPriceMinimumFloor);
+  }
+
+  function test_shouldRevert_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    gasPriceMinimum.gasPriceMinimumFloor();
+  }
+}

--- a/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasPriceMinimum.t.sol
@@ -337,3 +337,23 @@ contract GasPriceMinimumTest_adjustmentSpeed is GasPriceMinimumTest {
     gasPriceMinimum.adjustmentSpeed();
   }
 }
+
+contract GasPriceMinimumTest_baseFeeOpCodeActivationBlock is GasPriceMinimumTest {
+  uint256 baseFeeOpCodeActivationBlock = 123;
+
+  function setUp() public override {
+    super.setUp();
+    gasPriceMinimum.setBaseFeeOpCodeActivationBlock(baseFeeOpCodeActivationBlock);
+  }
+
+  function test_shouldReturnTheBaseFeeOpCodeActivationBlock() public {
+    uint256 realBaseFeeOpCodeActivationBlock = gasPriceMinimum.baseFeeOpCodeActivationBlock();
+    assertEq(realBaseFeeOpCodeActivationBlock, baseFeeOpCodeActivationBlock);
+  }
+
+  function test_shouldRevert_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    gasPriceMinimum.baseFeeOpCodeActivationBlock();
+  }
+}

--- a/packages/protocol/test-sol/unit/governance/network/BlockchainParameters.t.sol
+++ b/packages/protocol/test-sol/unit/governance/network/BlockchainParameters.t.sol
@@ -173,3 +173,11 @@ contract BlockchainParametersTest_setUptimeLookbackWindow is BlockchainParameter
     blockchainParameters.setUptimeLookbackWindow(100);
   }
 }
+
+contract BlockchainParametersTest_blockGasLimit is BlockchainParametersTest {
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    blockchainParameters.blockGasLimit();
+  }
+}

--- a/packages/protocol/test-sol/unit/governance/network/BlockchainParameters.t.sol
+++ b/packages/protocol/test-sol/unit/governance/network/BlockchainParameters.t.sol
@@ -181,3 +181,13 @@ contract BlockchainParametersTest_blockGasLimit is BlockchainParametersTest {
     blockchainParameters.blockGasLimit();
   }
 }
+
+contract BlockchainParametersTest_intrinsicGasForAlternativeFeeCurrency is
+  BlockchainParametersTest
+{
+  function test_Reverts_WhenCalledOnL2() public {
+    _whenL2();
+    vm.expectRevert("This method is no longer supported in L2.");
+    blockchainParameters.intrinsicGasForAlternativeFeeCurrency();
+  }
+}

--- a/packages/protocol/test-sol/unit/identity/Random.t.sol
+++ b/packages/protocol/test-sol/unit/identity/Random.t.sol
@@ -8,16 +8,18 @@ import { TestConstants } from "@test-sol/constants.sol";
 import "@celo-contracts/identity/Random.sol";
 import "@celo-contracts/identity/test/RandomTest.sol";
 
-contract RandomnessTest_SetRandomnessRetentionWindow is Test, TestConstants, IsL2Check {
-  event RandomnessBlockRetentionWindowSet(uint256 value);
-
+contract RandomTest_ is Test, TestConstants, Utils, IsL2Check {
   RandomTest random;
+
+  event RandomnessBlockRetentionWindowSet(uint256 value);
 
   function setUp() public {
     random = new RandomTest();
     random.initialize(256);
   }
+}
 
+contract RandomTest_SetRandomnessRetentionWindow is RandomTest_ {
   function test_ShouldSetTheVariable() public {
     random.setRandomnessBlockRetentionWindow(1000);
     assertEq(random.randomnessBlockRetentionWindow(), 1000);
@@ -42,16 +44,9 @@ contract RandomnessTest_SetRandomnessRetentionWindow is Test, TestConstants, IsL
   }
 }
 
-contract RandomnessTest_AddTestRandomness is Test, TestConstants, Utils, IsL2Check {
+contract RandomTest_AddTestRandomness is RandomTest_ {
   uint256 constant RETENTION_WINDOW = 5;
   uint256 constant EPOCH_SIZE = 10;
-
-  RandomTest random;
-
-  function setUp() public {
-    random = new RandomTest();
-    random.initialize(256);
-  }
 
   function test_ShouldBeAbleToSimulateAddingRandomness() public {
     random.addTestRandomness(1, 0x0000000000000000000000000000000000000000000000000000000000000001);
@@ -225,15 +220,12 @@ contract RandomnessTest_AddTestRandomness is Test, TestConstants, Utils, IsL2Che
   }
 }
 
-contract RandomnessTest_RevealAndCommit is Test, TestConstants, Utils, IsL2Check {
+contract RandomTest_RevealAndCommit is RandomTest_ {
   address constant ACCOUNT = address(0x01);
   bytes32 constant RANDONMESS = bytes32(uint256(0x00));
 
-  RandomTest random;
-
   function setUp() public {
-    random = new RandomTest();
-    random.initialize(256);
+    super.setUp();
     random.setRandomnessBlockRetentionWindow(256);
   }
 


### PR DESCRIPTION
### Description

As part of cleanup for L2, we want to revert implicit functions created for `public` variables that will be deprecated on CEL2. This is done by:

- Renaming the variable to `deprecated_x`
- Making it `private`
- Adding a public, view, `onlyL1` function that returns the variable (for full compatibility until the L2 switch is flipped)

TODO:
- [x] Decide what still needs deprecated in GasPriceMinimum.

### Other changes

Minor cleanup in tests.

### Tested

Unit tests that verify the variables can still be retrieved on L1 but revert on L2.

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/653#issue-2564961955