### PR TITLE
chore: removed dead CircleCI link

### DIFF
--- a/packages/protocol/runTests.js
+++ b/packages/protocol/runTests.js
@@ -9,7 +9,6 @@ const network = require('./truffle-config.js').networks[networkName]
 
 const sleep = (seconds) => new Promise((resolve) => setTimeout(resolve, 1000 * seconds))
 
-// As documented https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 const isCI = process.env.CI === 'true'
 
 async function startGanache() {


### PR DESCRIPTION
### Description

the comment had a link to CircleCI docs that doesn’t exist anymore.
took it out to avoid confusion.

### Other changes

none.

### Tested

no functional changes, just removed a comment.

### Related issues

none.

### Backwards compatibility

fully compatible, no code changes.

### Documentation

not needed, the link was removed from a comment.