### PR TITLE
Soloseng/L2-goldToken-test

### DIFF
--- a/packages/protocol/test-sol/unit/common/CeloTokenMock.sol
+++ b/packages/protocol/test-sol/unit/common/CeloTokenMock.sol
@@ -6,7 +6,7 @@ import "@celo-contracts/common/GoldToken.sol";
 /**
  * @title A mock GoldToken for testing.
  */
-contract GoldTokenMock is GoldToken(true) {
+contract CeloTokenMock is GoldToken(true) {
   uint8 public constant decimals = 18;
   mapping(address => uint256) balances;
 

--- a/packages/protocol/test-sol/unit/common/FeeHandlerSeller.t.sol
+++ b/packages/protocol/test-sol/unit/common/FeeHandlerSeller.t.sol
@@ -6,7 +6,7 @@ pragma experimental ABIEncoderV2;
 import { Test } from "celo-foundry/Test.sol";
 import { TestConstants } from "@test-sol/constants.sol";
 
-import { GoldTokenMock } from "@test-sol/unit/common/GoldTokenMock.sol";
+import { CeloTokenMock } from "@test-sol/unit/common/CeloTokenMock.sol";
 import { FeeHandlerSeller } from "@celo-contracts/common/FeeHandlerSeller.sol";
 import { MentoFeeHandlerSeller } from "@celo-contracts/common/MentoFeeHandlerSeller.sol";
 import { UniswapFeeHandlerSeller } from "@celo-contracts/common/UniswapFeeHandlerSeller.sol";
@@ -21,7 +21,7 @@ contract FeeHandlerSellerTest is Test, TestConstants {
   address NON_OWNER_ADDRESS = actor("Arbitrary Non-Owner");
 
   // Contract instances
-  GoldTokenMock celoToken; // Using mock token to work around missing transfer precompile
+  CeloTokenMock celoToken; // Using mock token to work around missing transfer precompile
   FeeHandlerSeller mentoFeeHandlerSeller;
   FeeHandlerSeller uniswapFeeHandlerSeller;
 
@@ -35,7 +35,7 @@ contract FeeHandlerSellerTest is Test, TestConstants {
     deployCodeTo("Registry.sol", abi.encode(false), REGISTRY_ADDRESS);
     IRegistry registry = IRegistry(REGISTRY_ADDRESS);
 
-    celoToken = new GoldTokenMock();
+    celoToken = new CeloTokenMock();
     oracle = actor("oracle");
     sortedOracles = actor("sortedOracles");
 

--- a/packages/protocol/test-sol/unit/common/GoldToken.t.sol
+++ b/packages/protocol/test-sol/unit/common/GoldToken.t.sol
@@ -7,7 +7,7 @@ import "@test-sol/unit/common/GoldTokenMock.sol";
 import { Utils } from "@test-sol/utils.sol";
 import "@test-sol/utils/WhenL2.sol";
 
-contract GoldTokenTest is Utils {
+contract CeloTokenTest is Utils {
   GoldToken celoToken;
 
   uint256 constant ONE_CELOTOKEN = 1000000000000000000;
@@ -52,7 +52,7 @@ contract GoldTokenTest is Utils {
   }
 }
 
-contract GoldTokenTest_Pre_L2 is GoldTokenTest {
+contract CeloTokenTest_PreL2 is CeloTokenTest {
   function setUp() public {
     super.setUp();
 
@@ -63,9 +63,9 @@ contract GoldTokenTest_Pre_L2 is GoldTokenTest {
     vm.deal(address(0), 0);
   }
 }
-contract GoldTokenTest_L2 is GoldTokenTest_Pre_L2, WhenL2 {}
+contract CeloTokenTest_L2 is CeloTokenTest_PreL2, WhenL2 {}
 
-contract GoldTokenTest_general is GoldTokenTest {
+contract CeloTokenTest_general is CeloTokenTest {
   function test_name() public {
     assertEq(celoToken.name(), "Celo native asset");
   }
@@ -111,9 +111,9 @@ contract GoldTokenTest_general is GoldTokenTest {
   }
 }
 
-contract GoldTokenTest_general_L2 is GoldTokenTest_L2, GoldTokenTest_general {}
+contract CeloTokenTest_general_L2 is CeloTokenTest_L2, CeloTokenTest_general {}
 
-contract GoldTokenTest_transfer is GoldTokenTest {
+contract CeloTokenTest_transfer is CeloTokenTest {
   function setUp() public {
     super.setUp();
   }
@@ -168,9 +168,9 @@ contract GoldTokenTest_transfer is GoldTokenTest {
   }
 }
 
-contract GoldTokenTest_transfer_L2 is GoldTokenTest_L2, GoldTokenTest_transfer {}
+contract CeloTokenTest_transfer_L2 is CeloTokenTest_L2, CeloTokenTest_transfer {}
 
-contract GoldTokenTest_transferFrom is GoldTokenTest {
+contract CeloTokenTest_transferFrom is CeloTokenTest {
   function setUp() public {
     super.setUp();
     vm.prank(sender);
@@ -215,9 +215,9 @@ contract GoldTokenTest_transferFrom is GoldTokenTest {
   }
 }
 
-contract GoldTokenTest_transferFrom_L2 is GoldTokenTest_L2, GoldTokenTest_transferFrom {}
+contract CeloTokenTest_transferFrom_L2 is CeloTokenTest_L2, CeloTokenTest_transferFrom {}
 
-contract GoldTokenTest_burn is GoldTokenTest {
+contract CeloTokenTest_burn is CeloTokenTest {
   uint256 startBurn;
   address burnAddress = address(0x000000000000000000000000000000000000dEaD);
 
@@ -244,9 +244,9 @@ contract GoldTokenTest_burn is GoldTokenTest {
   }
 }
 
-contract GoldTokenTest_burn_L2 is GoldTokenTest_L2, GoldTokenTest_burn {}
+contract CeloTokenTest_burn_L2 is CeloTokenTest_L2, CeloTokenTest_burn {}
 
-contract GoldTokenTest_mint is GoldTokenTest {
+contract CeloTokenTest_mint is CeloTokenTest {
   function test_Reverts_whenCalledByOtherThanVm() public {
     vm.prank(celoTokenOwner);
     vm.expectRevert("Only VM can call");
@@ -282,7 +282,7 @@ contract GoldTokenTest_mint is GoldTokenTest {
   }
 }
 
-contract GoldTokenTest_mint_L2 is GoldTokenTest_L2 {
+contract CeloTokenTest_mint_L2 is CeloTokenTest_L2 {
   function test_Reverts_whenL2() public {
     vm.expectRevert("This method is no longer supported in L2.");
     vm.prank(celoUnreleasedTreasuryAddress);
@@ -293,7 +293,7 @@ contract GoldTokenTest_mint_L2 is GoldTokenTest_L2 {
   }
 }
 
-contract GoldTokenTest_increaseSupply is GoldTokenTest {
+contract CeloTokenTest_increaseSupply is CeloTokenTest {
   function test_ShouldIncreaseTotalSupply() public {
     uint256 celoTokenSupplyBefore = celoToken.totalSupply();
     vm.prank(address(0));
@@ -309,7 +309,7 @@ contract GoldTokenTest_increaseSupply is GoldTokenTest {
   }
 }
 
-contract GoldTokenTest_increaseSupply_L2 is GoldTokenTest_L2 {
+contract CeloTokenTest_increaseSupply_L2 is CeloTokenTest_L2 {
   function test_Reverts_WhenL2() public {
     vm.prank(celoTokenOwner);
     vm.expectRevert("This method is no longer supported in L2.");
@@ -317,7 +317,7 @@ contract GoldTokenTest_increaseSupply_L2 is GoldTokenTest_L2 {
   }
 }
 
-contract CeloTokenMock_circulatingSupply is GoldTokenTest {
+contract CeloTokenTest_circulatingSupply is CeloTokenTest {
   function test_ShouldMatchCirculatingSupply_WhenNoBurn() public {
     assertEq(celoToken.circulatingSupply(), celoToken.allocatedSupply());
     assertEq(celoToken.circulatingSupply(), L1_MINTED_CELO_SUPPLY);
@@ -331,20 +331,20 @@ contract CeloTokenMock_circulatingSupply is GoldTokenTest {
   }
 }
 
-contract CeloTokenMock_circulatingSupply_L2 is GoldTokenTest_L2, CeloTokenMock_circulatingSupply {
+contract CeloTokenTest_circulatingSupply_L2 is CeloTokenTest_L2, CeloTokenMock_circulatingSupply {
   function test_ShouldBeLessThanTheTotalSupply() public {
     assertLt(celoToken.circulatingSupply(), celoToken.totalSupply());
   }
 }
 
-contract GoldTokenTest_AllocatedSupply is GoldTokenTest {
+contract CeloTokenTest_AllocatedSupply is CeloTokenTest {
   function test_ShouldReturnTotalSupply() public {
     assertEq(celoToken.allocatedSupply(), L1_MINTED_CELO_SUPPLY);
     assertEq(celoToken.allocatedSupply(), celoToken.totalSupply());
   }
 }
 
-contract GoldTokenTest_AllocatedSupply_L2 is GoldTokenTest_L2 {
+contract CeloTokenTest_AllocatedSupply_L2 is CeloTokenTest_L2 {
   function test_ShouldReturnTotalSupplyMinusCeloUnreleasedTreasuryBalance() public {
     assertEq(celoToken.allocatedSupply(), CELO_SUPPLY_CAP - L2_INITIAL_STASH_BALANCE);
     assertEq(celoToken.allocatedSupply(), celoToken.totalSupply() - L2_INITIAL_STASH_BALANCE);
@@ -356,13 +356,13 @@ contract GoldTokenTest_AllocatedSupply_L2 is GoldTokenTest_L2 {
   }
 }
 
-contract GoldTokenTest_TotalSupply is GoldTokenTest {
+contract CeloTokenTest_TotalSupply is CeloTokenTest {
   function test_ShouldReturnL1MintedSupply() public {
     assertEq(celoToken.totalSupply(), L1_MINTED_CELO_SUPPLY);
   }
 }
 
-contract GoldTokenTest_TotalSupply_L2 is GoldTokenTest_L2 {
+contract CeloTokenTest_TotalSupply_L2 is CeloTokenTest_L2 {
   function test_ShouldReturnSupplyCap_WhenL2() public {
     assertEq(celoToken.totalSupply(), CELO_SUPPLY_CAP);
   }

--- a/packages/protocol/test-sol/unit/common/GoldToken.t.sol
+++ b/packages/protocol/test-sol/unit/common/GoldToken.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.5.13;
 
 import "@celo-contracts/common/GoldToken.sol";
-import "@test-sol/unit/common/GoldTokenMock.sol";
 
 import { Utils } from "@test-sol/utils.sol";
 import "@test-sol/utils/WhenL2.sol";

--- a/packages/protocol/test-sol/unit/common/GoldToken.t.sol
+++ b/packages/protocol/test-sol/unit/common/GoldToken.t.sol
@@ -270,15 +270,6 @@ contract CeloTokenTest_mint is CeloTokenTest {
     emit Transfer(address(0), receiver, ONE_CELOTOKEN);
     celoToken.mint(receiver, ONE_CELOTOKEN);
   }
-
-  function test_Reverts_whenL2() public _whenL22 {
-    vm.expectRevert("This method is no longer supported in L2.");
-    vm.prank(celoUnreleasedTreasuryAddress);
-    celoToken.mint(receiver, ONE_CELOTOKEN);
-    vm.expectRevert("This method is no longer supported in L2.");
-    vm.prank(address(0));
-    celoToken.mint(receiver, ONE_CELOTOKEN);
-  }
 }
 
 contract CeloTokenTest_mint_L2 is CeloTokenTest_L2 {
@@ -330,7 +321,7 @@ contract CeloTokenTest_circulatingSupply is CeloTokenTest {
   }
 }
 
-contract CeloTokenTest_circulatingSupply_L2 is CeloTokenTest_L2, CeloTokenMock_circulatingSupply {
+contract CeloTokenTest_circulatingSupply_L2 is CeloTokenTest_L2, CeloTokenTest_circulatingSupply {
   function test_ShouldBeLessThanTheTotalSupply() public {
     assertLt(celoToken.circulatingSupply(), celoToken.totalSupply());
   }

--- a/packages/protocol/test-sol/unit/governance/network/EpochRewards.t.sol
+++ b/packages/protocol/test-sol/unit/governance/network/EpochRewards.t.sol
@@ -11,7 +11,7 @@ import { Reserve } from "@lib/mento-core/contracts/Reserve.sol";
 
 import { MockSortedOracles } from "@celo-contracts/stability/test/MockSortedOracles.sol";
 import { MockStableToken } from "@celo-contracts/stability/test/MockStableToken.sol";
-import { GoldTokenMock } from "@test-sol/unit/common/GoldTokenMock.sol";
+import { CeloTokenMock } from "@test-sol/unit/common/CeloTokenMock.sol";
 
 import { TestConstants } from "@test-sol/constants.sol";
 import { Utils } from "@test-sol/utils.sol";
@@ -42,7 +42,7 @@ contract EpochRewardsTest is Test, TestConstants, Utils {
   MockElection election;
   MockSortedOracles mockSortedOracles;
   MockStableToken mockStableToken;
-  GoldTokenMock mockGoldToken;
+  CeloTokenMock mockCeloToken;
   Reserve reserve;
   Freezer freezer;
 
@@ -67,7 +67,7 @@ contract EpochRewardsTest is Test, TestConstants, Utils {
     election = new MockElection();
     mockSortedOracles = new MockSortedOracles();
     mockStableToken = new MockStableToken();
-    mockGoldToken = new GoldTokenMock();
+    mockCeloToken = new CeloTokenMock();
 
     freezer = new Freezer(true);
     registry = new Registry(true);
@@ -75,7 +75,7 @@ contract EpochRewardsTest is Test, TestConstants, Utils {
     registry.setAddressFor(ElectionContract, address(election));
     registry.setAddressFor(SortedOraclesContract, address(mockSortedOracles));
     registry.setAddressFor(StableTokenContract, address(mockStableToken));
-    registry.setAddressFor(CeloTokenContract, address(mockGoldToken));
+    registry.setAddressFor(CeloTokenContract, address(mockCeloToken));
     registry.setAddressFor(FreezerContract, address(freezer));
 
     mockSortedOracles.setMedianRate(
@@ -482,7 +482,7 @@ contract EpochRewardsTest_getRewardsMultiplier is EpochRewardsTest {
   }
 
   function test_ShouldReturnOne_WhenTheTargetSupplyIsEqualToTheActualSupplyAfterRewards() public {
-    mockGoldToken.setTotalSupply(expectedTargetTotalSupply - targetEpochReward);
+    mockCeloToken.setTotalSupply(expectedTargetTotalSupply - targetEpochReward);
     assertEq(epochRewards.getRewardsMultiplier(), FIXED1);
   }
 
@@ -491,7 +491,7 @@ contract EpochRewardsTest_getRewardsMultiplier is EpochRewardsTest {
   {
     uint256 actualRemainingSupply = uint256((expectedTargetRemainingSupply * 11) / 10);
     uint256 totalSupply = SUPPLY_CAP - actualRemainingSupply - targetEpochReward;
-    mockGoldToken.setTotalSupply(totalSupply);
+    mockCeloToken.setTotalSupply(totalSupply);
 
     uint256 actual = epochRewards.getRewardsMultiplier();
     uint256 expected = uint256((FIXED1 + (rewardsMultiplierAdjustmentsUnderspend / 10)));
@@ -503,7 +503,7 @@ contract EpochRewardsTest_getRewardsMultiplier is EpochRewardsTest {
   {
     uint256 actualRemainingSupply = uint256((expectedTargetRemainingSupply * 9) / 10);
     uint256 totalSupply = SUPPLY_CAP - actualRemainingSupply - targetEpochReward;
-    mockGoldToken.setTotalSupply(totalSupply);
+    mockCeloToken.setTotalSupply(totalSupply);
 
     uint256 actual = epochRewards.getRewardsMultiplier();
     uint256 expected = uint256((FIXED1 - (rewardsMultiplierAdjustmentsOverspend / 10)));
@@ -540,7 +540,7 @@ contract EpochRewardsTest_updateTargetVotingYield is EpochRewardsTest {
       2 * FIXED1
     );
 
-    mockGoldToken.setTotalSupply(totalSupply);
+    mockCeloToken.setTotalSupply(totalSupply);
     vm.deal(address(reserve), reserveBalance);
   }
 
@@ -796,7 +796,7 @@ contract EpochRewardsTest_WhenThereAreActiveVotesAStableTokenExchangeRateIsSetAn
     uint256 expectedTargetRemainingSupply = SUPPLY_CAP - expectedTargetTotalSupply;
     uint256 actualRemainingSupply = (expectedTargetRemainingSupply * 11) / 10;
     uint256 totalSupply = SUPPLY_CAP - actualRemainingSupply - expectedTargetGoldSupplyIncrease;
-    mockGoldToken.setTotalSupply(totalSupply);
+    mockCeloToken.setTotalSupply(totalSupply);
     expectedMultiplier = (FIXED1 + rewardsMultiplierAdjustmentsUnderspend / 10);
 
     validatorReward = (targetValidatorEpochPayment * numberValidators) / exchangeRate;
@@ -875,22 +875,22 @@ contract EpochRewardsTest_isReserveLow is EpochRewardsTest {
       2 * FIXED1
     );
     reserve.addToken(address(mockStableToken));
-    mockGoldToken.setTotalSupply(totalSupply);
+    mockCeloToken.setTotalSupply(totalSupply);
     mockStableToken.setTotalSupply(stableBalance);
   }
 
   // reserve ratio of 0.5'
   function test_ShouldBeLowAtStart_WhenReserveRatioIs05() public {
-    uint256 goldBalance = ((stableBalance / exchangeRate) / 2) / 2;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((stableBalance / exchangeRate) / 2) / 2;
+    vm.deal(address(reserve), celoBalance);
     // no time travel
     assertEq(epochRewards.isReserveLow(), true);
   }
 
   // reserve ratio of 1.5
   function test_ShouldBeLowAt15Years_WhenReserveRatioIs05() public {
-    uint256 goldBalance = ((stableBalance / exchangeRate) / 2) / 2;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((stableBalance / exchangeRate) / 2) / 2;
+    vm.deal(address(reserve), celoBalance);
     uint256 timeDelta = YEAR * 15;
     timeTravel(timeDelta);
 
@@ -898,8 +898,8 @@ contract EpochRewardsTest_isReserveLow is EpochRewardsTest {
   }
 
   function test_ShouldBeLowAt25Years_WhenReserveRatioIs05() public {
-    uint256 goldBalance = ((stableBalance / exchangeRate) / 2) / 2;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((stableBalance / exchangeRate) / 2) / 2;
+    vm.deal(address(reserve), celoBalance);
     uint256 timeDelta = YEAR * 25;
     timeTravel(timeDelta);
 
@@ -907,54 +907,54 @@ contract EpochRewardsTest_isReserveLow is EpochRewardsTest {
   }
 
   function test_ShouldBeLowAtStar_WhenReserveRatioIs1point5() public {
-    uint256 goldBalance = ((3 * stableBalance) / exchangeRate) / 4;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((3 * stableBalance) / exchangeRate) / 4;
+    vm.deal(address(reserve), celoBalance);
     // no time travel
     assertEq(epochRewards.isReserveLow(), true);
   }
 
   function test_ShouldBeLowAt12Years_WhenReserveRatioIs1point5() public {
-    uint256 goldBalance = ((3 * stableBalance) / exchangeRate) / 4;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((3 * stableBalance) / exchangeRate) / 4;
+    vm.deal(address(reserve), celoBalance);
     uint256 timeDelta = YEAR * 12;
     timeTravel(timeDelta);
     assertEq(epochRewards.isReserveLow(), true);
   }
 
   function test_ShouldNotBeLowAt15Years_WhenReserveRatioIs1point5() public {
-    uint256 goldBalance = ((3 * stableBalance) / exchangeRate) / 4;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((3 * stableBalance) / exchangeRate) / 4;
+    vm.deal(address(reserve), celoBalance);
     uint256 timeDelta = YEAR * 15;
     timeTravel(timeDelta);
     assertEq(epochRewards.isReserveLow(), false);
   }
 
   function test_ShouldNotBeLowAt25Years_WhenReserveRatioIs1point5() public {
-    uint256 goldBalance = ((3 * stableBalance) / exchangeRate) / 4;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((3 * stableBalance) / exchangeRate) / 4;
+    vm.deal(address(reserve), celoBalance);
     uint256 timeDelta = YEAR * 25;
     timeTravel(timeDelta);
     assertEq(epochRewards.isReserveLow(), false);
   }
 
   function test_ShouldBeLowAtStar_WhenReserveRatioIs2point5() public {
-    uint256 goldBalance = ((5 * stableBalance) / exchangeRate) / 4;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((5 * stableBalance) / exchangeRate) / 4;
+    vm.deal(address(reserve), celoBalance);
     // no time travel
     assertEq(epochRewards.isReserveLow(), false);
   }
 
   function test_ShouldNotBeLowAt15Years_WhenReserveRatioIs2point5() public {
-    uint256 goldBalance = ((5 * stableBalance) / exchangeRate) / 4;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((5 * stableBalance) / exchangeRate) / 4;
+    vm.deal(address(reserve), celoBalance);
     uint256 timeDelta = YEAR * 15;
     timeTravel(timeDelta);
     assertEq(epochRewards.isReserveLow(), false);
   }
 
   function test_ShouldNotBeLowAt25Years_WhenReserveRatioIs2point5() public {
-    uint256 goldBalance = ((5 * stableBalance) / exchangeRate) / 4;
-    vm.deal(address(reserve), goldBalance);
+    uint256 celoBalance = ((5 * stableBalance) / exchangeRate) / 4;
+    vm.deal(address(reserve), celoBalance);
     uint256 timeDelta = YEAR * 25;
     timeTravel(timeDelta);
     assertEq(epochRewards.isReserveLow(), false);

--- a/packages/protocol/test-sol/unit/governance/voting/LockedGold.t.sol
+++ b/packages/protocol/test-sol/unit/governance/voting/LockedGold.t.sol
@@ -7,7 +7,7 @@ import "@test-sol/utils/WhenL2.sol";
 
 import "@celo-contracts/common/FixidityLib.sol";
 import "@celo-contracts/common/Accounts.sol";
-import "@test-sol/unit/common/GoldTokenMock.sol";
+import "@test-sol/unit/common/CeloTokenMock.sol";
 import "@celo-contracts/governance/LockedGold.sol";
 import "@celo-contracts/governance/ReleaseGold.sol";
 import "@celo-contracts/governance/Election.sol";
@@ -22,7 +22,7 @@ contract LockedGoldTest is Utils {
   using FixidityLib for FixidityLib.Fraction;
 
   Accounts accounts;
-  GoldToken goldToken;
+  GoldToken celoToken;
   MockStableToken stableToken;
   MockElection election;
   MockGovernance governance;
@@ -68,7 +68,7 @@ contract LockedGoldTest is Utils {
   function setUp() public {
     super.setUp();
 
-    goldToken = new GoldTokenMock();
+    celoToken = new CeloTokenMock();
     accounts = new Accounts(true);
     lockedGold = new LockedGold(true);
     election = new MockElection();


### PR DESCRIPTION
### Description

setup the CeloToken test to use the new L2 test setup.

### Other changes

removed the use of `mockGoldToken` for circulatingSupply, allocatedSupply and totalSupply tests


### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/756

