### PR TITLE
Fix check-versions script invocations

### DIFF
--- a/packages/protocol/releaseData/README.md
+++ b/packages/protocol/releaseData/README.md
@@ -10,10 +10,10 @@ arguments to newly deployed contracts.
 
 ## `versionReports/`
 
-This subdirectory contains the version reports output by the `utils:check:versions`
+This subdirectory contains the version reports output by the `release:check-versions`
 script between each successive major release. They are used by the
 `protocol-test-release-snapshots` CI job as a regression snapshot test for the
-`utils:check:versions` script, so the `oldArtifactsFolder` and `newArtifactsFolder`
+`release:check-versions` script, so the `oldArtifactsFolder` and `newArtifactsFolder`
 should be set to paths that CircleCI jobs use (`/home/circleci/app/...`, see one
 of the files for an example).
 

--- a/packages/protocol/scripts/bash/release-snapshots.sh
+++ b/packages/protocol/scripts/bash/release-snapshots.sh
@@ -4,7 +4,7 @@ N=`echo -n $RELEASE_TAG | tail -c -1`
 
 for i in `eval echo {1..$N}`
 do
-    yarn utils:check:versions \
+    yarn release:check-versions \
         -a "core-contracts.v$(($i - 1))" \
         -b "core-contracts.v$i" \
         -r "releaseData/versionReports/release$i-report.json"


### PR DESCRIPTION
### Description

Several places used the wrong name for the check-versions script (`utils:check:versions` instead of `release:check-versions`). 