### PR TITLE
fix(proxy-utils): rethrow error in setAndInitializeImplementation

### DIFF
--- a/packages/protocol/lib/proxy-utils.ts
+++ b/packages/protocol/lib/proxy-utils.ts
@@ -68,6 +68,7 @@ export async function setAndInitializeImplementation(
       return retryTx(proxy._setAndInitializeImplementation, [implementationAddress, callData as any])
     }
   } catch (error) {
-    console.log("errror", error);
+    console.error("error", error);
+    throw error
   }
 }


### PR DESCRIPTION
- Ensure initialization errors are not swallowed; callers now receive thrown exceptions instead of undefined.
- Replace console.log typo with console.error for consistency.
- Aligns behavior with web3-utils caller which expects a valid receipt or an exception.