### PR TITLE
Fix typos in test contracts and comments for better readability

### DIFF
--- a/packages/protocol/test-sol/devchain/e2e/common/EpochManager.t.sol
+++ b/packages/protocol/test-sol/devchain/e2e/common/EpochManager.t.sol
@@ -49,7 +49,7 @@ contract E2E_EpochManager is ECDSAHelper08, Devchain {
 
     epochDuration = epochManagerContract.epochDuration();
 
-    vm.deal(address(celoUnreleasedTreasuryContract), L2_INITIAL_STASH_BALANCE); // 80% of the total supply to the treasury - whis will be yet distributed
+    vm.deal(address(celoUnreleasedTreasuryContract), L2_INITIAL_STASH_BALANCE); // 80% of the total supply to the treasury - this will be yet distributed
   }
 
   function authorizeVoteSigner(uint256 signerPk, address account) internal {

--- a/packages/protocol/test-sol/devchain/e2e/utils.sol
+++ b/packages/protocol/test-sol/devchain/e2e/utils.sol
@@ -31,7 +31,7 @@ contract Devchain is TestWithUtils08 {
   ICeloToken celoTokenContract;
 
   constructor() {
-    // Fetch all core contracts that are expeceted to be in the Registry on the devchain
+    // Fetch all core contracts that are expected to be in the Registry on the devchain
     sortedOracles = getSortedOracles();
     feeCurrencyDirectory = FeeCurrencyDirectory(
       registryContract.getAddressForStringOrDie("FeeCurrencyDirectory")

--- a/packages/protocol/test-sol/unit/common/EpochManager.t.sol
+++ b/packages/protocol/test-sol/unit/common/EpochManager.t.sol
@@ -696,7 +696,7 @@ contract EpochManagerTest_processGroup is EpochManagerTest {
   }
 
   function test_Reverts_WhenNotStarted() public {
-    vm.expectRevert("Indivudual epoch process is not started");
+    vm.expectRevert("Individual epoch process is not started");
     epochManagerContract.processGroup(group, address(0), address(0));
   }
 

--- a/packages/protocol/test/common/recoverFunds.ts
+++ b/packages/protocol/test/common/recoverFunds.ts
@@ -34,7 +34,7 @@ contract('Proxy', (accounts: string[]) => {
       await proxy._setImplementation(getSet.address)
     })
 
-    it('recovers funds from an incorrectly intialized implementation', async () => {
+    it('recovers funds from an incorrectly initialized implementation', async () => {
       const Freezer: FreezerContract = artifacts.require('Freezer')
       const GoldToken: GoldTokenContract = artifacts.require('GoldToken')
       const CeloUnreleasedTreasury: CeloUnreleasedTreasuryContract =


### PR DESCRIPTION
- **EpochManager.t.sol (devchain & unit)**: Fixed "whis" → "this" and
  "Indivudual" → "Individual".
- **utils.sol**: Corrected "expeceted" → "expected".
- **recoverFunds.ts**: Fixed "intialized" → "initialized".