### PR TITLE
chore: fix working directory and variable declaration problems

### DIFF
--- a/scripts/check-packages.js
+++ b/scripts/check-packages.js
@@ -5,7 +5,7 @@ const chalk = require('chalk')
 const FirebaseOrGAEProjects = ['faucet', 'web', 'notification-service']
 
 // Set CWD to monorepo root
-process.cwd(path.join(__dirname, '..'))
+process.chdir(path.join(__dirname, '..'))
 
 const pkgJsonPath = (name) => path.join('./packages', name, 'package.json')
 const readJSON = (path) => JSON.parse(fs.readFileSync(path))
@@ -40,7 +40,7 @@ function getErrors(pkgJson) {
     )
 
   const errors = []
-  for ([name, versionString] of interDependencies) {
+  for (const [name, versionString] of interDependencies) {
     if (extractVersionNumber(versionString) != versionMap.get(name)) {
       errors.push({
         from: pkgJson.name,


### PR DESCRIPTION
### Description

fixed two problems that were causing unexpected behavior in strict mode:

1. replaced `process.cwd(...)` with `process.chdir(...)` to properly change the working directory to the monorepo root.
2. added `const` in the `for` loop declaration to avoid `ReferenceError` in strict mode.

### Other changes

no other changes were made.

### Tested

manually verified that the working directory changes correctly and that the loop runs without errors in strict mode.

### Backwards compatibility

fully backwards compatible; the behavior for other parts of the script remains unchanged.

### Documentation

no documentation updates needed; the change is internal and does not affect external interfaces.
