### PR TITLE
docs: document reserve.spec in Certora specs README

### DIFF
--- a/packages/protocol/specs/README.md
+++ b/packages/protocol/specs/README.md
@@ -18,3 +18,6 @@ This directory contains all necessary material in order to execute the Certora P
 - `governance_with_dequeue.spec` - rules for Governance that require reasoning about the dequeue mechanism
 - `governance_old_rules.spec` - rules used in the 2019 formal verification project, and require some re-formulation.
 - `governance-referendumVotes.spec` - a rule checking the consistency of referendum votes.
+
+### Reserve
+- `reserve.spec` - general rules for the Reserve contract.


### PR DESCRIPTION
Add a short description and dedicated section for reserve.spec in the Certora specs README so that all existing specification files are reflected in the documentation and users can more easily discover and understand the Reserve contract rules.