### PR TITLE
Close most recent dispute game

### DIFF
--- a/packages/op-tooling/README.md
+++ b/packages/op-tooling/README.md
@@ -2,5 +2,6 @@
 
 Sections:
 - [impls](./impls/) - scripts for deployment & upgrade of individual OpStack contracts
+- [scripts](./scripts/) - scripts for interacting with OpStack contracts
 - [verify](./verify/) - scripts for performing smart contract verification for OpStack
 - [withdrawal](./withdrawal/) - scripts for performing L2 to L1 withdrawal via L2L1MessagePasser & OptimismPortal

--- a/packages/op-tooling/impls/DeployMIPS.sol
+++ b/packages/op-tooling/impls/DeployMIPS.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// This script requires running with --root and the following env vars:
+// PREIMAGE_ORACLE (optional) - if not provided, MIN_PROPOSAL_SIZE and CHALLENGE_PERIOD must be provided
+// MIN_PROPOSAL_SIZE (optional) - minimum proposal size for a new PreimageOracle if PREIMAGE_ORACLE is not provided
+// CHALLENGE_PERIOD (optional) - challenge period for a new PreimageOracle if PREIMAGE_ORACLE is not provided
+
 import { Script } from "forge-std/Script.sol";
 import { console } from "forge-std/console.sol";
 

--- a/packages/op-tooling/impls/DeployMIPS.sol
+++ b/packages/op-tooling/impls/DeployMIPS.sol
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-// This script requires running with --root and the following env vars:
-// PREIMAGE_ORACLE (optional) - if not provided, MIN_PROPOSAL_SIZE and CHALLENGE_PERIOD must be provided
-// MIN_PROPOSAL_SIZE (optional) - minimum proposal size for a new PreimageOracle if PREIMAGE_ORACLE is not provided
-// CHALLENGE_PERIOD (optional) - challenge period for a new PreimageOracle if PREIMAGE_ORACLE is not provided
-
 import { Script } from "forge-std/Script.sol";
 import { console } from "forge-std/console.sol";
 
@@ -14,6 +9,11 @@ import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 contract DeployMIPS is Script {
+  // This script requires running with --root and the following env vars:
+  // PREIMAGE_ORACLE (optional) - if not provided, MIN_PROPOSAL_SIZE and CHALLENGE_PERIOD must be provided
+  // MIN_PROPOSAL_SIZE (optional) - minimum proposal size for a new PreimageOracle if PREIMAGE_ORACLE is not provided
+  // CHALLENGE_PERIOD (optional) - challenge period for a new PreimageOracle if PREIMAGE_ORACLE is not provided
+
   error MissingEnvVars();
 
   function run() external {

--- a/packages/op-tooling/impls/DeployPortalImpl.s.sol
+++ b/packages/op-tooling/impls/DeployPortalImpl.s.sol
@@ -8,6 +8,10 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 contract DeployPortalImpl is Script {
+  // This script requires running with --root and the following env vars:
+  // PROOF_MATURITY_DELAY_SECONDS (required) - proof maturity delay for the OptimismPortal2
+  // DISPUTE_GAME_FINALITY_DELAY_SECONDS (required) - dispute game finality delay
+
   function run() external {
     uint256 proofMaturityDelaySeconds_ = vm.envUint("PROOF_MATURITY_DELAY_SECONDS");
     uint256 disputeGameFinalityDelaySeconds_ = vm.envUint("DISPUTE_GAME_FINALITY_DELAY_SECONDS");

--- a/packages/op-tooling/impls/RedeployGames.s.sol
+++ b/packages/op-tooling/impls/RedeployGames.s.sol
@@ -19,6 +19,14 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 
 contract RedeployGames is Script {
+  // This script requires running with --root and the following env vars:
+  // OPCM (required) - address of the old OPContractsManager
+  // FACTORY (required) - address of the DisputeGameFactory
+  // SYSTEM_CONFIG (required) - address of the SystemConfig proxy
+  // MAX_CLOCK_DURATION (required) - new max clock duration for the dispute games
+  // CLOCK_EXTENSION (optional) - new clock extension for the dispute games
+  // MIPS (optional) - new MIPS address for the dispute games
+
   struct Blueprints {
     address permissionedDisputeGame1;
     address permissionedDisputeGame2;

--- a/packages/op-tooling/impls/SafeSetGames.s.sol
+++ b/packages/op-tooling/impls/SafeSetGames.s.sol
@@ -12,6 +12,14 @@ import { GameTypes } from "src/dispute/lib/Types.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 
 contract SafeSetGames is Script {
+  // This script requires running with --root and the following env vars:
+  // FACTORY (required) - address of the DisputeGameFactory
+  // PERMISSIONED_GAME (required) - address of the new PermissionedDisputeGame implementation
+  // PERMISSIONLESS_GAME (required) - address of the new PermissionlessDisputeGame implementation
+  // SAFE (required) - address of the Gnosis Safe to execute the transaction
+  // SENDER (required) - address of the sender in the Gnosis Safe
+  // SIG (optional) - signatures for the Safe transaction; if not provided, the transaction
+
   error MissingSignatures();
 
   struct EnvConfig {

--- a/packages/op-tooling/impls/SafeSetPortal.s.sol
+++ b/packages/op-tooling/impls/SafeSetPortal.s.sol
@@ -11,6 +11,14 @@ import { Enum } from "safe-contracts/common/Enum.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 contract SafeSetPortal is Script {
+  // This script requires running with --root and the following env vars:
+  // PORTAL_PROXY (required) - address of the OptimismPortal2 proxy
+  // PORTAL_IMPL (required) - address of the new OptimismPortal2 implementation
+  // PROXY_ADMIN (required) - address of the ProxyAdmin managing the OptimismPortal
+  // SAFE (required) - address of the Gnosis Safe to execute the transaction
+  // SENDER (required) - address of the sender in the Gnosis Safe
+  // SIG (optional) - signatures for the Safe transaction; if not provided, the transaction
+
   error MissingSignatures();
 
   struct EnvConfig {

--- a/packages/op-tooling/scripts/CloseRecentGame.s.sol
+++ b/packages/op-tooling/scripts/CloseRecentGame.s.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { GameType, GameStatus, Timestamp, BondDistributionMode } from "src/dispute/lib/Types.sol";
+
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+
+contract CloseRecentGame is Script {
+  // This script requires running with --root and the following env vars:
+  // FACTORY (required) - address of the dispute game factory
+  // REGISTRY (required) - address of the anchor state registry
+
+  event AnchorStateUpdated(
+    address indexed game,
+    uint256 indexed index,
+    GameStatus status,
+    Timestamp created
+  );
+  event AnchorStateUpToDate();
+  event NoGamesFound();
+  event NoEligibleGamesFound();
+
+  uint256 constant MAX_GAMES_TO_CHECK = 50;
+
+  bool private foundEligibleGame;
+
+  function run() external {
+    IDisputeGameFactory factory_ = IDisputeGameFactory(vm.envAddress("FACTORY"));
+    console.log("Factory present at:", address(factory_));
+
+    IAnchorStateRegistry registry_ = IAnchorStateRegistry(vm.envAddress("REGISTRY"));
+    console.log("Registry present at:", address(registry_));
+
+    uint256 gamesCount_ = factory_.gameCount();
+    console2.log("Total games:", gamesCount_);
+
+    if (gamesCount_ == 0) {
+      console.log("No games found in factory");
+      emit NoGamesFound();
+      return;
+    }
+
+    for (uint256 i = 0; i < MAX_GAMES_TO_CHECK && i < gamesCount_; i++) {
+      uint256 gameIndex_ = gamesCount_ - 1 - i;
+      (GameType gameType_, Timestamp created_, IDisputeGame game_) = factory_.gameAtIndex(
+        gameIndex_
+      );
+      console.log("Checking game at:", address(game_));
+      console2.log("  Type:", uint256(gameType_.unwrap()));
+      console2.log("  Created:", uint64(created_.unwrap()));
+
+      // check game status
+      GameStatus status_ = game_.status();
+      console2.log("  Status:", uint256(status_.unwrap()));
+      if (status_ == GameStatus.IN_PROGRESS) {
+        console.log("    >>> Game still in progress. Skipping...");
+        continue;
+      }
+
+      // check if game is resolved
+      if (game_.resolvedAt().raw() == 0) {
+        console.log("    >>> Game not resolved yet. Skipping...");
+        continue;
+      }
+
+      // check if game is finalized
+      if (!registry_.isGameFinalized(game_)) {
+        console.log("    >>> Game not finalized yet. Skipping...");
+        continue;
+      }
+
+      // check if game already closed
+      if (game_.bondDistributionMode() != BondDistributionMode.UNDECIDED) {
+        console.log("    >>> Game already closed. Anchor state up to date...");
+
+        foundEligibleGame = true;
+        emit AnchorStateUpToDate();
+        break;
+      }
+
+      // update anchor state by closing the game
+      vm.startBroadcast();
+      console.log("    >>> Closing game at:", address(game_));
+      game_.closeGame();
+      vm.stopBroadcast();
+
+      foundEligibleGame = true;
+      emit AnchorStateUpdated(address(game_), gameIndex_, game_.status(), created_);
+      break;
+    }
+
+    if (!foundEligibleGame) {
+      console.log("No eligible games found to close");
+      emit NoEligibleGamesFound();
+    }
+  }
+}

--- a/packages/op-tooling/scripts/CloseRecentGame.s.sol
+++ b/packages/op-tooling/scripts/CloseRecentGame.s.sol
@@ -16,6 +16,7 @@ contract CloseRecentGame is Script {
   // This script requires running with --root and the following env vars:
   // FACTORY (required) - address of the dispute game factory
   // REGISTRY (required) - address of the anchor state registry
+  // MAX (optional) - maximum number of recent games to check (default: 50)
 
   event AnchorStateUpdated(
     address indexed game,

--- a/packages/op-tooling/scripts/CloseRecentGame.s.sol
+++ b/packages/op-tooling/scripts/CloseRecentGame.s.sol
@@ -27,8 +27,6 @@ contract CloseRecentGame is Script {
   event NoGamesFound();
   event NoEligibleGamesFound();
 
-  uint256 constant MAX_GAMES_TO_CHECK = 50;
-
   bool private foundEligibleGame;
 
   function run() external {
@@ -37,6 +35,8 @@ contract CloseRecentGame is Script {
 
     IAnchorStateRegistry registry_ = IAnchorStateRegistry(vm.envAddress("REGISTRY"));
     console.log("Registry present at:", address(registry_));
+
+    uint256 MAX_GAMES_TO_CHECK = vm.envOr("MAX", uint256(50));
 
     uint256 gamesCount_ = factory_.gameCount();
     console2.log("Total games:", gamesCount_);

--- a/packages/op-tooling/scripts/README.md
+++ b/packages/op-tooling/scripts/README.md
@@ -1,0 +1,76 @@
+# Optimism Utility Scripts
+
+This directory contains Foundry scripts and shell utilities for managing Optimism dispute games and anchor state. These scripts interact with the Optimism repository and must be executed from the Optimism contracts-bedrock directory.
+
+## Important Usage Note
+
+**All Foundry scripts in this directory must be executed with root pointing to the Optimism repository contracts folder:**
+```bash
+forge script --root $PATH_TO_OP_REPO/packages/contracts-bedrock
+```
+
+## Scripts
+
+### `CloseRecentGame.s.sol`
+
+Closes the most recent eligible fault dispute game, which updates the anchor state in the registry. The script searches through recent games to find one that is resolved, finalized, and ready to be closed.
+
+**Features:**
+- Iterates through recent games in reverse chronological order (newest first)
+- Validates game status (not in progress, resolved, finalized)
+- Checks if game is already closed before attempting to close
+- Limits search to MAX_GAMES_TO_CHECK (50) games for efficiency
+- Emits events for all execution paths
+- Proper use of broadcast for state-changing operations
+
+**Required Environment Variables:**
+- `FACTORY` - Address of the DisputeGameFactory
+- `REGISTRY` - Address of the AnchorStateRegistry
+
+**Example Execution:**
+```bash
+FACTORY="0x..." REGISTRY="0x..." forge script CloseRecentGame.s.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
+```
+
+**Events Emitted:**
+- `AnchorStateUpdated(address game, uint256 index, GameStatus status, Timestamp created)` - Game successfully closed
+- `AnchorStateUpToDate()` - Most recent eligible game already closed
+- `NoGamesFound()` - Factory has no games
+- `NoEligibleGamesFound()` - No games in the checked range are eligible for closing
+
+**Validation Checks:**
+1. Game status is not IN_PROGRESS
+2. Game has been resolved (resolvedAt != 0)
+3. Game has been finalized by the registry
+4. Game hasn't already been closed (bondDistributionMode == UNDECIDED)
+
+### `close-recent-game.sh`
+
+Shell wrapper script that simplifies execution of CloseRecentGame.s.sol by handling environment variable validation and forge command construction.
+
+**Features:**
+- Validates required environment variables before execution
+- Provides clear error messages for missing configuration
+- Uses proper error handling with set -euo pipefail
+- Executes forge script with broadcast enabled
+
+**Required Environment Variables:**
+- `L1_RPC_URL` - RPC URL for L1 network
+- `PK` - Private key for transaction signing
+- `FACTORY` - Address of the DisputeGameFactory (passed to forge script)
+- `REGISTRY` - Address of the AnchorStateRegistry (passed to forge script)
+
+**Example Execution:**
+```bash
+export L1_RPC_URL="https://..."
+export PK="0x..."
+export FACTORY="0x..."
+export REGISTRY="0x..."
+./close-recent-game.sh
+```
+
+## Notes
+
+- **Critical**: All Foundry scripts must be executed from the Optimism contracts-bedrock directory using `--root` flag
+- Only one game will be closed per script execution (stops after first eligible game)
+- Games must pass all validation checks before being closed

--- a/packages/op-tooling/scripts/close-recent-game.sh
+++ b/packages/op-tooling/scripts/close-recent-game.sh
@@ -15,10 +15,12 @@ check_env_var() {
 
 echo "Checking environment variables..."
 check_env_var "L1_RPC_URL"
+check_env_var "OP_DIR"
 check_env_var "PK"
 
 echo "Closing recent fault dispute game..."
 forge script CloseRecentGame.s.sol \
   --rpc-url $L1_RPC_URL \
+  --root $OP_DIR/packages/contracts-bedrock \
   --private-key $PK \
   --broadcast

--- a/packages/op-tooling/scripts/close-recent-game.sh
+++ b/packages/op-tooling/scripts/close-recent-game.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -euo pipefail
+
+check_env_var() {
+    local var_name=$1
+    local var_value=${!var_name:-}
+    
+    if [ -z "$var_value" ]; then
+        print_error "$var_name is not set"
+        echo "Please export $var_name while running this script"
+        exit 1
+    fi
+}
+
+echo "Checking environment variables..."
+check_env_var "L1_RPC_URL"
+check_env_var "PK"
+
+echo "Closing recent fault dispute game..."
+forge script CloseRecentGame.s.sol \
+  --rpc-url $L1_RPC_URL \
+  --private-key $PK \
+  --broadcast


### PR DESCRIPTION
### Description

This PR adds a new `scripts/` directory to the op-tooling package containing utility scripts for managing Optimism dispute games and anchor state. The main addition is a `CloseRecentGame.s.sol` Foundry script that automates the process of closing eligible fault dispute games to update the anchor state in the registry.

**Current behavior:** There was no automated way to close resolved and finalized dispute games, requiring manual intervention to update the anchor state registry.

**Updated behavior:** The new script automatically finds and closes the most recent eligible dispute game, updating the anchor state registry. It includes comprehensive validation checks to ensure only properly resolved and finalized games are closed, with detailed logging and event emission for monitoring.

### Other changes

- Added comprehensive README.md documentation explaining script usage, required environment variables, and execution examples
- Included a shell wrapper script (`close-recent-game.sh`) that simplifies execution by handling environment variable validation
- Added proper error handling and validation throughout the scripts
- Implemented event emission for all execution paths to enable monitoring and logging

### Tested

The scripts include comprehensive validation checks and error handling:
- Validates game status (not in progress, resolved, finalized)
- Checks if games are already closed to prevent duplicate operations
- Limits search scope to 50 most recent games for efficiency
- Emits events for all execution paths (success, already up-to-date, no games found, no eligible games)
- Uses proper Foundry broadcast patterns for state-changing operations

The scripts are designed to be safe and idempotent - they can be run multiple times without causing issues.

### Related issues

- Fixes [#1253](https://github.com/celo-org/celo-blockchain-planning/issues/1253)

### Backwards compatibility

These changes are fully backwards compatible as they only add new functionality without modifying existing code. The new scripts are self-contained and don't affect any existing contracts or interfaces.

### Documentation

- Added comprehensive README.md in `packages/op-tooling/scripts/` explaining:
  - Script purpose and functionality
  - Required environment variables
  - Execution examples and usage patterns
  - Event descriptions and validation checks
  - Important usage notes about running from Optimism contracts-bedrock directory