### PR TITLE
fix: update broken documentation links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,4 +10,4 @@ If you wish to submit more complex changes, please sync with a core developer fi
 This will help ensure those changes are in line with the general philosophy of the project
 and enable you to get some early feedback.
 
-See the [contributing guide](https://docs.celo.org/community/contributing) for details on how to participate.
+See the [contributing guide](https://docs.celo.org/what-is-celo/joining-celo/contributors/code-contributors) for details on how to participate.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The repository has the following packages (sub projects):
 
 - [celotool](packages/celotool) - scripts for deploying and managing testnets
 - [helm-charts](packages/helm-charts) - (DEPRECATED) templatized deployments of entire environments to Kubernetes clusters. Check [celo-org/charts](https://github.com/celo-org/charts) instead.
-- [protocol](packages/protocol) - identity, stability and other smart contracts for the Celo protocol ([docs](https://docs.celo.org/protocol))
+- [protocol](packages/protocol) - identity, stability and other smart contracts for the Celo protocol ([docs](https://docs.celo.org/what-is-celo/using-celo/protocol))
 
 Code owners for each package can be found in [.github/CODEOWNERS](.github/CODEOWNERS).
 


### PR DESCRIPTION
## Fixed Dead Links

This PR fixes several broken documentation links that were returning 404 errors


