### PR TITLE
fix: typo in release script console messages

### DIFF
--- a/packages/protocol/scripts/make-release-3-changes.ts
+++ b/packages/protocol/scripts/make-release-3-changes.ts
@@ -30,7 +30,7 @@ try {
   )
   const releaseProposal: ProposalTx[] = readJsonSync(argv.input_proposal)
   writeJsonSync(argv.output_proposal, makeRelease3Changes(releaseProposal), { spaces: 2 })
-  console.info(`Modifications made sucessfully; written to ${argv.output_proposal}`)
+  console.info(`Modifications made successfully; written to ${argv.output_proposal}`)
 } catch (e) {
   console.error(`Something went wrong: ${e?.message || e?.toString()}`)
 }

--- a/packages/protocol/scripts/make-release-6-changes.ts
+++ b/packages/protocol/scripts/make-release-6-changes.ts
@@ -30,7 +30,7 @@ try {
   )
   const releaseProposal: ProposalTx[] = readJsonSync(argv.input_proposal)
   writeJsonSync(argv.output_proposal, makeRelease6Changes(releaseProposal), { spaces: 2 })
-  console.info(`Modifications made sucessfully; written to ${argv.output_proposal}`)
+  console.info(`Modifications made successfully; written to ${argv.output_proposal}`)
 } catch (e) {
   console.error(`Something went wrong: ${e instanceof Error ? JSON.stringify(e) : e?.toString()}`)
 }


### PR DESCRIPTION
Corrected the misspelling of "successfully" in console.info messages
in the release scripts:

- packages/protocol/scripts/make-release-3-changes.ts
- packages/protocol/scripts/make-release-6-changes.ts

This improves log message accuracy and consistency. No functional
changes were made.
