### PR TITLE
Fix typos and improve NatSpec comments in EpochManager and SortedLinkedList

### DIFF
--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -72,13 +72,13 @@ contract EpochManager is
   uint256 public toProcessGroups = 0;
 
   /**
-   * @notice Event emited when epochProcessing has begun.
+   * @notice Event emitted when epochProcessing has begun.
    * @param epochNumber The epoch number that is being processed.
    */
   event EpochProcessingStarted(uint256 indexed epochNumber);
 
   /**
-   * @notice Event emited when epochProcessing has ended.
+   * @notice Event emitted when epochProcessing has ended.
    * @param epochNumber The epoch number that is finished being processed.
    */
   event EpochProcessingEnded(uint256 indexed epochNumber);
@@ -552,7 +552,7 @@ contract EpochManager is
 
   /**
    * @notice Returns the epoch number of a specified blockNumber.
-   * @param _blockNumber Block number of the epoch info is retreived.
+   * @param _blockNumber Block number of the epoch info is retrieved.
    */
   function getEpochNumberOfBlock(
     uint256 _blockNumber
@@ -563,7 +563,7 @@ contract EpochManager is
 
   /**
    * @notice Returns the epoch info of a specified blockNumber.
-   * @param _blockNumber Block number of the epoch info is retreived.
+   * @param _blockNumber Block number of the epoch info is retrieved.
    * @return firstEpoch The first block of the given block number.
    * @return lastBlock The first block of the given block number.
    * @return startTimestamp The starting timestamp of the given block number.
@@ -655,7 +655,7 @@ contract EpochManager is
 
   /**
    * @notice Returns the epoch info of a specified epoch.
-   * @param epochNumber Epoch number where the epoch info is retreived.
+   * @param epochNumber Epoch number where the epoch info is retrieved.
    * @return firstEpoch The first block of the given epoch.
    * @return lastBlock The first block of the given epoch.
    * @return startTimestamp The starting timestamp of the given epoch.
@@ -762,7 +762,7 @@ contract EpochManager is
   /**
    * @notice Returns the epoch info of a specified blockNumber.
    * @dev This function is here for backward compatibility. It is rather gas heavy and can run out of gas.
-   * @param _blockNumber Block number of the epoch info is retreived.
+   * @param _blockNumber Block number of the epoch info is retrieved.
    * @return firstEpoch The first block of the given block number.
    * @return lastBlock The first block of the given block number.
    * @return startTimestamp The starting timestamp of the given block number.

--- a/packages/protocol/contracts-0.8/common/linkedlists/SortedLinkedList.sol
+++ b/packages/protocol/contracts-0.8/common/linkedlists/SortedLinkedList.sol
@@ -160,7 +160,7 @@ library SortedLinkedList {
   }
 
   /**
-   * @notice Returns the keys of the elements greaterKey than and less than the provided value.
+   * @notice Returns the keys of the elements greater than and less than the provided value.
    * @param list A storage pointer to the underlying list.
    * @param value The element value.
    * @param lesserKey The key of the element which could be just left of the new value.


### PR DESCRIPTION
Updated NatSpec comments for better readability and correctness:

- **EpochManager.sol**
  - Fixed "emited" → "emitted" in event descriptions.
  - Corrected multiple instances of "retreived" → "retrieved" in function parameter docs.

- **SortedLinkedList.sol**
  - Fixed misleading comment: "greaterKey than and less than" → "greater than and less than".

These changes improve documentation quality without affecting contract logic.
