### PR TITLE
fix: correct typos

### DIFF
--- a/packages/protocol/test-sol/unit/common/Fixidity.t.sol
+++ b/packages/protocol/test-sol/unit/common/Fixidity.t.sol
@@ -166,7 +166,7 @@ contract FixidityTest is Test {
     assertEq(fixidity.reciprocal(FIXED1_UINT), FIXED1_UINT);
   }
 
-  function test_divide_intergers() public {
+  function test_divide_integers() public {
     uint256 a = fixidity.newFixedFraction(840, 10);
     uint256 b = fixidity.newFixedFraction(20, 10);
     uint256 expected = fixidity.newFixedFraction(420, 10);

--- a/packages/protocol/test-sol/unit/common/Proxy.t.sol
+++ b/packages/protocol/test-sol/unit/common/Proxy.t.sol
@@ -143,14 +143,14 @@ contract ProxyTest_transferOwnership is ProxyTest {
     proxy._transferOwnership(newOwner);
   }
 
-  function test_ShouldAllowTheNewOwnerToPerformOwneronlyActions_AfterTransferingOwnership() public {
+  function test_ShouldAllowTheNewOwnerToPerformOwneronlyActions_AfterTransferringOwnership() public {
     GetSetV1 getSet1 = new GetSetV1();
     proxy._transferOwnership(newOwner);
     vm.prank(newOwner);
     proxy._setImplementation(address(getSet1));
   }
 
-  function test_Reverts_OldOwnerPerformsOwnerOnlyActions_AfterTransferingOwnership() public {
+  function test_Reverts_OldOwnerPerformsOwnerOnlyActions_AfterTransferringOwnership() public {
     GetSetV1 getSet1 = new GetSetV1();
     proxy._transferOwnership(newOwner);
     vm.expectRevert("sender was not owner");

--- a/packages/protocol/test-sol/unit/common/ScoreManager.t.sol
+++ b/packages/protocol/test-sol/unit/common/ScoreManager.t.sol
@@ -127,7 +127,7 @@ contract ScoreManagerTest_setValidatorScore is ScoreManagerTest {
 }
 
 contract ScoreManagerTest_setScoreManagerSetter is ScoreManagerTest {
-  function test_onlyOwnwerCanSetScoreManager() public {
+  function test_onlyOwnerCanSetScoreManager() public {
     vm.prank(nonOwner);
     vm.expectRevert("Ownable: caller is not the owner");
     scoreManager.setScoreManagerSetter(owner);


### PR DESCRIPTION
* Fixed typo in function name: `test_divide_intergers` → `test_divide_integers`
* Fixed typo in function name: `test_onlyOwnwerCanSetScoreManager` → `test_onlyOwnerCanSetScoreManager`
* Fixed typo in function name: `Transfering` → `Transferring`

