### PR TITLE
Add production environment to workflow for oidc trusted publishing

### DIFF
--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -33,6 +33,8 @@ jobs:
         working-directory: packages/protocol
     name: Generate anvil
     runs-on: ['self-hosted', 'monorepo-node18']
+    environment:
+      name: production
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
### Description

Update the protocol-devchain-anvil.yml ci/cd workflow file to use production environment
for trusted publishing


### Tested

  Not tested, because requires adding it to ci/cd to test.


### Backwards compatibility

Should cause no backwards compatibility issues, this is only to secure a deployment environment for OIDC trusted publishing to npm registry.