### PR TITLE
Update reporter delegated amount during slashing

### DIFF
--- a/packages/protocol/contracts/governance/LockedGold.sol
+++ b/packages/protocol/contracts/governance/LockedGold.sol
@@ -507,6 +507,7 @@ contract LockedGold is
     }
 
     _updateDelegatedAmount(account);
+    _updateDelegatedAmount(reporter);
 
     address communityFund = registry.getAddressForOrDie(GOVERNANCE_REGISTRY_ID);
     address payable communityFundPayable = address(uint160(communityFund));


### PR DESCRIPTION

### Description
Enhance LockedGold contract to update delegated amounts for reporter when slashed and receiving rewards. Add unit tests to verify correct behavior for both reporter and account delegation scenarios.

### Tested

Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `LockedGold.slash` to recalculate reporter’s delegated amount when reward is granted and add unit tests covering reporter/account delegation updates.
> 
> - **Contracts**:
>   - `contracts/governance/LockedGold.sol`:
>     - In `slash`, after balance adjustments, also call `_updateDelegatedAmount(reporter)` to refresh reporter delegation state.
> - **Tests**:
>   - `test-sol/unit/governance/voting/LockedGold.t.sol`:
>     - Add tests ensuring reporter’s delegated amount and delegatee voting power update when reporter is delegating and receives reward.
>     - Add tests validating both slashed account and reporter delegations are updated when both are delegating.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62adde12ce5dd4e44fff479e1d03fc138c99b5f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->