### PR TITLE
Fixes the broken `yarn test:ts` tests

### DIFF
--- a/packages/protocol/lib/compatibility/ast-code.ts
+++ b/packages/protocol/lib/compatibility/ast-code.ts
@@ -5,7 +5,7 @@ import {
   MethodMutabilityChange, MethodRemovedChange, MethodReturnChange,
   MethodVisibilityChange, NewContractChange
 } from '@celo/protocol/lib/compatibility/change'
-import { makeZContract } from '@celo/protocol/lib/compatibility/internal'
+import { makeZContract, getArtifactByName, getContractName } from '@celo/protocol/lib/compatibility/internal'
 import {
   BuildArtifacts,
   Contract as ZContract
@@ -301,12 +301,13 @@ export function reportASTIncompatibilities(
           return truffleProjectContractPathPattern.test(path) || foundryCoreContractPathPattern.test(path) || foundryTestContractPathPattern.test(path)
         })
         .map((newArtifact) => {
-          const oldArtifact = matchingOldArtifacts!.getArtifactByName(newArtifact.contractName)
+          const newContractName = getContractName(newArtifact)
+          const oldArtifact = getArtifactByName(newContractName, matchingOldArtifacts!)
           if (oldArtifact) {
             return generateASTCompatibilityReport(makeZContract(oldArtifact), matchingOldArtifacts!, makeZContract(newArtifact), newArtifacts)
           } else {
             // Contract doesn't exist in old artifacts of same version
-            console.log(`[INFO] New contract detected: ${newArtifact.contractName} (compiler: ${newCompilerVersion})`)
+            console.log(`[INFO] New contract detected: ${newContractName} (compiler: ${newCompilerVersion})`)
             return generateASTCompatibilityReport(null, matchingOldArtifacts!, makeZContract(newArtifact), newArtifacts)
           }
         })
@@ -318,7 +319,8 @@ export function reportASTIncompatibilities(
       if (fallbackOldArtifacts) {
         const reports = newArtifacts.listArtifacts()
           .map((newArtifact) => {
-            console.log(`[INFO] New contract (no matching old version): ${newArtifact.contractName} (compiler: ${newCompilerVersion})`)
+            const newContractName = getContractName(newArtifact)
+            console.log(`[INFO] New contract (no matching old version): ${newContractName} (compiler: ${newCompilerVersion})`)
             return generateASTCompatibilityReport(null, fallbackOldArtifacts!, makeZContract(newArtifact), newArtifacts)
           })
         out = [...out, ...reports]
@@ -344,7 +346,7 @@ export function reportASTIncompatibilities(
 
     if (!hasMatchingNewArtifacts) {
       console.log(`[INFO] Old artifacts with compiler ${oldCompilerVersion} have no matching new artifacts - contracts may have been removed`)
-      const potentiallyRemovedContracts = oldArtifacts.listArtifacts().map(artifact => artifact.contractName)
+      const potentiallyRemovedContracts = oldArtifacts.listArtifacts().map(artifact => getContractName(artifact))
       console.log(`[INFO] Potentially removed contracts: ${potentiallyRemovedContracts.join(', ')}`)
     }
   }


### PR DESCRIPTION
### Description

A few of the already ported mocha tests were broken. This PR fixes them, by using the new helper functions to get contract names from non-Truffle artifacts.

### Tested

`yarn test:ts` now works

### Related issues

- Part of #11605 