### PR TITLE
Stop modifying global git config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "SEE LICENSE IN SUB-PACKAGES",
   "private": true,
   "scripts": {
-    "preinstall": "git config --global url.\"https://\".insteadOf ssh://",
     "lint": "yarn lerna run lint && yarn run --silent lint:do-not-merge",
     "lint:do-not-merge": "! git grep -E 'DO[ _]*NOT[ _]*MERGE'",
     "prettify": "yarn run prettier --config .prettierrc.js --write '**/*.+(ts|js|sol)'",


### PR DESCRIPTION
### Description

The top-level package.json's `preinstall` script used to modify the global git config to use https instead of ssh.

Not sure what the original reason for this was (introduced in #10560, no comment there on this particular change), and probably should never have been done this way (not nice to modify every user's global git config).

As far as I can tell, if this was necessary for something back then, it no longer is today (yarn install works, tests pass, etc.). Could have been a quirk of some component that is no longer relevant (CircleCI, one of the other packages that no longer lives in the monorepo).

### Tested

`yarn install` works. CI passes.

### Related issues

- Fixes #10919