### PR TITLE
Fix unquoted variable bug in bash scripts

### DIFF
--- a/packages/op-release/exec-mocked.sh
+++ b/packages/op-release/exec-mocked.sh
@@ -21,7 +21,7 @@ if [ -n "$EXTERNAL_SIG" ] && [ -n "$EXTERNAL_ACCOUNT" ]; then
   esac
   echo "External sig: $EXTERNAL_SIG"
 fi
-if [ -n $GRAND_CHILD_MULTISIG ] && [ $EXTERNAL_TEAM != "council" ]; then
+if [ -n "$GRAND_CHILD_MULTISIG" ] && [ $EXTERNAL_TEAM != "council" ]; then
   echo "Grand Child multisig is not supported for other team than council" && exit 1
 fi
 
@@ -179,7 +179,7 @@ COUNCIL_TX_HASH=$(cast call $COUNCIL_SAFE_ADDRESS \
 echo "Council hash: $COUNCIL_TX_HASH"
 
 # approve or sign Council
-if [ -n $GRAND_CHILD_MULTISIG ]; then
+if [ -n "$GRAND_CHILD_MULTISIG" ]; then
   echo "Detected Grand Child multisig: $GRAND_CHILD_MULTISIG"
 
   GRAND_CHILD_NONCE=$(cast call $GRAND_CHILD_MULTISIG "nonce()(uint256)" -r $RPC_URL)
@@ -209,7 +209,7 @@ if [ $APPROVE_OR_SIGN = 'approve' ]; then
   echo "Council hash approved"
 else
   echo "Sign Council hash"
-  if [ -z $GRAND_CHILD_MULTISIG ]; then
+  if [ -z "$GRAND_CHILD_MULTISIG" ]; then
     if [ -z "$EXTERNAL_SIG" ] || [ -z "$EXTERNAL_ACCOUNT" ] || [ "$EXTERNAL_TEAM" != "council" ]; then
       COUNCIL_SIG_1=$(cast wallet sign --no-hash $COUNCIL_TX_HASH --private-key $SIGNER_3_PK)
     else
@@ -227,7 +227,7 @@ echo "Exec Council approval"
 if [ $APPROVE_OR_SIGN = 'approve' ]; then
   COUNCIL_SIG=0x000000000000000000000000${MOCKED_SIGNER_4:2}000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000${MOCKED_SIGNER_3:2}000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000
 else
-  if [ -z $GRAND_CHILD_MULTISIG ]; then
+  if [ -z "$GRAND_CHILD_MULTISIG" ]; then
     if [ -z "$EXTERNAL_SIG" ] || [ -z "$EXTERNAL_ACCOUNT" ] || [ "$EXTERNAL_TEAM" != "council" ]; then
       COUNCIL_SIG=0x${COUNCIL_SIG_2:2}${COUNCIL_SIG_1:2}
     elif [[ ${MOCKED_SIGNER_4:2} < ${EXTERNAL_ACCOUNT:2} ]]; then

--- a/packages/op-release/fork/mock-mainnet.sh
+++ b/packages/op-release/fork/mock-mainnet.sh
@@ -24,7 +24,7 @@ if [ -n "$EXTERNAL_ACCOUNT" ]; then
       ;;
   esac
 fi
-if [ -n $GRAND_CHILD_MULTISIG ] && [ $EXTERNAL_TEAM != "council" ]; then
+if [ -n "$GRAND_CHILD_MULTISIG" ] && [ $EXTERNAL_TEAM != "council" ]; then
   echo "Grand Child multisig is not supported for other team than council" && exit 1
 fi
 
@@ -63,7 +63,7 @@ cast rpc anvil_setStorageAt $CLABS_MULTISIG 0x0000000000000000000000000000000000
 cast rpc anvil_setStorageAt $COUNCIL_MULTISIG 0x0000000000000000000000000000000000000000000000000000000000000004 0x0000000000000000000000000000000000000000000000000000000000000002 -r $RPC_URL
 
 # change threshold to 1 for Grand Child multisig
-if [ -n $GRAND_CHILD_MULTISIG ]; then
+if [ -n "$GRAND_CHILD_MULTISIG" ]; then
   cast rpc anvil_setStorageAt $GRAND_CHILD_MULTISIG 0x0000000000000000000000000000000000000000000000000000000000000004 0x0000000000000000000000000000000000000000000000000000000000000001 -r $RPC_URL
 fi
 
@@ -74,7 +74,7 @@ cast rpc anvil_setStorageAt $CLABS_MULTISIG 0x0000000000000000000000000000000000
 cast rpc anvil_setStorageAt $COUNCIL_MULTISIG 0x0000000000000000000000000000000000000000000000000000000000000003 0x0000000000000000000000000000000000000000000000000000000000000002 -r $RPC_URL
 
 # change owner count to 1 for Grand Child multisig
-if [ -n $GRAND_CHILD_MULTISIG ]; then
+if [ -n "$GRAND_CHILD_MULTISIG" ]; then
   cast rpc anvil_setStorageAt $GRAND_CHILD_MULTISIG 0x0000000000000000000000000000000000000000000000000000000000000003 0x0000000000000000000000000000000000000000000000000000000000000001 -r $RPC_URL
 fi
 
@@ -96,7 +96,7 @@ cast rpc anvil_setStorageAt $CLABS_MULTISIG $SIGNER_1_SLOT 0x0000000000000000000
 # Signer #2 -> Sentinel: cast index address 0x865d05C8bB46E7AF16D6Dc99ddfb2e64BBec1345 2 -> 0x18877be3912428d756ff6389ee4e71768eb68d3e723f7c81e68919c0a11fe761
 cast rpc anvil_setStorageAt $CLABS_MULTISIG 0x18877be3912428d756ff6389ee4e71768eb68d3e723f7c81e68919c0a11fe761 0x000000000000000000000000${SENTINEL_ADDRESS:2} -r $RPC_URL
 # [Council]
-if [ -z $GRAND_CHILD_MULTISIG ]; then
+if [ -z "$GRAND_CHILD_MULTISIG" ]; then
   # Sentinel -> Signer #3: cast index address 0x0000000000000000000000000000000000000001 2 -> 0xe90b7bceb6e7df5418fb78d8ee546e97c83a08bbccc01a0644d599ccd2a7c2e0
   cast rpc anvil_setStorageAt $COUNCIL_MULTISIG 0xe90b7bceb6e7df5418fb78d8ee546e97c83a08bbccc01a0644d599ccd2a7c2e0 0x000000000000000000000000${MOCKED_SIGNER_3:2} -r $RPC_URL
   # Signer #3 -> Signer #4: cast index address 0x8Af6f11c501c082bD880B3ceC83e6bB249Fa32c9 2 -> 0xfe2b681ac5bf197b6e6f3e6e8cb27c9abb3fa4018a18e1b5762ed302770b84e2
@@ -135,7 +135,7 @@ echo "cLabs signer is Signer #2: $(cast call $CLABS_MULTISIG "isOwner(address)(b
 echo "--- Council ---"
 echo "Council threshold: $(cast call $COUNCIL_MULTISIG "getThreshold()(uint256)" -r $RPC_URL)"
 echo "Council owners: $(cast call $COUNCIL_MULTISIG "getOwners()(address[])" -r $RPC_URL)"
-if [ -z $GRAND_CHILD_MULTISIG ]; then
+if [ -z "$GRAND_CHILD_MULTISIG" ]; then
   echo "Council signer is Signer #3: $(cast call $COUNCIL_MULTISIG "isOwner(address)(bool)" $MOCKED_SIGNER_3 -r $RPC_URL)"
   echo "Council signer is Signer #4: $(cast call $COUNCIL_MULTISIG "isOwner(address)(bool)" $MOCKED_SIGNER_4 -r $RPC_URL)"
 else


### PR DESCRIPTION
### Description

This PR fixes a bug where the `$GRAND_CHILD_MULTISIG` variable was unquoted in bash test conditions (`[ -n $VAR ]`, `[ -z $VAR ]`).

The previous behavior caused incorrect logic:
*   `[ -n $GRAND_CHILD_MULTISIG ]` would incorrectly evaluate to `true` when the variable was empty or unset.
*   `[ -z $GRAND_CHILD_MULTISIG ]` would incorrectly evaluate to `false` when the variable was empty or unset.

The updated behavior ensures that these conditions evaluate correctly by quoting the variable (e.g., `[ -n "$GRAND_CHILD_MULTISIG" ]`), leading to the intended script flow.

### Other changes

N/A

### Tested

The changes were verified by searching for any remaining unquoted instances of `$GRAND_CHILD_MULTISIG` in test conditions after the fix.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

These changes are backwards compatible as they fix a logical bug without altering the intended functionality or external interfaces.

### Documentation

N/A