### PR TITLE
Move CI release test to Foundry-based scripts.

### DIFF
--- a/packages/protocol/scripts/bash/release-on-devchain.sh
+++ b/packages/protocol/scripts/bash/release-on-devchain.sh
@@ -53,7 +53,7 @@ source scripts/bash/contract-exclusion-regex.sh
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR/contracts --new_contracts build/contracts --exclude $CONTRACT_EXCLUSION_REGEX --new_branch $BRANCH --output_file report.json
 
 echo "- Clean git modified file"
-git restore migrationsConfig.js
+git restore --source $BASE_COMMIT --staged --worktree migrationsConfig.js
 
 
 # From make-release.sh

--- a/packages/protocol/scripts/bash/release-on-devchain.sh
+++ b/packages/protocol/scripts/bash/release-on-devchain.sh
@@ -37,7 +37,7 @@ echo "- Verify bytecode of the network"
 
 
 # this commands compiles the output
-yarn --cwd packages/protocol release:verify-deployed -n anvil -b $BRANCH
+yarn --cwd packages/protocol release:verify-deployed:foundry -n anvil -b $BRANCH
 
 
 echo "- Check versions of current branch"

--- a/packages/protocol/scripts/bash/release-on-devchain.sh
+++ b/packages/protocol/scripts/bash/release-on-devchain.sh
@@ -59,8 +59,10 @@ yarn release:make:foundry \
 
 # From verify-release.sh
 echo "- Verify release"
-yarn truffle exec --network anvil ./scripts/truffle/verify-bytecode.js --build_artifacts build/contracts --proposal ../../proposal.json --branch $BRANCH --initialize_data $INITIALIZATION_FILE
-
+yarn --cwd packages/protocol release:verify-deployed:foundry \
+    -n anvil \
+    -b $BRANCH \
+    -p proposal.json
 
 if [[ -n $ANVIL_PID ]]; then
     kill $ANVIL_PID

--- a/packages/protocol/scripts/bash/release-on-devchain.sh
+++ b/packages/protocol/scripts/bash/release-on-devchain.sh
@@ -39,22 +39,8 @@ echo "- Verify bytecode of the network"
 # this commands compiles the output
 yarn --cwd packages/protocol release:verify-deployed:foundry -n anvil -b $BRANCH
 
-
 echo "- Check versions of current branch"
-
-# From check-versions.sh
-
-BASE_COMMIT=$(git rev-parse HEAD)
-echo " - Base commit $BASE_COMMIT"
-echo " - Checkout migrationsConfig.js at $BRANCH"
-git checkout $BRANCH -- migrationsConfig.js
-
-source scripts/bash/contract-exclusion-regex.sh
-yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR/contracts --new_contracts build/contracts --exclude $CONTRACT_EXCLUSION_REGEX --new_branch $BRANCH --output_file report.json
-
-echo "- Clean git modified file"
-git restore --source $BASE_COMMIT --staged --worktree migrationsConfig.js
-
+yarn release:check-versions:foundry -a $BRANCH -b HEAD -r report.json
 
 # From make-release.sh
 echo "- Deploy release of current branch"

--- a/packages/protocol/scripts/bash/release-on-devchain.sh
+++ b/packages/protocol/scripts/bash/release-on-devchain.sh
@@ -45,7 +45,17 @@ yarn release:check-versions:foundry -a $BRANCH -b HEAD -r report.json
 # From make-release.sh
 echo "- Deploy release of current branch"
 INITIALIZATION_FILE=`ls releaseData/initializationData/release*.json | sort -V | tail -n 1 | xargs realpath`
-yarn truffle exec --network anvil ./scripts/truffle/make-release.js --build_directory build/ --branch $BRANCH --report report.json --proposal proposal.json --librariesFile libraries.json --initialize_data $INITIALIZATION_FILE
+
+ANVIL_DEVNET_PRIVATE_KEY='0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+yarn release:make:foundry \
+  -b "$BRANCH" \
+  -k "$ANVIL_DEVNET_PRIVATE_KEY" \
+  -i "$INITIALIZATION_FILE" \
+  -l libraries.json \
+  -n anvil \
+  -p proposal.json \
+  -r report.json \
+  -u "http://localhost:$ANVIL_PORT"
 
 # From verify-release.sh
 echo "- Verify release"

--- a/packages/protocol/scripts/bash/verify-deployed-forge.sh
+++ b/packages/protocol/scripts/bash/verify-deployed-forge.sh
@@ -10,18 +10,22 @@ set -euo pipefail
 # -f: Boolean flag to indicate if the Forno service should be used to connect to
 #     the network
 # -l: Path to a file to which logs should be appended
+# -p: Path to an optional proposal file, to verify the bytecodes of the core contracts after a
+# proposed release.
 
 BRANCH=""
 NETWORK=""
 FORNO=""
 LOG_FILE="/dev/stdout"
+PROPOSAL=""
 
-while getopts 'b:n:fl:' flag; do
+while getopts 'b:n:fl:p:' flag; do
   case "${flag}" in
     b) BRANCH="${OPTARG}" ;;
     n) NETWORK="${OPTARG}" ;;
     f) FORNO="--forno" ;;
     l) LOG_FILE="${OPTARG}" ;;
+    p) PROPOSAL="--proposal ${OPTARG}" ;;
     *) error "Unexpected option ${flag}" ;;
   esac
 done
@@ -38,4 +42,4 @@ build_tag_foundry $BRANCH $LOG_FILE truffle-compat8 foundry.toml.bak
 
 mv foundry.toml.bak foundry.toml
 
-yarn ts-node ./scripts/foundry/verify-bytecode-foundry.ts --network $NETWORK --branch $BRANCH --librariesFile "libraries.json" $FORNO
+yarn ts-node ./scripts/foundry/verify-bytecode-foundry.ts --network $NETWORK --branch $BRANCH --librariesFile "libraries.json" $FORNO $PROPOSAL

--- a/packages/protocol/scripts/foundry/make-release-foundry.sh
+++ b/packages/protocol/scripts/foundry/make-release-foundry.sh
@@ -53,7 +53,17 @@ done
 [ -z "$PROPOSAL" ] && echo "Need to set the proposal outfile via the -p flag" && exit 1;
 [ -z "$REPORT" ] && echo "Need to set the compatibility report input via the -r flag" && exit 1;
 
-BUILD_DIR="./out/"
+source scripts/bash/release-lib.sh
+
+cp foundry.toml foundry.toml.bak
+
+build_tag_foundry "$BRANCH" /dev/stdout truffle-compat foundry.toml.bak
+BUILD_DIR_05=$BUILD_DIR
+
+build_tag_foundry "$BRANCH" /dev/stdout truffle-compat8 foundry.toml.bak
+BUILD_DIR_08=$BUILD_DIR
+
+mv foundry.toml.bak foundry.toml
 
 # Build the command with optional flags
 OPTIONAL_FLAGS=""
@@ -75,5 +85,6 @@ yarn ts-node --transpile-only ./scripts/foundry/make-release.ts \
   --network "$NETWORK" \
   --proposal "$PROPOSAL" \
   --report "$REPORT" \
-  --buildDirectory "$BUILD_DIR" \
+  --buildDirectory05 "$BUILD_DIR_05" \
+  --buildDirectory08 "$BUILD_DIR_08" \
   $OPTIONAL_FLAGS

--- a/packages/protocol/scripts/foundry/make-release.ts
+++ b/packages/protocol/scripts/foundry/make-release.ts
@@ -70,7 +70,8 @@ interface MakeReleaseArgv {
   proposal: string
   librariesFile: string
   initializeData: string
-  buildDirectory: string
+  buildDirectory05: string
+  buildDirectory08: string
   branch: string
   network: string
   privateKey?: string
@@ -1118,10 +1119,17 @@ async function main() {
         demandOption: true,
         description: 'Path to the JSON file with initialization data for contracts.',
       })
-      .option('buildDirectory', {
+      .option('buildDirectory05', {
         type: 'string',
         demandOption: true,
-        description: 'Path to the Foundry build output directory (e.g., out/).',
+        description:
+          'Path to the Foundry build output directory for Solidity 0.5 contracts (e.g., out-branch-truffle-compat).',
+      })
+      .option('buildDirectory08', {
+        type: 'string',
+        demandOption: true,
+        description:
+          'Path to the Foundry build output directory for Solidity 0.8 contracts (e.g., out-branch-truffle-compat8).',
       })
       .option('branch', {
         type: 'string',
@@ -1157,9 +1165,19 @@ async function main() {
       }).argv
 
     const networkName = argv.network!
-    const buildDir = argv.buildDirectory
-    if (!existsSync(buildDir)) {
-      throw new Error(`${buildDir} directory not found. Make sure to run foundry build first`)
+    const buildDir05 = argv.buildDirectory05
+    const buildDir08 = argv.buildDirectory08
+
+    if (!existsSync(buildDir05)) {
+      throw new Error(
+        `${buildDir05} directory not found. Make sure to run foundry build with truffle-compat profile first`
+      )
+    }
+
+    if (!existsSync(buildDir08)) {
+      throw new Error(
+        `${buildDir08} directory not found. Make sure to run foundry build with truffle-compat8 profile first`
+      )
     }
 
     // Check for Celoscan API key early (before deployment) for production networks
@@ -1248,21 +1266,20 @@ async function main() {
 
     const contractArtifactPaths = new Map<string, string>()
 
-    findContractArtifacts(buildDir, contractArtifactPaths)
+    findContractArtifacts(buildDir05, contractArtifactPaths)
+    findContractArtifacts(buildDir08, contractArtifactPaths)
 
     if (contractArtifactPaths.size === 0) {
       console.warn(
-        `No contract artifacts found in ${buildDir}. Ensure the directory is correct and contains Foundry outputs.`
+        `No contract artifacts found in ${buildDir05} or ${buildDir08}. Ensure the directories contain Foundry outputs.`
       )
     }
 
     const registryArtifactPath = contractArtifactPaths.get('Registry')
     if (!registryArtifactPath) {
       throw new Error(
-        `Registry.json artifact not found in ${buildDir} or its subdirectories. ` +
-          `Please ensure it is compiled and present in the Foundry output format (e.g., ${String(
-            buildDir
-          )}/Registry.sol/Registry.json).`
+        `Registry.json artifact not found in ${buildDir05} or ${buildDir08}. ` +
+          `Please ensure it is compiled and present in the Foundry output format (e.g., ${buildDir05}/Registry.sol/Registry.json).`
       )
     }
     const registryArtifact = loadContractArtifact('Registry', registryArtifactPath)

--- a/packages/protocol/scripts/foundry/start_anvil.sh
+++ b/packages/protocol/scripts/foundry/start_anvil.sh
@@ -27,7 +27,7 @@ timestamp=`date -Iseconds`
 mkdir -p $ANVIL_FOLDER
 
 # create package.json
-echo "{\"name\": \"@celo/devchain-anvil\",\"version\": \"1.0.0\",\"repository\": { \"url\": \"https://github.com/celo-org/celo-monorepo\", \"directory\": \"packages/protocol/migrations_sol\" },\"homepage\": \"https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/migrations_sol/README.md\",\"description\": \"Anvil based devchain that contains core smart contracts of celo\",\"author\":\"Celo\",\"license\": \"LGPL-3.0\"}" > $TMP_FOLDER/package.json
+echo "{\"name\": \"@celo/devchain-anvil\",\"version\": \"0.0.0-placeholder\",\"repository\": { \"url\": \"https://github.com/celo-org/celo-monorepo\", \"directory\": \"packages/protocol/migrations_sol\" },\"homepage\": \"https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/migrations_sol/README.md\",\"description\": \"Anvil based devchain that contains core smart contracts of celo\",\"author\":\"Celo\",\"license\": \"LGPL-3.0\"}" > $TMP_FOLDER/package.json
 
 cp $PWD/migrations_sol/README.md $TMP_FOLDER/README.md
 

--- a/packages/protocol/scripts/foundry/verify-bytecode-foundry.ts
+++ b/packages/protocol/scripts/foundry/verify-bytecode-foundry.ts
@@ -73,6 +73,16 @@ const getViemChain = (networkName: string): Chain => {
         },
         testnet: true,
       })
+    case 'anvil':
+      return {
+        ...viemChains.hardhat,
+        id: 31337,
+        rpcUrls: {
+          default: {
+            http: ['http://localhost:8546'],
+          },
+        },
+      }
     default:
       return { ...viemChains.hardhat, id: 31337 }
   }


### PR DESCRIPTION
### Description

`yarn ci:test-make-release` was still using Truffle-based release scripts. This PR uses the new Foundry ones instead.


### Other changes

- `make-release-foundry` now uses the two output directories generated with the Truffle compatibility profiles.
- `verify-deployed-forge` now accepts a `-p <proposal.json>` argument to verify an upcoming contract's release.

### Tested

Manually building the devchain for `core-contracts.v14.anvil` and running `ci:test-make-release` locally.

### Related issues

- Fixes #11640 