### PR TITLE
fix: correct typos in sols

### DIFF
--- a/packages/protocol/contracts-0.8/common/PrecompilesOverride.sol
+++ b/packages/protocol/contracts-0.8/common/PrecompilesOverride.sol
@@ -10,7 +10,7 @@ import "./UsingRegistry.sol";
 /**
  * @title PrecompilesOverride Contract
  * @notice This contract allows for a smoother transition from L1 to L2
- * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 swtiching logic.
+ * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 switching logic.
  **/
 contract PrecompilesOverride is UsingPrecompiles, UsingRegistry {
   /**

--- a/packages/protocol/contracts-0.8/common/PrecompilesOverrideV2.sol
+++ b/packages/protocol/contracts-0.8/common/PrecompilesOverrideV2.sol
@@ -10,7 +10,7 @@ import "./UsingRegistryV2NoMento.sol";
 /**
  * @title PrecompilesOverride Contract
  * @notice This contract allows for a smoother transition from L1 to L2
- * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 swtiching logic.
+ * by abstracting away the usingPrecompile contract, and taking care of the L1 to L2 switching logic.
  **/
 abstract contract PrecompilesOverrideV2 is UsingPrecompiles, UsingRegistryV2NoMento {
   /**

--- a/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
+++ b/packages/protocol/contracts/governance/DoubleSigningSlasher.sol
@@ -109,7 +109,7 @@ contract DoubleSigningSlasher is ICeloVersionedContract, SlasherUtil {
    * @param index Validator index at the block.
    * @param headerA First double signed block header.
    * @param headerB Second double signed block header.
-   * @return Block number where double signing occured. Throws if no double signing is detected.
+   * @return Block number where double signing occurred. Throws if no double signing is detected.
    */
   function checkForDoubleSigning(
     address signer,

--- a/packages/protocol/contracts/governance/Governance.sol
+++ b/packages/protocol/contracts/governance/Governance.sol
@@ -903,7 +903,7 @@ contract Governance is
    * @param index The index in `dequeued`.
    * @return The corresponding proposal ID, vote value, and weight.
    * @return The depreciated vote value.
-   * @return The deprecieated weight.
+   * @return The depreciated weight.
    * @return The yes weight.
    * @return The no weight.
    * @return The abstain weight.


### PR DESCRIPTION
### Description

swtiching - switching
occured - occurred
deprecieated - depreciated

### Other changes

na

### Tested

just typos

### Related issues

na

### Backwards compatibility

na

### Documentation

na