### PR TITLE
Fix minor typos in protocol utils and migrations

### DIFF
--- a/packages/protocol/lib/proxy-utils.ts
+++ b/packages/protocol/lib/proxy-utils.ts
@@ -68,6 +68,6 @@ export async function setAndInitializeImplementation(
       return retryTx(proxy._setAndInitializeImplementation, [implementationAddress, callData as any])
     }
   } catch (error) {
-    console.log("errror", error);
+    console.log("error", error);
   }
 }

--- a/packages/protocol/lib/registry-utils.ts
+++ b/packages/protocol/lib/registry-utils.ts
@@ -2,7 +2,7 @@
  * Be careful when adding to this file or relying on this file.
  * The verification tooling uses the CeloContractName enum as a
  * source of truth for what contracts are considered "core" and
- * need to be checked for backwards compatability and bytecode on
+ * need to be checked for backwards compatibility and bytecode on
  * an environment.
  */
 

--- a/packages/protocol/migrations_ts/00_initial_migration.ts
+++ b/packages/protocol/migrations_ts/00_initial_migration.ts
@@ -9,7 +9,7 @@ module.exports = async (deployer: any, network: any) => {
   const currentNetwork = { ...networks[network], name: network }
 
   console.log('Current network is', JSON.stringify(currentNetwork))
-  // Instad of setting this in a singleton, it could have been set in every migration
+  // Instead of setting this in a singleton, it could have been set in every migration
   // but it would have required quite a lot of refactoring
   ArtifactsSingleton.setNetwork(currentNetwork)
 }


### PR DESCRIPTION
“errorr” → “error”
“compatbility” → “compatibility”
“Instad” → “Instead”

