### PR TITLE
Add yarn script to run mocha tests

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -45,6 +45,7 @@
     "test": "forge test",
     "test:release-snapshots": "./scripts/bash/release-snapshots.sh",
     "test:truffle:compatibility": "rm test/**/*.js ; node runTests.js compatibility/",
+    "test:ts": "yarn mocha --recursive test-ts",
     "truffle:console": "./scripts/bash/console.sh",
     "truffle:verify": "yarn truffle run verify",
     "utils:prepare-contracts-and-abis-publishing": "yarn ts-node --preferTsExts ./scripts/prepare-contracts-and-abis-publishing.ts",


### PR DESCRIPTION
### Description

Add yarn script for running the new Truffle-free mocha tests.

These are mostly replacements for `test/compatibility/` tests. They test TypeScript libraries under `lib/` rather than Solidity smart contracts which are tested with `foundry test` and currently live under `test-sol/`.

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]