### PR TITLE
fix: bug in price handling causes cUSD to be minted without CELO backing 🚨

### DIFF
--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -699,7 +699,7 @@ contract EpochManager is
       address(getStableToken())
     );
 
-    uint256 CELOequivalent = (numerator * totalRewards) / denominator;
+    uint256 CELOequivalent = (denominator * totalRewards) / numerator;
     getCeloUnreleasedTreasury().release(
       registry.getAddressForOrDie(RESERVE_REGISTRY_ID),
       CELOequivalent


### PR DESCRIPTION
### Description

There's a serious issue in the EpochManager in how the reserve payback is calculated:
```solidity
(uint256 numerator, uint256 denominator) = IOracle(oracleAddress).getExchangeRate(
  address(getStableToken())
);

uint256 CELOequivalent = (numerator * totalRewards) / denominator;
```

Let's break it down: `totalRewards` represents the amount of cUSD, let's say it's `10,000 cUSD`, that was minted for the validators. Sorted oracles returns the dollar price of CELO, so for example, that's `0.3 $/CELO`.  By multiplying the two, you get `3,000 $^2/CELO`, but what you need to do is invert the price so you get, in this example, `3,333 CELO/$`, which, multiplied by `10,000 cUSD`, results in `33333 CELO`. 

Here's an [example transaction](https://celoscan.io/tx/0xe4ea572ac70ff1134609baa16937ca96c5d9848e22d00f68e6c38a1575db1d41) that shows this clearly: 
<img width="928" height="145" alt="image" src="https://github.com/user-attachments/assets/d725ea34-0684-449e-ba6a-a98dc319714b" />

cUSD minted (totalRewards) ~= 8794 cUSD
celo price ~= 0.27
celo released = 2359 CELO ~= 0.27 * 8794
actual celo required to back cUSD ~= 8794 / 0.27 ~= 32.570 CELO

The reserve has been slowly becoming undercollateralized as a result. I've written a [dune query](https://dune.com/queries/5847731) to calculate the extent of the damage:

cUSD Minted ~= 1,630,273
CELO Released ~= 531,173.
CELO Required to back the cUSD at the current price ~= 6,296,921
CELO Owed to the Mento Reserve = 5.765.748


### Other changes

N/A

### Tested

Requires testing, and probably to fix existing tests.

### Related issues

N/A

### Backwards compatibility

Yes

### Documentation

N/A