### PR TITLE
test(ast-layout): align assertContractErrorsMatch with multi-error reports

### DIFF
--- a/packages/protocol/test/compatibility/ast-layout.ts
+++ b/packages/protocol/test/compatibility/ast-layout.ts
@@ -58,7 +58,12 @@ const selectReportFor = (report, contractName) => {
  */
 const assertContractErrorsMatch = (report, contractName: string, expectedMatches) => {
   const contractReport = selectReportFor(report, contractName)
-  assert.equal(contractReport.errors.length, 1)
+  assert.isOk(contractReport, `Contract report not found: ${contractName}`)
+  assert.equal(
+    contractReport.errors.length,
+    expectedMatches.length,
+    `Expected ${expectedMatches.length} error(s), got ${contractReport.errors.length}`
+  )
 
   contractReport.errors.forEach((error, i) => {
     assert.match(error, expectedMatches[i])


### PR DESCRIPTION
The compatibility reporter concatenates layout and struct incompatibilities, so a contract can legitimately produce multiple error messages. The test helper asserted errors.length === 1 while its comment implied matching a sequence of errors. This change:
- Asserts the contract report exists before accessing it.
- Compares errors.length to expectedMatches.length.
- Matches each error against its corresponding regex.
This aligns the tests with the reporter’s behavior and makes them future-proof for multi-error scenarios.