### PR TITLE
Removal of build warnings

### DIFF
--- a/packages/protocol/contracts-0.8/common/CeloUnreleasedTreasury.sol
+++ b/packages/protocol/contracts-0.8/common/CeloUnreleasedTreasury.sol
@@ -28,7 +28,7 @@ contract CeloUnreleasedTreasury is UsingRegistry, ReentrancyGuard, Initializable
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice A constructor for initialising a new instance of a CeloUnreleasedTreasury contract.

--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -122,7 +122,7 @@ contract EpochManager is
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts-0.8/common/EpochManagerEnabler.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManagerEnabler.sol
@@ -29,7 +29,7 @@ contract EpochManagerEnabler is
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts-0.8/common/FeeCurrencyDirectory.sol
+++ b/packages/protocol/contracts-0.8/common/FeeCurrencyDirectory.sol
@@ -16,7 +16,7 @@ contract FeeCurrencyDirectory is
   mapping(address => CurrencyConfig) public currencies;
   address[] private currencyList;
 
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Initializes the contract with the owner set.

--- a/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/GasPriceMinimum.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.7 <0.8.20;
 
 import "@openzeppelin/contracts8/access/Ownable.sol";
@@ -48,7 +48,7 @@ contract GasPriceMinimum is
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts-0.8/common/IsL2Check.sol
+++ b/packages/protocol/contracts-0.8/common/IsL2Check.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.5.13 <0.8.20;
 
 /**

--- a/packages/protocol/contracts-0.8/common/MentoFeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/common/MentoFeeCurrencyAdapter.sol
@@ -14,7 +14,7 @@ contract MentoFeeCurrencyAdapter is IOracle, Initializable, Ownable {
   mapping(address => MentoCurrencyConfig) public currencies;
   address[] private currencyList;
 
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Initializes the contract with the owner set.

--- a/packages/protocol/contracts-0.8/common/PrecompilesOverride.sol
+++ b/packages/protocol/contracts-0.8/common/PrecompilesOverride.sol
@@ -45,7 +45,7 @@ contract PrecompilesOverride is UsingPrecompiles, UsingRegistry {
     if (isL2()) {
       return getEpochManager().getElectedSignerByIndex(index);
     } else {
-      super.validatorSignerAddressFromCurrentSet(index);
+      return super.validatorSignerAddressFromCurrentSet(index);
     }
   }
 

--- a/packages/protocol/contracts-0.8/common/ScoreManager.sol
+++ b/packages/protocol/contracts-0.8/common/ScoreManager.sol
@@ -43,7 +43,7 @@ contract ScoreManager is
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts-0.8/common/interfaces/IGasPriceMinimum.sol
+++ b/packages/protocol/contracts-0.8/common/interfaces/IGasPriceMinimum.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.5.13 <0.9.0;
 
 // TODO add to GasPrice

--- a/packages/protocol/contracts-0.8/common/interfaces/IGasPriceMinimumInitializer.sol
+++ b/packages/protocol/contracts-0.8/common/interfaces/IGasPriceMinimumInitializer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.5.13 <0.9.0;
 
 interface IGasPriceMinimumInitializer {

--- a/packages/protocol/contracts-0.8/common/linkedlists/AddressLinkedList.sol
+++ b/packages/protocol/contracts-0.8/common/linkedlists/AddressLinkedList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.8.20;
 
 import "@openzeppelin/contracts8/utils/math/SafeMath.sol";

--- a/packages/protocol/contracts-0.8/common/linkedlists/IntegerSortedLinkedList.sol
+++ b/packages/protocol/contracts-0.8/common/linkedlists/IntegerSortedLinkedList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.8.20;
 
 import "@openzeppelin/contracts8/utils/math/SafeMath.sol";

--- a/packages/protocol/contracts-0.8/common/linkedlists/LinkedList.sol
+++ b/packages/protocol/contracts-0.8/common/linkedlists/LinkedList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.8.20;
 
 import "@openzeppelin/contracts8/utils/math/SafeMath.sol";

--- a/packages/protocol/contracts-0.8/common/linkedlists/SortedLinkedList.sol
+++ b/packages/protocol/contracts-0.8/common/linkedlists/SortedLinkedList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.8.20;
 
 import "@openzeppelin/contracts8/utils/math/SafeMath.sol";

--- a/packages/protocol/contracts-0.8/common/linkedlists/SortedLinkedListWithMedian.sol
+++ b/packages/protocol/contracts-0.8/common/linkedlists/SortedLinkedListWithMedian.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.8.20;
 
 import "@openzeppelin/contracts8/utils/math/SafeMath.sol";

--- a/packages/protocol/contracts-0.8/common/mocks/MockAccounts.sol
+++ b/packages/protocol/contracts-0.8/common/mocks/MockAccounts.sol
@@ -20,7 +20,7 @@ contract MockAccounts {
     accountToSigner[account] = signer;
   }
 
-  function getValidatorSigner(address account) external returns (address) {
+  function getValidatorSigner(address account) external view returns (address) {
     return accountToSigner[account];
   }
 

--- a/packages/protocol/contracts-0.8/common/test/MockCeloToken.sol
+++ b/packages/protocol/contracts-0.8/common/test/MockCeloToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.9.0;
 // solhint-disable no-unused-vars
 

--- a/packages/protocol/contracts-0.8/common/test/MockCeloUnreleasedTreasury.sol
+++ b/packages/protocol/contracts-0.8/common/test/MockCeloUnreleasedTreasury.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.9.0;
 // solhint-disable no-unused-vars
 

--- a/packages/protocol/contracts-0.8/common/test/MockEpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/test/MockEpochManager.sol
@@ -71,9 +71,9 @@ contract MockEpochManager is IEpochManager {
 
   function startNextEpochProcess() external {}
   function finishNextEpochProcess(
-    address[] calldata groups,
-    address[] calldata lessers,
-    address[] calldata greaters
+    address[] calldata,
+    address[] calldata,
+    address[] calldata
   ) external {
     epochs[currentEpochNumber].lastBlock = block.number - 1;
 
@@ -150,7 +150,7 @@ contract MockEpochManager is IEpochManager {
   }
 
   function getEpochByBlockNumber(
-    uint256 _blockNumber
+    uint256
   ) external view returns (uint256, uint256, uint256, uint256) {
     return (0, 0, 0, 0);
   }

--- a/packages/protocol/contracts-0.8/common/test/MockRegistry.sol
+++ b/packages/protocol/contracts-0.8/common/test/MockRegistry.sol
@@ -22,7 +22,7 @@ contract MockRegistry is IRegistry, IRegistryInitializer, Ownable, Initializable
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts-0.8/governance/Validators.sol
+++ b/packages/protocol/contracts-0.8/governance/Validators.sol
@@ -172,7 +172,7 @@ contract Validators is
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.
@@ -1305,7 +1305,7 @@ contract Validators is
     emit ValidatorScoreUpdated(account, validators[account].score.unwrap(), epochScore.unwrap());
   }
 
-  function _isRegistrationAllowed(address account) private returns (bool) {
+  function _isRegistrationAllowed(address account) private {
     require(
       !getElection().allowedToVoteOverMaxNumberOfGroups(account),
       "Cannot vote for more than max number of groups"

--- a/packages/protocol/contracts-0.8/governance/test/EpochRewardsMock.sol
+++ b/packages/protocol/contracts-0.8/governance/test/EpochRewardsMock.sol
@@ -21,13 +21,11 @@ contract EpochRewardsMock08 is IEpochRewards {
 
   function updateTargetVotingYield() external {}
 
-  function getRewardsMultiplier(
-    uint256 targetGoldTotalSupplyIncrease
-  ) external view returns (uint256) {
+  function getRewardsMultiplier(uint256) external pure returns (uint256) {
     return 0;
   }
 
-  function isReserveLow() external view returns (bool) {
+  function isReserveLow() external pure returns (bool) {
     return false;
   }
   function calculateTargetEpochRewards()
@@ -37,22 +35,22 @@ contract EpochRewardsMock08 is IEpochRewards {
   {
     return (perValidatorReward, totalRewardsVoter, totalRewardsCommunity, totalRewardsCarbonFund);
   }
-  function getTargetVotingYieldParameters() external view returns (uint256, uint256, uint256) {
+  function getTargetVotingYieldParameters() external pure returns (uint256, uint256, uint256) {
     return (0, 0, 0);
   }
-  function getRewardsMultiplierParameters() external view returns (uint256, uint256, uint256) {
+  function getRewardsMultiplierParameters() external pure returns (uint256, uint256, uint256) {
     return (0, 0, 0);
   }
-  function getCommunityRewardFraction() external view returns (uint256) {
+  function getCommunityRewardFraction() external pure returns (uint256) {
     return 0;
   }
-  function getCarbonOffsettingFraction() external view returns (uint256) {
+  function getCarbonOffsettingFraction() external pure returns (uint256) {
     return 0;
   }
-  function getTargetVotingGoldFraction() external view returns (uint256) {
+  function getTargetVotingGoldFraction() external pure returns (uint256) {
     return 0;
   }
-  function getRewardsMultiplier() external view returns (uint256) {
+  function getRewardsMultiplier() external pure returns (uint256) {
     return 0;
   }
 

--- a/packages/protocol/contracts-0.8/governance/test/IMockValidators.sol
+++ b/packages/protocol/contracts-0.8/governance/test/IMockValidators.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.7 <0.8.20;
 
 interface IMockValidators {

--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -31,7 +31,7 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
    * @notice Sets initialized == true on implementation contracts
    * @param test Set to true to skip implementation initialization
    */
-  constructor(bool test) public Initializable(test) {}
+  constructor(bool test) Initializable(test) {}
 
   /**
    * @notice Used in place of the constructor to allow the contract to be upgradable via proxy.

--- a/packages/protocol/contracts-0.8/stability/interfaces/IDecimals.sol
+++ b/packages/protocol/contracts-0.8/stability/interfaces/IDecimals.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.13;
 
 interface IDecimals {

--- a/packages/protocol/contracts-0.8/stability/interfaces/IFeeCurrency.sol
+++ b/packages/protocol/contracts-0.8/stability/interfaces/IFeeCurrency.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts8/token/ERC20/IERC20.sol";

--- a/packages/protocol/contracts-0.8/stability/test/MockStableToken.sol
+++ b/packages/protocol/contracts-0.8/stability/test/MockStableToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.9.0;
 // solhint-disable no-unused-vars
 
@@ -19,7 +20,7 @@ contract MockStableToken08 {
   // Stored as units. Value can be found using unitsToValue().
   mapping(address => uint256) public balances;
 
-  constructor() public {
+  constructor() {
     setInflationFactor(FixidityLib.fixed1().unwrap());
   }
 

--- a/packages/protocol/contracts/common/FeeHandler.sol
+++ b/packages/protocol/contracts/common/FeeHandler.sol
@@ -681,9 +681,6 @@ contract FeeHandler is
       ignoreRenaming_carbonFeeBeneficiary != address(0),
       "Can't distribute to the zero address"
     );
-    IERC20 token = IERC20(tokenAddress);
-    token.balanceOf(address(this));
-
     TokenState storage tokenState = tokenStates[tokenAddress];
 
     FixidityLib.Fraction

--- a/packages/protocol/contracts/common/FeeHandler.sol
+++ b/packages/protocol/contracts/common/FeeHandler.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -488,7 +489,7 @@ contract FeeHandler is
     return balanceToBurn;
   }
 
-  function checkTotalBeneficiary() internal {
+  function checkTotalBeneficiary() internal view {
     require(
       getTotalFractionOfOtherBeneficiariesAndCarbonFixidity().lt(FixidityLib.fixed1()),
       "Total beneficiaries fraction must be less than 1"
@@ -663,7 +664,7 @@ contract FeeHandler is
     FixidityLib.Fraction memory thisTokenFraction,
     FixidityLib.Fraction memory totalFractionOfOtherBeneficiariesAndCarbonFixidity,
     uint256 toDistribute
-  ) private returns (uint256) {
+  ) private pure returns (uint256) {
     FixidityLib.Fraction memory proportionOfThisToken = thisTokenFraction.divide(
       totalFractionOfOtherBeneficiariesAndCarbonFixidity
     );
@@ -681,7 +682,7 @@ contract FeeHandler is
       "Can't distribute to the zero address"
     );
     IERC20 token = IERC20(tokenAddress);
-    uint256 tokenBalance = token.balanceOf(address(this));
+    token.balanceOf(address(this));
 
     TokenState storage tokenState = tokenStates[tokenAddress];
 
@@ -761,7 +762,6 @@ contract FeeHandler is
   // new handle
   // tokenAddresses should not contain the Celo address
   function _handle(address[] memory tokenAddresses) private {
-    address celoToken = getCeloTokenAddress();
     // Celo doesn't have to be exchanged for anything
     for (uint256 i = 0; i < tokenAddresses.length; i++) {
       address token = tokenAddresses[i];

--- a/packages/protocol/contracts/common/GoldToken.sol
+++ b/packages/protocol/contracts/common/GoldToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/packages/protocol/contracts/common/interfaces/IFeeHandlerSeller.sol
+++ b/packages/protocol/contracts/common/interfaces/IFeeHandlerSeller.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.5.13 <0.9.0;
 
 interface IFeeHandlerSeller {

--- a/packages/protocol/contracts/common/interfaces/IProxy.sol
+++ b/packages/protocol/contracts/common/interfaces/IProxy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.5.13 <0.9.0;
 
 interface IProxy {

--- a/packages/protocol/contracts/common/libraries/ReentrancyGuard.sol
+++ b/packages/protocol/contracts/common/libraries/ReentrancyGuard.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.5.13 <0.8.20;
 
 /**

--- a/packages/protocol/contracts/governance/test/MockElection.sol
+++ b/packages/protocol/contracts/governance/test/MockElection.sol
@@ -35,23 +35,23 @@ contract MockElection is IsL2Check {
     electedValidators = _electedValidators;
   }
 
-  function vote(address, uint256, address, address) external returns (bool) {
+  function vote(address, uint256, address, address) external pure returns (bool) {
     return true;
   }
 
-  function activate(address) external returns (bool) {
+  function activate(address) external pure returns (bool) {
     return true;
   }
 
-  function revokeAllActive(address, address, address, uint256) external returns (bool) {
+  function revokeAllActive(address, address, address, uint256) external pure returns (bool) {
     return true;
   }
 
-  function revokeActive(address, uint256, address, address, uint256) external returns (bool) {
+  function revokeActive(address, uint256, address, address, uint256) external pure returns (bool) {
     return true;
   }
 
-  function revokePending(address, uint256, address, address, uint256) external returns (bool) {
+  function revokePending(address, uint256, address, address, uint256) external pure returns (bool) {
     return true;
   }
 
@@ -74,7 +74,7 @@ contract MockElection is IsL2Check {
     return active;
   }
 
-  function getTotalVotesByAccount(address) external view returns (uint256) {
+  function getTotalVotesByAccount(address) external pure returns (uint256) {
     return 0;
   }
 
@@ -91,8 +91,8 @@ contract MockElection is IsL2Check {
 
   function getGroupEpochRewardsBasedOnScore(
     address group,
-    uint256 totalEpochRewards,
-    uint256 groupScore
+    uint256,
+    uint256
   ) external view returns (uint256) {
     return groupRewardsBasedOnScore[group];
   }
@@ -101,12 +101,7 @@ contract MockElection is IsL2Check {
     groupRewardsBasedOnScore[group] = groupRewards;
   }
 
-  function distributeEpochRewards(
-    address group,
-    uint256 value,
-    address lesser,
-    address greater
-  ) external {
+  function distributeEpochRewards(address group, uint256 value, address, address) external {
     distributedEpochRewards[group] = value;
   }
 

--- a/packages/protocol/contracts/governance/test/MockGovernance.sol
+++ b/packages/protocol/contracts/governance/test/MockGovernance.sol
@@ -27,22 +27,16 @@ contract MockGovernance is IGovernance {
     removeVotesCalledFor[account] = maxAmountAllowed;
   }
 
-  function setConstitution(address destination, bytes4 functionId, uint256 threshold) external {
+  function setConstitution(address, bytes4, uint256) external {
     revert("not implemented");
   }
 
-  function votePartially(
-    uint256 proposalId,
-    uint256 index,
-    uint256 yesVotes,
-    uint256 noVotes,
-    uint256 abstainVotes
-  ) external returns (bool) {
+  function votePartially(uint256, uint256, uint256, uint256, uint256) external returns (bool) {
     return true;
   }
 
   function getProposal(
-    uint256 proposalId
+    uint256
   ) external view returns (address, uint256, uint256, uint256, string memory, uint256, bool) {
     return (address(0), 0, 0, 0, "", 0, false);
   }

--- a/packages/protocol/contracts/governance/test/MockLockedGold.sol
+++ b/packages/protocol/contracts/governance/test/MockLockedGold.sol
@@ -115,10 +115,7 @@ contract MockLockedGold is ILockedGold {
     return totalGovernancePower[account];
   }
 
-  function getPendingWithdrawal(
-    address account,
-    uint256 index
-  ) external view returns (uint256, uint256) {
+  function getPendingWithdrawal(address, uint256) external view returns (uint256, uint256) {
     return (0, 0);
   }
 
@@ -126,7 +123,7 @@ contract MockLockedGold is ILockedGold {
     return 0;
   }
 
-  function getAccountNonvotingLockedGold(address account) external view returns (uint256) {
+  function getAccountNonvotingLockedGold(address) external view returns (uint256) {
     return 0;
   }
 

--- a/packages/protocol/contracts/governance/test/MockValidators.sol
+++ b/packages/protocol/contracts/governance/test/MockValidators.sol
@@ -169,7 +169,7 @@ contract MockValidators is IValidators, IsL2Check {
     revert("Method not implemented in mock");
   }
 
-  function registerValidatorNoBls(bytes calldata ecdsaPublicKey) external returns (bool) {
+  function registerValidatorNoBls(bytes calldata) external returns (bool) {
     revert("Method not implemented in mock");
   }
   function removeMember(address) external returns (bool) {
@@ -208,7 +208,7 @@ contract MockValidators is IValidators, IsL2Check {
     revert("Method not implemented in mock");
   }
 
-  function setDowntimeGracePeriod(uint256 value) external {
+  function setDowntimeGracePeriod(uint256) external {
     revert("Method not implemented in mock");
   }
 
@@ -304,11 +304,7 @@ contract MockValidators is IValidators, IsL2Check {
     revert("Method not implemented in mock");
   }
 
-  function computeEpochReward(
-    address account,
-    uint256 score,
-    uint256 maxPayment
-  ) external view returns (uint256) {
+  function computeEpochReward(address account, uint256, uint256) external view returns (uint256) {
     return epochRewards[account];
   }
 
@@ -331,7 +327,7 @@ contract MockValidators is IValidators, IsL2Check {
   }
 
   function getValidator(
-    address account
+    address
   ) external view returns (bytes memory, bytes memory, address, uint256, address) {
     revert("Method not implemented in mock");
   }

--- a/packages/protocol/contracts/identity/IdentityProxyHub.sol
+++ b/packages/protocol/contracts/identity/IdentityProxyHub.sol
@@ -103,10 +103,7 @@ contract IdentityProxyHub is UsingRegistry, ICeloVersionedContract {
     for (uint256 i = 0; i < addresses.length; i++) {
       address otherAddr = addresses[i];
       if (otherAddr != addr) {
-        (uint32 otherCompleted,) = attestations.getAttestationStats(
-          identifier,
-          otherAddr
-        );
+        (uint32 otherCompleted, ) = attestations.getAttestationStats(identifier, otherAddr);
         hasMostCompletions = hasMostCompletions && otherCompleted <= completed;
       }
     }

--- a/packages/protocol/contracts/identity/IdentityProxyHub.sol
+++ b/packages/protocol/contracts/identity/IdentityProxyHub.sol
@@ -103,7 +103,7 @@ contract IdentityProxyHub is UsingRegistry, ICeloVersionedContract {
     for (uint256 i = 0; i < addresses.length; i++) {
       address otherAddr = addresses[i];
       if (otherAddr != addr) {
-        (uint32 otherCompleted, uint32 _requested) = attestations.getAttestationStats(
+        (uint32 otherCompleted,) = attestations.getAttestationStats(
           identifier,
           otherAddr
         );

--- a/packages/protocol/test-sol/devchain/e2e/common/EpochManager.t.sol
+++ b/packages/protocol/test-sol/devchain/e2e/common/EpochManager.t.sol
@@ -650,10 +650,7 @@ contract E2E_GasTest_Setup is E2E_EpochManager {
     }
 
     for (uint256 i = 0; i < validatorGroupCount; i++) {
-      registerNewValidatorGroupWithValidator(
-        i,
-        validatorPerGroupCount
-      );
+      registerNewValidatorGroupWithValidator(i, validatorPerGroupCount);
     }
 
     timeTravel(vm, epochDuration + 1);
@@ -815,10 +812,7 @@ contract E2E_FinishNextEpochProcess_Split is E2E_GasTest_Setup {
     uint256 validatorPerGroupCount = 2;
 
     for (uint256 i = 0; i < validatorGroupCount; i++) {
-      registerNewValidatorGroupWithValidator(
-        i,
-        validatorPerGroupCount
-      );
+      registerNewValidatorGroupWithValidator(i, validatorPerGroupCount);
     }
 
     timeTravel(vm, epochDuration + 1);

--- a/packages/protocol/test-sol/integration/CompileValidatorMock.t.sol
+++ b/packages/protocol/test-sol/integration/CompileValidatorMock.t.sol
@@ -8,7 +8,7 @@ import "forge-std/console.sol";
 import "@test-sol/unit/governance/validators/mocks/ValidatorsMock.sol";
 
 contract CompileValidatorMock is Test {
-  function test_nop() public {
+  function test_nop() public view {
     console.log("nop");
   }
 }

--- a/packages/protocol/test-sol/integration/RevokeCeloAfterL2Transition.sol
+++ b/packages/protocol/test-sol/integration/RevokeCeloAfterL2Transition.sol
@@ -302,7 +302,7 @@ contract RevokeCeloAfterL2Transition is Test, TestConstants, ECDSAHelper, Utils 
     epochManager.initializeSystem(l1EpochNumber, block.number, _elected);
   }
 
-  function _registerValidatorGroupHelper(address _group, uint256 numMembers) internal {
+  function _registerValidatorGroupHelper(address _group, uint256) internal {
     vm.startPrank(_group);
     if (!accounts.isAccount(_group)) {
       accounts.createAccount();
@@ -485,10 +485,7 @@ contract RevokeCeloAfterL2TransitionTest is RevokeCeloAfterL2Transition {
     address _validator,
     uint256 signerPk
   ) internal returns (bytes memory) {
-    (bytes memory _ecdsaPubKey, uint8 v, bytes32 r, bytes32 s) = _generateEcdsaPubKeyWithSigner(
-      _validator,
-      signerPk
-    );
+    (bytes memory _ecdsaPubKey, , , ) = _generateEcdsaPubKeyWithSigner(_validator, signerPk);
 
     ph.mockSuccess(ph.PROOF_OF_POSSESSION(), abi.encodePacked(_validator, blsPublicKey, blsPop));
 

--- a/packages/protocol/test-sol/unit/common/Blockable.t.sol
+++ b/packages/protocol/test-sol/unit/common/Blockable.t.sol
@@ -26,7 +26,7 @@ contract BlockableMock is Blockable, Ownable {
 }
 
 contract TestBlockable is BlockableMock {
-  function functionToBeBlocked() public onlyWhenNotBlocked {
+  function functionToBeBlocked() public view onlyWhenNotBlocked {
     return;
   }
 }
@@ -65,7 +65,7 @@ contract BlockableTest_setBlockable is BlockableTest {
 }
 
 contract BlockableTest_isBlocked is BlockableTest {
-  function test_isFalse_WhenBlockableNotSet() public {
+  function test_isFalse_WhenBlockableNotSet() public view {
     assert(blockable.isBlocked() == false);
   }
 
@@ -92,7 +92,7 @@ contract BlockableTest_onlyWhenNotBlocked is BlockableTest {
     blockableWithFunction.functionToBeBlocked();
   }
 
-  function test_callsucceeds_WhenNotBlocked() public {
+  function test_callsucceeds_WhenNotBlocked() public view {
     blockableWithFunction.functionToBeBlocked();
   }
 }

--- a/packages/protocol/test-sol/unit/common/CeloUnreleasedTreasury.t.sol
+++ b/packages/protocol/test-sol/unit/common/CeloUnreleasedTreasury.t.sol
@@ -80,7 +80,7 @@ contract CeloUnreleasedTreasuryTest is Test, TestConstants, IsL2Check {
     assertEq(celoToken.allocatedSupply(), L1_MINTED_CELO_SUPPLY, "total supply incorrect.");
   }
 
-  function newCeloUnreleasedTreasury() internal returns (CeloUnreleasedTreasury) {
+  function newCeloUnreleasedTreasury() internal {
     vm.warp(block.timestamp + l2StartTime);
     vm.prank(celoDistributionOwner);
     celoUnreleasedTreasury = new CeloUnreleasedTreasury(true);

--- a/packages/protocol/test-sol/unit/common/EpochManager.t.sol
+++ b/packages/protocol/test-sol/unit/common/EpochManager.t.sol
@@ -170,6 +170,7 @@ contract EpochManagerTest is Test, TestConstants, Utils08 {
 
   function getGroupsWithLessersAndGreaters()
     public
+    view
     returns (address[] memory, address[] memory, address[] memory)
   {
     address[] memory groups = new address[](1);
@@ -304,7 +305,6 @@ contract EpochManagerTest_startNextEpochProcess is EpochManagerTest {
 
   function test_ShouldMintTotalValidatorStableRewardsToEpochManager() public {
     initializeEpochManagerSystem();
-    uint256 beforeBalance = stableToken.balanceOf(address(epochManager));
     epochManager.startNextEpochProcess();
 
     assertEq(validators.mintedStable(), validator1Reward + validator2Reward);
@@ -312,7 +312,6 @@ contract EpochManagerTest_startNextEpochProcess is EpochManagerTest {
 
   function test_ShouldReleaseCorrectAmountToReserve() public {
     initializeEpochManagerSystem();
-    uint256 reserveBalanceBefore = celoToken.balanceOf(reserveAddress);
     epochManager.startNextEpochProcess();
     uint256 reserveBalanceAfter = celoToken.balanceOf(reserveAddress);
     assertEq(
@@ -687,18 +686,12 @@ contract EpochManagerTest_setToProcessGroups is EpochManagerTest {
   }
 
   function test_Reverts_WhenNotStarted() public {
-    address[] memory groups = new address[](0);
-
     vm.expectRevert("Epoch process is not started");
     epochManager.setToProcessGroups();
   }
 
   function test_setsToProcessGroups() public {
-    (
-      address[] memory groups,
-      address[] memory lessers,
-      address[] memory greaters
-    ) = getGroupsWithLessersAndGreaters();
+    (address[] memory groups, , ) = getGroupsWithLessersAndGreaters();
 
     epochManager.startNextEpochProcess();
     epochManager.setToProcessGroups();
@@ -707,12 +700,7 @@ contract EpochManagerTest_setToProcessGroups is EpochManagerTest {
   }
 
   function test_setsGroupRewards() public {
-    (
-      address[] memory groups,
-      address[] memory lessers,
-      address[] memory greaters
-    ) = getGroupsWithLessersAndGreaters();
-
+    (address[] memory groups, , ) = getGroupsWithLessersAndGreaters();
     epochManager.startNextEpochProcess();
     epochManager.setToProcessGroups();
 
@@ -779,12 +767,6 @@ contract EpochManagerTest_processGroup is EpochManagerTest {
   }
 
   function test_ProcessesGroup() public {
-    (
-      address[] memory groups,
-      address[] memory lessers,
-      address[] memory greaters
-    ) = getGroupsWithLessersAndGreaters();
-
     epochManager.startNextEpochProcess();
     epochManager.setToProcessGroups();
     epochManager.processGroup(group, address(0), address(0));
@@ -794,12 +776,6 @@ contract EpochManagerTest_processGroup is EpochManagerTest {
   }
 
   function test_TransfersToCommunityAndCarbonOffsetting() public {
-    (
-      address[] memory groups,
-      address[] memory lessers,
-      address[] memory greaters
-    ) = getGroupsWithLessersAndGreaters();
-
     epochManager.startNextEpochProcess();
     epochManager.setToProcessGroups();
     epochManager.processGroup(group, address(0), address(0));
@@ -809,12 +785,6 @@ contract EpochManagerTest_processGroup is EpochManagerTest {
   }
 
   function test_TransfersToValidatorGroup() public {
-    (
-      address[] memory groups,
-      address[] memory lessers,
-      address[] memory greaters
-    ) = getGroupsWithLessersAndGreaters();
-
     epochManager.startNextEpochProcess();
     epochManager.setToProcessGroups();
     epochManager.processGroup(group, address(0), address(0));
@@ -869,12 +839,8 @@ contract EpochManagerTest_getEpochByNumber is EpochManagerTest {
     initializeEpochManagerSystem();
     uint256 _startingEpochNumber = epochManager.getCurrentEpochNumber();
 
-    (
-      uint256 startingEpochFirstBlock,
-      uint256 startingEpochLastBlock,
-      uint256 startingEpochStartTimestamp,
-      uint256 startingEpochRewardBlock
-    ) = epochManager.getCurrentEpoch();
+    (uint256 startingEpochFirstBlock, , uint256 startingEpochStartTimestamp, ) = epochManager
+      .getCurrentEpoch();
 
     _travelAndProcess_N_L2Epoch(numberOfEpochsToTravel);
 
@@ -925,7 +891,6 @@ contract EpochManagerTest_getEpochByNumber is EpochManagerTest {
 
   function test_ReturnsZeroForFutureEpochs() public {
     initializeEpochManagerSystem();
-    address[] memory _expectedElected = new address[](0);
     (
       uint256 _firstBlock,
       uint256 _lastBlock,
@@ -958,12 +923,9 @@ contract EpochManagerTest_getEpochByBlockNumber is EpochManagerTest {
 
     _travelAndProcess_N_L2Epoch(2);
 
-    (
-      uint256 _firstBlock,
-      uint256 _lastBlock,
-      uint256 _timestamp,
-      uint256 rewardsBlock
-    ) = epochManager.getEpochByBlockNumber(firstEpochBlock + (3 * L2_BLOCK_IN_EPOCH));
+    (uint256 _firstBlock, uint256 _lastBlock, , ) = epochManager.getEpochByBlockNumber(
+      firstEpochBlock + (3 * L2_BLOCK_IN_EPOCH)
+    );
     assertEq(_firstBlock, firstEpochBlock + 1 + (2 * L2_BLOCK_IN_EPOCH));
     assertEq(_lastBlock, firstEpochBlock + 1 + (3 * L2_BLOCK_IN_EPOCH) - 1);
   }

--- a/packages/protocol/test-sol/unit/common/FeeHandler.t.sol
+++ b/packages/protocol/test-sol/unit/common/FeeHandler.t.sol
@@ -282,7 +282,7 @@ contract FeeHandlerTest_changeOtherBeneficiaryAllocation is FeeHandlerTest {
 
   function test_changedSucsesfully() public {
     feeHandler.changeOtherBeneficiaryAllocation(op, (30 * 1e24) / 100);
-    (uint256 fraction, string memory name, ) = feeHandler.getOtherBeneficiariesInfo(op);
+    (uint256 fraction, , ) = feeHandler.getOtherBeneficiariesInfo(op);
     assertEq(fraction, (30 * 1e24) / 100);
   }
 
@@ -1158,7 +1158,7 @@ contract FeeHandlerTest_SetBeneficiaryFraction is FeeHandlerTestAbstract {
 
   function test_setFractionSucsesfully() public {
     feeHandler.setBeneficiaryFraction(op, (30 * 1e24) / 100);
-    (uint256 fraction, string memory name, ) = feeHandler.getOtherBeneficiariesInfo(op);
+    (uint256 fraction, , ) = feeHandler.getOtherBeneficiariesInfo(op);
     assertEq(fraction, (30 * 1e24) / 100);
   }
 
@@ -1192,7 +1192,7 @@ contract FeeHandlerTest_SetBeneficiaryName is FeeHandlerTestAbstract {
 
   function test_setNameSucsesfully() public {
     feeHandler.setBeneficiaryName(op, "OP revenue share updated");
-    (uint256 fraction, string memory name, ) = feeHandler.getOtherBeneficiariesInfo(op);
+    (, string memory name, ) = feeHandler.getOtherBeneficiariesInfo(op);
     assertEq(name, "OP revenue share updated");
   }
 

--- a/packages/protocol/test-sol/unit/common/Multisig.t.sol
+++ b/packages/protocol/test-sol/unit/common/Multisig.t.sol
@@ -67,7 +67,8 @@ contract MultiSigTest_fallbackFunction is MultiSigTest {
   uint256 amount = 100;
 
   function uncheckedSendViaCall(address payable _to, uint256 _amount) public payable {
-    _to.call.value(_amount)("");
+    (bool res, ) = _to.call.value(_amount)("");
+    require(res, "call failed");
   }
 
   function test_Emits_DepositEventWithCorrectParameters_whenReceivingCelo() public payable {

--- a/packages/protocol/test-sol/unit/common/ProxyFactory08.t.sol
+++ b/packages/protocol/test-sol/unit/common/ProxyFactory08.t.sol
@@ -25,7 +25,7 @@ contract ProxyFactoryTest is Test, Utils08 {
   }
 
   function test_Reverts_WhenDeployingWithSameSenderAddressAndBytecode() public {
-    address deployedAddress = proxyFactory08.deployArbitraryByteCode(0, owner, 0, proxyInitCode);
+    proxyFactory08.deployArbitraryByteCode(0, owner, 0, proxyInitCode);
     vm.expectRevert("Create2: Failed on deploy");
     proxyFactory08.deployArbitraryByteCode(0, owner, 0, proxyInitCode);
   }
@@ -49,7 +49,7 @@ contract ProxyFactoryTest is Test, Utils08 {
     string memory compiler,
     bytes memory bytecode,
     string memory artifactPath
-  ) public {
+  ) public view {
     string memory bytecodeBackUp = vm.readFile(string.concat(artifactPath, compiler, ".hex"));
     string memory bytecodeString = vm.toString(bytecode);
 

--- a/packages/protocol/test-sol/unit/governance/mock/MockGovernance.sol
+++ b/packages/protocol/test-sol/unit/governance/mock/MockGovernance.sol
@@ -42,22 +42,22 @@ contract MockGovernance is IGovernance {
     removeVotesCalledFor[account] = maxAmountAllowed;
   }
 
-  function setConstitution(address destination, bytes4 functionId, uint256 threshold) external {
+  function setConstitution(address, bytes4, uint256) external {
     revert("not implemented");
   }
 
   function votePartially(
-    uint256 proposalId,
-    uint256 index,
-    uint256 yesVotes,
-    uint256 noVotes,
-    uint256 abstainVotes
+    uint256,
+    uint256,
+    uint256,
+    uint256,
+    uint256
   ) external returns (bool) {
     return true;
   }
 
   function getProposal(
-    uint256 proposalId
+    uint256
   ) external view returns (address, uint256, uint256, uint256, string memory, uint256, bool) {
     return (address(0), 0, 0, 0, "", 0, false);
   }
@@ -66,7 +66,7 @@ contract MockGovernance is IGovernance {
     return totalVotes[account];
   }
 
-  function getReferendumStageDuration() external view returns (uint256) {
+  function getReferendumStageDuration() external pure returns (uint256) {
     return 0;
   }
 }

--- a/packages/protocol/test-sol/unit/governance/mock/MockGovernance.sol
+++ b/packages/protocol/test-sol/unit/governance/mock/MockGovernance.sol
@@ -46,13 +46,7 @@ contract MockGovernance is IGovernance {
     revert("not implemented");
   }
 
-  function votePartially(
-    uint256,
-    uint256,
-    uint256,
-    uint256,
-    uint256
-  ) external returns (bool) {
+  function votePartially(uint256, uint256, uint256, uint256, uint256) external returns (bool) {
     return true;
   }
 

--- a/packages/protocol/test-sol/unit/governance/network/Governance.t.sol
+++ b/packages/protocol/test-sol/unit/governance/network/Governance.t.sol
@@ -145,7 +145,7 @@ contract GovernanceTest is Test, TestConstants, Utils {
     }
   }
 
-  function makeValidProposal() internal returns (uint256 proposalId) {
+  function makeValidProposal() internal returns (uint256) {
     return
       governance.propose.value(DEPOSIT)(
         okProp.values,
@@ -156,7 +156,7 @@ contract GovernanceTest is Test, TestConstants, Utils {
       );
   }
 
-  function makeEmptyProposal() internal returns (uint256 proposalId) {
+  function makeEmptyProposal() internal returns (uint256) {
     Proposal memory emptyProposal;
     return
       governance.propose.value(DEPOSIT)(
@@ -584,12 +584,7 @@ contract GovernanceTest_setParticipationFloor is GovernanceTest {
   function test_SetsValue() public {
     vm.prank(accOwner);
     governance.setParticipationFloor(NEW_VALUE);
-    (
-      uint256 baseline,
-      uint256 baselineFloor,
-      uint256 _baselineUpdateFactor,
-      uint256 _baselineQuorumFactor
-    ) = governance.getParticipationParameters();
+    (, uint256 baselineFloor, , ) = governance.getParticipationParameters();
     assertEq(baselineFloor, NEW_VALUE);
   }
 
@@ -619,12 +614,7 @@ contract GovernanceTest_setBaselineUpdateFactor is GovernanceTest {
   function test_SetsValue() public {
     vm.prank(accOwner);
     governance.setBaselineUpdateFactor(NEW_VALUE);
-    (
-      uint256 baseline,
-      uint256 baselineFloor,
-      uint256 _baselineUpdateFactor,
-      uint256 _baselineQuorumFactor
-    ) = governance.getParticipationParameters();
+    (, , uint256 _baselineUpdateFactor, ) = governance.getParticipationParameters();
     assertEq(_baselineUpdateFactor, NEW_VALUE);
   }
 
@@ -654,12 +644,7 @@ contract GovernanceTest_setBaselineQuorumFactor is GovernanceTest {
   function test_SetsValue() public {
     vm.prank(accOwner);
     governance.setBaselineQuorumFactor(NEW_VALUE);
-    (
-      uint256 baseline,
-      uint256 baselineFloor,
-      uint256 _baselineUpdateFactor,
-      uint256 _baselineQuorumFactor
-    ) = governance.getParticipationParameters();
+    (, , , uint256 _baselineQuorumFactor) = governance.getParticipationParameters();
     assertEq(_baselineQuorumFactor, NEW_VALUE);
   }
 
@@ -1288,7 +1273,6 @@ contract GovernanceTest_revokeUpvote is GovernanceTest {
   function test_markAccountAsNotHavingUpvoted_whenMoreThanDequeueFrequencySinceLastDequeue()
     public
   {
-    uint256 originalLastDequeue = governance.lastDequeue();
     vm.warp(block.timestamp + governance.dequeueFrequency());
     governance.revokeUpvote(0, 0);
     (uint256 recordId, uint256 recordWeight) = governance.getUpvoteRecord(accVoter);
@@ -1758,7 +1742,7 @@ contract GovernanceTest_vote_WhenProposalIsApproved is GovernanceTest {
     vm.startPrank(accVoter);
     governance.vote(proposalId, 0, Proposals.VoteValue.Yes);
     governance.vote(proposalId, 0, Proposals.VoteValue.No);
-    (uint256 yes, uint256 no, uint256 abstain) = governance.getVoteTotals(proposalId);
+    (uint256 yes, uint256 no, ) = governance.getVoteTotals(proposalId);
     assertEq(yes, 0);
     assertEq(no, VOTER_GOLD);
   }
@@ -1767,8 +1751,7 @@ contract GovernanceTest_vote_WhenProposalIsApproved is GovernanceTest {
     vm.startPrank(accVoter);
     governance.vote(proposalId, 0, Proposals.VoteValue.Yes);
     governance.vote(proposalId, 0, Proposals.VoteValue.No);
-    (uint256 id, uint256 _1, uint256 _2, uint256 yes, uint256 no, uint256 abstain) = governance
-      .getVoteRecord(accVoter, 0);
+    (uint256 id, , , uint256 yes, uint256 no, ) = governance.getVoteRecord(accVoter, 0);
     assertEq(id, proposalId);
     assertEq(yes, 0);
     assertEq(no, VOTER_GOLD);
@@ -1778,7 +1761,7 @@ contract GovernanceTest_vote_WhenProposalIsApproved is GovernanceTest {
     vm.startPrank(accVoter);
     governance.vote(proposalId, 0, Proposals.VoteValue.No);
     governance.vote(proposalId, 0, Proposals.VoteValue.Abstain);
-    (uint256 yes, uint256 no, uint256 abstain) = governance.getVoteTotals(proposalId);
+    (, uint256 no, uint256 abstain) = governance.getVoteTotals(proposalId);
     assertEq(no, 0);
     assertEq(abstain, VOTER_GOLD);
   }
@@ -1787,8 +1770,7 @@ contract GovernanceTest_vote_WhenProposalIsApproved is GovernanceTest {
     vm.startPrank(accVoter);
     governance.vote(proposalId, 0, Proposals.VoteValue.No);
     governance.vote(proposalId, 0, Proposals.VoteValue.Abstain);
-    (uint256 id, uint256 _1, uint256 _2, uint256 yes, uint256 no, uint256 abstain) = governance
-      .getVoteRecord(accVoter, 0);
+    (uint256 id, , , , uint256 no, uint256 abstain) = governance.getVoteRecord(accVoter, 0);
     assertEq(id, proposalId);
     assertEq(no, 0);
     assertEq(abstain, VOTER_GOLD);
@@ -1798,7 +1780,7 @@ contract GovernanceTest_vote_WhenProposalIsApproved is GovernanceTest {
     vm.startPrank(accVoter);
     governance.vote(proposalId, 0, Proposals.VoteValue.Abstain);
     governance.vote(proposalId, 0, Proposals.VoteValue.Yes);
-    (uint256 yes, uint256 no, uint256 abstain) = governance.getVoteTotals(proposalId);
+    (uint256 yes, , uint256 abstain) = governance.getVoteTotals(proposalId);
     assertEq(abstain, 0);
     assertEq(yes, VOTER_GOLD);
   }
@@ -1807,8 +1789,7 @@ contract GovernanceTest_vote_WhenProposalIsApproved is GovernanceTest {
     vm.startPrank(accVoter);
     governance.vote(proposalId, 0, Proposals.VoteValue.Abstain);
     governance.vote(proposalId, 0, Proposals.VoteValue.Yes);
-    (uint256 id, uint256 _1, uint256 _2, uint256 yes, uint256 no, uint256 abstain) = governance
-      .getVoteRecord(accVoter, 0);
+    (uint256 id, , , uint256 yes, , uint256 abstain) = governance.getVoteRecord(accVoter, 0);
     assertEq(id, proposalId);
     assertEq(abstain, 0);
     assertEq(yes, VOTER_GOLD);
@@ -2241,8 +2222,10 @@ contract GovernanceTest_vote_PartiallyWhenProposalIsApproved is GovernanceTest {
     vm.startPrank(accVoter);
     governance.votePartially(proposalId, 0, 10, 50, 30);
     governance.votePartially(proposalId, 0, 30, 20, 40);
-    (uint256 id, uint256 _1, uint256 _2, uint256 yes, uint256 no, uint256 abstain) = governance
-      .getVoteRecord(accVoter, 0);
+    (uint256 id, , , uint256 yes, uint256 no, uint256 abstain) = governance.getVoteRecord(
+      accVoter,
+      0
+    );
     assertEq(id, proposalId);
     assertEq(yes, 30);
     assertEq(no, 20);

--- a/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/Validators.t.sol
@@ -175,7 +175,6 @@ contract ValidatorsTest is Test, TestConstants, Utils, ECDSAHelper {
     lockedGold = new MockLockedGold();
     election = new MockElection();
     address validatorsAddress = actor("Validators");
-    address validatorsMockFactoryAddress = actor("validatorsMockFactory");
 
     deployCodeTo("ValidatorsMock.sol", validatorsAddress);
     validators = IValidators(validatorsAddress);

--- a/packages/protocol/test-sol/unit/governance/validators/mocks/CompileValidatorIntegrationMock.t.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/mocks/CompileValidatorIntegrationMock.t.sol
@@ -8,7 +8,7 @@ import "forge-std/console.sol";
 import "@test-sol/unit/governance/validators/mocks/ValidatorsMock.sol";
 
 contract CompileValidatorIntegrationMock is Test {
-  function test_nop() public {
+  function test_nop() public view {
     console.log("nop");
   }
 }

--- a/packages/protocol/test-sol/unit/governance/validators/mocks/ValidatorsMock.sol
+++ b/packages/protocol/test-sol/unit/governance/validators/mocks/ValidatorsMock.sol
@@ -8,11 +8,7 @@ import "@celo-contracts/common/FixidityLib.sol";
  * @title A wrapper around Validators that exposes onlyVm functions for testing.
  */
 contract ValidatorsMock is Validators(true) {
-  function computeEpochReward(
-    address account,
-    uint256 score,
-    uint256 maxPayment
-  ) external view override returns (uint256) {
+  function computeEpochReward(address, uint256, uint256) external pure override returns (uint256) {
     return 1;
   }
 }

--- a/packages/protocol/test-sol/unit/governance/voting/ReleaseGold.t.sol
+++ b/packages/protocol/test-sol/unit/governance/voting/ReleaseGold.t.sol
@@ -846,7 +846,7 @@ contract ReleaseGoldTest_AuthorizationTests is ReleaseGoldTest {
   }
 
   function test_ShouldRevertIfTheSignatureIsIncorrect() public {
-    (address otherAccount, uint256 otherAccountPK) = actorWithPK("otherAccount");
+    (, uint256 otherAccountPK) = actorWithPK("otherAccount");
     (uint8 otherV, bytes32 otherR, bytes32 otherS) = getParsedSignatureOfAddress(
       address(releaseGold),
       otherAccountPK
@@ -1039,7 +1039,7 @@ contract ReleaseGoldTest_AuthorizeWithPublicKeys is ReleaseGoldTest {
 
   bytes ecdsaPublicKey;
 
-  function _randomBytes32() internal returns (bytes32) {
+  function _randomBytes32() internal view returns (bytes32) {
     return keccak256(abi.encodePacked(block.timestamp, block.difficulty, msg.sender));
   }
 

--- a/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
@@ -106,13 +106,7 @@ contract FeeCurrencyAdapterTest is Test {
     feeCurrencyAdapter = new CeloFeeCurrencyAdapterTestContract(true);
     feeCurrencyAdapterForFuzzyTests = new CeloFeeCurrencyAdapterTestContract(true);
 
-    address feeCurrencyAddress = actor("feeCurrency");
-
-    string memory name = "tokenName";
-    string memory symbol = "tN";
-
     feeCurrency = new FeeCurrency6DecimalsTest(initialSupply);
-
     feeCurrencyAdapter.initialize(address(feeCurrency), "wrapper", "wr", 18);
   }
 }


### PR DESCRIPTION
### Description

Removal of build warnings as much as possible. Since we are using both Solidity 0.5 and 0.8 it is unfortunately not possible to remove all warnings since one breaks other.