### PR TITLE
fix(migration): transfer Mento contract ownership to Governance

### DIFF
--- a/.github/workflows/protocol-devchain-anvil.yml
+++ b/.github/workflows/protocol-devchain-anvil.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Generate migrations on local devchain
         if: success() || failure()
         run: |
-          LOAD_STATE=${{ github.workspace }}/celo-optimism/packages/contracts-bedrock/anvil-state.json ./scripts/foundry/create_and_migrate_anvil_devchain.sh
+          LOAD_STATE=${{ github.workspace }}/celo-optimism/packages/contracts-bedrock/anvil-state.json yarn anvil-devchain:start
 
       - name: Run migration tests against local op-geth devchain
         run: |

--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -186,6 +186,7 @@ jobs:
       - name: Restore script permissions
         run: chmod +x scripts/foundry/*.sh
       - name: Generate migrations and run devchain
+        # Using bash command instead of yarn anvil-devchain:start to avoid yarn dependency
         run: ./scripts/foundry/create_and_migrate_anvil_devchain.sh
       - name: Run migration tests against local anvil devchain
         run: |

--- a/packages/protocol/migrations_sol/Migration.s.sol
+++ b/packages/protocol/migrations_sol/Migration.s.sol
@@ -909,8 +909,18 @@ contract Migration is Script, UsingRegistry, MigrationsConstants {
       ".governance.skipTransferOwnership"
     );
     if (!skipTransferOwnership) {
+      string[] memory contractsToTransfer = new string[](
+        contractsInRegistry.length + mentoContractsInRegistry.length
+      );
       for (uint256 i = 0; i < contractsInRegistry.length; i++) {
-        string memory contractToTransfer = contractsInRegistry[i];
+        contractsToTransfer[i] = contractsInRegistry[i];
+      }
+      for (uint256 i = 0; i < mentoContractsInRegistry.length; i++) {
+        contractsToTransfer[contractsInRegistry.length + i] = mentoContractsInRegistry[i];
+      }
+
+      for (uint256 i = 0; i < contractsToTransfer.length; i++) {
+        string memory contractToTransfer = contractsToTransfer[i];
         console.log("Transferring ownership of: ", contractToTransfer);
 
         // Transfer proxy ownership

--- a/packages/protocol/migrations_sol/constants.sol
+++ b/packages/protocol/migrations_sol/constants.sol
@@ -35,7 +35,7 @@ contract MigrationsConstants is TestConstants {
     "Freezer",
     "Governance",
     "GovernanceSlasher",
-    "LockedGold",
+    "LockedGold", // TODO: eventually has to be renamed to LockedCelo
     "OdisPayments",
     "Registry",
     "ScoreManager",
@@ -43,6 +43,15 @@ contract MigrationsConstants is TestConstants {
     "Validators",
     "MentoFeeHandlerSeller",
     "UniswapFeeHandlerSeller"
+  ];
+
+  // Mento contracts deployed by the migration but not part of the core
+  // contractsInRegistry set (kept around mainly for StableToken compatibility).
+  string[] mentoContractsInRegistry = [
+    "Reserve",
+    "StableToken",
+    "StableTokenEUR",
+    "StableTokenBRL"
   ];
 
   function _markAs08Contract(string memory contractName) internal {


### PR DESCRIPTION
## Summary
- The devchain migration only transferred ownership of contracts in `contractsInRegistry`, leaving Reserve and the StableTokens owned by the deployer.
- Add a `mentoContractsInRegistry` list and append it to the ownership-transfer loop.