### PR TITLE
ci: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: 'Setup yarn'

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -62,7 +62,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           #scope: '@celo'
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 18.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)