### PR TITLE
Update Celo Protocol docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The repository has the following packages (sub projects):
 
 - [celotool](packages/celotool) - scripts for deploying and managing testnets
 - [helm-charts](packages/helm-charts) - (DEPRECATED) templatized deployments of entire environments to Kubernetes clusters. Check [celo-org/charts](https://github.com/celo-org/charts) instead.
-- [protocol](packages/protocol) - identity, stability and other smart contracts for the Celo protocol ([docs](https://docs.celo.org/protocol))
+- [protocol](packages/protocol) - identity, stability and other smart contracts for the Celo protocol ([docs](https://docs.celo.org/learn/celo-protocol))
 
 Code owners for each package can be found in [.github/CODEOWNERS](.github/CODEOWNERS).
 


### PR DESCRIPTION
Replaced the outdated link to the Celo Protocol documentation (https://docs.celo.org/protocol) with the current and correct URL (https://docs.celo.org/learn/celo-protocol) in the README. This ensures users are directed to the latest protocol documentation.