### PR TITLE
fix: use floor division for credits, ceil for debit in FeeCurrencyAdapter

### DIFF
--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -168,15 +168,14 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
 
   /**
    * @notice Downscales value to the adapted token's native digits.
-   * @dev Downscale is rounding up in favour of protocol. User possibly can pay a bit more than expected (up to 1 unit of a token).
-   * Example:
-   * USDC has 6 decimals and in such case user can pay up to 0.000001 USDC more than expected.
-   * WBTC (currently not supported by Celo chain as fee currency) has 8 decimals and in such case user can pay up to 0.00000001 WBTC more than expected.
-   * Considering the current price of WBTC, it's less than 0.0005 USD. Even when WBTC price would be 1 mil USD, it's still would be only 0.01 USD.
-   * In general it is a very small amount and it is acceptable to round up in favor of the protocol.
+   * @dev Downscale rounds down (floor division). Rounding up each component independently
+   * would violate the invariant that the sum of credited components must not exceed the
+   * debited amount: ceil(a/d) + ceil(b/d) + ceil(c/d) >= ceil((a+b+c)/d), with strict
+   * inequality whenever two or more components have non-zero remainders. Any undershoot
+   * from floor division is corrected by the roundingError adjustment in creditGasFees.
    * @param value The value to downscale.
    */
   function downscale(uint256 value) internal view returns (uint256) {
-    return (value + digitDifference - 1) / digitDifference;
+    return value / digitDifference;
   }
 }

--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -65,7 +65,8 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
    * @param value Debited value in the adapted digits.
    */
   function debitGasFees(address from, uint256 value) external onlyVm {
-    uint256 valueScaled = downscale(value);
+    // Ceiling division: ensures any non-zero fee always debits at least 1 native unit.
+    uint256 valueScaled = (value + digitDifference - 1) / digitDifference;
     require(valueScaled > 0, "Scaled debit value must be > 0.");
     debited = valueScaled;
     adaptedToken.debitGasFees(from, valueScaled);
@@ -167,12 +168,13 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
   }
 
   /**
-   * @notice Downscales value to the adapted token's native digits.
-   * @dev Downscale rounds down (floor division). Rounding up each component independently
-   * would violate the invariant that the sum of credited components must not exceed the
-   * debited amount: ceil(a/d) + ceil(b/d) + ceil(c/d) >= ceil((a+b+c)/d), with strict
-   * inequality whenever two or more components have non-zero remainders. Any undershoot
-   * from floor division is corrected by the roundingError adjustment in creditGasFees.
+   * @notice Downscales value to the adapted token's native digits using floor division.
+   * @dev Used only for credit-side components. Floor division guarantees
+   * floor(a/d) + floor(b/d) + floor(c/d) <= floor((a+b+c)/d), so the sum of credited
+   * components never exceeds debited. Any undershoot is absorbed by the roundingError
+   * correction in creditGasFees.
+   * Debit uses ceiling division (inlined in debitGasFees) to ensure any non-zero fee
+   * always collects at least 1 native unit.
    * @param value The value to downscale.
    */
   function downscale(uint256 value) internal view returns (uint256) {

--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -65,8 +65,7 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
    * @param value Debited value in the adapted digits.
    */
   function debitGasFees(address from, uint256 value) external onlyVm {
-    // Ceiling division: ensures any non-zero fee always debits at least 1 native unit.
-    uint256 valueScaled = (value + digitDifference - 1) / digitDifference;
+    uint256 valueScaled = downscaleCeil(value);
     require(valueScaled > 0, "Scaled debit value must be > 0.");
     debited = valueScaled;
     adaptedToken.debitGasFees(from, valueScaled);
@@ -98,9 +97,9 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
       return;
     }
 
-    uint256 refundScaled = downscale(refundAmount);
-    uint256 tipTxFeeScaled = downscale(tipAmount);
-    uint256 baseTxFeeScaled = downscale(baseFeeAmount);
+    uint256 refundScaled = downscaleFloor(refundAmount);
+    uint256 tipTxFeeScaled = downscaleFloor(tipAmount);
+    uint256 baseTxFeeScaled = downscaleFloor(baseFeeAmount);
 
     require(
       refundScaled + tipTxFeeScaled + baseTxFeeScaled <= debited,
@@ -168,16 +167,24 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
   }
 
   /**
+   * @notice Downscales value to the adapted token's native digits using ceiling division.
+   * @dev Used for debiting: ensures any non-zero fee always collects at least 1 native
+   * unit, protecting the protocol from sub-unit fees being rounded to zero.
+   * @param value The value to downscale.
+   */
+  function downscaleCeil(uint256 value) internal view returns (uint256) {
+    return (value + digitDifference - 1) / digitDifference;
+  }
+
+  /**
    * @notice Downscales value to the adapted token's native digits using floor division.
-   * @dev Used only for credit-side components. Floor division guarantees
+   * @dev Used for crediting: floor division guarantees
    * floor(a/d) + floor(b/d) + floor(c/d) <= floor((a+b+c)/d), so the sum of credited
    * components never exceeds debited. Any undershoot is absorbed by the roundingError
    * correction in creditGasFees.
-   * Debit uses ceiling division (inlined in debitGasFees) to ensure any non-zero fee
-   * always collects at least 1 native unit.
    * @param value The value to downscale.
    */
-  function downscale(uint256 value) internal view returns (uint256) {
+  function downscaleFloor(uint256 value) internal view returns (uint256) {
     return value / digitDifference;
   }
 }

--- a/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
@@ -231,6 +231,49 @@ contract FeeCurrencyAdapter_CreditGasFees is FeeCurrencyAdapterTest {
     assertEq(feeCurrencyAdapter.balanceOf(address(this)), initialSupply * 1e12);
   }
 
+  /**
+   * @notice Regression test: ceiling division caused refundScaled + tipScaled + baseFeeScaled
+   * to exceed debited whenever two or more components had non-zero remainders mod digitDifference.
+   * With floor division the sum is always <= debited and the rounding error is absorbed by baseFee.
+   *
+   * Example: debit 2e12 (debited=2), split as refund=5e11, tip=5e11, baseFee=1e12.
+   *   ceil: 1+1+1=3 > 2 → would revert
+   *   floor: 0+0+1=1 <= 2 → roundingError=1 added to baseFee → baseFee credited as 2 ✓
+   */
+  function test_shouldCreditGasFees_WhenComponentsHaveNonZeroRemainders() public {
+    // debit 2 native units (2e12 in 18-dec)
+    uint256 debitAmount = 2 * 1e12;
+    vm.prank(address(0));
+    feeCurrencyAdapter.debitGasFees(address(this), debitAmount);
+    assertEq(feeCurrencyAdapter.debited(), 2);
+
+    address tipRecipient = actor("tipRecipient");
+    address baseFeeRecipient = actor("baseFeeRecipient");
+
+    // split: refund=5e11, tip=5e11, baseFee=1e12 (sums to 2e12 = debitAmount)
+    // floor: 0 + 0 + 1 = 1; roundingError = 1 → baseFee credited as 2
+    vm.prank(address(0));
+    feeCurrencyAdapter.creditGasFees(
+      address(this),
+      tipRecipient,
+      address(0),
+      baseFeeRecipient,
+      5e11, // refund — floors to 0
+      5e11, // tip   — floors to 0
+      0,
+      1e12 // baseFee — floors to 1, roundingError adds 1 → credited as 2
+    );
+
+    // refund recipient gets 0 native units (sub-unit refund lost to rounding)
+    assertEq(feeCurrency.balanceOf(address(this)), initialSupply - 2);
+    // tip recipient gets 0
+    assertEq(feeCurrency.balanceOf(tipRecipient), 0);
+    // baseFee recipient gets all 2 native units (1 direct + 1 roundingError)
+    assertEq(feeCurrency.balanceOf(baseFeeRecipient), 2);
+    // debited cleared
+    assertEq(feeCurrencyAdapter.debited(), 0);
+  }
+
   function test_shouldRevert_WhenTryingToCreditMoreThanBurned() public {
     uint256 amount = 1 * 1e12;
     vm.prank(address(0));
@@ -364,10 +407,11 @@ contract FeeCurrencyAdapter_UpscaleAndDownScaleTests is FeeCurrencyAdapterTest {
     assertEq(feeCurrencyAdapter.downscaleVisible(1e24), 1e12);
   }
 
-  function test_ShouldReturn1_WhenSmallEnoughAndRoundingUp() public {
-    assertEq(feeCurrencyAdapter.downscaleVisible(1), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 1);
+  function test_ShouldReturnZero_WhenValueLessThanDigitDifference() public {
+    assertEq(feeCurrencyAdapter.downscaleVisible(0), 0);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1), 0);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 0);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 0);
   }
 }
 

--- a/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
@@ -179,6 +179,15 @@ contract FeeCurrencyAdapter_DebitGasFees is FeeCurrencyAdapterTest {
     feeCurrencyAdapter.debitGasFees(address(this), 0);
   }
 
+  function test_ShouldDebitOneNativeUnit_WhenValueLessThanDigitDifference() public {
+    // Debit uses ceiling division: any non-zero value below digitDifference debits 1 native unit.
+    uint256 subUnitValue = 1e12 - 1;
+    vm.prank(address(0));
+    feeCurrencyAdapter.debitGasFees(address(this), subUnitValue);
+    assertEq(feeCurrencyAdapter.debited(), 1);
+    assertEq(feeCurrency.balanceOf(address(this)), initialSupply - 1);
+  }
+
   function test_ShouldDebitCorrectAmount_WhenExpectedDigitsOnlyOneBigger() public {
     debitFuzzyHelper(7, 1e1);
   }

--- a/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
@@ -72,8 +72,12 @@ contract CeloFeeCurrencyAdapterTestContract is CeloFeeCurrencyAdapterOwnable {
     return upscale(value);
   }
 
-  function downscaleVisible(uint256 value) external view returns (uint256) {
-    return downscale(value);
+  function downscaleCeilVisible(uint256 value) external view returns (uint256) {
+    return downscaleCeil(value);
+  }
+
+  function downscaleFloorVisible(uint256 value) external view returns (uint256) {
+    return downscaleFloor(value);
   }
 }
 
@@ -410,17 +414,29 @@ contract FeeCurrencyAdapter_UpscaleAndDownScaleTests is FeeCurrencyAdapterTest {
     feeCurrencyAdapter.upscaleVisible(boundaryValue);
   }
 
-  function test_shouldDownscale() public {
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e12), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e18), 1e6);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e24), 1e12);
+  function test_shouldDownscaleFloor() public {
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e12), 1);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e18), 1e6);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e24), 1e12);
   }
 
-  function test_ShouldReturnZero_WhenValueLessThanDigitDifference() public {
-    assertEq(feeCurrencyAdapter.downscaleVisible(0), 0);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1), 0);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 0);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 0);
+  function test_shouldDownscaleCeil() public {
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e12), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e18), 1e6);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e24), 1e12);
+  }
+
+  function test_downscaleFloor_ShouldReturnZero_WhenValueLessThanDigitDifference() public {
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(0), 0);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1), 0);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e6 - 1), 0);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e12 - 1), 0);
+  }
+
+  function test_downscaleCeil_ShouldReturnOne_WhenValueLessThanDigitDifference() public {
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e6 - 1), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e12 - 1), 1);
   }
 }
 


### PR DESCRIPTION
## Summary

- `FeeCurrencyAdapter.downscale()` used ceiling division for all three credit components in `creditGasFees`. This violates the invariant: when two or more components have non-zero remainders mod `digitDifference`, `ceil(a/d) + ceil(b/d) + ceil(c/d) > debited`, causing the `require(...<= debited)` check to revert
- A revert in `creditGasFees` propagates through op-geth's `CreditFees` → `TransitionDb`, making the block invalid
- However, ceiling division is correct for `debitGasFees`: it ensures a non-zero fee always debits at least 1 native unit (prevents sub-unit fees rounding to zero)

**Fix:** refactor the single `downscale()` into two explicit functions:
- `downscaleCeil()` — ceiling division, used in `debitGasFees` only
- `downscaleFloor()` — floor division, used in `creditGasFees` for all three components

Floor division guarantees `floor(a/d) + floor(b/d) + floor(c/d) <= debited`; any undershoot is absorbed by the existing `roundingError` correction. This matches the approach independently taken by both Tether's `FeeCurrencyWrapper` and Circle's `FiatTokenFeeAdapterV1`.

## Test plan

- [x] All 31 existing `FeeCurrencyAdapter` tests pass
- [x] Regression test `test_shouldCreditGasFees_WhenComponentsHaveNonZeroRemainders` confirms the previously-reverting scenario (debit=2, refund=5e11, tip=5e11, baseFee=1e12) now succeeds — this test would fail with the old ceiling code
- [x] `test_ShouldDebitOneNativeUnit_WhenValueLessThanDigitDifference` confirms ceiling is preserved for debit (sub-unit value debits 1 native unit)
- [x] Dedicated `test_shouldDownscaleCeil` / `test_shouldDownscaleFloor` and boundary tests for each function