### PR TITLE
use secure actions

### DIFF
--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -47,7 +47,7 @@ jobs:
   install-dependencies:
     name: Install dependencies
     outputs:
-      # Propagate more outputs if you need https://github.com/tj-actions/changed-files#outputs
+      # Propagate more outputs if you need https://github.com/step-security/changed-files#outputs
       # Adding a initial comma so ',<path>' matches also for the first file
       all_modified_files: ',${{ steps.changed-files.outputs.all_modified_files }}'
       artifacts_to_cache: ${{ steps.get_artifacts_to_cache.outputs.artifacts_to_cache }}
@@ -99,7 +99,7 @@ jobs:
       # Get workdir local changes and fail if there are any change
       - name: Verify Changed files
         id: verify-changed-files
-        uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687
+        uses: step-security/verify-changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         with:
           fail-if-changed: 'true'
           fail-message: 'Files changed during build. Please build locally and commit the changes.'
@@ -130,7 +130,7 @@ jobs:
             code-${{ github.sha }}
       - name: Detect files changed in PR (or commit), and expose as output
         id: changed-files
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         with:
           # Using comma as separator to be able to easily match full paths (using ,<path>)
           separator: ','

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -21,14 +21,14 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      # Propagate more outputs if you need https://github.com/tj-actions/changed-files#outputs
+      # Propagate more outputs if you need https://github.com/step-security/changed-files#outputs
       # Adding a initial comma so ',<path>' matches also for the first file
       all_modified_files: ',${{ steps.changed-files.outputs.all_modified_files }}'
     steps:
       - uses: actions/checkout@v4
       - name: Detect files changed in PR (or commit), and expose as output
         id: changed-files
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         with:
           # Using comma as separator to be able to easily match full paths (using ,<path>)
           separator: ','


### PR DESCRIPTION
Switching to use step-security maintained action due to vulnerability with tj-actions/changed-files

