### PR TITLE
Update GitHub Actions in CI Workflow

### DIFF
--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -58,7 +58,7 @@ jobs:
       image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:34b1c5e90f9613964160cdf6bc292b410362ec6d
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Restore node cache
@@ -149,7 +149,7 @@ jobs:
     timeout-minutes: 30
     needs: install-dependencies
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Sync workspace
@@ -173,7 +173,7 @@ jobs:
       contains(needs.install-dependencies.outputs.all_modified_files, ',yarn.lock') ||
       false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
@@ -235,7 +235,7 @@ jobs:
             command: |
               yarn --cwd packages/protocol test:scripts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Sync workspace
@@ -326,7 +326,7 @@ jobs:
 
           #     ./ci_test_validator_order.sh checkout ${CELO_BLOCKCHAIN_BRANCH_TO_TEST}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Sync workspace
@@ -385,7 +385,7 @@ jobs:
               cd packages/protocol
               ./specs/scripts/reserve.sh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Sync workspace

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -26,7 +26,7 @@ jobs:
       # Adding a initial comma so ',<path>' matches also for the first file
       all_modified_files: ',${{ steps.changed-files.outputs.all_modified_files }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Detect files changed in PR (or commit), and expose as output
         id: changed-files
         uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -38,7 +38,7 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Fail if there are test with wrong extension

--- a/.github/workflows/protocol-devchain.yml
+++ b/.github/workflows/protocol-devchain.yml
@@ -26,7 +26,7 @@ jobs:
           - tag: core-contracts.v12-renamed
             node-version: 18
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ matrix.tag }}
           fetch-depth: 0

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
           swap-size-gb: 32
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Fail if there are test with wrong extension

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
       repository-projects: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Akeyless Get Secrets


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0

