### PR TITLE
Improve ABIS release process

### DIFF
--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -15,6 +15,7 @@ on:
       - '!packages/protocol/scripts/foundry/**'  
       - '!packages/protocol/scripts/truffle/**' 
 
+  # pull requests result in dry runs, since no git tag is present unless current branch folllows release branch pattern
   pull_request:
     branches: [release/core-contracts/*, master]
     paths:
@@ -100,7 +101,12 @@ jobs:
         run: |
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN
-          npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH          
+          echo 'tagging version' $RELEASE_VERSION 'with commit hash' $COMMIT_HASH
+          if [ -n "$DRY_RUN" ]; then
+            echo "Dry run mode, exiting successfully."
+            exit 0
+          fi
+          npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH              
         working-directory: packages/protocol/contracts
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
@@ -113,6 +119,11 @@ jobs:
         run: |
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN
+          echo 'tagging version' $RELEASE_VERSION 'with commit hash' $COMMIT_HASH
+          if [ -n "$DRY_RUN" ]; then
+            echo "Dry run mode, exiting successfully."
+            exit 0
+          fi
           npm dist-tag add @celo/abis@$RELEASE_VERSION $COMMIT_HASH          
         working-directory: packages/protocol/abis
         env:

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -1,13 +1,30 @@
 name: Publish ABIs and Solidity files to NPM
 on:
   push:
-    branches: [release/core-contracts/*]
     tags:
       - core-contracts.v*
+    # If you define both branches/branches-ignore and paths/paths-ignore, the workflow will only run when both filters are satisfied.
+    branches: [release/core-contracts/*]
+    paths:
+      - 'packages/protocol/abis/**'
+      - 'packages/protocol/contracts/**'
+      - 'packages/protocol/contracts-0.8/**'
+      - 'packages/protocol/lib/**'
+      - 'packages/protocol/scripts/**'
+    paths-ignore: 
+      - 'packages/protocol/scripts/foundry/**'
+      - 'packages/protocol/scripts/truffle/**'  
   pull_request:
     branches: [release/core-contracts/*, master]
     paths:
-      - 'packages/protocol/**'
+      - 'packages/protocol/abis/**'
+      - 'packages/protocol/contracts/**'
+      - 'packages/protocol/contracts-0.8/**'
+      - 'packages/protocol/lib/**'
+      - 'packages/protocol/scripts/**'
+    paths-ignore: 
+      - 'packages/protocol/scripts/foundry/**'  
+      - 'packages/protocol/scripts/truffle/**'  
   release:
     types: [released]
   workflow_dispatch:

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -92,24 +92,31 @@ jobs:
         shell: bash
         run: yarn validate_abis_exports
         working-directory: packages/protocol
+      - name: 'Get git commit hash'
+        id: get_COMMIT_HASH
+        run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Publish @celo/contracts
         run: |
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN
+          npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH          
         working-directory: packages/protocol/contracts
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
           DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}
 
       - name: Publish @celo/abis
         run: |
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN
+          npm dist-tag add @celo/abis@$RELEASE_VERSION $COMMIT_HASH          
         working-directory: packages/protocol/abis
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
           DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -35,17 +35,13 @@ on:
         required: true
         type: string
 jobs:
-  setup:
+  publish:
     runs-on: ['self-hosted', 'org', 'npm-publish']
     permissions:
       contents: write
       id-token: write
       pull-requests: write
       repository-projects: write
-    outputs:
-      RELEASE_TYPE: ${{ steps.determine_release.outputs.RELEASE_TYPE }}
-      RELEASE_VERSION: ${{ steps.determine_release.outputs.RELEASE_VERSION }}
-      COMMIT_HASH: ${{ steps.get_COMMIT_HASH.outputs.COMMIT_HASH }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,21 +59,21 @@ jobs:
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
+          #scope: '@celo'
+
       - name: 'Setup yarn'
         shell: bash
         run: |
           npm install --global yarn
           source ~/.bashrc
+
       - name: 'Install packages'
         shell: bash
         run: yarn
+
       - name: Determine release type and version (or dry run)
         # This is what sets the RELEASE_TYPE and RELEASE_VERSION env variables
-        id: determine_release
-        run: |
-          yarn --silent determine-release-version >> "$GITHUB_ENV"
-          echo "::set-output name=RELEASE_TYPE::${{ env.RELEASE_TYPE }}"
-          echo "::set-output name=RELEASE_VERSION::${{ env.RELEASE_VERSION }}"
+        run: yarn --silent determine-release-version >> "$GITHUB_ENV"
         working-directory: packages/protocol
         env:
           GITHUB_TAG: ${{ github.ref_name }}
@@ -85,47 +81,43 @@ jobs:
           NPM_TAG: ${{ inputs.npm_tag }}
       - name: 'Build packages'
         shell: bash
-        run: yarn build --ignore @celo/celotool --ignore @celo/env-tests --include-dependencies
+        run:  yarn build --ignore @celo/celotool --ignore @celo/env-tests --include-dependencies
       - name: Compile solidity contracts and typescript files
         run: yarn prepare_contracts_and_abis_publishing
         working-directory: packages/protocol
         env:
           RELEASE_TYPE: ${{ env.RELEASE_TYPE }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        # a safety check especially useful if some package is upgraded
       - name: 'Validate ABIS Exports'
         shell: bash
         run: yarn validate_abis_exports
         working-directory: packages/protocol
       - name: 'Get git commit hash'
         id: get_COMMIT_HASH
-        run: echo "::set-output name=COMMIT_HASH::$(git rev-parse --short HEAD)"
-
-  publish:
-    needs: setup
-    runs-on: ['self-hosted', 'org', 'npm-publish']
-    strategy:
-      matrix:
-        package: [contracts, abis]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Publish packages
-        working-directory: packages/protocol/${{ matrix.package }}
-        env:
-          RELEASE_TYPE: --tag ${{ needs.setup.outputs.RELEASE_TYPE != '' && needs.setup.outputs.RELEASE_TYPE || 'canary' }}
-          RELEASE_VERSION: ${{ needs.setup.outputs.RELEASE_VERSION }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ needs.setup.outputs.RELEASE_VERSION == '' && '--dry-run' || '' }}
-          COMMIT_HASH: ${{ needs.setup.outputs.COMMIT_HASH }}
-        shell: bash
+        run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Publish @celo/contracts
         run: |
-          echo "Publishing @celo/${{ matrix.package }}"
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN
-          if [ -n "$DRY_RUN" ]; then
-            echo "Dry run mode, exiting successfully."
-            exit 0
-          fi
-          echo 'tagging version' $RELEASE_VERSION 'with commit hash' $COMMIT_HASH
-          npm dist-tag add @celo/${{ matrix.package }}@$RELEASE_VERSION $COMMIT_HASH
+          npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH          
+        working-directory: packages/protocol/contracts
+        env:
+          RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}
+
+      - name: Publish @celo/abis
+        run: |
+          cat package.json
+          npm publish $RELEASE_TYPE $DRY_RUN
+          npm dist-tag add @celo/abis@$RELEASE_VERSION $COMMIT_HASH          
+        working-directory: packages/protocol/abis
+        env:
+          RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -1,4 +1,5 @@
 name: Publish ABIs and Solidity files to NPM
+
 on:
   push:
     tags:
@@ -11,9 +12,9 @@ on:
       - 'packages/protocol/contracts-0.8/**'
       - 'packages/protocol/lib/**'
       - 'packages/protocol/scripts/**'
-    paths-ignore: 
-      - 'packages/protocol/scripts/foundry/**'
-      - 'packages/protocol/scripts/truffle/**'  
+      - '!packages/protocol/scripts/foundry/**'  
+      - '!packages/protocol/scripts/truffle/**' 
+
   pull_request:
     branches: [release/core-contracts/*, master]
     paths:
@@ -22,9 +23,9 @@ on:
       - 'packages/protocol/contracts-0.8/**'
       - 'packages/protocol/lib/**'
       - 'packages/protocol/scripts/**'
-    paths-ignore: 
-      - 'packages/protocol/scripts/foundry/**'  
-      - 'packages/protocol/scripts/truffle/**'  
+      - '!packages/protocol/scripts/foundry/**'  
+      - '!packages/protocol/scripts/truffle/**'  
+     
   release:
     types: [released]
   workflow_dispatch:

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -35,13 +35,17 @@ on:
         required: true
         type: string
 jobs:
-  publish:
+  setup:
     runs-on: ['self-hosted', 'org', 'npm-publish']
     permissions:
       contents: write
       id-token: write
       pull-requests: write
       repository-projects: write
+    outputs:
+      RELEASE_TYPE: ${{ steps.determine_release.outputs.RELEASE_TYPE }}
+      RELEASE_VERSION: ${{ steps.determine_release.outputs.RELEASE_VERSION }}
+      COMMIT_HASH: ${{ steps.get_COMMIT_HASH.outputs.COMMIT_HASH }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,21 +63,21 @@ jobs:
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
-          #scope: '@celo'
-
       - name: 'Setup yarn'
         shell: bash
         run: |
           npm install --global yarn
           source ~/.bashrc
-
       - name: 'Install packages'
         shell: bash
         run: yarn
-
       - name: Determine release type and version (or dry run)
         # This is what sets the RELEASE_TYPE and RELEASE_VERSION env variables
-        run: yarn --silent determine-release-version >> "$GITHUB_ENV"
+        id: determine_release
+        run: |
+          yarn --silent determine-release-version >> "$GITHUB_ENV"
+          echo "::set-output name=RELEASE_TYPE::${{ env.RELEASE_TYPE }}"
+          echo "::set-output name=RELEASE_VERSION::${{ env.RELEASE_VERSION }}"
         working-directory: packages/protocol
         env:
           GITHUB_TAG: ${{ github.ref_name }}
@@ -81,43 +85,47 @@ jobs:
           NPM_TAG: ${{ inputs.npm_tag }}
       - name: 'Build packages'
         shell: bash
-        run:  yarn build --ignore @celo/celotool --ignore @celo/env-tests --include-dependencies
+        run: yarn build --ignore @celo/celotool --ignore @celo/env-tests --include-dependencies
       - name: Compile solidity contracts and typescript files
         run: yarn prepare_contracts_and_abis_publishing
         working-directory: packages/protocol
         env:
           RELEASE_TYPE: ${{ env.RELEASE_TYPE }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-        # a safety check especially useful if some package is upgraded
       - name: 'Validate ABIS Exports'
         shell: bash
         run: yarn validate_abis_exports
         working-directory: packages/protocol
       - name: 'Get git commit hash'
         id: get_COMMIT_HASH
-        run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: Publish @celo/contracts
-        run: |
-          cat package.json
-          npm publish $RELEASE_TYPE $DRY_RUN
-          npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH          
-        working-directory: packages/protocol/contracts
-        env:
-          RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
-          DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
-          COMMIT_HASH: ${{ env.COMMIT_HASH }}
+        run: echo "::set-output name=COMMIT_HASH::$(git rev-parse --short HEAD)"
 
-      - name: Publish @celo/abis
+  publish:
+    needs: setup
+    runs-on: ['self-hosted', 'org', 'npm-publish']
+    strategy:
+      matrix:
+        package: [contracts, abis]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Publish packages
+        working-directory: packages/protocol/${{ matrix.package }}
+        env:
+          RELEASE_TYPE: --tag ${{ needs.setup.outputs.RELEASE_TYPE != '' && needs.setup.outputs.RELEASE_TYPE || 'canary' }}
+          RELEASE_VERSION: ${{ needs.setup.outputs.RELEASE_VERSION }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ needs.setup.outputs.RELEASE_VERSION == '' && '--dry-run' || '' }}
+          COMMIT_HASH: ${{ needs.setup.outputs.COMMIT_HASH }}
+        shell: bash
         run: |
+          echo "Publishing @celo/${{ matrix.package }}"
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN
-          npm dist-tag add @celo/abis@$RELEASE_VERSION $COMMIT_HASH          
-        working-directory: packages/protocol/abis
-        env:
-          RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
-          DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
-          COMMIT_HASH: ${{ env.COMMIT_HASH }}
+          if [ -n "$DRY_RUN" ]; then
+            echo "Dry run mode, exiting successfully."
+            exit 0
+          fi
+          echo 'tagging version' $RELEASE_VERSION 'with commit hash' $COMMIT_HASH
+          npm dist-tag add @celo/${{ matrix.package }}@$RELEASE_VERSION $COMMIT_HASH

--- a/packages/protocol/abis/package.json
+++ b/packages/protocol/abis/package.json
@@ -4,7 +4,7 @@
   "license": "LGPL-3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "private": "true",
+  "private": true,
   "types": "./dist/types/index.d.ts",
   "typings": "./dist/types/index.d.ts",
   "repository": {
@@ -33,6 +33,9 @@
     "./BlockchainParameters.json": {
       "default": "./dist/BlockchainParameters.json"
     },
+    "./CeloUnreleasedTreasury.json": {
+      "default": "./dist/CeloUnreleasedTreasury.json"
+    },
     "./DoubleSigningSlasher.json": {
       "default": "./dist/DoubleSigningSlasher.json"
     },
@@ -41,6 +44,12 @@
     },
     "./Election.json": {
       "default": "./dist/Election.json"
+    },
+    "./EpochManager.json": {
+      "default": "./dist/EpochManager.json"
+    },
+    "./EpochManagerEnabler.json": {
+      "default": "./dist/EpochManagerEnabler.json"
     },
     "./EpochRewards.json": {
       "default": "./dist/EpochRewards.json"
@@ -60,6 +69,9 @@
     "./FederatedAttestations.json": {
       "default": "./dist/FederatedAttestations.json"
     },
+    "./FeeCurrencyDirectory.json": {
+      "default": "./dist/FeeCurrencyDirectory.json"
+    },
     "./FeeCurrencyWhitelist.json": {
       "default": "./dist/FeeCurrencyWhitelist.json"
     },
@@ -75,11 +87,17 @@
     "./GoldToken.json": {
       "default": "./dist/GoldToken.json"
     },
+    "./CeloToken.json": {
+      "default": "./dist/GoldToken.json"
+    },
     "./Governance.json": {
       "default": "./dist/Governance.json"
     },
     "./GovernanceApproverMultiSig.json": {
       "default": "./dist/GovernanceApproverMultiSig.json"
+    },
+    "./GovernanceSlasher.json": {
+      "default": "./dist/GovernanceSlasher.json"
     },
     "./GrandaMento.json": {
       "default": "./dist/GrandaMento.json"
@@ -94,6 +112,9 @@
       "default": "./dist/IERC20.json"
     },
     "./LockedGold.json": {
+      "default": "./dist/LockedGold.json"
+    },
+    "./LockedCelo.json": {
       "default": "./dist/LockedGold.json"
     },
     "./MentoFeeHandlerSeller.json": {
@@ -122,6 +143,9 @@
     },
     "./ReserveSpenderMultiSig.json": {
       "default": "./dist/ReserveSpenderMultiSig.json"
+    },
+    "./ScoreManager.json": {
+      "default": "./dist/ScoreManager.json"
     },
     "./SortedOracles.json": {
       "default": "./dist/SortedOracles.json"
@@ -156,6 +180,11 @@
       "require": "./dist/cjs/BlockchainParameters.js",
       "types": "./dist/types/BlockchainParameters.d.ts"
     },
+    "./CeloUnreleasedTreasury": {
+      "import": "./dist/esm/CeloUnreleasedTreasury.js",
+      "require": "./dist/cjs/CeloUnreleasedTreasury.js",
+      "types": "./dist/types/CeloUnreleasedTreasury.d.ts"
+    },
     "./DoubleSigningSlasher": {
       "import": "./dist/esm/DoubleSigningSlasher.js",
       "require": "./dist/cjs/DoubleSigningSlasher.js",
@@ -170,6 +199,16 @@
       "import": "./dist/esm/Election.js",
       "require": "./dist/cjs/Election.js",
       "types": "./dist/types/Election.d.ts"
+    },
+    "./EpochManager": {
+      "import": "./dist/esm/EpochManager.js",
+      "require": "./dist/cjs/EpochManager.js",
+      "types": "./dist/types/EpochManager.d.ts"
+    },
+    "./EpochManagerEnabler": {
+      "import": "./dist/esm/EpochManagerEnabler.js",
+      "require": "./dist/cjs/EpochManagerEnabler.js",
+      "types": "./dist/types/EpochManagerEnabler.d.ts"
     },
     "./EpochRewards": {
       "import": "./dist/esm/EpochRewards.js",
@@ -201,6 +240,11 @@
       "require": "./dist/cjs/FederatedAttestations.js",
       "types": "./dist/types/FederatedAttestations.d.ts"
     },
+    "./FeeCurrencyDirectory": {
+      "import": "./dist/esm/FeeCurrencyDirectory.js",
+      "require": "./dist/cjs/FeeCurrencyDirectory.js",
+      "types": "./dist/types/FeeCurrencyDirectory.d.ts"
+    },
     "./FeeCurrencyWhitelist": {
       "import": "./dist/esm/FeeCurrencyWhitelist.js",
       "require": "./dist/cjs/FeeCurrencyWhitelist.js",
@@ -226,6 +270,11 @@
       "require": "./dist/cjs/GoldToken.js",
       "types": "./dist/types/GoldToken.d.ts"
     },
+    "./CeloToken": {
+      "import": "./dist/esm/GoldToken.js",
+      "require": "./dist/cjs/GoldToken.js",
+      "types": "./dist/types/GoldToken.d.ts"
+    },
     "./Governance": {
       "import": "./dist/esm/Governance.js",
       "require": "./dist/cjs/Governance.js",
@@ -235,6 +284,11 @@
       "import": "./dist/esm/GovernanceApproverMultiSig.js",
       "require": "./dist/cjs/GovernanceApproverMultiSig.js",
       "types": "./dist/types/GovernanceApproverMultiSig.d.ts"
+    },
+    "./GovernanceSlasher": {
+      "import": "./dist/esm/GovernanceSlasher.js",
+      "require": "./dist/cjs/GovernanceSlasher.js",
+      "types": "./dist/types/GovernanceSlasher.d.ts"
     },
     "./GrandaMento": {
       "import": "./dist/esm/GrandaMento.js",
@@ -257,6 +311,11 @@
       "types": "./dist/types/IERC20.d.ts"
     },
     "./LockedGold": {
+      "import": "./dist/esm/LockedGold.js",
+      "require": "./dist/cjs/LockedGold.js",
+      "types": "./dist/types/LockedGold.d.ts"
+    },
+    "./LockedCelo": {
       "import": "./dist/esm/LockedGold.js",
       "require": "./dist/cjs/LockedGold.js",
       "types": "./dist/types/LockedGold.d.ts"
@@ -306,6 +365,11 @@
       "require": "./dist/cjs/ReserveSpenderMultiSig.js",
       "types": "./dist/types/ReserveSpenderMultiSig.d.ts"
     },
+    "./ScoreManager": {
+      "import": "./dist/esm/ScoreManager.js",
+      "require": "./dist/cjs/ScoreManager.js",
+      "types": "./dist/types/ScoreManager.d.ts"
+    },
     "./SortedOracles": {
       "import": "./dist/esm/SortedOracles.js",
       "require": "./dist/cjs/SortedOracles.js",
@@ -336,10 +400,40 @@
       "require": "./dist/cjs/Validators.js",
       "types": "./dist/types/Validators.d.ts"
     },
+    "./web3/0.8/CeloUnreleasedTreasury": {
+      "import": "./dist/esm/web3/0.8/CeloUnreleasedTreasury.js",
+      "require": "./dist/cjs/web3/0.8/CeloUnreleasedTreasury.js",
+      "types": "./dist/types/web3/0.8/CeloUnreleasedTreasury.d.ts"
+    },
+    "./web3/0.8/EpochManager": {
+      "import": "./dist/esm/web3/0.8/EpochManager.js",
+      "require": "./dist/cjs/web3/0.8/EpochManager.js",
+      "types": "./dist/types/web3/0.8/EpochManager.d.ts"
+    },
+    "./web3/0.8/EpochManagerEnabler": {
+      "import": "./dist/esm/web3/0.8/EpochManagerEnabler.js",
+      "require": "./dist/cjs/web3/0.8/EpochManagerEnabler.js",
+      "types": "./dist/types/web3/0.8/EpochManagerEnabler.d.ts"
+    },
+    "./web3/0.8/FeeCurrencyDirectory": {
+      "import": "./dist/esm/web3/0.8/FeeCurrencyDirectory.js",
+      "require": "./dist/cjs/web3/0.8/FeeCurrencyDirectory.js",
+      "types": "./dist/types/web3/0.8/FeeCurrencyDirectory.d.ts"
+    },
     "./web3/0.8/GasPriceMinimum": {
       "import": "./dist/esm/web3/0.8/GasPriceMinimum.js",
       "require": "./dist/cjs/web3/0.8/GasPriceMinimum.js",
       "types": "./dist/types/web3/0.8/GasPriceMinimum.d.ts"
+    },
+    "./web3/0.8/ScoreManager": {
+      "import": "./dist/esm/web3/0.8/ScoreManager.js",
+      "require": "./dist/cjs/web3/0.8/ScoreManager.js",
+      "types": "./dist/types/web3/0.8/ScoreManager.d.ts"
+    },
+    "./web3/0.8/Validators": {
+      "import": "./dist/esm/web3/0.8/Validators.js",
+      "require": "./dist/cjs/web3/0.8/Validators.js",
+      "types": "./dist/types/web3/0.8/Validators.d.ts"
     },
     "./web3/Accounts": {
       "import": "./dist/esm/web3/Accounts.js",
@@ -356,6 +450,11 @@
       "require": "./dist/cjs/web3/BlockchainParameters.js",
       "types": "./dist/types/web3/BlockchainParameters.d.ts"
     },
+    "./web3/CeloUnreleasedTreasury": {
+      "import": "./dist/esm/web3/CeloUnreleasedTreasury.js",
+      "require": "./dist/cjs/web3/CeloUnreleasedTreasury.js",
+      "types": "./dist/types/web3/CeloUnreleasedTreasury.d.ts"
+    },
     "./web3/DoubleSigningSlasher": {
       "import": "./dist/esm/web3/DoubleSigningSlasher.js",
       "require": "./dist/cjs/web3/DoubleSigningSlasher.js",
@@ -371,6 +470,16 @@
       "require": "./dist/cjs/web3/Election.js",
       "types": "./dist/types/web3/Election.d.ts"
     },
+    "./web3/EpochManager": {
+      "import": "./dist/esm/web3/EpochManager.js",
+      "require": "./dist/cjs/web3/EpochManager.js",
+      "types": "./dist/types/web3/EpochManager.d.ts"
+    },
+    "./web3/EpochManagerEnabler": {
+      "import": "./dist/esm/web3/EpochManagerEnabler.js",
+      "require": "./dist/cjs/web3/EpochManagerEnabler.js",
+      "types": "./dist/types/web3/EpochManagerEnabler.d.ts"
+    },
     "./web3/EpochRewards": {
       "import": "./dist/esm/web3/EpochRewards.js",
       "require": "./dist/cjs/web3/EpochRewards.js",
@@ -385,6 +494,11 @@
       "import": "./dist/esm/web3/FederatedAttestations.js",
       "require": "./dist/cjs/web3/FederatedAttestations.js",
       "types": "./dist/types/web3/FederatedAttestations.d.ts"
+    },
+    "./web3/FeeCurrencyDirectory": {
+      "import": "./dist/esm/web3/FeeCurrencyDirectory.js",
+      "require": "./dist/cjs/web3/FeeCurrencyDirectory.js",
+      "types": "./dist/types/web3/FeeCurrencyDirectory.d.ts"
     },
     "./web3/FeeCurrencyWhitelist": {
       "import": "./dist/esm/web3/FeeCurrencyWhitelist.js",
@@ -411,6 +525,11 @@
       "require": "./dist/cjs/web3/GoldToken.js",
       "types": "./dist/types/web3/GoldToken.d.ts"
     },
+    "./web3/CeloToken": {
+      "import": "./dist/esm/web3/GoldToken.js",
+      "require": "./dist/cjs/web3/GoldToken.js",
+      "types": "./dist/types/web3/GoldToken.d.ts"
+    },
     "./web3/Governance": {
       "import": "./dist/esm/web3/Governance.js",
       "require": "./dist/cjs/web3/Governance.js",
@@ -420,6 +539,11 @@
       "import": "./dist/esm/web3/GovernanceApproverMultiSig.js",
       "require": "./dist/cjs/web3/GovernanceApproverMultiSig.js",
       "types": "./dist/types/web3/GovernanceApproverMultiSig.d.ts"
+    },
+    "./web3/GovernanceSlasher": {
+      "import": "./dist/esm/web3/GovernanceSlasher.js",
+      "require": "./dist/cjs/web3/GovernanceSlasher.js",
+      "types": "./dist/types/web3/GovernanceSlasher.d.ts"
     },
     "./web3/ICeloToken": {
       "import": "./dist/esm/web3/ICeloToken.js",
@@ -437,6 +561,11 @@
       "types": "./dist/types/web3/IERC20.d.ts"
     },
     "./web3/LockedGold": {
+      "import": "./dist/esm/web3/LockedGold.js",
+      "require": "./dist/cjs/web3/LockedGold.js",
+      "types": "./dist/types/web3/LockedGold.d.ts"
+    },
+    "./web3/LockedCelo": {
       "import": "./dist/esm/web3/LockedGold.js",
       "require": "./dist/cjs/web3/LockedGold.js",
       "types": "./dist/types/web3/LockedGold.d.ts"
@@ -475,6 +604,11 @@
       "import": "./dist/esm/web3/ReleaseGold.js",
       "require": "./dist/cjs/web3/ReleaseGold.js",
       "types": "./dist/types/web3/ReleaseGold.d.ts"
+    },
+    "./web3/ScoreManager": {
+      "import": "./dist/esm/web3/ScoreManager.js",
+      "require": "./dist/cjs/web3/ScoreManager.js",
+      "types": "./dist/types/web3/ScoreManager.d.ts"
     },
     "./web3/SortedOracles": {
       "import": "./dist/esm/web3/SortedOracles.js",

--- a/packages/protocol/contracts/package.json
+++ b/packages/protocol/contracts/package.json
@@ -5,7 +5,7 @@
   "private": "true",
   "repository": {
     "type": "git",
-    "url": "https://github.com/celo-org/celo-monorepo.git",
+    "url": "git+https://github.com/celo-org/celo-monorepo.git",
     "directory": "packages/protocol/contracts"
   },
   "scripts": {},

--- a/packages/protocol/contracts/package.json
+++ b/packages/protocol/contracts/package.json
@@ -5,7 +5,7 @@
   "private": "true",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/celo-org/celo-monorepo.git",
+    "url": "https://github.com/celo-org/celo-monorepo.git",
     "directory": "packages/protocol/contracts"
   },
   "scripts": {},

--- a/packages/protocol/scripts/build.ts
+++ b/packages/protocol/scripts/build.ts
@@ -116,9 +116,8 @@ function generateFilesForEthers({ coreContractsOnly, ethersTypes: outdir }: Buil
   console.info(`protocol: Generating Ethers Types to ${outdir}`)
   exec(`rm -rf "${outdir}"`)
 
-  const contractKitContracts = coreContractsOnly
-    ? CoreContracts
-    : CoreContracts.concat('Proxy').concat(Interfaces)
+  const contractKitContracts = getContractList(coreContractsOnly)
+
   const globPattern = `${BUILD_DIR}/contracts/@(${contractKitContracts.join('|')}).json`
 
   exec(`yarn run --silent typechain --target=ethers-v5 --outDir "${outdir}" "${globPattern}"`)
@@ -129,9 +128,7 @@ async function generateFilesForContractKit({ coreContractsOnly, web3Types: outdi
   exec(`rm -rf ${outdir}`)
   const relativePath = path.relative(ROOT_DIR, outdir)
 
-  const contractKitContracts = coreContractsOnly
-    ? CoreContracts
-    : CoreContracts.concat('Proxy').concat(Interfaces)
+  const contractKitContracts = getContractList(coreContractsOnly)
 
   const globPattern = `${BUILD_DIR}/contracts*/@(${contractKitContracts.join('|')}).json`
 
@@ -175,6 +172,10 @@ const _buildTargets: ParsedArgs = {
 } as const
 type BuildTargets = Record<keyof typeof _buildTargets, string> & {
   coreContractsOnly: boolean
+}
+
+function getContractList(coreContractsOnly: boolean) {
+  return coreContractsOnly ? CoreContracts : [...CoreContracts, 'Proxy', ...Interfaces]
 }
 
 async function main(buildTargets: BuildTargets) {

--- a/packages/protocol/scripts/consts.ts
+++ b/packages/protocol/scripts/consts.ts
@@ -41,7 +41,7 @@ export const ProxyContracts = [
   'CeloUnreleasedTreasuryProxy',
 ]
 
-export const CoreContracts = [
+export const CoreContracts: string[] = [
   // common
   CeloContractName.Accounts,
   CeloContractName.GasPriceMinimum,

--- a/packages/protocol/scripts/consts.ts
+++ b/packages/protocol/scripts/consts.ts
@@ -1,3 +1,4 @@
+import { CeloContractName } from '@celo/protocol/lib/registry-utils'
 import path from 'path'
 import { MENTO_PACKAGE, SOLIDITY_08_PACKAGE } from '../contractPackages'
 
@@ -42,44 +43,44 @@ export const ProxyContracts = [
 
 export const CoreContracts = [
   // common
-  'Accounts',
-  'GasPriceMinimum',
-  'FeeHandler',
-  'MentoFeeHandlerSeller',
-  'UniswapFeeHandlerSeller',
-  'FeeCurrencyDirectory',
-  'FeeCurrencyWhitelist',
-  'GoldToken',
-  'MultiSig',
-  'Registry',
-  'Freezer',
-  'CeloUnreleasedTreasury',
+  CeloContractName.Accounts,
+  CeloContractName.GasPriceMinimum,
+  CeloContractName.FeeHandler,
+  CeloContractName.MentoFeeHandlerSeller,
+  CeloContractName.UniswapFeeHandlerSeller,
+  CeloContractName.FeeCurrencyDirectory,
+  CeloContractName.FeeCurrencyWhitelist,
+  CeloContractName.GoldToken,
+  'MultiSig' as const,
+  'Registry' as const,
+  CeloContractName.Freezer,
+  CeloContractName.CeloUnreleasedTreasury,
 
   // governance
-  'Election',
-  'EpochRewards',
-  'EpochManager',
-  'EpochManagerEnabler',
-  'Governance',
-  'GovernanceSlasher',
-  'GovernanceApproverMultiSig',
-  'BlockchainParameters',
-  'DoubleSigningSlasher',
-  'DowntimeSlasher',
-  'LockedGold',
-  'Validators',
-  'ReleaseGold',
-  'ScoreManager',
+  CeloContractName.Election,
+  CeloContractName.EpochRewards,
+  CeloContractName.EpochManager,
+  CeloContractName.EpochManagerEnabler,
+  CeloContractName.Governance,
+  CeloContractName.GovernanceSlasher,
+  CeloContractName.GovernanceApproverMultiSig,
+  CeloContractName.BlockchainParameters,
+  CeloContractName.DoubleSigningSlasher,
+  CeloContractName.DowntimeSlasher,
+  CeloContractName.LockedGold,
+  CeloContractName.Validators,
+  'ReleaseGold' as const,
+  CeloContractName.ScoreManager,
 
   // identity
-  'Attestations',
-  'Escrow',
-  'FederatedAttestations',
-  'Random',
-  'OdisPayments',
+  CeloContractName.Attestations,
+  CeloContractName.Escrow,
+  CeloContractName.FederatedAttestations,
+  CeloContractName.Random,
+  CeloContractName.OdisPayments,
 
   // stability
-  'SortedOracles',
+  CeloContractName.SortedOracles,
 ]
 
 export const OtherContracts = [
@@ -92,13 +93,21 @@ export const OtherContracts = [
 
 export const contractPackages = [MENTO_PACKAGE, SOLIDITY_08_PACKAGE].filter(Boolean)
 
-export const Interfaces = ['ICeloToken', 'IERC20', 'ICeloVersionedContract']
+export const Interfaces = ['ICeloToken', 'IERC20', 'ICeloVersionedContract'] as const
 
 export const ImplContracts = OtherContracts.concat(ProxyContracts).concat(CoreContracts)
 
-export const PublishContracts = CoreContracts.concat(Interfaces)
-  .concat(PROXY_CONTRACT)
-  .concat(MENTO_PACKAGE.contracts)
+export const PublishContracts = [
+  ...CoreContracts,
+  ...Interfaces,
+  PROXY_CONTRACT,
+  ...MENTO_PACKAGE.contracts,
+]
+
+export const AliasedContracts = {
+  [CeloContractName.GoldToken]: CeloContractName.CeloToken,
+  [CeloContractName.LockedGold]: CeloContractName.LockedCelo,
+}
 
 export enum BuildTarget {
   CJS = 'cjs',

--- a/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
+++ b/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
@@ -8,6 +8,7 @@ import {
   ABIS_BUILD_DIR,
   ABIS_DIST_DIR,
   ABIS_PACKAGE_SRC_DIR,
+  AliasedContracts,
   BUILD_EXECUTABLE,
   BuildTarget,
   CONTRACTS_08_PACKAGE_DESTINATION_DIR,
@@ -142,45 +143,61 @@ function prepareTargetTypesExports() {
           path.relative(ABIS_PACKAGE_SRC_DIR, parsedPath.dir),
           parsedPathName
         )
-        const exportKey = `./${path.join(
+        const defaultExportKey = toExportKey(parsedPathName)
+
+        const exportKeys = [defaultExportKey]
+
+        // sometimes we want files to be exports via 2 keys like LockedGold and LockeCelo
+        // so place it in the AliasedContracts object and will be exported like
+        // "./LockedGold": { default: "./LockedGold.json", types: "./LockedGold.d.ts" }
+        // "./LockedCelo": { default: "./LockedGold.json", types: "./LockedGold.d.ts" }
+        if (typeof AliasedContracts[parsedPathName] === 'string') {
+          const aliasKey = toExportKey(AliasedContracts[parsedPathName] as string)
+          exportKeys.push(aliasKey)
+        }
+        for (const exportKey of exportKeys) {
+          // eslint-disable-next-line no-prototype-builtins
+          if (!exports.hasOwnProperty(exportKey)) {
+            exports[exportKey] = {}
+          }
+
+          if (target === BuildTarget.ESM) {
+            const importPath = `./${relativePath}.js`
+
+            expectFileExists(importPath)
+
+            exports[exportKey] = {
+              ...exports[exportKey],
+              import: importPath,
+            }
+          } else if (target === BuildTarget.CJS) {
+            const requirePath = `./${relativePath}.js`
+
+            expectFileExists(requirePath)
+
+            exports[exportKey] = {
+              ...exports[exportKey],
+              require: requirePath,
+            }
+          } else {
+            // types
+            const typesPath = `./${relativePath}.d.ts`
+
+            expectFileExists(typesPath)
+
+            exports[exportKey] = {
+              ...exports[exportKey],
+              types: typesPath,
+            }
+          }
+        }
+      }
+
+      function toExportKey(name: string) {
+        return `./${path.join(
           path.relative(path.join(ABIS_DIST_DIR, target), parsedPath.dir),
-          parsedPathName
+          name
         )}`
-
-        // eslint-disable-next-line no-prototype-builtins
-        if (!exports.hasOwnProperty(exportKey)) {
-          exports[exportKey] = {}
-        }
-
-        if (target === BuildTarget.ESM) {
-          const importPath = `./${relativePath}.js`
-
-          expectFileExists(importPath)
-
-          exports[exportKey] = {
-            ...exports[exportKey],
-            import: importPath,
-          }
-        } else if (target === BuildTarget.CJS) {
-          const requirePath = `./${relativePath}.js`
-
-          expectFileExists(requirePath)
-
-          exports[exportKey] = {
-            ...exports[exportKey],
-            require: requirePath,
-          }
-        } else {
-          // types
-          const typesPath = `./${relativePath}.d.ts`
-
-          expectFileExists(typesPath)
-
-          exports[exportKey] = {
-            ...exports[exportKey],
-            types: typesPath,
-          }
-        }
       }
     })
   })
@@ -225,8 +242,17 @@ function processRawJsonsAndPrepareExports() {
 
       expectFileExists(defaultPath)
 
-      exports[`./${parsedPath.name}.json`] = {
-        default: `./${defaultPath}`,
+      const getJsonKey = (name: string) => `./${name}.json`
+
+      const makeDefaultExportValue = (value: string) => ({
+        default: `./${value}`,
+      })
+
+      exports[getJsonKey(parsedPath.name)] = makeDefaultExportValue(defaultPath)
+
+      if (AliasedContracts[parsedPath.name] !== undefined) {
+        exports[getJsonKey(AliasedContracts[parsedPath.name] as string)] =
+          makeDefaultExportValue(defaultPath)
       }
     }
   })


### PR DESCRIPTION
### Description

1. add aliasing so that package.json includes both GoldToken (the name of file) and CeloToken (how abis consumers will want it)
2. be more specific about what changes trigger a canary release (modifying tests will not for example)
3. as well as tagging with the relese type (canary, latest, post-audit, pre-audit) tag each version on npm with the git commit hash 


## other

made some strings into enums


### Tested


### Related issues


### Backwards compatibility

yes.

### Documentation

n.a