### PR TITLE
Migrate anvil devchain npm to OIDC trusted publishing

### DIFF
--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -171,6 +171,7 @@ jobs:
         with:
           name: ${{ steps.artifact-name.outputs.name }}
           path: packages/protocol/.tmp
+          include-hidden-files: true
           # Max retention time is 90 days for public repos
           # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy
           retention-days: 90

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -106,7 +106,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: 'Setup yarn'

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -164,6 +164,7 @@ jobs:
 
       - name: Publish @celo/devchain-anvil
         run: |
+          npm config delete //registry.npmjs.org/:_authToken || true
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN --access public --provenance
         working-directory: packages/protocol/.tmp

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -107,7 +107,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: 'Setup yarn'
         shell: bash
@@ -162,11 +161,13 @@ jobs:
           # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy
           retention-days: 90
 
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish @celo/devchain-anvil
         run: |
-          npm config delete //registry.npmjs.org/:_authToken || true
           cat package.json
-          npm publish $RELEASE_TYPE $DRY_RUN --access public --provenance
+          npm publish $RELEASE_TYPE $DRY_RUN --access public
         working-directory: packages/protocol/.tmp
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -104,23 +104,10 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      - name: Akeyless Get Secrets
-        id: get_auth_token
-        uses: docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
-        with:
-          api-url: https://api.gateway.akeyless.celo-networks-dev.org
-          access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/primitives-circle/NPM/npm-publish-token":"NPM_TOKEN"}'
-
       - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Verify NPM Token
-        run: npm whoami --registry https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: 'Setup yarn'
         shell: bash
@@ -178,10 +165,9 @@ jobs:
       - name: Publish @celo/devchain-anvil
         run: |
           cat package.json
-          npm publish $RELEASE_TYPE $DRY_RUN --access public
+          npm publish $RELEASE_TYPE $DRY_RUN --access public --provenance
         working-directory: packages/protocol/.tmp
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
           DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -36,6 +36,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    outputs:
+      release_type: ${{ steps.release-env.outputs.release_type }}
+      release_version: ${{ steps.release-env.outputs.release_version }}
+      artifact_name: ${{ steps.artifact-name.outputs.name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -145,6 +149,12 @@ jobs:
           NPM_PACKAGE: '@celo/devchain-anvil'
           NPM_TAG: ${{ inputs.npm_tag }}
 
+      - name: Set release outputs
+        id: release-env
+        run: |
+          echo "release_type=${{ env.RELEASE_TYPE }}" >> $GITHUB_OUTPUT
+          echo "release_version=${{ env.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
+
       - name: Prepare package for publishing
         run: yarn utils:prepare-devchain-anvil-publishing
         working-directory: packages/protocol
@@ -152,33 +162,18 @@ jobs:
           RELEASE_TYPE: ${{ env.RELEASE_TYPE }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
 
+      - name: Set artifact name
+        id: artifact-name
+        run: echo "name=devchain-${{ env.PR_NUMBER }}-${{ steps.date.outputs.date }}" >> $GITHUB_OUTPUT
+
       - name: Upload devchain as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: devchain-${{ env.PR_NUMBER }}-${{ steps.date.outputs.date }}
+          name: ${{ steps.artifact-name.outputs.name }}
           path: packages/protocol/.tmp
           # Max retention time is 90 days for public repos
           # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy
           retention-days: 90
-
-      - name: Upload devchain for publish job
-        uses: actions/upload-artifact@v4
-        with:
-          name: devchain-publish
-          path: packages/protocol/.tmp
-          retention-days: 1
-
-      - name: Save release env for publish job
-        run: |
-          echo "RELEASE_TYPE=${{ env.RELEASE_TYPE }}" >> release-env.txt
-          echo "RELEASE_VERSION=${{ env.RELEASE_VERSION }}" >> release-env.txt
-        working-directory: packages/protocol
-
-      - name: Upload release env
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-env
-          path: packages/protocol/release-env.txt
 
   publish:
     name: Publish to npm
@@ -188,18 +183,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Download release env
-        uses: actions/download-artifact@v4
-        with:
-          name: release-env
-
-      - name: Load release env
-        run: cat release-env.txt >> $GITHUB_ENV
-
       - name: Download devchain artifact
         uses: actions/download-artifact@v4
         with:
-          name: devchain-publish
+          name: ${{ needs.build.outputs.artifact_name }}
           path: package
 
       - uses: actions/setup-node@v4
@@ -215,6 +202,6 @@ jobs:
           npm publish $RELEASE_TYPE $DRY_RUN --access public
         working-directory: package
         env:
-          RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
+          RELEASE_TYPE: --tag ${{ needs.build.outputs.release_type != '' && needs.build.outputs.release_type || 'canary' }}
+          RELEASE_VERSION: ${{ needs.build.outputs.release_version }}
+          DRY_RUN: ${{ needs.build.outputs.release_version == '' && '--dry-run' || '' }}

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/primitives-circle/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/primitives-circle/NPM/npm-publish-token":"NPM_TOKEN"}'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -36,7 +36,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -152,6 +151,7 @@ jobs:
         env:
           RELEASE_TYPE: ${{ env.RELEASE_TYPE }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
       - name: Upload devchain as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -161,6 +161,51 @@ jobs:
           # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy
           retention-days: 90
 
+      - name: Upload devchain for publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: devchain-publish
+          path: packages/protocol/.tmp
+          retention-days: 1
+
+      - name: Save release env for publish job
+        run: |
+          echo "RELEASE_TYPE=${{ env.RELEASE_TYPE }}" >> release-env.txt
+          echo "RELEASE_VERSION=${{ env.RELEASE_VERSION }}" >> release-env.txt
+        working-directory: packages/protocol
+
+      - name: Upload release env
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-env
+          path: packages/protocol/release-env.txt
+
+  publish:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download release env
+        uses: actions/download-artifact@v4
+        with:
+          name: release-env
+
+      - name: Load release env
+        run: cat release-env.txt >> $GITHUB_ENV
+
+      - name: Download devchain artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: devchain-publish
+          path: package
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest
 
@@ -168,7 +213,7 @@ jobs:
         run: |
           cat package.json
           npm publish $RELEASE_TYPE $DRY_RUN --access public
-        working-directory: packages/protocol/.tmp
+        working-directory: package
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -117,6 +117,11 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Verify NPM Token
+        run: npm whoami --registry https://registry.npmjs.org
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+
       - name: 'Setup yarn'
         shell: bash
         run: |

--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/primitives-circle/npm-publish-token":"NPM_TOKEN"}'
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Migrated npm publishing from stored Akeyless token to OIDC Trusted Publishing, eliminating the need for long-lived npm secrets
- Split workflow into build (self-hosted) and publish (GitHub-hosted) jobs, since npm requires GitHub-hosted runners for provenance verification
- Fixed silent artifact upload failure caused by `upload-artifact@v4` skipping the `.tmp` directory (hidden directory)
- Upgraded Node.js from 18.x to 20.x

## Test plan
- [x] Verified canary publish succeeds with OIDC authentication
- [x] Verified provenance attestation is signed and published
- [x] Verified artifact upload includes `.tmp` contents