### PR TITLE
Change ABIs and contracts npm tagging logic

### DIFF
--- a/packages/protocol/scripts/determine-release-version.ts
+++ b/packages/protocol/scripts/determine-release-version.ts
@@ -6,13 +6,6 @@ const npmTag = process.env.NPM_TAG?.trim() || ''
 const gitTag = process.env.GITHUB_TAG || ''
 const branchName = execSync('git branch --show-current').toString().trim()
 
-// versioning is done by either
-// A Git tag of the form `core-contracts.vX.Y.Z.post-audit` (e.g. `core-contracts.v10.0.0.post-audit`) === latest release
-// Otherwise if on the release branch a canary tagged release well be created bumping
-// the canary version by one (e.g. `@celo/contracts@11.0.0-canary.1`)
-// if not on a release branch a dry-run will be done unless an NPM_TAG is provided
-// in which case we will try to fetch the last published version with that tag and bump or use the canary to get major and start versioning from there the new tag at 0
-//  (e.g. `@celo/contracts@11.0.0@custom-tag.0`)
 const nextVersion = determineNextVersion(gitTag, branchName, npmPackage, npmTag)
 
 if (nextVersion === null) {

--- a/packages/protocol/scripts/utils.test.ts
+++ b/packages/protocol/scripts/utils.test.ts
@@ -1,7 +1,12 @@
 import { expect } from '@jest/globals'
 import { execSync } from 'child_process'
 import { SemVer } from 'semver'
-import { determineNextVersion, getReleaseTypeFromSemVer, isValidNpmTag } from './utils'
+import {
+  determineNextVersion,
+  getReleaseTypeFromSemVer,
+  isValidNpmTag,
+  isValidPrereleaseIdentifier,
+} from './utils'
 
 jest.mock('child_process', () => ({
   execSync: jest.fn(),
@@ -19,7 +24,18 @@ describe('utils', () => {
   describe('determineNextVersion()', () => {
     const execSyncMock = execSync as jest.Mock
 
-    it('determines "latest" release type and extracts version from "post-audit" git tag directly', () => {
+    it('determines "latest" release type and extracts version from "post-audit" git tag directly for version 11.2.3', () => {
+      const nextVersion = determineNextVersion(
+        'core-contracts.v12',
+        'release/core-contracts/12',
+        '@celo/contracts',
+        'alpha'
+      )
+
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual(['12.0.0', 'latest'])
+    })
+
+    it('determines "post-audit" release type and extracts version from "post-audit" git tag directly', () => {
       const nextVersion = determineNextVersion(
         'core-contracts.v11.2.3.post-audit',
         'release/core-contracts/11.0.0',
@@ -27,7 +43,10 @@ describe('utils', () => {
         'alpha'
       )
 
-      expect(retrieveReleaseInformation(nextVersion)).toEqual(['11.2.3', 'latest'])
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual([
+        '11.2.3-post-audit.0',
+        'post-audit',
+      ])
     })
 
     it('determines "pre-audit" release type and extracts version from "pre-audit" git tag directly', () => {
@@ -38,7 +57,34 @@ describe('utils', () => {
         'alpha'
       )
 
-      expect(retrieveReleaseInformation(nextVersion)).toEqual(['11.2.3-pre-audit.0', 'pre-audit'])
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual(['11.2.3-pre-audit.0', 'pre-audit'])
+    })
+
+    it('uses the tag directly when a semver compliant prerelease identifier is used', () => {
+      const nextVersion = determineNextVersion(
+        'core-contracts.v12.post-audit',
+        'master',
+        '@celo/contracts',
+        ''
+      )
+
+      expect(nextVersion).not.toBeNull()
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual([
+        '12.0.0-post-audit.0',
+        'post-audit',
+      ])
+    })
+
+    it('falls back to alpha when non semver compliant prerelease identifier is used', () => {
+      const nextVersion = determineNextVersion(
+        'core-contracts.v12.post_audit_2',
+        'master',
+        '@celo/contracts',
+        ''
+      )
+
+      expect(nextVersion).not.toBeNull()
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual(['12.0.0-alpha.0', 'alpha'])
     })
 
     it('determines for release git branch when major version matches', () => {
@@ -57,7 +103,9 @@ describe('utils', () => {
         'npm view @celo/contracts@canary version',
         expect.anything()
       )
-      expect(retrieveReleaseInformation(nextVersion)).toEqual(['11.2.4-canary.0', 'canary'])
+
+      expect(nextVersion).not.toBeNull()
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual(['11.2.4-canary.0', 'canary'])
     })
 
     it("determines for release git branch when major version doesn't match", () => {
@@ -76,7 +124,9 @@ describe('utils', () => {
         'npm view @celo/contracts@canary version',
         expect.anything()
       )
-      expect(retrieveReleaseInformation(nextVersion)).toEqual(['12.0.0-canary.0', 'canary'])
+
+      expect(nextVersion).not.toBeNull()
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual(['12.0.0-canary.0', 'canary'])
     })
 
     it("determines based on manually provided npm tag that already exists, doesn't fallback to 'canary'", () => {
@@ -97,7 +147,9 @@ describe('utils', () => {
         'npm view @celo/contracts@alpha version',
         expect.anything()
       )
-      expect(retrieveReleaseInformation(nextVersion)).toEqual(['10.2.4-alpha.1', 'alpha'])
+
+      expect(nextVersion).not.toBeNull()
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual(['10.2.4-alpha.1', 'alpha'])
     })
 
     it("determines based on manually provided npm tag that doesn't exist yet, fallback to 'canary'", () => {
@@ -128,7 +180,8 @@ describe('utils', () => {
         expect.anything()
       )
 
-      expect(retrieveReleaseInformation(nextVersion)).toEqual(['10.1.2-alpha.0', 'alpha'])
+      expect(nextVersion).not.toBeNull()
+      expect(retrieveReleaseInformation(nextVersion!)).toEqual(['10.1.2-alpha.0', 'alpha'])
     })
 
     it("doesn't determine anything when wrong tag is provided", () => {
@@ -149,14 +202,46 @@ describe('utils', () => {
     })
   })
 
-  describe('isValidNpmTag()', () => {
-    it('recognizes valid tags', () => {
+  describe('tags', () => {
+    it('recognizes valid tags and prerelease identifiers', () => {
       expect(isValidNpmTag('latest')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('latest')).toEqual(true)
+
       expect(isValidNpmTag('alpha')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('alpha')).toEqual(true)
+
       expect(isValidNpmTag('beta')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('beta')).toEqual(true)
+
       expect(isValidNpmTag('canary')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('canary')).toEqual(true)
+
       expect(isValidNpmTag('rc')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('rc')).toEqual(true)
+
       expect(isValidNpmTag('valid-tag')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('valid-tag')).toEqual(true)
+
+      expect(isValidNpmTag('alfajores')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('alfajores')).toEqual(true)
+
+      expect(isValidNpmTag('alfajores2')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('alfajores2')).toEqual(true)
+
+      expect(isValidNpmTag('alfajores3')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('alfajores3')).toEqual(true)
+
+      expect(isValidNpmTag('baklava')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('baklava')).toEqual(true)
+
+      expect(isValidNpmTag('post-audit')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('post-audit')).toEqual(true)
+
+      expect(isValidNpmTag('post_audit')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('post_audit')).toEqual(false)
+
+      expect(isValidNpmTag('post_audit_2')).toEqual(true)
+      expect(isValidPrereleaseIdentifier('post_audit_2')).toEqual(false)
     })
 
     it('recognizes invalid tags', () => {

--- a/packages/protocol/scripts/utils.test.ts
+++ b/packages/protocol/scripts/utils.test.ts
@@ -24,7 +24,7 @@ describe('utils', () => {
   describe('determineNextVersion()', () => {
     const execSyncMock = execSync as jest.Mock
 
-    it('determines "latest" release type and extracts version from "post-audit" git tag directly for version 11.2.3', () => {
+    it('determines "latest" release type and extracts version from the git tag directly for generic v12', () => {
       const nextVersion = determineNextVersion(
         'core-contracts.v12',
         'release/core-contracts/12',

--- a/packages/protocol/scripts/utils.ts
+++ b/packages/protocol/scripts/utils.ts
@@ -17,6 +17,16 @@ export type Exports = Record<
 
 export type JSON = Record<string, string | boolean | Exports>
 
+// versioning is done by either
+// A Git tag of the form `core-contracts.vX` (e.g. `core-contracts.v12`) === latest release
+// Otherwise if on the release branch a canary tagged release well be created bumping
+// the canary version by one (e.g. `@celo/contracts@11.0.0-canary.1`)
+// if not on a release branch a dry-run will be done unless an NPM_TAG is provided
+// in which case we will try to fetch the last published version with that tag and bump or use the canary to get major and start versioning from there the new tag at 0
+//  (e.g. `@celo/contracts@11.0.0@custom-tag.0`)
+// It also supports git tags starting with core-contracts.vX-ANY to derive custom npm tags,
+// for example `core-contracts.v11.2.3.post-audit` will result in determining
+// the next version as `11.2.3-post-audit.0` and `post-audit` npm tag
 export const determineNextVersion = (
   gitTag: string,
   gitBranch: string,

--- a/packages/protocol/scripts/utils.ts
+++ b/packages/protocol/scripts/utils.ts
@@ -35,6 +35,7 @@ export const determineNextVersion = (
 ): SemVer | null => {
   let nextVersion: SemVer | null = null
   const matchesReleaseTag = gitTag.match(/^core-contracts.v([0-9]+)$/)
+  // eslint-disable-next-line
   const matchesAnyTag = gitTag.match(/core-contracts.v([0-9\.]+)\.(.+)/)
 
   if (matchesReleaseTag) {


### PR DESCRIPTION
### Description

This PR changes the npm tagging logic to allow any arbitrary tag to be used. Also adapts how the "latest" tag would be published by default.

### Other changes

None.

### Tested

Introduced new unit tests to cover more cases.