### PR TITLE
fix: command checks and encryption message

### DIFF
--- a/scripts/key_placer.sh
+++ b/scripts/key_placer.sh
@@ -38,8 +38,7 @@ if [[ $1 == "decrypt" ]]; then
   done
 fi
 
-command -v gcloud > /dev/null 2>&1
-if [[ $? -eq 1 ]]; then
+if ! command -v gcloud > /dev/null 2>&1; then
   echo "gcloud is not installed - skipping ${1}ion"
   exit 0
 fi
@@ -74,7 +73,7 @@ done
 if [[ $1 == "decrypt" ]]; then
   echo "Encrypted files decrypted"
 elif [[ $1 == "encrypt" ]]; then
-  echo "Decrypted files encrypted"
+  echo "Files encrypted"
 fi
 
 exit 0


### PR DESCRIPTION
### Description

Improved the script by making the command existence check more reliable and correcting the encryption output message.
Currently, the script used `$?` to check for `gcloud`, which could be error-prone. The message after encryption was misleading.

**With these updates, the script now correctly detects missing commands and shows an accurate encryption message.**

### Other changes

No other changes; only adjustments to the command check and echo message.

### Tested

Tested locally by running the script with and without `gcloud` installed and verifying the encryption output message.

### Related issues

NA

### Backwards compatibility

These changes are fully backwards compatible & they only improve reliability and correct output messages.

### Documentation

No doc changes needed.
