### PR TITLE
Prune dispute games

### DIFF
--- a/packages/op-tooling/scripts/DisputeGameFactoryPrunner.sol
+++ b/packages/op-tooling/scripts/DisputeGameFactoryPrunner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import { Hash, GameId, GameType, Timestamp, Claim } from "src/dispute/lib/Types.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";

--- a/packages/op-tooling/scripts/DisputeGameFactoryPrunner.sol
+++ b/packages/op-tooling/scripts/DisputeGameFactoryPrunner.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Hash, GameId, GameType, Timestamp, Claim } from "src/dispute/lib/Types.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+
+contract DisputeGameFactoryPrunner {
+  event GamePruned(
+    uint256 indexed index,
+    GameId indexed gameId,
+    Hash indexed gameUUID,
+    GameType gameType,
+    address gameProxy
+  );
+
+  uint256[103] internal __gap; // slots 0...102
+  mapping(Hash => GameId) internal _disputeGames; // slot 103
+  GameId[] internal _disputeGameList; // slot 104
+
+  function pruneGames(uint256 _desiredLength) external {
+    require(_desiredLength <= _disputeGameList.length, "Desired length exceeds current length");
+    while (_disputeGameList.length > _desiredLength) {
+      // Retrieve game id to prune
+      uint256 gameIndex_ = _disputeGameList.length - 1;
+      GameId gameId_ = _disputeGameList[gameIndex_];
+
+      // Unpack game id
+      (GameType gameType_, Timestamp timestamp_, address proxy_) = gameId_.unpack();
+
+      // Load game data
+      IDisputeGame game_ = IDisputeGame(proxy_);
+      Claim rootClaim_ = game_.rootClaim();
+      bytes memory extraData_ = game_.extraData();
+
+      // Compute game hash
+      Hash uuid_ = getGameUUID(gameType_, rootClaim_, extraData_);
+
+      // Delete game from storage
+      _disputeGames[uuid_] = GameId.wrap(bytes32(0));
+      _disputeGameList.pop();
+
+      // Emit event
+      emit GamePruned(gameIndex_, gameId_, uuid_, gameType_, proxy_);
+    }
+  }
+
+  function getGameUUID(
+    GameType _gameType,
+    Claim _rootClaim,
+    bytes memory _extraData
+  ) public pure returns (Hash uuid_) {
+    uuid_ = Hash.wrap(keccak256(abi.encode(_gameType, _rootClaim, _extraData)));
+  }
+}

--- a/packages/op-tooling/scripts/PruneGamesFromStorage.s.sol
+++ b/packages/op-tooling/scripts/PruneGamesFromStorage.s.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { GameType, Timestamp } from "src/dispute/lib/Types.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { DisputeGameFactoryPrunner } from "./DisputeGameFactoryPrunner.sol";
+
+contract PruneGamesFromStorage is Script {
+  // This script requires running with --root and the following env vars:
+  // FACTORY (required) - address of the dispute game factory
+  // PROXY_ADMIN (required) - address of the proxy admin
+  // OLDEST_INDEX (required) - oldest game index to stay
+
+  function run() external {
+    IDisputeGameFactory factory_ = IDisputeGameFactory(vm.envAddress("FACTORY"));
+    console.log("Factory present at:", address(factory_));
+
+    IProxyAdmin proxyAdmin_ = IProxyAdmin(vm.envAddress("PROXY_ADMIN"));
+    console.log("ProxyAdmin present at:", address(proxyAdmin_));
+
+    uint256 oldestIndex_ = vm.envUint("OLDEST_INDEX");
+    console.log("Oldest index to stay:", oldestIndex_);
+
+    // Store factory impl
+    address factoryImpl_ = proxyAdmin_.getProxyImplementation(address(factory_));
+
+    // Start broadcast
+    vm.startBroadcast();
+
+    // Upgrade factory to DisputeGameFactoryPrunner
+    console.log("Upgrading factory to DisputeGameFactoryPrunner...");
+    DisputeGameFactoryPrunner prunner_ = new DisputeGameFactoryPrunner();
+    proxyAdmin_.upgrade(payable(address(factory_)), address(prunner_));
+    console.log("Factory upgraded to DisputeGameFactoryPrunner at:", address(prunner_));
+
+    // Prune games from storage
+    console.log("Pruning games from storage...");
+    uint256 targetLength_ = oldestIndex_ + 1;
+    DisputeGameFactoryPrunner(payable(address(factory_))).pruneGames(targetLength_);
+    console.log("Pruning completed.");
+
+    // Restore factory implementation
+    console.log("Restoring factory implementation...");
+    proxyAdmin_.upgrade(payable(address(factory_)), factoryImpl_);
+    console.log("Factory implementation restored to:", factoryImpl_);
+
+    // Stop broadcast
+    vm.stopBroadcast();
+
+    // Log final game count
+    uint256 gameCount_ = factory_.gameCount();
+    console.log("Current game count in factory:", gameCount_);
+
+    // Log oldest game retained
+    (GameType gameType_, Timestamp timestamp_, IDisputeGame proxy_) = factory_.gameAtIndex(
+      oldestIndex_
+    );
+    console.log("Oldest game retained at index:", oldestIndex_);
+    console2.log("  Type:", uint32(gameType_.raw()));
+    console2.log("  Created:", uint64(timestamp_.raw()));
+    console.log("  Proxy:", address(proxy_));
+  }
+}

--- a/packages/op-tooling/scripts/PruneGamesFromStorage.s.sol
+++ b/packages/op-tooling/scripts/PruneGamesFromStorage.s.sol
@@ -15,7 +15,7 @@ contract PruneGamesFromStorage is Script {
   // This script requires running with --root and the following env vars:
   // FACTORY (required) - address of the dispute game factory
   // PROXY_ADMIN (required) - address of the proxy admin
-  // OLDEST_INDEX (required) - oldest game index to stay
+  // RETENTION_INDEX (required) - index up to which games are retained
 
   function run() external {
     IDisputeGameFactory factory_ = IDisputeGameFactory(vm.envAddress("FACTORY"));
@@ -24,8 +24,8 @@ contract PruneGamesFromStorage is Script {
     IProxyAdmin proxyAdmin_ = IProxyAdmin(vm.envAddress("PROXY_ADMIN"));
     console.log("ProxyAdmin present at:", address(proxyAdmin_));
 
-    uint256 oldestIndex_ = vm.envUint("OLDEST_INDEX");
-    console.log("Oldest index to stay:", oldestIndex_);
+    uint256 retentionIndex_ = vm.envUint("RETENTION_INDEX");
+    console.log("Game index to retain:", retentionIndex_);
 
     // Store factory impl
     address factoryImpl_ = proxyAdmin_.getProxyImplementation(address(factory_));
@@ -41,7 +41,7 @@ contract PruneGamesFromStorage is Script {
 
     // Prune games from storage
     console.log("Pruning games from storage...");
-    uint256 targetLength_ = oldestIndex_ + 1;
+    uint256 targetLength_ = retentionIndex_ + 1;
     DisputeGameFactoryPrunner(payable(address(factory_))).pruneGames(targetLength_);
     console.log("Pruning completed.");
 
@@ -57,11 +57,11 @@ contract PruneGamesFromStorage is Script {
     uint256 gameCount_ = factory_.gameCount();
     console.log("Current game count in factory:", gameCount_);
 
-    // Log oldest game retained
+    // Log retained game at retention index
     (GameType gameType_, Timestamp timestamp_, IDisputeGame proxy_) = factory_.gameAtIndex(
-      oldestIndex_
+      retentionIndex_
     );
-    console.log("Oldest game retained at index:", oldestIndex_);
+    console.log("Game retained at index:", retentionIndex_);
     console2.log("  Type:", uint32(gameType_.raw()));
     console2.log("  Created:", uint64(timestamp_.raw()));
     console.log("  Proxy:", address(proxy_));

--- a/packages/op-tooling/scripts/README.md
+++ b/packages/op-tooling/scripts/README.md
@@ -19,7 +19,7 @@ Closes the most recent eligible fault dispute game, which updates the anchor sta
 - Iterates through recent games in reverse chronological order (newest first)
 - Validates game status (not in progress, resolved, finalized)
 - Checks if game is already closed before attempting to close
-- Limits search to MAX_GAMES_TO_CHECK (50) games for efficiency
+- Configurable search limit via MAX environment variable
 - Emits events for all execution paths
 - Proper use of broadcast for state-changing operations
 
@@ -27,9 +27,15 @@ Closes the most recent eligible fault dispute game, which updates the anchor sta
 - `FACTORY` - Address of the DisputeGameFactory
 - `REGISTRY` - Address of the AnchorStateRegistry
 
+**Optional Environment Variables:**
+- `MAX` - Maximum number of recent games to check (default: 50)
+
 **Example Execution:**
 ```bash
 FACTORY="0x..." REGISTRY="0x..." forge script CloseRecentGame.s.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
+
+# With custom max games to check
+FACTORY="0x..." REGISTRY="0x..." MAX=100 forge script CloseRecentGame.s.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
 ```
 
 **Events Emitted:**
@@ -50,12 +56,14 @@ Shell wrapper script that simplifies execution of CloseRecentGame.s.sol by handl
 
 **Features:**
 - Validates required environment variables before execution
+- Automatically constructs --root path from OP_DIR
 - Provides clear error messages for missing configuration
 - Uses proper error handling with set -euo pipefail
 - Executes forge script with broadcast enabled
 
 **Required Environment Variables:**
 - `L1_RPC_URL` - RPC URL for L1 network
+- `OP_DIR` - Path to Optimism repository contracts directory
 - `PK` - Private key for transaction signing
 - `FACTORY` - Address of the DisputeGameFactory (passed to forge script)
 - `REGISTRY` - Address of the AnchorStateRegistry (passed to forge script)
@@ -63,14 +71,89 @@ Shell wrapper script that simplifies execution of CloseRecentGame.s.sol by handl
 **Example Execution:**
 ```bash
 export L1_RPC_URL="https://..."
+export OP_DIR="/path/to/optimism"
 export PK="0x..."
 export FACTORY="0x..."
 export REGISTRY="0x..."
 ./close-recent-game.sh
 ```
 
+### `PruneGamesFromStorage.s.sol`
+
+Maintenance script that removes games from the DisputeGameFactory storage to reduce storage costs and optimize factory performance. This is a critical operation that temporarily upgrades the factory to a pruning contract, removes games from the end of the array (higher indices), then restores the original implementation.
+
+**Features:**
+- Temporarily upgrades DisputeGameFactory to DisputeGameFactoryPrunner
+- Prunes games from the end of the storage array (higher indices)
+- Automatically restores original factory implementation
+- Verifies oldest retained game after pruning
+- Emits events for each pruned game via GamePruned event
+
+**Required Environment Variables:**
+- `FACTORY` - Address of the DisputeGameFactory proxy
+- `PROXY_ADMIN` - Address of the ProxyAdmin contract
+- `RETENTION_INDEX` - Index up to which games are retained (all games with index ≤ RETENTION_INDEX are kept, games with higher indices are removed)
+
+**Example Execution:**
+```bash
+# Keep games 0-100, remove games 101+
+FACTORY="0x..." PROXY_ADMIN="0x..." RETENTION_INDEX=100 forge script PruneGamesFromStorage.s.sol --root $PATH_TO_OP_REPO/packages/contracts-bedrock --broadcast --private-key $PK --rpc-url $RPC
+```
+
+**Process Flow:**
+1. Store original factory implementation address
+2. Deploy and upgrade to DisputeGameFactoryPrunner
+3. Call pruneGames() to remove games from storage (from end of array)
+4. Restore original factory implementation
+5. Verify final game count and oldest retained game
+
+**Safety Considerations:**
+- This operation modifies critical factory storage - use with caution
+- Requires ProxyAdmin privileges to upgrade factory
+- Games are permanently removed from factory storage (though on-chain game contracts remain)
+- Ensure RETENTION_INDEX is correct before execution
+- Consider creating games backup before pruning
+
+### `DisputeGameFactoryPrunner.sol`
+
+Helper contract used by `PruneGamesFromStorage.s.sol` to remove games from DisputeGameFactory storage. This contract replicates the factory's storage layout to safely manipulate the internal game arrays and mappings.
+
+**Features:**
+- Matches DisputeGameFactory storage layout exactly (slots 103-104)
+- Provides pruneGames() function to remove games from end of array
+- Emits GamePruned event for each removed game
+- Computes game UUIDs to properly clean up mapping storage
+
+**Storage Layout:**
+- `uint256[103] __gap` - Reserved slots 0-102 (matches factory layout)
+- `mapping(Hash => GameId) _disputeGames` - Slot 103 (game UUID to ID mapping)
+- `GameId[] _disputeGameList` - Slot 104 (array of all game IDs)
+
+**Key Function:**
+```solidity
+function pruneGames(uint256 _desiredLength) external
+```
+Removes games from storage until `_disputeGameList.length == _desiredLength`.
+
+**Event:**
+```solidity
+event GamePruned(
+  uint256 indexed index,
+  GameId indexed gameId,
+  Hash indexed gameUUID,
+  GameType gameType,
+  address gameProxy
+)
+```
+
+**Note:** This contract is only temporarily set as the factory implementation during the pruning operation and is immediately replaced with the original implementation afterwards.
+
 ## Notes
 
 - **Critical**: All Foundry scripts must be executed from the Optimism contracts-bedrock directory using `--root` flag
-- Only one game will be closed per script execution (stops after first eligible game)
+- The `CloseRecentGame.s.sol` script stops after finding and closing the first eligible game
 - Games must pass all validation checks before being closed
+- The `PruneGamesFromStorage.s.sol` script is a destructive operation - games are permanently removed from factory storage
+- Pruning games does not affect the deployed game contracts themselves, only the factory's internal tracking
+- Always verify the RETENTION_INDEX value before pruning to avoid removing games that should be retained
+- Consider the gas cost implications of pruning large numbers of games in a single transaction


### PR DESCRIPTION
### Description

This PR adds a script for pruning games from DisputeGameFactory. The script temporarily upgrades the DisputeGameFactory proxy to a specialized pruning contract (`DisputeGameFactoryPrunner`), removes games from the end of the storage array, then restores the original factory implementation. All games with indices greater than `RETENTION_INDEX` are pruned.

**Components added:**
- `PruneGamesFromStorage.s.sol` - Forge script that orchestrates the pruning operation via ProxyAdmin upgrade/downgrade
- `DisputeGameFactoryPrunner.sol` - Helper contract that replicates DisputeGameFactory's storage layout to safely manipulate the `_disputeGames` mapping and `_disputeGameList` array
- Documentation in `op-tooling/scripts/README.md`

**Key features:**
- Prunes games from end of array (indices > RETENTION_INDEX)
- Emits `GamePruned` event for each removed game
- Automatically restores original factory implementation
- Validates retained game after pruning

**⚠️ Important:** This script performs destructive storage operations. Test thoroughly on testnet before production use. Ensure `RETENTION_INDEX` is correct as pruned games cannot be recovered from factory storage.

### Documentation

- `packages/op-tooling/scripts/README.md`