### PR TITLE
fix: correct typo in packages/protocol/README.md

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -121,9 +121,9 @@ yarn truffle:verify MentoFeeHandlerSeller@0x4efa274b7e33476c961065000d58ee09f792
 
 ### Possible problems
 
-1.  Some of old smart contracts have slightly different bytecode when verified (it is usually just few bytes difference). Some of the smart contracts were originally deployed with version 0.5.8 instead of 0.5.13 even though there is no history trace about this in our monorepo.
+1.  Some of the old smart contracts have slightly different bytecode when verified (it is usually just few bytes difference). Some of the smart contracts were originally deployed with version 0.5.8 instead of 0.5.13 even though there is no history trace about this in our monorepo.
 
-2.  Bytecode differs because of missing library addresses on CeloScan. Json file that will be manually uploaded to CeloScan needs to have libraries root element updated. Library addresses is possible to get either manually or with command which will generate libraries.json.
+2.  Bytecode differs because of missing library addresses on CeloScan. Json file that will be manually uploaded to CeloScan needs to have libraries root element updated. Library addresses are possible to get either manually or with command which will generate libraries.json.
 
     ```bash
     yarn release:verify-deployed -n $NETWORK -b $PREVIOUS_RELEASE -f
@@ -268,5 +268,5 @@ Example output:
 
 PRs that made these changes:
 
-16442165a Deactivate BlochainParameters Contract on L2 (#11008)
+16442165a Deactivate BlockchainParameters Contract on L2 (#11008)
 198f6215a SortedLinkedList Foundry Migration (#10846)


### PR DESCRIPTION

## Description

This Pull Request addresses a simple but important typo in the documentation for the `packages/protocol` module.

Specifically, it corrects the misspelling of `BlochainParameters` to **`BlockchainParameters`** in the PR comparison example within `packages/protocol/README.md`.

