### PR TITLE
Soloseng/fix-name-conflict

### DIFF
--- a/.github/workflows/protocol-devchain.yml
+++ b/.github/workflows/protocol-devchain.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - tag: core-contracts.v9
             node-version: 12
-          - tag: core-contracts.v12-renamed
+          - tag: core-contracts.v11
             node-version: 18
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/protocol-devchain.yml
+++ b/.github/workflows/protocol-devchain.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - tag: core-contracts.v9
             node-version: 12
-          - tag: core-contracts.v11
+          - tag: core-contracts.v12-renamed
             node-version: 18
     steps:
       - uses: actions/checkout@v4

--- a/packages/protocol/contracts-0.8/common/CeloUnreleasedTreasury.sol
+++ b/packages/protocol/contracts-0.8/common/CeloUnreleasedTreasury.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.7 <0.8.20;
 
-import "@openzeppelin/contracts8/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts8/utils/math/Math.sol";
 
 import "./UsingRegistry.sol";
 
 import "../../contracts/common/Initializable.sol";
 import "./interfaces/ICeloUnreleasedTreasuryInitializer.sol";
+import "./libraries/ReentrancyGuard08.sol";
 
 /**
  * @title Contract for unreleased Celo tokens.
@@ -18,7 +18,7 @@ import "./interfaces/ICeloUnreleasedTreasuryInitializer.sol";
 contract CeloUnreleasedTreasury is
   ICeloUnreleasedTreasuryInitializer,
   UsingRegistry,
-  ReentrancyGuard,
+  ReentrancyGuard08,
   Initializable
 {
   bool internal hasAlreadyReleased;

--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.7 <0.8.20;
 
 import "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts8/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts8/access/Ownable.sol";
 
 import "./interfaces/IOracle.sol";
@@ -13,6 +12,7 @@ import "../../contracts/common/Initializable.sol";
 import "../../contracts/common/interfaces/IEpochManager.sol";
 import "../../contracts/common/interfaces/ICeloVersionedContract.sol";
 import "./interfaces/IEpochManagerInitializer.sol";
+import "./libraries/ReentrancyGuard08.sol";
 
 /**
  * @title Contract used for managing CELO L2 epoch and elections.
@@ -24,7 +24,7 @@ contract EpochManager is
   Initializable,
   UsingRegistry,
   IEpochManager,
-  ReentrancyGuard,
+  ReentrancyGuard08,
   ICeloVersionedContract,
   IEpochManagerInitializer
 {

--- a/packages/protocol/contracts-0.8/common/libraries/ReentrancyGuard08.sol
+++ b/packages/protocol/contracts-0.8/common/libraries/ReentrancyGuard08.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (security/ReentrancyGuard.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard08 {
+  // Booleans are more expensive than uint256 or any type that takes up a full
+  // word because each write operation emits an extra SLOAD to first read the
+  // slot's contents, replace the bits taken up by the boolean, and then write
+  // back. This is the compiler's defense against contract upgrades and
+  // pointer aliasing, and it cannot be disabled.
+
+  // The values being non-zero value makes deployment a bit more expensive,
+  // but in exchange the refund on every call to nonReentrant will be lower in
+  // amount. Since refunds are capped to a percentage of the total
+  // transaction's gas, it is best to keep them low in cases like this one, to
+  // increase the likelihood of the full refund coming into effect.
+  uint256 private constant _NOT_ENTERED = 1;
+  uint256 private constant _ENTERED = 2;
+
+  uint256 private _status;
+
+  constructor() {
+    _status = _NOT_ENTERED;
+  }
+
+  /**
+   * @dev Prevents a contract from calling itself, directly or indirectly.
+   * Calling a `nonReentrant` function from another `nonReentrant`
+   * function is not supported. It is possible to prevent this from happening
+   * by making the `nonReentrant` function external, and making it call a
+   * `private` function that does the actual work.
+   */
+  modifier nonReentrant() {
+    // On the first call to nonReentrant, _notEntered will be true
+    require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+
+    // Any calls to nonReentrant after this point will fail
+    _status = _ENTERED;
+
+    _;
+
+    // By storing the original value once again, a refund is triggered (see
+    // https://eips.ethereum.org/EIPS/eip-2200)
+    _status = _NOT_ENTERED;
+  }
+}


### PR DESCRIPTION
### Description

Updating the ReentrancyGuard contract name to `ReentrancyGuard08` to avoid naming conflict between different solidity versions.

This becomes an issue when testing CR13 against CR12.

See https://clabsco.slack.com/archives/C02LN9FRME1/p1744845840252149 for more details