### PR TITLE
fix(protocol): use floor division in FeeCurrencyAdapter.downscale()

### DIFF
--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -61,11 +61,13 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
 
   /**
    * Downscales value to the adapted token's native digits and debits it.
+   * @dev Uses ceiling division so the user is charged at least 1 native unit
+   * even when the 18-decimal fee is smaller than one native token unit.
    * @param from from address
    * @param value Debited value in the adapted digits.
    */
   function debitGasFees(address from, uint256 value) external onlyVm {
-    uint256 valueScaled = downscale(value);
+    uint256 valueScaled = downscaleCeil(value);
     require(valueScaled > 0, "Scaled debit value must be > 0.");
     debited = valueScaled;
     adaptedToken.debitGasFees(from, valueScaled);
@@ -167,16 +169,25 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
   }
 
   /**
-   * @notice Downscales value to the adapted token's native digits.
-   * @dev Downscale is rounding up in favour of protocol. User possibly can pay a bit more than expected (up to 1 unit of a token).
-   * Example:
-   * USDC has 6 decimals and in such case user can pay up to 0.000001 USDC more than expected.
-   * WBTC (currently not supported by Celo chain as fee currency) has 8 decimals and in such case user can pay up to 0.00000001 WBTC more than expected.
-   * Considering the current price of WBTC, it's less than 0.0005 USD. Even when WBTC price would be 1 mil USD, it's still would be only 0.01 USD.
-   * In general it is a very small amount and it is acceptable to round up in favor of the protocol.
+   * @notice Downscales value to the adapted token's native digits using floor division.
+   * @dev Rounding down guarantees that the sum of individually downscaled
+   * credit amounts never exceeds the downscaled debit amount, i.e.
+   * floor(a/n) + floor(b/n) + floor(c/n) <= floor((a+b+c)/n).
+   * Any remainder from rounding is absorbed into the base fee via the
+   * roundingError adjustment in creditGasFees.
    * @param value The value to downscale.
    */
   function downscale(uint256 value) internal view returns (uint256) {
+    return value / digitDifference;
+  }
+
+  /**
+   * @notice Downscales value using ceiling division (rounds up).
+   * @dev Used by debitGasFees so the user is charged at least 1 native unit
+   * even when the 18-decimal fee is smaller than one native token unit.
+   * @param value The value to downscale.
+   */
+  function downscaleCeil(uint256 value) internal view returns (uint256) {
     return (value + digitDifference - 1) / digitDifference;
   }
 }

--- a/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
@@ -75,6 +75,10 @@ contract CeloFeeCurrencyAdapterTestContract is CeloFeeCurrencyAdapterOwnable {
   function downscaleVisible(uint256 value) external view returns (uint256) {
     return downscale(value);
   }
+
+  function downscaleCeilVisible(uint256 value) external view returns (uint256) {
+    return downscaleCeil(value);
+  }
 }
 
 contract FeeCurrencyAdapterTest is Test {
@@ -281,6 +285,33 @@ contract FeeCurrencyAdapter_CreditGasFees is FeeCurrencyAdapterTest {
     assertEq(balanceBefore, balanceAfter);
   }
 
+  function test_shouldCreditGasFees_WithNonAlignedAmounts() public {
+    // Verifies that non-aligned amounts (not exact multiples of digitDifference)
+    // can be credited without reverting. Floor division guarantees
+    // floor(a/n) + floor(b/n) + floor(c/n) <= floor((a+b+c)/n).
+    uint256 debitAmount = 1000 * 1e12 + 7; // non-aligned amount
+    vm.prank(address(0));
+    feeCurrencyAdapter.debitGasFees(address(this), debitAmount);
+
+    // Split into three non-aligned parts that sum to debitAmount
+    uint256 refund = 333 * 1e12 + 3;
+    uint256 tip = 333 * 1e12 + 2;
+    uint256 baseFee = 334 * 1e12 + 2;
+    assertEq(refund + tip + baseFee, debitAmount);
+
+    vm.prank(address(0));
+    feeCurrencyAdapter.creditGasFees(
+      address(this),
+      address(this),
+      address(0),
+      address(this),
+      refund,
+      tip,
+      0,
+      baseFee
+    );
+  }
+
   function test_shouldCreditGasFees_WhenOnlyOneBigger() public {
     creditFuzzHelper(7, 1e1);
   }
@@ -364,10 +395,22 @@ contract FeeCurrencyAdapter_UpscaleAndDownScaleTests is FeeCurrencyAdapterTest {
     assertEq(feeCurrencyAdapter.downscaleVisible(1e24), 1e12);
   }
 
-  function test_ShouldReturn1_WhenSmallEnoughAndRoundingUp() public {
-    assertEq(feeCurrencyAdapter.downscaleVisible(1), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 1);
+  function test_ShouldReturn0_WhenValueSmallerThanDigitDifference() public {
+    assertEq(feeCurrencyAdapter.downscaleVisible(1), 0);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 0);
+    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 0);
+  }
+
+  function test_shouldDownscaleCeil() public {
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e12), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e18), 1e6);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e24), 1e12);
+  }
+
+  function test_ShouldReturn1_WhenSubUnitValueAndCeil() public {
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e6 - 1), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e12 - 1), 1);
   }
 }
 


### PR DESCRIPTION
## Summary

- Use floor division for credit operations and ceiling division for debit operations in `FeeCurrencyAdapter.downscale()`
- Prevents `creditGasFees()` from reverting on non-aligned amounts while preserving minimum-charge behavior for sub-unit fees

## Problem

`downscale()` used ceiling division uniformly for both debit and credit. When `creditGasFees()` individually downscales refund, tip, and baseFee, the ceiling-rounded sum can exceed the ceiling-rounded debit:

```
ceil(a/n) + ceil(b/n) + ceil(c/n) > ceil((a+b+c)/n)
```

This violates the `require(refundScaled + tipTxFeeScaled + baseTxFeeScaled <= debited)` check, causing valid transactions to revert.

## Fix

Split downscaling into two functions with appropriate rounding direction:

- **`downscale()`** (floor division) — used by `creditGasFees()`. Guarantees `floor(a/n) + floor(b/n) + floor(c/n) <= floor((a+b+c)/n)`. Any remainder is absorbed into the base fee via the existing `roundingError` adjustment.
- **`downscaleCeil()`** (ceiling division) — used by `debitGasFees()`. Ensures the user is charged at least 1 native unit even when the 18-decimal fee is smaller than one native token unit.

## Impact

- No deployed fee currency adapter is currently affected (USDT and USDC use custom adapters from Tether/Circle with floor division)
- This fix is preventive for future fee currency adapters using `FeeCurrencyAdapter.sol` with low-decimal tokens