### PR TITLE
specs(lockedGold): add pending timestamp precondition and reorder require in withdraw rule

### DIFF
--- a/packages/protocol/specs/lockedGold.spec
+++ b/packages/protocol/specs/lockedGold.spec
@@ -14,6 +14,7 @@ methods {
 	getPendingWithdrawalsLength(address) returns uint256 envfree
 	getPendingWithdrawalsIndex(address,uint256) returns uint256 envfree	
 	getunlockingPeriod() returns uint256 envfree
+	getPendingWithdrawal(address,uint256) returns (uint256,uint256) envfree
 	incrementNonvotingAccountBalance(address, uint256) 
 	decrementNonvotingAccountBalance(address, uint256) 
 	unlock(uint256) 
@@ -111,10 +112,13 @@ rule noChangeByOther(address a, address b, method f) {
  */
 rule withdraw(uint256 index) {
 	env e;
-	uint256 _balance = sinvoke ercBalanceOf(e.msg.sender);
-	uint256 val = sinvoke getPendingWithdrawalsIndex(e.msg.sender, index);
-	sinvoke withdraw(e, index);
 	require (e.msg.sender != currentContract);
+	uint256 _balance = sinvoke ercBalanceOf(e.msg.sender);
+	uint256 val;
+	uint256 ts;
+	(val, ts) = sinvoke getPendingWithdrawal(e.msg.sender, index);
+	require(e.block.timestamp >= ts);
+	sinvoke withdraw(e, index);
 	uint256 balance_ = sinvoke ercBalanceOf(e.msg.sender);
 	assert(
     _balance + val == balance_,


### PR DESCRIPTION
The withdraw rule could spuriously fail because it invoked withdraw without constraining time to or beyond the pending withdrawal’s availability, causing revert paths that invalidate the post-call balance equality assertion. This change declares getPendingWithdrawal in the methods block and updates the rule to read both the amount and its timestamp, then requires e.block.timestamp >= ts before invoking withdraw. It also moves the e.msg.sender != currentContract precondition before the call, so the environment is properly constrained. These adjustments mirror the contract’s own require for availability, focus the rule on the successful path the comment intends to model, and remove a source of non-deterministic failures without altering harnesses or contract code.