### PR TITLE
setup post release bumps

### DIFF
--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -53,7 +53,7 @@ jobs:
   install-dependencies:
     name: Install dependencies
     outputs:
-      # Propagate more outputs if you need https://github.com/tj-actions/changed-files#outputs
+      # Propagate more outputs if you need https://github.com/step-security/changed-files#outputs
       # Adding a initial comma so ',<path>' matches also for the first file
       all_modified_files: ',${{ steps.changed-files.outputs.all_modified_files }}'
       artifacts_to_cache: ${{ steps.get_artifacts_to_cache.outputs.artifacts_to_cache }}
@@ -136,7 +136,7 @@ jobs:
             code-${{ github.sha }}
       - name: Detect files changed in PR (or commit), and expose as output
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         with:
           # Using comma as separator to be able to easily match full paths (using ,<path>)
           separator: ','

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -19,14 +19,14 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      # Propagate more outputs if you need https://github.com/tj-actions/changed-files#outputs
+      # Propagate more outputs if you need https://github.com/step-security/changed-files#outputs
       # Adding a initial comma so ',<path>' matches also for the first file
       all_modified_files: ',${{ steps.changed-files.outputs.all_modified_files }}'
     steps:
       - uses: actions/checkout@v4
       - name: Detect files changed in PR (or commit), and expose as output
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         with:
           # Using comma as separator to be able to easily match full paths (using ,<path>)
           separator: ','

--- a/packages/protocol/scripts/utils.test.ts
+++ b/packages/protocol/scripts/utils.test.ts
@@ -39,15 +39,16 @@ describe('utils', () => {
           '',
           'release/core-contracts/12',
           '@celo/abis',
-          'latest'
+          'random-tag'
         )
         expect(execSyncMock).toHaveBeenCalledTimes(1)
+
+        expect(retrieveReleaseInformation(nextVersion as SemVer)).toEqual(['12.0.1', 'latest'])
         expect(execSyncMock).toHaveBeenNthCalledWith(
           1,
           'npm view @celo/abis@latest version',
           expect.anything()
         )
-        expect(retrieveReleaseInformation(nextVersion as SemVer)).toEqual(['12.0.1', 'latest'])
       })
     })
 
@@ -75,10 +76,10 @@ describe('utils', () => {
       expect(execSyncMock).toHaveBeenCalledTimes(1)
       expect(execSyncMock).toHaveBeenNthCalledWith(
         1,
-        'npm view @celo/contracts@canary version',
+        'npm view @celo/contracts@latest version',
         expect.anything()
       )
-      expect(retrieveReleaseInformation(nextVersion)).toEqual(['11.2.4-canary.0', 'canary'])
+      expect(retrieveReleaseInformation(nextVersion)).toEqual(['11.2.4', 'latest'])
     })
 
     it("determines for release git branch when major version doesn't match", () => {
@@ -91,9 +92,14 @@ describe('utils', () => {
         'alpha'
       )
 
-      expect(execSyncMock).toHaveBeenCalledTimes(1)
+      expect(execSyncMock).toHaveBeenCalledTimes(2)
       expect(execSyncMock).toHaveBeenNthCalledWith(
         1,
+        'npm view @celo/contracts@latest version',
+        expect.anything()
+      )
+      expect(execSyncMock).toHaveBeenNthCalledWith(
+        2,
         'npm view @celo/contracts@canary version',
         expect.anything()
       )

--- a/packages/protocol/scripts/utils.test.ts
+++ b/packages/protocol/scripts/utils.test.ts
@@ -30,6 +30,27 @@ describe('utils', () => {
       expect(retrieveReleaseInformation(nextVersion)).toEqual(['11.2.3', 'latest'])
     })
 
+    describe('when release branch is on same major as latest version', () => {
+      beforeEach(() => {
+        execSyncMock.mockReturnValue('12.0.0')
+      })
+      it('determines version bump will be patch', () => {
+        const nextVersion = determineNextVersion(
+          '',
+          'release/core-contracts/12',
+          '@celo/abis',
+          'latest'
+        )
+        expect(execSyncMock).toHaveBeenCalledTimes(1)
+        expect(execSyncMock).toHaveBeenNthCalledWith(
+          1,
+          'npm view @celo/abis@latest version',
+          expect.anything()
+        )
+        expect(retrieveReleaseInformation(nextVersion as SemVer)).toEqual(['12.0.1', 'latest'])
+      })
+    })
+
     it('determines "pre-audit" release type and extracts version from "pre-audit" git tag directly', () => {
       const nextVersion = determineNextVersion(
         'core-contracts.v11.2.3.pre-audit',

--- a/packages/protocol/scripts/utils.ts
+++ b/packages/protocol/scripts/utils.ts
@@ -30,18 +30,26 @@ export const determineNextVersion = (
       `${tempVersion.major}.${tempVersion.minor}.${tempVersion.patch}-pre-audit.0`
     )
   } else if (gitBranch.startsWith(WORKING_RELEASE_BRANCH_PREFIX)) {
+    const latestVersion = getPreviousVersion(npmPackage, 'latest')
+    const latestVersionSemVer = new SemVer(latestVersion)
+    // since branch names are of the form release/core-contracts.XX we can check the major from the branch name
+    const major = parseInt(gitBranch.split(WORKING_RELEASE_BRANCH_PREFIX)[1], 10)
+
+    // if release for this release branch has been made treat further pushes as patches
+    if (latestVersionSemVer.major === major) {
+      nextVersion = latestVersionSemVer.inc('patch')
+      return nextVersion
+    }
+
     const lastVersion = getPreviousVersion(npmPackage, DAILY_RELEASE_TAG, 'latest')
     const lastVersionSemVer = new SemVer(lastVersion)
 
-    // since branch names are of the form release/core-contracts.XX we can check the major from the branch name
-    const major = gitBranch.split(WORKING_RELEASE_BRANCH_PREFIX)[1]
-
-    const firstCanaryOfMajor = lastVersionSemVer.major !== parseInt(major, 10)
+    const firstCanaryOfMajor = lastVersionSemVer.major !== major
     nextVersion = lastVersionSemVer.inc(
       firstCanaryOfMajor ? 'premajor' : 'prerelease',
       DAILY_RELEASE_TAG
     )
-    nextVersion.major = parseInt(major, 10)
+    nextVersion.major = major
   } else if (isValidNpmTag(npmTag)) {
     const lastVersion = getPreviousVersion(npmPackage, npmTag, DAILY_RELEASE_TAG)
     nextVersion = new SemVer(lastVersion).inc('prerelease', npmTag)


### PR DESCRIPTION
### Description

Rather than push out more canaries after the major has been bumped when major of latest version on npm matchs the release branch major version instead create a patch bump.

This is useful for when there are fixes in the abis package such as adding LockedCelo to the exports. 

### Other changes

cherry picked the changed files security patch from master branch
### Tested

new test

### Related issues

- Fixes #11327

### Backwards compatibility

yes (well some releases that were canaries will now be patches but they were wrong)

### Documentation

n/a