### PR TITLE
fix: correct typo in PrecompilesOverride contracts comments

### DIFF
--- a/packages/protocol/contracts-0.8/common/PrecompilesOverride.sol
+++ b/packages/protocol/contracts-0.8/common/PrecompilesOverride.sol
@@ -10,7 +10,7 @@ import "./UsingRegistry.sol";
 /**
  * @title PrecompilesOverride Contract
  * @notice This contract allows for a smoother transition from L1 to L2
- * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 swtiching logic.
+ * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 switching logic.
  **/
 contract PrecompilesOverride is UsingPrecompiles, UsingRegistry {
   /**

--- a/packages/protocol/contracts-0.8/common/PrecompilesOverrideV2.sol
+++ b/packages/protocol/contracts-0.8/common/PrecompilesOverrideV2.sol
@@ -10,7 +10,7 @@ import "./UsingRegistryV2NoMento.sol";
 /**
  * @title PrecompilesOverride Contract
  * @notice This contract allows for a smoother transition from L1 to L2
- * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 swtiching logic.
+ * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 switching logic.
  **/
 abstract contract PrecompilesOverrideV2 is UsingPrecompiles, UsingRegistryV2NoMento {
   /**


### PR DESCRIPTION

### Description

Fixed a typo in the contract documentation comments for both `PrecompilesOverride.sol` and `PrecompilesOverrideV2.sol`. Changed "swtiching" to "switching" in the description of L1 to L2 transition logic.
