### PR TITLE
chore: fix grammatical issues

### DIFF
--- a/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
+++ b/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
@@ -109,7 +109,7 @@ contract DoubleSigningSlasher is ICeloVersionedContract, SlasherUtil {
    * @param index Validator index at the block.
    * @param headerA First double signed block header.
    * @param headerB Second double signed block header.
-   * @return Block number where double signing occured. Throws if no double signing is detected.
+   * @return Block number where double signing occurred. Throws if no double signing is detected.
    */
   function checkForDoubleSigning(
     address signer,

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -903,7 +903,7 @@ contract Governance is
    * @param index The index in `dequeued`.
    * @return The corresponding proposal ID, vote value, and weight.
    * @return The depreciated vote value.
-   * @return The deprecieated weight.
+   * @return The depreciated weight.
    * @return The yes weight.
    * @return The no weight.
    * @return The abstain weight.

--- a/packages/protocol/specs/accounts.spec
+++ b/packages/protocol/specs/accounts.spec
@@ -264,7 +264,7 @@ invariant authorizedByIsNeverReflexive(address a)
 	a != 0 => _getAuthorizedBy(a) != a
 
 /**
- * If we set signerAuthroization to be completed, it means the signer is marked as authorizedBy the account.
+ * If we set signerAuthorization to be completed, it means the signer is marked as authorizedBy the account.
  * The other direction may not be correct because authorizedBy is persistent while signer authorizations can be removed. 
  */
 invariant mustHaveAuthorizedByIfCompletedSignerAuthorization(address account, bytes32 role, address signer) 


### PR DESCRIPTION
Was careful not to break api, looks like these fixes are safe

occured -> occurred
deprecieated -> depreciated
signerAuthroization -> signerAuthorization