### PR TITLE
Use OIDC publishing for abis and solidity packages

### DIFF
--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -51,18 +51,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Akeyless Get Secrets
-        id: get_auth_token
-        uses: docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
-        with:
-          api-url: https://api.gateway.akeyless.celo-networks-dev.org
-          access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
 
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
           #scope: '@celo'
 
@@ -101,6 +94,10 @@ jobs:
       - name: 'Get git commit hash'
         id: get_COMMIT_HASH
         run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Update npm for OIDC trusted publishing (v11.5.1)
+        run: npm install -g npm@11.5.1
+
       - name: Publish @celo/contracts
         run: |
           cat package.json
@@ -115,7 +112,6 @@ jobs:
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
           DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
           COMMIT_HASH: ${{ env.COMMIT_HASH }}
 
@@ -133,6 +129,5 @@ jobs:
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
           DRY_RUN: ${{ env.RELEASE_VERSION == '' && '--dry-run' || '' }}
           COMMIT_HASH: ${{ env.COMMIT_HASH }}

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -96,6 +96,24 @@ jobs:
       - name: Update npm for OIDC trusted publishing (v11.5.1)
         run: npm install -g npm@11.5.1
 
+      # Fallback: ensure package.json has version (prepare script may not persist in CI)
+      - name: Ensure package.json has version
+        run: |
+          for pkg in packages/protocol/contracts packages/protocol/abis; do
+            node -e "
+              const fs = require('fs');
+              const pkgPath = process.argv[1] + '/package.json';
+              const pkg = JSON.parse(fs.readFileSync(pkgPath));
+              if (!pkg.version) {
+                pkg.version = process.env.RELEASE_VERSION || '0.0.0-dry-run';
+                pkg.private = false;
+                fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+              }
+            " "$pkg"
+          done
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
       - name: Publish @celo/contracts
         run: |
           cat package.json

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -105,7 +105,7 @@ jobs:
             echo "Dry run mode, exiting successfully."
             exit 0
           fi
-          # npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH              
+          # npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH
         working-directory: packages/protocol/contracts
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ['self-hosted', 'org', 'npm-publish']
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish-contracts-abi-release.yml
+++ b/.github/workflows/publish-contracts-abi-release.yml
@@ -56,8 +56,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-          #scope: '@celo'
 
       - name: 'Setup yarn'
         shell: bash
@@ -107,7 +105,7 @@ jobs:
             echo "Dry run mode, exiting successfully."
             exit 0
           fi
-          npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH              
+          # npm dist-tag add @celo/contracts@$RELEASE_VERSION $COMMIT_HASH              
         working-directory: packages/protocol/contracts
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}
@@ -124,7 +122,7 @@ jobs:
             echo "Dry run mode, exiting successfully."
             exit 0
           fi
-          npm dist-tag add @celo/abis@$RELEASE_VERSION $COMMIT_HASH          
+          # npm dist-tag add @celo/abis@$RELEASE_VERSION $COMMIT_HASH          
         working-directory: packages/protocol/abis
         env:
           RELEASE_TYPE: --tag ${{ env.RELEASE_TYPE != '' && env.RELEASE_TYPE || 'canary' }}

--- a/packages/protocol/abis/package.json
+++ b/packages/protocol/abis/package.json
@@ -18,6 +18,11 @@
     "./dist",
     "!**/*.js.map"
   ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/protocol/contracts/package.json
+++ b/packages/protocol/contracts/package.json
@@ -8,6 +8,11 @@
     "url": "https://github.com/celo-org/celo-monorepo.git",
     "directory": "packages/protocol/contracts"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
   "scripts": {},
   "dependencies": {}
 }

--- a/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
+++ b/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
@@ -260,22 +260,23 @@ function processRawJsonsAndPrepareExports() {
   return exports
 }
 
+const DRY_RUN_VERSION = '0.0.0-dry-run'
+
 function prepareAbisPackageJson(exports: Exports) {
   log('Preparing @celo/abis package.json')
   const packageJsonPath = path.join(ABIS_PACKAGE_SRC_DIR, 'package.json')
 
+  const version = process.env.RELEASE_VERSION || DRY_RUN_VERSION
   if (process.env.RELEASE_VERSION) {
-    log('Replacing @celo/abis version with RELEASE_VERSION)')
-
-    replacePackageVersionAndMakePublic(packageJsonPath, (json) => {
-      log('Setting @celo/abis exports')
-      json.exports = exports
-    })
-
-    return
+    log('Replacing @celo/abis version with RELEASE_VERSION')
+  } else {
+    log(`Using placeholder version ${DRY_RUN_VERSION} for dry run`)
   }
 
-  log('Skipping @celo/abis package.json preparation (no RELEASE_VERSION provided)')
+  replacePackageVersionAndMakePublic(packageJsonPath, version, (json) => {
+    log('Setting @celo/abis exports')
+    json.exports = exports
+  })
 }
 
 function prepareContractsPackage() {
@@ -283,15 +284,15 @@ function prepareContractsPackage() {
   log(contracts08CpCommand)
   child_process.execSync(contracts08CpCommand)
 
+  const version = process.env.RELEASE_VERSION || DRY_RUN_VERSION
   if (process.env.RELEASE_VERSION) {
-    log('Replacing @celo/contracts version with RELEASE_VERSION)')
-    const packageJsonPath = path.join(CONTRACTS_PACKAGE_SRC_DIR, 'package.json')
-    replacePackageVersionAndMakePublic(packageJsonPath)
-
-    return
+    log('Replacing @celo/contracts version with RELEASE_VERSION')
+  } else {
+    log(`Using placeholder version ${DRY_RUN_VERSION} for dry run`)
   }
 
-  log('Skipping @celo/contracts package.json preparation (no RELEASE_VERSION provided)')
+  const packageJsonPath = path.join(CONTRACTS_PACKAGE_SRC_DIR, 'package.json')
+  replacePackageVersionAndMakePublic(packageJsonPath, version)
 }
 
 function lsRecursive(dir: string): string[] {

--- a/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
+++ b/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
@@ -264,7 +264,8 @@ const DRY_RUN_VERSION = '0.0.0-dry-run'
 
 function prepareAbisPackageJson(exports: Exports) {
   log('Preparing @celo/abis package.json')
-  const packageJsonPath = path.join(ABIS_PACKAGE_SRC_DIR, 'package.json')
+  // Use process.cwd() so paths are correct when run with working-directory: packages/protocol (e.g. in CI)
+  const packageJsonPath = path.resolve(process.cwd(), 'abis', 'package.json')
 
   const version = process.env.RELEASE_VERSION || DRY_RUN_VERSION
   if (process.env.RELEASE_VERSION) {
@@ -291,7 +292,8 @@ function prepareContractsPackage() {
     log(`Using placeholder version ${DRY_RUN_VERSION} for dry run`)
   }
 
-  const packageJsonPath = path.join(CONTRACTS_PACKAGE_SRC_DIR, 'package.json')
+  // Use process.cwd() so paths are correct when run with working-directory: packages/protocol (e.g. in CI)
+  const packageJsonPath = path.resolve(process.cwd(), 'contracts', 'package.json')
   replacePackageVersionAndMakePublic(packageJsonPath, version)
 }
 

--- a/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
+++ b/packages/protocol/scripts/prepare-contracts-and-abis-publishing.ts
@@ -13,7 +13,7 @@ import {
   BuildTarget,
   CONTRACTS_08_PACKAGE_DESTINATION_DIR,
   CONTRACTS_08_SOURCE_DIR,
-  CONTRACTS_PACKAGE_SRC_DIR,
+  // CONTRACTS_PACKAGE_SRC_DIR - unused: we use process.cwd() for correct path resolution in CI
   PublishContracts,
   TSCONFIG_PATH,
 } from './consts'

--- a/packages/protocol/scripts/utils.ts
+++ b/packages/protocol/scripts/utils.ts
@@ -121,17 +121,19 @@ export function getReleaseTypeFromSemVer(version: SemVer): string | number {
 
 export function replacePackageVersionAndMakePublic(
   packageJsonPath: string,
+  version?: string,
   onDone?: (json: JSON) => void
 ) {
   const json: JSON = JSON.parse(fs.readFileSync(packageJsonPath).toString())
 
-  if (process.env.RELEASE_VERSION) {
-    console.info(`Replacing ${json.name as string} version with provided RELEASE_VERSION`)
+  const effectiveVersion = version ?? process.env.RELEASE_VERSION
+  if (effectiveVersion) {
+    console.info(`Replacing ${json.name as string} version with ${effectiveVersion}`)
 
-    json.version = process.env.RELEASE_VERSION
+    json.version = effectiveVersion
     json.private = false
   } else {
-    console.info('No RELEASE_VERSION provided')
+    console.info('No version provided')
   }
 
   if (onDone !== undefined) {


### PR DESCRIPTION
Publish contracts abi OIDC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the NPM release workflow authentication path (removing token-based publishing in favor of OIDC) and bumps the Node/npm toolchain, which could break or alter package publishing if the runner or npm configuration is incompatible.
> 
> **Overview**
> Updates the `publish-contracts-abi-release` GitHub Actions workflow to publish `@celo/contracts` and `@celo/abis` via **OIDC trusted publishing** instead of injecting an `NPM_TOKEN` from Akeyless.
> 
> The job now runs on **Node 20** and explicitly upgrades to `npm@11.5.1` before `npm publish`, removing `NODE_AUTH_TOKEN` usage from the publish steps while keeping the existing build/validation and dist-tagging behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d176e1b46e6061f21281d585f8a5e8da9cbec279. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->