### PR TITLE
chore: fixed broken links

### DIFF
--- a/developer_key_publishing.md
+++ b/developer_key_publishing.md
@@ -6,7 +6,7 @@ In support of these uses, [OpenPGP](https://www.openpgp.org/) public keys can be
 
 If you want to read more about OpenPGP keys, including their structure and metadata, check out [Anatomy of a GPG Key by Dave Steele](https://davesteele.github.io/gpg/2014/09/20/anatomy-of-a-gpg-key/).
 
-> Note: This guide assumes you have an @clabs.co email address, but if you do not, simply change the email domain to your primary developer email (e.g. @example.com for alice@example.com) Some additional setup will be required in the DNS records for your domain to configure [OpenPGP WKD]((https://gnupg.org/blog/20161027-hosting-a-web-key-directory.html)).
+> Note: This guide assumes you have an @clabs.co email address, but if you do not, simply change the email domain to your primary developer email (e.g. @example.com for alice@example.com) Some additional setup will be required in the DNS records for your domain to configure [OpenPGP WKD](https://gnupg.org/blog/20161027-hosting-a-web-key-directory.html).
 
 ## Setup
 
@@ -60,7 +60,7 @@ We recommend generating your developer key pair with a YubiKey. Generating your 
         4. You may add a comment, but it is not required.
     4. `quit`
 
-See the [official YubiKey documentation](https://support.yubico.com/support/solutions/articles/15000006420-using-your-yubikey-with-openpgp) for more information.
+See the [official YubiKey documentation](https://support.yubico.com/hc/en-us/articles/360013790259-Using-Your-YubiKey-with-OpenPGP) for more information.
 
 ### On your machine
 
@@ -87,7 +87,7 @@ If you've generated a key on your local machine, it can be imported onto your Yu
    2. `keytocard` and select `3` to set the authentication key on the YubiKey.
    3. `quit` and save your changes.
 
-See the [official YubiKey documentation](https://support.yubico.com/support/solutions/articles/15000006420-using-your-yubikey-with-openpgp)
+See the [official YubiKey documentation](https://support.yubico.com/hc/en-us/articles/360013790259-Using-Your-YubiKey-with-OpenPGP)
 
 #### Verify your signing key
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -8,7 +8,7 @@ The contents of this package are licensed under the terms of the GNU Lesser Publ
 
 ### Initial deployment
 
-See the [testnet helm chart README](../helm-charts/testnet/README.md) for how to expose the RPC endpoint.
+See the [testnet helm chart README](https://github.com/celo-org/charts/blob/main/charts/testnet/README.md) for how to expose the RPC endpoint.
 
 Then, to deploy contracts to a network run:
 

--- a/packages/protocol/artifacts/Proxy/Readme.md
+++ b/packages/protocol/artifacts/Proxy/Readme.md
@@ -1,4 +1,4 @@
-# About this folder
+s# About this folder
 
 This folder has files for the init code and bytecode used with the Celo smart contracts.
 
@@ -7,6 +7,6 @@ Leaving a note for future reference:
 1. The `proxyInitCode...` file seems to be require the bytecode for `Proxy.sol`. I'm not sure if this is the correct way to do it, but I simply copy/pasted the JSON value at `packages/protocol/out/Proxy.sol/Proxy.json` > `bytecode.object.` which is from the Foundry build artifacts.
 1. The `proxyBytecode...` file seems to be require the deployed bytecode for `Proxy.sol`. I'm not sure if this is the correct way to do it, but I simply copy/pasted the JSON value at `packages/protocol/out/Proxy.sol/Proxy.json` > `deployedBytecode.object.` which is from the Foundry build artifacts.
 
-Unless the bytecodes in these manual artifacts matches the actual Foundry artifacts, the `test_verifyArtifacts()` test in [`ProxyFactory08.t.sol`](packages/protocol/test-sol/unit/common/ProxyFactory08.t.sol) will fail.
+Unless the bytecodes in these manual artifacts matches the actual Foundry artifacts, the `test_verifyArtifacts()` test in [`ProxyFactory08.t.sol`](../../../../packages/protocol/test-sol/unit/common/ProxyFactory08.t.sol) will fail.
 
 I didn't have time to investigate this further or question why manual artifacts are needed in the first place. But, I'm leaving a note here for future reference.

--- a/packages/protocol/artifacts/Proxy/Readme.md
+++ b/packages/protocol/artifacts/Proxy/Readme.md
@@ -1,4 +1,4 @@
-s# About this folder
+# About this folder
 
 This folder has files for the init code and bytecode used with the Celo smart contracts.
 
@@ -7,6 +7,6 @@ Leaving a note for future reference:
 1. The `proxyInitCode...` file seems to be require the bytecode for `Proxy.sol`. I'm not sure if this is the correct way to do it, but I simply copy/pasted the JSON value at `packages/protocol/out/Proxy.sol/Proxy.json` > `bytecode.object.` which is from the Foundry build artifacts.
 1. The `proxyBytecode...` file seems to be require the deployed bytecode for `Proxy.sol`. I'm not sure if this is the correct way to do it, but I simply copy/pasted the JSON value at `packages/protocol/out/Proxy.sol/Proxy.json` > `deployedBytecode.object.` which is from the Foundry build artifacts.
 
-Unless the bytecodes in these manual artifacts matches the actual Foundry artifacts, the `test_verifyArtifacts()` test in [`ProxyFactory08.t.sol`](../../../../packages/protocol/test-sol/unit/common/ProxyFactory08.t.sol) will fail.
+Unless the bytecodes in these manual artifacts matches the actual Foundry artifacts, the `test_verifyArtifacts()` test in [`ProxyFactory08.t.sol`](../../test-sol/unit/common/ProxyFactory08.t.sol) will fail.
 
 I didn't have time to investigate this further or question why manual artifacts are needed in the first place. But, I'm leaving a note here for future reference.

--- a/packages/protocol/scripts/devchain.ts
+++ b/packages/protocol/scripts/devchain.ts
@@ -15,7 +15,7 @@ const gasLimit = 20000000
 
 const ProtocolRoot = path.normalize(path.join(__dirname, '../'))
 
-// As documented https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+// As documented https://circleci.com/docs/reference/variables/#built-in-environment-variables
 const isCI = process.env.CI === 'true'
 
 // Move to where the caller made the call So to have relative paths


### PR DESCRIPTION
### Description

Hi! I went through the docs and scripts and fixed a few broken and outdated links. Mostly small cleanup so everything points to the right place again.

### Other changes

- Updated the helm chart reference in `packages/protocol/README.md` with the correct GitHub link.  
- Fixed the relative path to `ProxyFactory08.t.sol` in `artifacts/Proxy/Readme.md`.  
- Updated the CircleCI env vars redirect link in `scripts/devchain.ts`. (potential phishing or malicious hack )  
- Replaced outdated YubiKey documentation links in `developer_key_publishing.md`.