### PR TITLE
Corrected typos

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -2,7 +2,7 @@
 
 ## How to run a local testnet
 
-Often when developing, it is useful to create a test network localy using the full celo-blockchain binary to go beyond what can be done with other options such as [Ganache](https://www.trufflesuite.com/ganache)
+Often when developing, it is useful to create a test network locally using the full celo-blockchain binary to go beyond what can be done with other options such as [Ganache](https://www.trufflesuite.com/ganache)
 
 The quickest way to get started with a local testnet is by running `yarn celotool local-testnet` from the `monorepo` root.
 

--- a/developer_key_publishing.md
+++ b/developer_key_publishing.md
@@ -133,13 +133,13 @@ This command will query [clabs.co](https://clabs.co) over HTTPS and retrieve the
 
 ### Manually fetching a key
 
-If you want to check a key is correctly hosted, or want to fetch a key manualy for some reason, you can do so with:
+If you want to check a key is correctly hosted, or want to fetch a key manually for some reason, you can do so with:
 
 ```bash
 curl https://openpgpkey.clabs.co/.well-known/openpgpkey/clabs.co/hu/$USER_HASH
 ```
 
-`$USER_HASH` can be obtained by observing the output of the WKD utility. It is the filename of the resulting key file that is added to the website repsitory for publishing. It can also be calculated directly following the specification in the WKD specification, [draft-koch-openpgp-webkey-service](https://datatracker.ietf.org/doc/draft-koch-openpgp-webkey-service/?include_text=1), section 3.1. (Warning: It uses an obscure varient of base32 :| )
+`$USER_HASH` can be obtained by observing the output of the WKD utility. It is the filename of the resulting key file that is added to the website repository for publishing. It can also be calculated directly following the specification in the WKD specification, [draft-koch-openpgp-webkey-service](https://datatracker.ietf.org/doc/draft-koch-openpgp-webkey-service/?include_text=1), section 3.1. (Warning: It uses an obscure variant of base32 :| )
 
 ## Document Signing
 

--- a/packages/helm-charts/celostats/README.md
+++ b/packages/helm-charts/celostats/README.md
@@ -10,7 +10,7 @@ Also, for compatibility reasons, include an ingress resource serving
 at DNS `https://ethstats-${env}.${celo-domain}`, so the old-configured
 clients can report/connect with that endpoint.
 
-To upgrade from an exisiting `ethstats` package, the easiest way is:
+To upgrade from an existing `ethstats` package, the easiest way is:
 
 1.  Remove the old `ethstats` package: `helm uninstall --purge ${env}-ethstats`
 

--- a/packages/helm-charts/testnet/README.md
+++ b/packages/helm-charts/testnet/README.md
@@ -116,7 +116,7 @@ The following table lists the configurable parameters of the vault chart and the
 | Parameter                   | Description                                                        | Default                      |
 | --------------------------- | ------------------------------------------------------------------ | ---------------------------- |
 | `imagePullPolicy`           | Container pull policy                                              | `IfNotPresent`               |
-| `nodeSelector`              | Node labels for pod assignmen                                      |                              |
+| `nodeSelector`              | Node labels for pod assignment, assign men                                      |                              |
 | `bootnode.image.repository` | bootnode container image to use                                    | `ethereum/client-go`         |
 | `bootnode.image.tag`        | bootnode container image tag to deploy                             | `alltools-v1.7.3`            |
 | `geth.image.repository`     | geth container image to use                                        | `ethereum/client-go`         |

--- a/packages/metadata-crawler/README.md
+++ b/packages/metadata-crawler/README.md
@@ -2,7 +2,7 @@
 
 This package connects to Blockscout database, get all the metadata urls, 
 verify the metadata claims and update the database if the user claims
-could be verified succesfully.
+could be verified successfully.
 
 For this package to work properly, the software must have SELECT and UPDATE 
 access to the Blockscout database.

--- a/packages/protocol/releaseData/README.md
+++ b/packages/protocol/releaseData/README.md
@@ -25,5 +25,5 @@ standard release process.
 ### `releaseBRL.json`
 
 This file is the initialization data used when deploying the `cREAL`
-stable token. The release occured between Core Contracts releases 5 and 6 and
+stable token. The release occurred between Core Contracts releases 5 and 6 and
 didn't exactly follow the release process.


### PR DESCRIPTION
Changes made in:

- /developer_key_publishing.md ("manualy" → "manually")

- /developer_key_publishing.md ("repsitory" → "repository")

- /developer_key_publishing.md ("varient" → "variant")

- /README-dev.md ("localy" → "locally")

- /packages/protocol/releaseData/README.md ("occured" → "occurred")

- /packages/metadata-crawler/README.md ("succesfully" → "successfully")

- /packages/helm-charts/testnet/README.md ("assignmen" → "assignment, assign men")

- /packages/helm-charts/celostats/README.md ("exisiting" → "existing")
