### PR TITLE
Contain scripts for MIPS redeployment.

### DIFF
--- a/packages/op-tooling/impls/DeployMIPS.sol
+++ b/packages/op-tooling/impls/DeployMIPS.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+
+import { IMIPS } from "interfaces/cannon/IMIPS.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+contract DeployMIPS is Script {
+  error MissingEnvVars();
+
+  function run() external {
+    address oracle_ = vm.envOr("PREIMAGE_ORACLE", address(0));
+    uint256 minProposalSize_ = vm.envOr("MIN_PROPOSAL_SIZE", uint256(0));
+    uint256 challengePeriod_ = vm.envOr("CHALLENGE_PERIOD", uint256(0));
+
+    if (oracle_ == address(0) && !(minProposalSize_ > 0 && challengePeriod_ > 0)) {
+      revert MissingEnvVars();
+    }
+
+    if (oracle_ == address(0)) {
+      oracle_ = DeployUtils.createDeterministic({
+        _name: "PreimageOracle",
+        _args: DeployUtils.encodeConstructor(
+          abi.encodeCall(IPreimageOracle.__constructor__, (minProposalSize_, challengePeriod_))
+        ),
+        _salt: DeployUtils.DEFAULT_SALT
+      });
+      console.log("Using new PreimageOracle:", oracle_);
+    } else {
+      console.log("Using provided PreimageOracle:", oracle_);
+    }
+
+    address mips_ = DeployUtils.createDeterministic({
+      _name: "MIPS",
+      _args: DeployUtils.encodeConstructor(
+        abi.encodeCall(IMIPS.__constructor__, (IPreimageOracle(oracle_)))
+      ),
+      _salt: DeployUtils.DEFAULT_SALT
+    });
+    console.log("MIPS deployed at:", mips_);
+  }
+}

--- a/packages/op-tooling/impls/README.md
+++ b/packages/op-tooling/impls/README.md
@@ -11,6 +11,32 @@ forge script --root $PATH_TO_OP_REPO/packages/contracts-bedrock
 
 ## Scripts
 
+### `DeployMIPS.sol`
+
+Deploys a new MIPS (MIPS Instruction Set Architecture) implementation contract with configurable preimage oracle parameters.
+
+**Features:**
+- Deploys MIPS implementation using deterministic deployment
+- Optionally deploys a new PreimageOracle if not provided
+- Configurable minimum proposal size and challenge period for the oracle
+- Uses DeployUtils for consistent deployment patterns
+- Outputs deployed MIPS and oracle addresses
+
+**Required Environment Variables:**
+- Either provide an existing oracle OR configure oracle parameters:
+  - `PREIMAGE_ORACLE` - Address of existing PreimageOracle (optional)
+  - `MIN_PROPOSAL_SIZE` - Minimum proposal size for new oracle (required if no existing oracle)
+  - `CHALLENGE_PERIOD` - Challenge period for new oracle (required if no existing oracle)
+
+**Example Execution:**
+```bash
+# Using existing oracle
+PREIMAGE_ORACLE="0x..." forge script DeployMIPS.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
+
+# Deploying new oracle with MIPS
+MIN_PROPOSAL_SIZE=1000 CHALLENGE_PERIOD=3600 forge script DeployMIPS.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
+```
+
 ### `DeployPortalImpl.s.sol`
 
 Deploys a new OptimismPortal2 implementation contract with configurable proof maturity and dispute game finality delays.
@@ -83,9 +109,17 @@ Redeploys dispute game implementations with updated configuration parameters, pa
 - `SYSTEM_CONFIG` - Address of the SystemConfig proxy
 - `MAX_CLOCK_DURATION` - New maximum clock duration in seconds
 
+**Optional Environment Variables:**
+- `CLOCK_EXTENSION` - Clock extension duration in seconds (defaults to existing value)
+- `MIPS` - Address of MIPS implementation to use (defaults to existing VM)
+
 **Example Execution:**
 ```bash
+# Basic redeployment with new max clock duration
 OPCM="0x..." FACTORY="0x..." SYSTEM_CONFIG="0x..." MAX_CLOCK_DURATION=604800 forge script RedeployGames.s.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
+
+# Redeployment with custom clock extension and MIPS
+OPCM="0x..." FACTORY="0x..." SYSTEM_CONFIG="0x..." MAX_CLOCK_DURATION=604800 CLOCK_EXTENSION=1800 MIPS="0x..." forge script RedeployGames.s.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
 ```
 
 ### `SafeSetGames.s.sol`


### PR DESCRIPTION
### Description

This PR adds a new MIPS deployment script (`DeployMIPS.sol`) to the op-tooling package and updates the `RedeployGames.s.sol` script with enhanced functionality for dispute game redeployment. The current behavior only supported basic dispute game redeployment with limited configuration options. The updated behavior now provides:

1. **New MIPS deployment capability**: A dedicated script for deploying MIPS (MIPS Instruction Set Architecture) implementation contracts with configurable preimage oracle parameters
2. **Enhanced dispute game redeployment**: Added support for custom clock extension and MIPS implementation selection during dispute game redeployment
3. **Comprehensive documentation**: Updated the impls README with detailed usage instructions for all scripts including the new DeployMIPS functionality

### Other changes

- Updated `RedeployGames.s.sol` to support optional `CLOCK_EXTENSION` and `MIPS` environment variables
- Enhanced documentation in `impls/README.md` with detailed examples for both basic and advanced usage scenarios
- Added comprehensive documentation for the new `DeployMIPS.sol` script including environment variable requirements and execution examples

### Tested

These changes are deployment and configuration scripts that don't require traditional testing as they are:
- Foundry scripts for contract deployment and management
- Configuration utilities that interact with existing Optimism contracts
- Documentation updates that don't affect runtime behavior

The scripts follow established patterns used by other deployment scripts in the repository and use the same DeployUtils library for deterministic deployments.

### Related issues

- Prepared on purpose to further shorten proving / withdrawal time on Alfajores / Baklava during tests of latest upgrade on last days of Holesky

### Backwards compatibility

These changes are fully backwards compatible:
- The new `DeployMIPS.sol` script is additive and doesn't modify existing functionality
- The `RedeployGames.s.sol` changes only add optional parameters that default to existing behavior when not provided
- All existing environment variables and script behaviors remain unchanged
- Documentation updates don't affect any runtime behavior

### Documentation

- **Modified**: `packages/op-tooling/impls/README.md` - Added comprehensive documentation for the new `DeployMIPS.sol` script and updated `RedeployGames.s.sol` documentation with new optional parameters and usage examples
- **Community impact**: The enhanced documentation provides clear guidance for developers using these deployment scripts during Optimism releases, including detailed environment variable requirements and execution examples for both basic and advanced scenarios