### PR TITLE
fix(ci): speed up CI builds

### DIFF
--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -159,7 +159,7 @@ jobs:
   protocol-test-release:
     name: Protocol Test Release
     runs-on: ['self-hosted', 'org', 'ubuntu22-node18']
-    timeout-minutes: 500
+    timeout-minutes: 90
     needs: install-dependencies
     if: |
       github.base_ref == 'master' || contains(github.base_ref, 'release') || contains(github.base_ref, 'production') ||

--- a/.github/workflows/celo-monorepo.yml
+++ b/.github/workflows/celo-monorepo.yml
@@ -160,7 +160,7 @@ jobs:
     name: Protocol Test Release
     runs-on: ['self-hosted', 'org', 'ubuntu22-node18']
     timeout-minutes: 500
-    needs: [install-dependencies, lint-checks]
+    needs: install-dependencies
     if: |
       github.base_ref == 'master' || contains(github.base_ref, 'release') || contains(github.base_ref, 'production') ||
       contains(needs.install-dependencies.outputs.all_modified_files, 'packages/protocol') ||
@@ -201,7 +201,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ['self-hosted', 'org', 'ubuntu22-node18']
     timeout-minutes: 60
-    needs: [install-dependencies, lint-checks]
+    needs: install-dependencies
     if: |
       github.base_ref == 'master' || contains(github.base_ref, 'release') || contains(github.base_ref, 'staging') || contains(github.base_ref, 'production') ||
       contains(needs.install-dependencies.outputs.all_modified_files, 'packages/protocol') ||
@@ -256,7 +256,7 @@ jobs:
     container:
       image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/celo-monorepo:34b1c5e90f9613964160cdf6bc292b410362ec6d
     timeout-minutes: 30
-    needs: [install-dependencies, lint-checks]
+    needs: install-dependencies
     # Disable as certora license is not active
     if: |
       false && (

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -33,6 +33,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          # Fetch enough history for git-restore-mtime to set accurate timestamps.
+          # Files modified beyond this depth keep the checkout timestamp and will be
+          # recompiled, but that's a small subset so still a net win over full recompile.
+          fetch-depth: 100
+      - name: Restore file timestamps for Foundry cache
+        run: |
+          sudo apt-get install -qq -y git-restore-mtime
+          git restore-mtime
+          git submodule foreach --recursive git restore-mtime
+        working-directory: .
       - name: Fail if there are test with wrong extension
         if: success() || failure()
         run: |

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -160,6 +160,8 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: 'v1.0.0'
+      - name: Restore script permissions
+        run: chmod +x scripts/foundry/*.sh
       - name: Generate migrations and run devchain
         run: ./scripts/foundry/create_and_migrate_anvil_l2_devchain.sh
       - name: Run migration tests against local anvil devchain

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -19,12 +19,58 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  lint-checks:
     defaults:
       run:
         working-directory: packages/protocol
-    name: Run tests
+    name: Lint checks
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Fail if there are test with wrong extension
+        run: |
+          if  tree test-sol | grep -i ".sol" | grep -v ".sol"; then
+            echo "There are tests with wrong extensions"
+            tree test-sol | grep -i ".sol" | grep -v ".sol"
+            exit 1
+          fi
+      - name: Fail if there are tests without folder
+        run: |
+          if ls test-sol | grep -qi '\.t\.sol'; then
+            echo "All tests should be in a folder"
+            exit 1
+          fi
+
+  unit-tests:
+    defaults:
+      run:
+        working-directory: packages/protocol
+    name: Unit tests (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: common
+            path: "test-sol/unit/common/*"
+          - name: governance/network
+            path: "test-sol/unit/governance/network/*"
+            block_gas_limit: 50000000
+          - name: governance/validators
+            path: "test-sol/unit/governance/validators/*"
+            block_gas_limit: 50000000
+          - name: governance/voting
+            path: "test-sol/unit/governance/voting/*"
+          - name: stability
+            path: "test-sol/unit/stability/*"
+            block_gas_limit: 50000000
+          - name: identity
+            path: "test-sol/unit/identity/*"
+            block_gas_limit: 50000000
+          - name: all (catch-all)
+            path: "test-sol/unit/*"
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
@@ -33,14 +79,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Fail if there are test with wrong extension
-        if: success() || failure()
-        run: |
-          if  tree test-sol | grep -i ".sol" | grep -v ".sol"; then
-            echo "There are tests with wrong extensions"
-            tree test-sol | grep -i ".sol" | grep -v ".sol"
-            exit 1
-          fi
       # NOTE: Foundry cache/out caching does not speed up compilation because
       # git checkout sets all file timestamps to "now", causing forge to treat
       # every source file as dirty and recompile regardless of cached artifacts.
@@ -65,78 +103,99 @@ jobs:
       - name: Install forge dependencies
         run: forge install
 
-      # "Run tests" already tries to compile the contracts
-      # Making it explicit here to have easier to read errors
       - name: Compile Contracts
         run: forge --version && forge compile
 
-      - name: Run unit tests common
-        # can't use gas limit because some setUp function use more than the limit
+      - name: Run tests
         run: |
           forge test -vvv \
-          --match-path "test-sol/unit/common/*"
+          --match-path "${{ matrix.path }}" \
+          ${{ matrix.block_gas_limit && format('--block-gas-limit {0}', matrix.block_gas_limit) || '' }}
 
-      - name: Run unit tests governance/network
-        if: success() || failure()
+  integration-tests:
+    defaults:
+      run:
+        working-directory: packages/protocol
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
+        with:
+          swap-size-gb: 32
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Foundry cache
+        id: foundry-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/protocol/cache
+          key: ${{ runner.os }}-foundry-cache-${{ env.FOUNDRY_CACHE_KEY }}
+      - name: Foundry out
+        id: foundry-out
+        uses: actions/cache@v4
+        with:
+          path: packages/protocol/out
+          key: ${{ runner.os }}-foundry-out-${{ env.FOUNDRY_CACHE_KEY }}
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 'v1.0.0'
+
+      - name: Install forge dependencies
+        run: forge install
+
+      - name: Compile Contracts
+        run: forge --version && forge compile
+
+      - name: Run integration tests
         run: |
           forge test -vvv \
-          --match-path "test-sol/unit/governance/network/*" \
-          --block-gas-limit 50000000
+          --match-path "test-sol/integration/*"
 
-      - name: Run unit tests governance/validators
-        if: success() || failure()
-        run: | 
-          forge test -vvv \
-          --match-path "test-sol/unit/governance/validators/*" \
-          --block-gas-limit 50000000
+  devchain-tests:
+    defaults:
+      run:
+        working-directory: packages/protocol
+    name: Devchain tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
+        with:
+          swap-size-gb: 32
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Foundry cache
+        id: foundry-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/protocol/cache
+          key: ${{ runner.os }}-foundry-cache-${{ env.FOUNDRY_CACHE_KEY }}
+      - name: Foundry out
+        id: foundry-out
+        uses: actions/cache@v4
+        with:
+          path: packages/protocol/out
+          key: ${{ runner.os }}-foundry-out-${{ env.FOUNDRY_CACHE_KEY }}
 
-      - name: Run unit tests governance/voting
-        # can't use gas limit because some setUp function use more than the limit
-        if: success() || failure()
-        run: | 
-          forge test -vvv \
-          --match-path "test-sol/unit/governance/voting/*"
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 'v1.0.0'
 
-      - name: Run unit tests stability
-        if: success() || failure()
-        run: |
-          forge test -vvv \
-          --match-path "test-sol/unit/stability/*" \
-          --block-gas-limit 50000000
+      - name: Install forge dependencies
+        run: forge install
 
-      - name: Run unit tests identity
-        if: success() || failure()
-        run: |
-          forge test -vvv \
-          --match-path "test-sol/unit/identity/*" \
-          --block-gas-limit 50000000
-
-      - name: Fail if there are tests without folder
-        if: success() || failure()
-        run: |
-          if ls test-sol | grep -qi '\.t\.sol'; then
-            echo "All tests should be in a folder"
-            exit 1
-          fi
-
-      - name: Run all unit tests in case some were missed (excl. integration and e2e tests)
-        # can't use gas limit because some setUp function use more than the limit
-        # Excludes e2e and integration tests, because they require a connection to an anvil devchain
-        # serving at localhost.
-        run: |
-          forge test -vvv \
-          --match-path "test-sol/unit/*"
-      
-      - name: Run integration tests (that don't require an anvil devchain)
-        if: success() || failure()
-        run: |
-          forge test -vvv \
-          --match-path "test-sol/integration/*" \
+      - name: Compile Contracts
+        run: forge --version && forge compile
 
       - name: Generate migrations and run devchain
-        if: success() || failure()
         run: ./scripts/foundry/create_and_migrate_anvil_l2_devchain.sh
-      
+
       - name: Run migration tests against local anvil devchain
         run: |
           source ./scripts/foundry/constants.sh
@@ -144,7 +203,7 @@ jobs:
           FOUNDRY_PROFILE=devchain forge test -vvv \
           --match-path "test-sol/devchain/migration/*" \
           --fork-url $ANVIL_RPC_URL
-      
+
       - name: Run e2e tests against local anvil devchain
         run: |
           source ./scripts/foundry/constants.sh

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -10,8 +10,6 @@ on:
       - 'release/**'
 
 env:
-  # Increment these to force cache rebuilding
-  FOUNDRY_CACHE_KEY: 2
   # Supported Foundry version defined at celo-org (GitHub organisation) level, for consistency across workflows. Please contact DevOps to update value.
   SUPPORTED_FOUNDRY_VERSION: ${{ vars.SUPPORTED_FOUNDRY_VERSION }}
 
@@ -65,11 +63,13 @@ jobs:
         run: forge install
       - name: Compile Contracts
         run: forge --version && forge compile
-      - name: Upload compiled artifacts
+      # Upload the full workspace (source + compiled artifacts) so child jobs
+      # skip both git clone and recompilation.
+      - name: Upload workspace
         uses: actions/upload-artifact@v4
         with:
-          name: foundry-out
-          path: packages/protocol/out
+          name: protocol-workspace
+          path: packages/protocol
           retention-days: 1
 
   unit-tests:
@@ -102,25 +102,15 @@ jobs:
           - name: all (catch-all)
             path: "test-sol/unit/*"
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Download compiled artifacts
+      - name: Download workspace
         uses: actions/download-artifact@v4
         with:
-          name: foundry-out
-          path: packages/protocol/out
-      # Touch all artifacts so forge sees them as newer than source files
-      # and skips recompilation. This works because the compile job already
-      # verified the build succeeds.
-      - name: Mark artifacts as up-to-date
-        run: find out -type f -exec touch {} +
+          name: protocol-workspace
+          path: packages/protocol
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: 'v1.0.0'
-      - name: Install forge dependencies
-        run: forge install
       - name: Run tests
         run: |
           forge test -vvv \
@@ -135,22 +125,15 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Download compiled artifacts
+      - name: Download workspace
         uses: actions/download-artifact@v4
         with:
-          name: foundry-out
-          path: packages/protocol/out
-      - name: Mark artifacts as up-to-date
-        run: find out -type f -exec touch {} +
+          name: protocol-workspace
+          path: packages/protocol
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: 'v1.0.0'
-      - name: Install forge dependencies
-        run: forge install
       - name: Run integration tests
         run: |
           forge test -vvv \
@@ -168,22 +151,15 @@ jobs:
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
           swap-size-gb: 32
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Download compiled artifacts
+      - name: Download workspace
         uses: actions/download-artifact@v4
         with:
-          name: foundry-out
-          path: packages/protocol/out
-      - name: Mark artifacts as up-to-date
-        run: find out -type f -exec touch {} +
+          name: protocol-workspace
+          path: packages/protocol
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: 'v1.0.0'
-      - name: Install forge dependencies
-        run: forge install
       - name: Generate migrations and run devchain
         run: ./scripts/foundry/create_and_migrate_anvil_l2_devchain.sh
       - name: Run migration tests against local anvil devchain

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -33,16 +33,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          # Fetch enough history for git-restore-mtime to set accurate timestamps.
-          # Files modified beyond this depth keep the checkout timestamp and will be
-          # recompiled, but that's a small subset so still a net win over full recompile.
-          fetch-depth: 100
-      - name: Restore file timestamps for Foundry cache
-        run: |
-          sudo apt-get install -qq -y git-restore-mtime
-          git restore-mtime
-          git submodule foreach --recursive git restore-mtime
-        working-directory: .
       - name: Fail if there are test with wrong extension
         if: success() || failure()
         run: |
@@ -51,6 +41,9 @@ jobs:
             tree test-sol | grep -i ".sol" | grep -v ".sol"
             exit 1
           fi
+      # NOTE: Foundry cache/out caching does not speed up compilation because
+      # git checkout sets all file timestamps to "now", causing forge to treat
+      # every source file as dirty and recompile regardless of cached artifacts.
       - name: Foundry cache
         id: foundry-cache
         uses: actions/cache@v4

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -45,13 +45,13 @@ jobs:
         id: foundry-cache
         uses: actions/cache@v4
         with:
-          path: ./cache
+          path: packages/protocol/cache
           key: ${{ runner.os }}-foundry-cache-${{ env.FOUNDRY_CACHE_KEY }}
       - name: Foundry out
         id: foundry-out
         uses: actions/cache@v4
         with:
-          path: ./out
+          path: packages/protocol/out
           key: ${{ runner.os }}-foundry-out-${{ env.FOUNDRY_CACHE_KEY }}
 
       - name: Install Foundry

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -43,7 +43,37 @@ jobs:
             exit 1
           fi
 
+  compile:
+    defaults:
+      run:
+        working-directory: packages/protocol
+    name: Compile contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
+        with:
+          swap-size-gb: 32
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 'v1.0.0' # TODO: revert back to env var
+      - name: Install forge dependencies
+        run: forge install
+      - name: Compile Contracts
+        run: forge --version && forge compile
+      - name: Upload compiled artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: foundry-out
+          path: packages/protocol/out
+          retention-days: 1
+
   unit-tests:
+    needs: compile
     defaults:
       run:
         working-directory: packages/protocol
@@ -72,40 +102,25 @@ jobs:
           - name: all (catch-all)
             path: "test-sol/unit/*"
     steps:
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 32
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      # NOTE: Foundry cache/out caching does not speed up compilation because
-      # git checkout sets all file timestamps to "now", causing forge to treat
-      # every source file as dirty and recompile regardless of cached artifacts.
-      - name: Foundry cache
-        id: foundry-cache
-        uses: actions/cache@v4
+      - name: Download compiled artifacts
+        uses: actions/download-artifact@v4
         with:
-          path: packages/protocol/cache
-          key: ${{ runner.os }}-foundry-cache-${{ env.FOUNDRY_CACHE_KEY }}
-      - name: Foundry out
-        id: foundry-out
-        uses: actions/cache@v4
-        with:
+          name: foundry-out
           path: packages/protocol/out
-          key: ${{ runner.os }}-foundry-out-${{ env.FOUNDRY_CACHE_KEY }}
-
+      # Touch all artifacts so forge sees them as newer than source files
+      # and skips recompilation. This works because the compile job already
+      # verified the build succeeds.
+      - name: Mark artifacts as up-to-date
+        run: find out -type f -exec touch {} +
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: 'v1.0.0' # TODO: revert back to env var
-
+          version: 'v1.0.0'
       - name: Install forge dependencies
         run: forge install
-
-      - name: Compile Contracts
-        run: forge --version && forge compile
-
       - name: Run tests
         run: |
           forge test -vvv \
@@ -113,49 +128,36 @@ jobs:
           ${{ matrix.block_gas_limit && format('--block-gas-limit {0}', matrix.block_gas_limit) || '' }}
 
   integration-tests:
+    needs: compile
     defaults:
       run:
         working-directory: packages/protocol
     name: Integration tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 32
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Foundry cache
-        id: foundry-cache
-        uses: actions/cache@v4
+      - name: Download compiled artifacts
+        uses: actions/download-artifact@v4
         with:
-          path: packages/protocol/cache
-          key: ${{ runner.os }}-foundry-cache-${{ env.FOUNDRY_CACHE_KEY }}
-      - name: Foundry out
-        id: foundry-out
-        uses: actions/cache@v4
-        with:
+          name: foundry-out
           path: packages/protocol/out
-          key: ${{ runner.os }}-foundry-out-${{ env.FOUNDRY_CACHE_KEY }}
-
+      - name: Mark artifacts as up-to-date
+        run: find out -type f -exec touch {} +
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: 'v1.0.0'
-
       - name: Install forge dependencies
         run: forge install
-
-      - name: Compile Contracts
-        run: forge --version && forge compile
-
       - name: Run integration tests
         run: |
           forge test -vvv \
           --match-path "test-sol/integration/*"
 
   devchain-tests:
+    needs: compile
     defaults:
       run:
         working-directory: packages/protocol
@@ -169,33 +171,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Foundry cache
-        id: foundry-cache
-        uses: actions/cache@v4
+      - name: Download compiled artifacts
+        uses: actions/download-artifact@v4
         with:
-          path: packages/protocol/cache
-          key: ${{ runner.os }}-foundry-cache-${{ env.FOUNDRY_CACHE_KEY }}
-      - name: Foundry out
-        id: foundry-out
-        uses: actions/cache@v4
-        with:
+          name: foundry-out
           path: packages/protocol/out
-          key: ${{ runner.os }}-foundry-out-${{ env.FOUNDRY_CACHE_KEY }}
-
+      - name: Mark artifacts as up-to-date
+        run: find out -type f -exec touch {} +
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: 'v1.0.0'
-
       - name: Install forge dependencies
         run: forge install
-
-      - name: Compile Contracts
-        run: forge --version && forge compile
-
       - name: Generate migrations and run devchain
         run: ./scripts/foundry/create_and_migrate_anvil_l2_devchain.sh
-
       - name: Run migration tests against local anvil devchain
         run: |
           source ./scripts/foundry/constants.sh
@@ -203,7 +193,6 @@ jobs:
           FOUNDRY_PROFILE=devchain forge test -vvv \
           --match-path "test-sol/devchain/migration/*" \
           --fork-url $ANVIL_RPC_URL
-
       - name: Run e2e tests against local anvil devchain
         run: |
           source ./scripts/foundry/constants.sh


### PR DESCRIPTION
## Summary
- Fix Foundry cache paths in `protocol_tests.yml` — `actions/cache` resolves from repo root, not `working-directory`
- Run test jobs in parallel with lint checks instead of waiting for lint to finish first
- Parallelize Foundry tests with matrix strategy — split sequential test steps into separate jobs (unit tests by group, integration, devchain)
- Lower `protocol-test-release` timeout from 500 to 90 minutes
- Add note explaining why Foundry out/cache caching doesn't help (git checkout resets timestamps)