### PR TITLE
feat(protocol): add GasSponsoredOFTBridge for stablecoin-only bridging

### DIFF
--- a/.github/workflows/protocol_tests.yml
+++ b/.github/workflows/protocol_tests.yml
@@ -180,14 +180,34 @@ jobs:
           name: protocol-workspace
           path: packages/protocol
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        # foundry-toolchain v1.7.0 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.7.0
+        uses: foundry-rs/foundry-toolchain@8f1998e9878d786675189ef566a2e4bf24869773
         with:
-          version: 'v1.0.0'
+          version: 'v1.5.0'
       - name: Restore script permissions
-        run: chmod +x scripts/foundry/*.sh
+        run: chmod +x scripts/foundry/*.sh scripts/bash/*.sh
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Setup yarn
+        run: npm install --global yarn
+      - name: Install packages
+        run: yarn
+        working-directory: ${{ github.workspace }}
+      - name: Checkout Optimism repo
+        uses: actions/checkout@v4
+        with:
+          repository: 'celo-org/optimism'
+          ref: 'celo/core-contracts-base'
+          path: celo-optimism
+          submodules: recursive
+      - name: Generate initial state for devchain
+        run: yarn devchain:generate-initial-state --contracts-dir ${{ github.workspace }}/celo-optimism/packages/contracts-bedrock
+      - name: Install celocli
+        run: sudo npm install -g @celo/celocli@latest --unsafe-perm
       - name: Generate migrations and run devchain
-        # Using bash command instead of yarn anvil-devchain:start to avoid yarn dependency
-        run: ./scripts/foundry/create_and_migrate_anvil_devchain.sh
+        run: |
+          LOAD_STATE=${{ github.workspace }}/celo-optimism/packages/contracts-bedrock/anvil-state.json ./scripts/foundry/create_and_migrate_anvil_devchain.sh
       - name: Run migration tests against local anvil devchain
         run: |
           source ./scripts/foundry/constants.sh

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -249,11 +249,12 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
    */
   function _celoToToken(uint256 _celoAmount) internal view returns (uint256) {
     (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(oracleRateFeedId);
+    // denominator == 0 means no oracle rates exist (SortedOracles returns 0 when numRates == 0).
+    // Note: isOldestReportExpired is NOT used here because it doesn't follow the
+    // equivalentToken mapping that medianRate uses — it would always return true for
+    // rate feeds that rely on an equivalent token (e.g. USDT adapter → cUSD).
     require(denominator > 0, "No oracle rate available");
     require(numerator > 0, "Oracle rate numerator is zero");
-
-    (bool isExpired, ) = sortedOracles.isOldestReportExpired(oracleRateFeedId);
-    require(!isExpired, "Oracle rate is stale");
 
     return
       (_celoAmount * numerator * tokenPrecision * priceFactor) /

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -12,18 +12,58 @@ import "./interfaces/ILayerZeroOFT.sol";
 
 /**
  * @title GasSponsoredOFTBridge
+ * @author cLabs
  * @notice Enables users to bridge tokens out of Celo via LayerZero OFT without holding CELO.
- * The contract sponsors the CELO needed for the LayerZero messaging fee and charges the user
- * the equivalent amount in the bridged token, using Celo's SortedOracles for the CELO/token
- * exchange rate.
  *
- * Supports multiple tokens — each registered OFT is mapped to its token and oracle config.
+ * The contract pre-funds CELO to cover the LayerZero messaging fee on behalf of the user,
+ * then charges the user the equivalent amount in the bridged token (e.g. USDT), converting
+ * at the live Celo SortedOracles rate plus a configurable markup (default 1.2x).
  *
- * Combined with Celo's fee currency system (where transaction gas can also be paid in USDT),
- * this allows the entire bridge operation to be paid in a single stablecoin.
+ * Supports multiple tokens simultaneously — each registered OFT is mapped to its own
+ * ERC-20 token and oracle rate feed via the `oftConfigs` mapping.
+ *
+ * Combined with Celo's fee currency system (where the transaction gas itself can be paid
+ * in USDT), this allows the entire bridge operation — tx gas, bridge amount, and LZ
+ * messaging fee — to be paid 100% in a single stablecoin, with zero CELO required.
+ *
+ * Mainnet deployment: 0x60Cc7285ccA898c232FB392362A748117998acf3 (Celo, chain 42220)
+ * Tested end-to-end: Celo → Arbitrum via USDT0 OFT (0xf10e161027410128e63e75d0200fb6d34b2db243)
  *
  * Adapted from Arbitrum's TransactionValueHelper
- * (0xa90f03c856D01F698E7071B393387cd75a8a319A) for the Celo ecosystem.
+ * (0xa90f03c856D01F698E7071B393387cd75a8a319A).
+ *
+ * @dev Architecture:
+ *
+ *   User (holds only USDT)
+ *     │
+ *     ├─ TX gas: paid in USDT via Celo fee currency
+ *     │
+ *     └─ calls bridge.send(oft, sendParam, fee)
+ *          │
+ *          ├─ transferFrom(user → bridge, amountLD)        // pull bridge tokens
+ *          ├─ approve(OFT, amountLD)
+ *          ├─ OFT.send{value: celoFee}(sendParam, fee)     // bridge sponsors CELO
+ *          ├─ celoSpent = celoBefore - balance              // measure actual CELO used
+ *          ├─ feeInToken = _celoToToken(celoSpent)          // convert via oracle + markup
+ *          ├─ transferFrom(user → bridge, feeInToken)       // charge user the fee in token
+ *          └─ emit LogSend(...)
+ *
+ * @dev Trust model:
+ *   - Owner: can register/remove OFTs, set oracle, set maxGas/priceFactor, set operators.
+ *   - Operators: can call execute() for maintenance (withdraw fees, rebalance CELO).
+ *     execute() is an unrestricted arbitrary-call primitive (cannot target this contract).
+ *     Operators should be trusted addresses (e.g. a multisig).
+ *   - Users: only interact via send(). Must approve the bridge for amountLD + feeInToken.
+ *     Use quoteSend() to estimate the total before approving.
+ *
+ * @dev Oracle notes:
+ *   - Uses SortedOracles.medianRate(rateFeedId) which returns (numerator, denominator)
+ *     in 1e24 fixed-point representing the token-per-CELO rate.
+ *   - The rateFeedId may differ from the token address when using the equivalentToken
+ *     mapping (e.g. USDT adapter → cUSD rate feed).
+ *   - isOldestReportExpired() is NOT used because it doesn't follow the equivalentToken
+ *     mapping — it would always return true for adapter-based rate feeds. The
+ *     denominator > 0 check is sufficient (SortedOracles returns 0 when no rates exist).
  */
 contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   using SafeERC20 for IERC20;
@@ -32,10 +72,16 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   // Types
   // ---------------------------------------------------------------------------
 
+  /// @notice Configuration for a registered OFT.
+  /// @param token The ERC-20 token the OFT bridges (e.g. USDT at 0x48065f... on Celo).
+  /// @param oracleRateFeedId The rate feed ID to query in SortedOracles for this token's
+  ///        CELO exchange rate. May be a fee currency adapter address rather than the
+  ///        token address itself (see MentoFeeCurrencyAdapter pattern).
+  /// @param tokenPrecision 10^decimals of the token (e.g. 1e6 for 6-decimal USDT).
   struct OFTConfig {
-    IERC20 token; // The ERC-20 token the OFT bridges (e.g. USDT, USDC)
-    address oracleRateFeedId; // Rate feed ID for this token in SortedOracles
-    uint256 tokenPrecision; // 10^decimals of the token (e.g. 1e6 for USDT)
+    IERC20 token;
+    address oracleRateFeedId;
+    uint256 tokenPrecision;
   }
 
   // ---------------------------------------------------------------------------
@@ -53,6 +99,14 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     uint256 tokenPrecision
   );
   event LogOFTConfigRemoved(address indexed oft);
+
+  /// @notice Emitted on every successful bridge send.
+  /// @param sender The user who initiated the bridge.
+  /// @param oft The OFT contract used.
+  /// @param amountLD The token amount bridged (in local decimals).
+  /// @param nativeFee The CELO amount the bridge spent on the LZ messaging fee.
+  /// @param feeInToken The token amount charged to the user for the CELO sponsorship.
+  /// @param totalAmount amountLD + feeInToken (total token cost to the user).
   event LogSend(
     address indexed sender,
     address indexed oft,
@@ -61,6 +115,7 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     uint256 feeInToken,
     uint256 totalAmount
   );
+
   event LogExecute(address indexed operator, address indexed target, uint256 value, bytes data);
 
   // ---------------------------------------------------------------------------
@@ -68,23 +123,27 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   // ---------------------------------------------------------------------------
 
   /// @notice Maximum CELO (in wei) the contract will spend per send() call.
+  ///         Acts as a safety cap. Set to 0 to pause all sends.
   uint256 public maxGas;
 
   /// @notice Precision constant for CELO (18 decimals).
   uint256 public constant NATIVE_PRECISION = 1e18;
 
-  /// @notice Markup applied to the oracle rate (12000 / 10000 = 1.2x by default).
+  /// @notice Markup multiplier for the fee conversion (basis: PRICE_FACTOR_PRECISION).
+  ///         Default 12000 = 1.2x markup over the raw oracle rate.
+  ///         Covers oracle lag, gas price volatility, and operational costs.
   uint256 public priceFactor;
   uint256 public constant PRICE_FACTOR_PRECISION = 10_000;
 
-  /// @notice Celo SortedOracles contract for CELO/token exchange rates.
+  /// @notice Celo SortedOracles contract used for all CELO/token exchange rate lookups.
   ISortedOracles public sortedOracles;
 
-  /// @notice Addresses authorized to call execute().
+  /// @notice Addresses authorized to call execute() (in addition to the owner).
   mapping(address => bool) public operators;
 
-  /// @notice Registered OFT contracts and their token configuration.
-  /// @dev If oftConfigs[oft].token == address(0), the OFT is not registered.
+  /// @notice Registered OFT contracts and their per-token configuration.
+  /// @dev An OFT is considered registered iff oftConfigs[oft].token != address(0).
+  ///      Use setOFTConfig() to register and removeOFTConfig() to deregister.
   mapping(address => OFTConfig) public oftConfigs;
 
   // ---------------------------------------------------------------------------
@@ -100,10 +159,8 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   // Constructor
   // ---------------------------------------------------------------------------
 
-  /**
-   * @param _sortedOracles Address of the Celo SortedOracles contract.
-   * @param _maxGas Initial cap on CELO spent per send() call.
-   */
+  /// @param _sortedOracles Address of the Celo SortedOracles contract.
+  /// @param _maxGas Initial cap on CELO spent per send() call (in wei).
   constructor(ISortedOracles _sortedOracles, uint256 _maxGas) {
     require(address(_sortedOracles) != address(0), "Oracle is zero address");
 
@@ -112,6 +169,7 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     priceFactor = 12_000; // 1.2x default markup
   }
 
+  /// @notice Accept CELO deposits to fund the gas sponsorship pool.
   receive() external payable {}
 
   // ---------------------------------------------------------------------------
@@ -119,17 +177,26 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   // ---------------------------------------------------------------------------
 
   /**
-   * @notice Bridge tokens via LayerZero OFT, paying both the bridge amount and LZ
-   *         messaging fee in the OFT's token. The contract fronts the CELO for the
-   *         messaging fee and charges the caller the equivalent in the token (plus markup).
-   * @dev The caller must have approved this contract for at least
-   *      `_sendParam.amountLD + feeInToken` of the OFT's token. Use quoteSend() to
-   *      estimate the total.
+   * @notice Bridge tokens via a registered LayerZero OFT. The contract sponsors the
+   *         CELO for the LZ messaging fee and charges the caller the equivalent in the
+   *         OFT's token at the live oracle rate (plus priceFactor markup).
+   *
+   * @dev Flow:
+   *   1. Pull amountLD of token from user.
+   *   2. Approve OFT and call OFT.send{value: nativeFee}().
+   *   3. Measure actual CELO spent, convert to token via _celoToToken().
+   *   4. Pull the fee amount from user.
+   *
+   * The caller must have approved this contract for at least (amountLD + feeInToken).
+   * Use quoteSend() beforehand to estimate the total approval needed.
+   *
    * @param _oft The registered OFT contract to route the bridge through.
-   * @param _sendParam LayerZero SendParam (destination, recipient, amount, etc.).
-   * @param _fee LayerZero MessagingFee (nativeFee, lzTokenFee).
-   * @return msgReceipt LayerZero messaging receipt.
-   * @return oftReceipt OFT receipt with actual amounts sent/received.
+   * @param _sendParam LayerZero SendParam. Note: `to` must be encoded as
+   *        bytes32(uint256(uint160(recipientAddress))) for EVM destinations.
+   * @param _fee LayerZero MessagingFee. Only nativeFee is supported (lzTokenFee must be 0).
+   *        Obtain the correct nativeFee by calling OFT.quoteSend() beforehand.
+   * @return msgReceipt LayerZero messaging receipt (contains guid, nonce, fee).
+   * @return oftReceipt OFT receipt (contains amountSentLD, amountReceivedLD).
    */
   function send(
     IOFT _oft,
@@ -160,7 +227,8 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     // Reset leftover allowance to prevent dangling approvals.
     config.token.safeApprove(address(_oft), 0);
 
-    // Calculate how much CELO was actually spent.
+    // Calculate how much CELO was actually spent (may differ from _fee.nativeFee
+    // if the OFT refunds unused CELO back to this contract).
     uint256 celoSpent = celoBefore - address(this).balance;
 
     // Convert CELO spent to token amount using oracle rate + markup.
@@ -181,10 +249,14 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
 
   /**
    * @notice Estimate the total token amount a user needs for a send() call.
+   *         Returns amountLD + the fee converted from nativeFee at the current oracle rate.
+   * @dev Reverts if the OFT is not registered or the oracle has no rate.
+   *      The actual fee may differ slightly if the oracle rate changes between
+   *      this call and the send() transaction.
    * @param _oft The OFT contract (must be registered).
-   * @param _sendParam The send parameters (only amountLD is used).
-   * @param _fee The messaging fee (only nativeFee is used).
-   * @return totalAmount amountLD + fee converted to token.
+   * @param _sendParam The send parameters (only amountLD is used for the quote).
+   * @param _fee The messaging fee (only nativeFee is used for the quote).
+   * @return totalAmount amountLD + feeInToken.
    */
   function quoteSend(
     IOFT _oft,
@@ -198,14 +270,17 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   }
 
   // ---------------------------------------------------------------------------
-  // Admin
+  // Admin — OFT registration
   // ---------------------------------------------------------------------------
 
   /**
-   * @notice Register an OFT with its token and oracle configuration.
-   * @param _oft The OFT contract address.
-   * @param _token The ERC-20 token the OFT bridges.
-   * @param _oracleRateFeedId Rate feed ID for the token in SortedOracles.
+   * @notice Register an OFT with its token and oracle configuration. Also serves as
+   *         the whitelist — only registered OFTs can be used with send().
+   * @dev The tokenPrecision is derived automatically from the token's decimals().
+   *      Re-calling with the same _oft overwrites the previous config.
+   * @param _oft The LayerZero OFT contract address (must implement IOFT.send()).
+   * @param _token The ERC-20 token that the OFT bridges.
+   * @param _oracleRateFeedId The SortedOracles rate feed ID for this token's CELO rate.
    */
   function setOFTConfig(
     address _oft,
@@ -227,8 +302,8 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   }
 
   /**
-   * @notice Remove an OFT registration (disables bridging through it).
-   * @param _oft The OFT contract address to remove.
+   * @notice Remove an OFT registration, disabling bridging through it.
+   * @param _oft The OFT contract address to deregister.
    */
   function removeOFTConfig(address _oft) external onlyOwner {
     require(address(oftConfigs[_oft].token) != address(0), "OFT not registered");
@@ -236,11 +311,18 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     emit LogOFTConfigRemoved(_oft);
   }
 
+  // ---------------------------------------------------------------------------
+  // Admin — global settings
+  // ---------------------------------------------------------------------------
+
+  /// @notice Update the maximum CELO the contract will spend per send() call.
   function setMaxGas(uint256 _maxGas) external onlyOwner {
     maxGas = _maxGas;
     emit LogSetMaxGas(_maxGas);
   }
 
+  /// @notice Update the fee markup multiplier (basis: PRICE_FACTOR_PRECISION = 10000).
+  ///         E.g. 12000 = 1.2x, 15000 = 1.5x, 10000 = no markup.
   function setPriceFactor(uint256 _newPriceFactor) external onlyOwner {
     require(_newPriceFactor > 0, "Price factor must be > 0");
     uint256 old = priceFactor;
@@ -248,6 +330,7 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     emit LogSetPriceFactor(old, _newPriceFactor);
   }
 
+  /// @notice Update the SortedOracles contract address.
   function setSortedOracles(ISortedOracles _sortedOracles) external onlyOwner {
     require(address(_sortedOracles) != address(0), "Oracle is zero address");
     address old = address(sortedOracles);
@@ -255,15 +338,26 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     emit LogSetSortedOracles(old, address(_sortedOracles));
   }
 
+  /// @notice Grant or revoke operator privileges for an address.
   function setOperator(address _operator, bool _enabled) external onlyOwner {
     operators[_operator] = _enabled;
     emit LogOperatorChanged(_operator, _enabled);
   }
 
+  // ---------------------------------------------------------------------------
+  // Admin — operator maintenance
+  // ---------------------------------------------------------------------------
+
   /**
    * @notice Execute an arbitrary call with native value. Intended for operator
-   *         maintenance tasks (e.g. withdrawing accumulated fees, rebalancing CELO).
+   *         maintenance: withdrawing accumulated token fees, rebalancing CELO,
+   *         or emergency recovery.
    * @dev Cannot target this contract to prevent self-destructive calls.
+   *      Operators are trusted — this function can call any external contract
+   *      with any calldata. Ensure operators are secure (e.g. a multisig).
+   * @param _to Target address (must not be this contract).
+   * @param _value CELO value to send with the call.
+   * @param _data Calldata for the external call.
    */
   function execute(address _to, uint256 _value, bytes calldata _data) external onlyOperators {
     require(_to != address(this), "Cannot call self");
@@ -281,10 +375,20 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
    *      then apply the priceFactor markup.
    *
    *      SortedOracles.medianRate(rateFeedId) returns (numerator, denominator) where
-   *      numerator/denominator represents the token-per-CELO rate in fixed-point 1e24.
+   *      numerator/denominator represents the token-per-CELO rate in 1e24 fixed-point.
    *
-   *      tokenAmount = celoAmount * (numerator / denominator) * (tokenPrecision / NATIVE_PRECISION)
-   *                  * (priceFactor / PRICE_FACTOR_PRECISION)
+   *      Formula:
+   *        tokenAmount = celoAmount
+   *                    × (numerator / denominator)        // oracle rate
+   *                    × (tokenPrecision / NATIVE_PRECISION)  // decimal adjustment
+   *                    × (priceFactor / PRICE_FACTOR_PRECISION) // markup
+   *
+   *      Example (USDT, 6 decimals, CELO ≈ $0.096, 1.2x markup):
+   *        0.825 CELO → 0.825 × 0.096 × (1e6/1e18) × 1.2 = 0.094 USDT = 94,xxx units
+   *
+   * @param _celoAmount The CELO amount to convert (in wei, 18 decimals).
+   * @param _config The OFT config containing oracleRateFeedId and tokenPrecision.
+   * @return The equivalent token amount (in the token's native decimals).
    */
   function _celoToToken(
     uint256 _celoAmount,

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -14,8 +14,10 @@ import "./interfaces/ILayerZeroOFT.sol";
  * @title GasSponsoredOFTBridge
  * @notice Enables users to bridge tokens out of Celo via LayerZero OFT without holding CELO.
  * The contract sponsors the CELO needed for the LayerZero messaging fee and charges the user
- * the equivalent amount in the bridged token (e.g. USDT), using Celo's SortedOracles for
- * the CELO/token exchange rate.
+ * the equivalent amount in the bridged token, using Celo's SortedOracles for the CELO/token
+ * exchange rate.
+ *
+ * Supports multiple tokens — each registered OFT is mapped to its token and oracle config.
  *
  * Combined with Celo's fee currency system (where transaction gas can also be paid in USDT),
  * this allows the entire bridge operation to be paid in a single stablecoin.
@@ -26,11 +28,31 @@ import "./interfaces/ILayerZeroOFT.sol";
 contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   using SafeERC20 for IERC20;
 
+  // ---------------------------------------------------------------------------
+  // Types
+  // ---------------------------------------------------------------------------
+
+  struct OFTConfig {
+    IERC20 token; // The ERC-20 token the OFT bridges (e.g. USDT, USDC)
+    address oracleRateFeedId; // Rate feed ID for this token in SortedOracles
+    uint256 tokenPrecision; // 10^decimals of the token (e.g. 1e6 for USDT)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Events
+  // ---------------------------------------------------------------------------
+
   event LogSetMaxGas(uint256 maxGas);
   event LogSetPriceFactor(uint256 oldPriceFactor, uint256 newPriceFactor);
   event LogSetSortedOracles(address indexed oldOracle, address indexed newOracle);
-  event LogSetOracleRateFeedId(address indexed oldFeedId, address indexed newFeedId);
   event LogOperatorChanged(address indexed operator, bool enabled);
+  event LogOFTConfigSet(
+    address indexed oft,
+    address indexed token,
+    address oracleRateFeedId,
+    uint256 tokenPrecision
+  );
+  event LogOFTConfigRemoved(address indexed oft);
   event LogSend(
     address indexed sender,
     address indexed oft,
@@ -40,6 +62,10 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     uint256 totalAmount
   );
   event LogExecute(address indexed operator, address indexed target, uint256 value, bytes data);
+
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
 
   /// @notice Maximum CELO (in wei) the contract will spend per send() call.
   uint256 public maxGas;
@@ -51,50 +77,37 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   uint256 public priceFactor;
   uint256 public constant PRICE_FACTOR_PRECISION = 10_000;
 
-  /// @notice Precision of the bridged token, derived from its decimals (e.g. 1e6 for USDT).
-  uint256 public immutable tokenPrecision;
-
-  /// @notice The token users bridge and pay fees in (e.g. USDT).
-  IERC20 public immutable token;
-
   /// @notice Celo SortedOracles contract for CELO/token exchange rates.
   ISortedOracles public sortedOracles;
-
-  /// @notice The rate feed identifier used to query SortedOracles.
-  /// @dev May differ from the token address (see MentoFeeCurrencyAdapter pattern).
-  address public oracleRateFeedId;
 
   /// @notice Addresses authorized to call execute().
   mapping(address => bool) public operators;
 
-  /// @notice Whitelisted OFT contracts that send() can route through.
-  mapping(address => bool) public allowedOFTs;
+  /// @notice Registered OFT contracts and their token configuration.
+  /// @dev If oftConfigs[oft].token == address(0), the OFT is not registered.
+  mapping(address => OFTConfig) public oftConfigs;
+
+  // ---------------------------------------------------------------------------
+  // Modifiers
+  // ---------------------------------------------------------------------------
 
   modifier onlyOperators() {
     require(operators[msg.sender] || msg.sender == owner(), "Not operator or owner");
     _;
   }
 
+  // ---------------------------------------------------------------------------
+  // Constructor
+  // ---------------------------------------------------------------------------
+
   /**
-   * @param _token The ERC-20 token used for bridging and fee payment.
    * @param _sortedOracles Address of the Celo SortedOracles contract.
-   * @param _oracleRateFeedId Rate feed ID for the token in SortedOracles.
    * @param _maxGas Initial cap on CELO spent per send() call.
    */
-  constructor(
-    IERC20Metadata _token,
-    ISortedOracles _sortedOracles,
-    address _oracleRateFeedId,
-    uint256 _maxGas
-  ) {
-    require(address(_token) != address(0), "Token is zero address");
+  constructor(ISortedOracles _sortedOracles, uint256 _maxGas) {
     require(address(_sortedOracles) != address(0), "Oracle is zero address");
-    require(_oracleRateFeedId != address(0), "Feed ID is zero address");
 
-    token = _token;
-    tokenPrecision = 10 ** _token.decimals();
     sortedOracles = _sortedOracles;
-    oracleRateFeedId = _oracleRateFeedId;
     maxGas = _maxGas;
     priceFactor = 12_000; // 1.2x default markup
   }
@@ -107,12 +120,12 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
 
   /**
    * @notice Bridge tokens via LayerZero OFT, paying both the bridge amount and LZ
-   *         messaging fee in `token`. The contract fronts the CELO for the messaging
-   *         fee and charges the caller the equivalent in `token` (plus markup).
+   *         messaging fee in the OFT's token. The contract fronts the CELO for the
+   *         messaging fee and charges the caller the equivalent in the token (plus markup).
    * @dev The caller must have approved this contract for at least
-   *      `_sendParam.amountLD + feeInToken` of `token`. Use quoteSend() to
+   *      `_sendParam.amountLD + feeInToken` of the OFT's token. Use quoteSend() to
    *      estimate the total.
-   * @param _oft The OFT contract to route the bridge through.
+   * @param _oft The registered OFT contract to route the bridge through.
    * @param _sendParam LayerZero SendParam (destination, recipient, amount, etc.).
    * @param _fee LayerZero MessagingFee (nativeFee, lzTokenFee).
    * @return msgReceipt LayerZero messaging receipt.
@@ -127,7 +140,8 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     nonReentrant
     returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
   {
-    require(allowedOFTs[address(_oft)], "OFT not whitelisted");
+    OFTConfig memory config = oftConfigs[address(_oft)];
+    require(address(config.token) != address(0), "OFT not registered");
     require(_fee.lzTokenFee == 0, "LZ token fee not supported");
     require(_fee.nativeFee <= maxGas, "Gas limit exceeded");
     require(address(this).balance >= _fee.nativeFee, "Insufficient CELO balance");
@@ -135,25 +149,25 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     uint256 celoBefore = address(this).balance;
 
     // Pull bridge amount from user and approve OFT to spend it.
-    token.safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
+    config.token.safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
     // Reset allowance to 0 first to avoid safeApprove revert on non-zero -> non-zero.
-    token.safeApprove(address(_oft), 0);
-    token.safeApprove(address(_oft), _sendParam.amountLD);
+    config.token.safeApprove(address(_oft), 0);
+    config.token.safeApprove(address(_oft), _sendParam.amountLD);
 
     // Execute the OFT send, sponsoring the CELO.
     (msgReceipt, oftReceipt) = _oft.send{ value: _fee.nativeFee }(_sendParam, _fee, address(this));
 
     // Reset leftover allowance to prevent dangling approvals.
-    token.safeApprove(address(_oft), 0);
+    config.token.safeApprove(address(_oft), 0);
 
     // Calculate how much CELO was actually spent.
     uint256 celoSpent = celoBefore - address(this).balance;
 
     // Convert CELO spent to token amount using oracle rate + markup.
-    uint256 feeInToken = _celoToToken(celoSpent);
+    uint256 feeInToken = _celoToToken(celoSpent, config);
 
     // Charge the user for the CELO that was spent.
-    token.safeTransferFrom(msg.sender, address(this), feeInToken);
+    config.token.safeTransferFrom(msg.sender, address(this), feeInToken);
 
     emit LogSend(
       msg.sender,
@@ -167,21 +181,60 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
 
   /**
    * @notice Estimate the total token amount a user needs for a send() call.
+   * @param _oft The OFT contract (must be registered).
    * @param _sendParam The send parameters (only amountLD is used).
    * @param _fee The messaging fee (only nativeFee is used).
    * @return totalAmount amountLD + fee converted to token.
    */
   function quoteSend(
+    IOFT _oft,
     SendParam calldata _sendParam,
     MessagingFee calldata _fee
   ) external view returns (uint256 totalAmount) {
-    uint256 feeInToken = _celoToToken(_fee.nativeFee);
+    OFTConfig memory config = oftConfigs[address(_oft)];
+    require(address(config.token) != address(0), "OFT not registered");
+    uint256 feeInToken = _celoToToken(_fee.nativeFee, config);
     totalAmount = _sendParam.amountLD + feeInToken;
   }
 
   // ---------------------------------------------------------------------------
   // Admin
   // ---------------------------------------------------------------------------
+
+  /**
+   * @notice Register an OFT with its token and oracle configuration.
+   * @param _oft The OFT contract address.
+   * @param _token The ERC-20 token the OFT bridges.
+   * @param _oracleRateFeedId Rate feed ID for the token in SortedOracles.
+   */
+  function setOFTConfig(
+    address _oft,
+    IERC20Metadata _token,
+    address _oracleRateFeedId
+  ) external onlyOwner {
+    require(_oft != address(0), "OFT is zero address");
+    require(address(_token) != address(0), "Token is zero address");
+    require(_oracleRateFeedId != address(0), "Feed ID is zero address");
+
+    uint256 precision = 10 ** _token.decimals();
+    oftConfigs[_oft] = OFTConfig({
+      token: IERC20(address(_token)),
+      oracleRateFeedId: _oracleRateFeedId,
+      tokenPrecision: precision
+    });
+
+    emit LogOFTConfigSet(_oft, address(_token), _oracleRateFeedId, precision);
+  }
+
+  /**
+   * @notice Remove an OFT registration (disables bridging through it).
+   * @param _oft The OFT contract address to remove.
+   */
+  function removeOFTConfig(address _oft) external onlyOwner {
+    require(address(oftConfigs[_oft].token) != address(0), "OFT not registered");
+    delete oftConfigs[_oft];
+    emit LogOFTConfigRemoved(_oft);
+  }
 
   function setMaxGas(uint256 _maxGas) external onlyOwner {
     maxGas = _maxGas;
@@ -202,23 +255,9 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     emit LogSetSortedOracles(old, address(_sortedOracles));
   }
 
-  function setOracleRateFeedId(address _oracleRateFeedId) external onlyOwner {
-    require(_oracleRateFeedId != address(0), "Feed ID is zero address");
-    address old = oracleRateFeedId;
-    oracleRateFeedId = _oracleRateFeedId;
-    emit LogSetOracleRateFeedId(old, _oracleRateFeedId);
-  }
-
   function setOperator(address _operator, bool _enabled) external onlyOwner {
     operators[_operator] = _enabled;
     emit LogOperatorChanged(_operator, _enabled);
-  }
-
-  event LogAllowedOFTChanged(address indexed oft, bool allowed);
-
-  function setAllowedOFT(address _oft, bool _allowed) external onlyOwner {
-    allowedOFTs[_oft] = _allowed;
-    emit LogAllowedOFTChanged(_oft, _allowed);
   }
 
   /**
@@ -247,8 +286,11 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
    *      tokenAmount = celoAmount * (numerator / denominator) * (tokenPrecision / NATIVE_PRECISION)
    *                  * (priceFactor / PRICE_FACTOR_PRECISION)
    */
-  function _celoToToken(uint256 _celoAmount) internal view returns (uint256) {
-    (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(oracleRateFeedId);
+  function _celoToToken(
+    uint256 _celoAmount,
+    OFTConfig memory _config
+  ) internal view returns (uint256) {
+    (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(_config.oracleRateFeedId);
     // denominator == 0 means no oracle rates exist (SortedOracles returns 0 when numRates == 0).
     // Note: isOldestReportExpired is NOT used here because it doesn't follow the
     // equivalentToken mapping that medianRate uses — it would always return true for
@@ -257,7 +299,7 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     require(numerator > 0, "Oracle rate numerator is zero");
 
     return
-      (_celoAmount * numerator * tokenPrecision * priceFactor) /
+      (_celoAmount * numerator * _config.tokenPrecision * priceFactor) /
       (denominator * NATIVE_PRECISION * PRICE_FACTOR_PRECISION);
   }
 }

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -122,7 +122,11 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     IOFT _oft,
     SendParam calldata _sendParam,
     MessagingFee calldata _fee
-  ) external nonReentrant returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+  )
+    external
+    nonReentrant
+    returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
+  {
     require(allowedOFTs[address(_oft)], "OFT not whitelisted");
     require(_fee.lzTokenFee == 0, "LZ token fee not supported");
     require(_fee.nativeFee <= maxGas, "Gas limit exceeded");
@@ -137,11 +141,7 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     token.safeApprove(address(_oft), _sendParam.amountLD);
 
     // Execute the OFT send, sponsoring the CELO.
-    (msgReceipt, oftReceipt) = _oft.send{ value: _fee.nativeFee }(
-      _sendParam,
-      _fee,
-      address(this)
-    );
+    (msgReceipt, oftReceipt) = _oft.send{ value: _fee.nativeFee }(_sendParam, _fee, address(this));
 
     // Reset leftover allowance to prevent dangling approvals.
     token.safeApprove(address(_oft), 0);

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -124,6 +124,7 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     MessagingFee calldata _fee
   ) external nonReentrant returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
     require(allowedOFTs[address(_oft)], "OFT not whitelisted");
+    require(_fee.lzTokenFee == 0, "LZ token fee not supported");
     require(_fee.nativeFee <= maxGas, "Gas limit exceeded");
     require(address(this).balance >= _fee.nativeFee, "Insufficient CELO balance");
 
@@ -213,8 +214,11 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     emit LogOperatorChanged(_operator, _enabled);
   }
 
+  event LogAllowedOFTChanged(address indexed oft, bool allowed);
+
   function setAllowedOFT(address _oft, bool _allowed) external onlyOwner {
     allowedOFTs[_oft] = _allowed;
+    emit LogAllowedOFTChanged(_oft, _allowed);
   }
 
   /**
@@ -246,6 +250,7 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   function _celoToToken(uint256 _celoAmount) internal view returns (uint256) {
     (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(oracleRateFeedId);
     require(denominator > 0, "No oracle rate available");
+    require(numerator > 0, "Oracle rate numerator is zero");
 
     (bool isExpired, ) = sortedOracles.isOldestReportExpired(oracleRateFeedId);
     require(!isExpired, "Oracle rate is stale");

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.7 <0.8.20;
 
 import "@openzeppelin/contracts8/access/Ownable.sol";
+import "@openzeppelin/contracts8/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts8/token/ERC20/utils/SafeERC20.sol";
@@ -22,7 +23,7 @@ import "./interfaces/ILayerZeroOFT.sol";
  * Adapted from Arbitrum's TransactionValueHelper
  * (0xa90f03c856D01F698E7071B393387cd75a8a319A) for the Celo ecosystem.
  */
-contract GasSponsoredOFTBridge is Ownable {
+contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   using SafeERC20 for IERC20;
 
   event LogSetMaxGas(uint256 maxGas);
@@ -65,6 +66,9 @@ contract GasSponsoredOFTBridge is Ownable {
 
   /// @notice Addresses authorized to call execute().
   mapping(address => bool) public operators;
+
+  /// @notice Whitelisted OFT contracts that send() can route through.
+  mapping(address => bool) public allowedOFTs;
 
   modifier onlyOperators() {
     require(operators[msg.sender] || msg.sender == owner(), "Not operator or owner");
@@ -118,7 +122,8 @@ contract GasSponsoredOFTBridge is Ownable {
     IOFT _oft,
     SendParam calldata _sendParam,
     MessagingFee calldata _fee
-  ) external returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+  ) external nonReentrant returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+    require(allowedOFTs[address(_oft)], "OFT not whitelisted");
     require(_fee.nativeFee <= maxGas, "Gas limit exceeded");
     require(address(this).balance >= _fee.nativeFee, "Insufficient CELO balance");
 
@@ -126,6 +131,8 @@ contract GasSponsoredOFTBridge is Ownable {
 
     // Pull bridge amount from user and approve OFT to spend it.
     token.safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
+    // Reset allowance to 0 first to avoid safeApprove revert on non-zero -> non-zero.
+    token.safeApprove(address(_oft), 0);
     token.safeApprove(address(_oft), _sendParam.amountLD);
 
     // Execute the OFT send, sponsoring the CELO.
@@ -134,6 +141,9 @@ contract GasSponsoredOFTBridge is Ownable {
       _fee,
       address(this)
     );
+
+    // Reset leftover allowance to prevent dangling approvals.
+    token.safeApprove(address(_oft), 0);
 
     // Calculate how much CELO was actually spent.
     uint256 celoSpent = celoBefore - address(this).balance;
@@ -203,11 +213,17 @@ contract GasSponsoredOFTBridge is Ownable {
     emit LogOperatorChanged(_operator, _enabled);
   }
 
+  function setAllowedOFT(address _oft, bool _allowed) external onlyOwner {
+    allowedOFTs[_oft] = _allowed;
+  }
+
   /**
    * @notice Execute an arbitrary call with native value. Intended for operator
    *         maintenance tasks (e.g. withdrawing accumulated fees, rebalancing CELO).
+   * @dev Cannot target this contract to prevent self-destructive calls.
    */
   function execute(address _to, uint256 _value, bytes calldata _data) external onlyOperators {
+    require(_to != address(this), "Cannot call self");
     (bool success, ) = _to.call{ value: _value }(_data);
     require(success, "Execute call failed");
     emit LogExecute(msg.sender, _to, _value, _data);
@@ -230,6 +246,9 @@ contract GasSponsoredOFTBridge is Ownable {
   function _celoToToken(uint256 _celoAmount) internal view returns (uint256) {
     (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(oracleRateFeedId);
     require(denominator > 0, "No oracle rate available");
+
+    (bool isExpired, ) = sortedOracles.isOldestReportExpired(oracleRateFeedId);
+    require(!isExpired, "Oracle rate is stale");
 
     return
       (_celoAmount * numerator * tokenPrecision * priceFactor) /

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.7 <0.8.20;
+
+import "@openzeppelin/contracts8/access/Ownable.sol";
+import "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts8/token/ERC20/utils/SafeERC20.sol";
+
+import "../../contracts/stability/interfaces/ISortedOracles.sol";
+import "./interfaces/ILayerZeroOFT.sol";
+
+/**
+ * @title GasSponsoredOFTBridge
+ * @notice Enables users to bridge tokens out of Celo via LayerZero OFT without holding CELO.
+ * The contract sponsors the CELO needed for the LayerZero messaging fee and charges the user
+ * the equivalent amount in the bridged token (e.g. USDT), using Celo's SortedOracles for
+ * the CELO/token exchange rate.
+ *
+ * Combined with Celo's fee currency system (where transaction gas can also be paid in USDT),
+ * this allows the entire bridge operation to be paid in a single stablecoin.
+ *
+ * Adapted from Arbitrum's TransactionValueHelper
+ * (0xa90f03c856D01F698E7071B393387cd75a8a319A) for the Celo ecosystem.
+ */
+contract GasSponsoredOFTBridge is Ownable {
+  using SafeERC20 for IERC20;
+
+  event LogSetMaxGas(uint256 maxGas);
+  event LogSetPriceFactor(uint256 oldPriceFactor, uint256 newPriceFactor);
+  event LogSetSortedOracles(address indexed oldOracle, address indexed newOracle);
+  event LogSetOracleRateFeedId(address indexed oldFeedId, address indexed newFeedId);
+  event LogOperatorChanged(address indexed operator, bool enabled);
+  event LogSend(
+    address indexed sender,
+    address indexed oft,
+    uint256 amountLD,
+    uint256 nativeFee,
+    uint256 feeInToken,
+    uint256 totalAmount
+  );
+  event LogExecute(address indexed operator, address indexed target, uint256 value, bytes data);
+
+  /// @notice Maximum CELO (in wei) the contract will spend per send() call.
+  uint256 public maxGas;
+
+  /// @notice Precision constant for CELO (18 decimals).
+  uint256 public constant NATIVE_PRECISION = 1e18;
+
+  /// @notice Markup applied to the oracle rate (12000 / 10000 = 1.2x by default).
+  uint256 public priceFactor;
+  uint256 public constant PRICE_FACTOR_PRECISION = 10_000;
+
+  /// @notice Precision of the bridged token, derived from its decimals (e.g. 1e6 for USDT).
+  uint256 public immutable tokenPrecision;
+
+  /// @notice The token users bridge and pay fees in (e.g. USDT).
+  IERC20 public immutable token;
+
+  /// @notice Celo SortedOracles contract for CELO/token exchange rates.
+  ISortedOracles public sortedOracles;
+
+  /// @notice The rate feed identifier used to query SortedOracles.
+  /// @dev May differ from the token address (see MentoFeeCurrencyAdapter pattern).
+  address public oracleRateFeedId;
+
+  /// @notice Addresses authorized to call execute().
+  mapping(address => bool) public operators;
+
+  modifier onlyOperators() {
+    require(operators[msg.sender] || msg.sender == owner(), "Not operator or owner");
+    _;
+  }
+
+  /**
+   * @param _token The ERC-20 token used for bridging and fee payment.
+   * @param _sortedOracles Address of the Celo SortedOracles contract.
+   * @param _oracleRateFeedId Rate feed ID for the token in SortedOracles.
+   * @param _maxGas Initial cap on CELO spent per send() call.
+   */
+  constructor(
+    IERC20Metadata _token,
+    ISortedOracles _sortedOracles,
+    address _oracleRateFeedId,
+    uint256 _maxGas
+  ) {
+    require(address(_token) != address(0), "Token is zero address");
+    require(address(_sortedOracles) != address(0), "Oracle is zero address");
+    require(_oracleRateFeedId != address(0), "Feed ID is zero address");
+
+    token = _token;
+    tokenPrecision = 10 ** _token.decimals();
+    sortedOracles = _sortedOracles;
+    oracleRateFeedId = _oracleRateFeedId;
+    maxGas = _maxGas;
+    priceFactor = 12_000; // 1.2x default markup
+  }
+
+  receive() external payable {}
+
+  // ---------------------------------------------------------------------------
+  // Core
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @notice Bridge tokens via LayerZero OFT, paying both the bridge amount and LZ
+   *         messaging fee in `token`. The contract fronts the CELO for the messaging
+   *         fee and charges the caller the equivalent in `token` (plus markup).
+   * @dev The caller must have approved this contract for at least
+   *      `_sendParam.amountLD + feeInToken` of `token`. Use quoteSend() to
+   *      estimate the total.
+   * @param _oft The OFT contract to route the bridge through.
+   * @param _sendParam LayerZero SendParam (destination, recipient, amount, etc.).
+   * @param _fee LayerZero MessagingFee (nativeFee, lzTokenFee).
+   * @return msgReceipt LayerZero messaging receipt.
+   * @return oftReceipt OFT receipt with actual amounts sent/received.
+   */
+  function send(
+    IOFT _oft,
+    SendParam calldata _sendParam,
+    MessagingFee calldata _fee
+  ) external returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+    require(_fee.nativeFee <= maxGas, "Gas limit exceeded");
+    require(address(this).balance >= _fee.nativeFee, "Insufficient CELO balance");
+
+    uint256 celoBefore = address(this).balance;
+
+    // Pull bridge amount from user and approve OFT to spend it.
+    token.safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
+    token.safeApprove(address(_oft), _sendParam.amountLD);
+
+    // Execute the OFT send, sponsoring the CELO.
+    (msgReceipt, oftReceipt) = _oft.send{ value: _fee.nativeFee }(
+      _sendParam,
+      _fee,
+      address(this)
+    );
+
+    // Calculate how much CELO was actually spent.
+    uint256 celoSpent = celoBefore - address(this).balance;
+
+    // Convert CELO spent to token amount using oracle rate + markup.
+    uint256 feeInToken = _celoToToken(celoSpent);
+
+    // Charge the user for the CELO that was spent.
+    token.safeTransferFrom(msg.sender, address(this), feeInToken);
+
+    emit LogSend(
+      msg.sender,
+      address(_oft),
+      _sendParam.amountLD,
+      celoSpent,
+      feeInToken,
+      _sendParam.amountLD + feeInToken
+    );
+  }
+
+  /**
+   * @notice Estimate the total token amount a user needs for a send() call.
+   * @param _sendParam The send parameters (only amountLD is used).
+   * @param _fee The messaging fee (only nativeFee is used).
+   * @return totalAmount amountLD + fee converted to token.
+   */
+  function quoteSend(
+    SendParam calldata _sendParam,
+    MessagingFee calldata _fee
+  ) external view returns (uint256 totalAmount) {
+    uint256 feeInToken = _celoToToken(_fee.nativeFee);
+    totalAmount = _sendParam.amountLD + feeInToken;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Admin
+  // ---------------------------------------------------------------------------
+
+  function setMaxGas(uint256 _maxGas) external onlyOwner {
+    maxGas = _maxGas;
+    emit LogSetMaxGas(_maxGas);
+  }
+
+  function setPriceFactor(uint256 _newPriceFactor) external onlyOwner {
+    require(_newPriceFactor > 0, "Price factor must be > 0");
+    uint256 old = priceFactor;
+    priceFactor = _newPriceFactor;
+    emit LogSetPriceFactor(old, _newPriceFactor);
+  }
+
+  function setSortedOracles(ISortedOracles _sortedOracles) external onlyOwner {
+    require(address(_sortedOracles) != address(0), "Oracle is zero address");
+    address old = address(sortedOracles);
+    sortedOracles = _sortedOracles;
+    emit LogSetSortedOracles(old, address(_sortedOracles));
+  }
+
+  function setOracleRateFeedId(address _oracleRateFeedId) external onlyOwner {
+    require(_oracleRateFeedId != address(0), "Feed ID is zero address");
+    address old = oracleRateFeedId;
+    oracleRateFeedId = _oracleRateFeedId;
+    emit LogSetOracleRateFeedId(old, _oracleRateFeedId);
+  }
+
+  function setOperator(address _operator, bool _enabled) external onlyOwner {
+    operators[_operator] = _enabled;
+    emit LogOperatorChanged(_operator, _enabled);
+  }
+
+  /**
+   * @notice Execute an arbitrary call with native value. Intended for operator
+   *         maintenance tasks (e.g. withdrawing accumulated fees, rebalancing CELO).
+   */
+  function execute(address _to, uint256 _value, bytes calldata _data) external onlyOperators {
+    (bool success, ) = _to.call{ value: _value }(_data);
+    require(success, "Execute call failed");
+    emit LogExecute(msg.sender, _to, _value, _data);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @dev Convert a CELO amount to the equivalent token amount using SortedOracles,
+   *      then apply the priceFactor markup.
+   *
+   *      SortedOracles.medianRate(rateFeedId) returns (numerator, denominator) where
+   *      numerator/denominator represents the token-per-CELO rate in fixed-point 1e24.
+   *
+   *      tokenAmount = celoAmount * (numerator / denominator) * (tokenPrecision / NATIVE_PRECISION)
+   *                  * (priceFactor / PRICE_FACTOR_PRECISION)
+   */
+  function _celoToToken(uint256 _celoAmount) internal view returns (uint256) {
+    (uint256 numerator, uint256 denominator) = sortedOracles.medianRate(oracleRateFeedId);
+    require(denominator > 0, "No oracle rate available");
+
+    return
+      (_celoAmount * numerator * tokenPrecision * priceFactor) /
+      (denominator * NATIVE_PRECISION * PRICE_FACTOR_PRECISION);
+  }
+}

--- a/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
+++ b/packages/protocol/contracts-0.8/common/GasSponsoredOFTBridge.sol
@@ -103,10 +103,10 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
   /// @notice Emitted on every successful bridge send.
   /// @param sender The user who initiated the bridge.
   /// @param oft The OFT contract used.
-  /// @param amountLD The token amount bridged (in local decimals).
+  /// @param amountLD The token amount actually bridged (in local decimals, after OFT dust removal).
   /// @param nativeFee The CELO amount the bridge spent on the LZ messaging fee.
   /// @param feeInToken The token amount charged to the user for the CELO sponsorship.
-  /// @param totalAmount amountLD + feeInToken (total token cost to the user).
+  /// @param totalAmount amountLD + feeInToken (net token cost to the user, dust refunded).
   event LogSend(
     address indexed sender,
     address indexed oft,
@@ -227,6 +227,14 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     // Reset leftover allowance to prevent dangling approvals.
     config.token.safeApprove(address(_oft), 0);
 
+    // The OFT may debit less than amountLD due to shared-decimal dust removal
+    // (amountSentLD <= amountLD). Refund the non-bridgeable dust to the user so they
+    // are only charged for what was actually bridged, never leaving it stuck here.
+    uint256 dust = _sendParam.amountLD - oftReceipt.amountSentLD;
+    if (dust > 0) {
+      config.token.safeTransfer(msg.sender, dust);
+    }
+
     // Calculate how much CELO was actually spent (may differ from _fee.nativeFee
     // if the OFT refunds unused CELO back to this contract).
     uint256 celoSpent = celoBefore - address(this).balance;
@@ -237,13 +245,14 @@ contract GasSponsoredOFTBridge is Ownable, ReentrancyGuard {
     // Charge the user for the CELO that was spent.
     config.token.safeTransferFrom(msg.sender, address(this), feeInToken);
 
+    // Report the amount actually bridged (post dust refund), not the requested amountLD.
     emit LogSend(
       msg.sender,
       address(_oft),
-      _sendParam.amountLD,
+      oftReceipt.amountSentLD,
       celoSpent,
       feeInToken,
-      _sendParam.amountLD + feeInToken
+      oftReceipt.amountSentLD + feeInToken
     );
   }
 

--- a/packages/protocol/contracts-0.8/common/interfaces/ILayerZeroOFT.sol
+++ b/packages/protocol/contracts-0.8/common/interfaces/ILayerZeroOFT.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.7 <0.8.20;
+
+/**
+ * @title Minimal LayerZero OFT interfaces
+ * @notice Only the types and function signatures needed by GasSponsoredOFTBridge.
+ * The actual OFT contracts are deployed independently (e.g. by Stargate or the token issuer).
+ */
+
+struct MessagingFee {
+  uint256 nativeFee;
+  uint256 lzTokenFee;
+}
+
+struct MessagingReceipt {
+  bytes32 guid;
+  uint64 nonce;
+  MessagingFee fee;
+}
+
+struct SendParam {
+  uint32 dstEid;
+  bytes32 to;
+  uint256 amountLD;
+  uint256 minAmountLD;
+  bytes extraOptions;
+  bytes composeMsg;
+  bytes oftCmd;
+}
+
+struct OFTReceipt {
+  uint256 amountSentLD;
+  uint256 amountReceivedLD;
+}
+
+interface IOFT {
+  function send(
+    SendParam calldata _sendParam,
+    MessagingFee calldata _fee,
+    address _refundAddress
+  ) external payable returns (MessagingReceipt memory, OFTReceipt memory);
+
+  function token() external view returns (address);
+}

--- a/packages/protocol/scripts/DeployGasSponsoredOFTBridge.s.sol
+++ b/packages/protocol/scripts/DeployGasSponsoredOFTBridge.s.sol
@@ -13,7 +13,10 @@ contract DeployGasSponsoredOFTBridge is Script {
     require(tokenAddress != address(0), "TOKEN_ADDRESS environment variable not set");
 
     address sortedOraclesAddress = vm.envAddress("SORTED_ORACLES_ADDRESS");
-    require(sortedOraclesAddress != address(0), "SORTED_ORACLES_ADDRESS environment variable not set");
+    require(
+      sortedOraclesAddress != address(0),
+      "SORTED_ORACLES_ADDRESS environment variable not set"
+    );
 
     address oracleRateFeedId = vm.envAddress("ORACLE_RATE_FEED_ID");
     require(oracleRateFeedId != address(0), "ORACLE_RATE_FEED_ID environment variable not set");

--- a/packages/protocol/scripts/DeployGasSponsoredOFTBridge.s.sol
+++ b/packages/protocol/scripts/DeployGasSponsoredOFTBridge.s.sol
@@ -9,17 +9,11 @@ contract DeployGasSponsoredOFTBridge is Script {
     uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
     require(deployerPrivateKey != 0, "PRIVATE_KEY environment variable not set");
 
-    address tokenAddress = vm.envAddress("TOKEN_ADDRESS");
-    require(tokenAddress != address(0), "TOKEN_ADDRESS environment variable not set");
-
     address sortedOraclesAddress = vm.envAddress("SORTED_ORACLES_ADDRESS");
     require(
       sortedOraclesAddress != address(0),
       "SORTED_ORACLES_ADDRESS environment variable not set"
     );
-
-    address oracleRateFeedId = vm.envAddress("ORACLE_RATE_FEED_ID");
-    require(oracleRateFeedId != address(0), "ORACLE_RATE_FEED_ID environment variable not set");
 
     uint256 maxGas = vm.envUint("MAX_GAS");
     require(maxGas > 0, "MAX_GAS environment variable not set");
@@ -27,13 +21,12 @@ contract DeployGasSponsoredOFTBridge is Script {
     vm.startBroadcast(deployerPrivateKey);
 
     GasSponsoredOFTBridge bridge = new GasSponsoredOFTBridge(
-      IERC20Metadata(tokenAddress),
       ISortedOracles(sortedOraclesAddress),
-      oracleRateFeedId,
       maxGas
     );
 
     console.log("GasSponsoredOFTBridge deployed at:", address(bridge));
+    console.log("Register OFTs with: bridge.setOFTConfig(oft, token, rateFeedId)");
 
     vm.stopBroadcast();
   }

--- a/packages/protocol/scripts/DeployGasSponsoredOFTBridge.s.sol
+++ b/packages/protocol/scripts/DeployGasSponsoredOFTBridge.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.15;
+
+import "forge-std/Script.sol";
+import "../contracts-0.8/common/GasSponsoredOFTBridge.sol";
+
+contract DeployGasSponsoredOFTBridge is Script {
+  function run() external {
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    require(deployerPrivateKey != 0, "PRIVATE_KEY environment variable not set");
+
+    address tokenAddress = vm.envAddress("TOKEN_ADDRESS");
+    require(tokenAddress != address(0), "TOKEN_ADDRESS environment variable not set");
+
+    address sortedOraclesAddress = vm.envAddress("SORTED_ORACLES_ADDRESS");
+    require(sortedOraclesAddress != address(0), "SORTED_ORACLES_ADDRESS environment variable not set");
+
+    address oracleRateFeedId = vm.envAddress("ORACLE_RATE_FEED_ID");
+    require(oracleRateFeedId != address(0), "ORACLE_RATE_FEED_ID environment variable not set");
+
+    uint256 maxGas = vm.envUint("MAX_GAS");
+    require(maxGas > 0, "MAX_GAS environment variable not set");
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    GasSponsoredOFTBridge bridge = new GasSponsoredOFTBridge(
+      IERC20Metadata(tokenAddress),
+      ISortedOracles(sortedOraclesAddress),
+      oracleRateFeedId,
+      maxGas
+    );
+
+    console.log("GasSponsoredOFTBridge deployed at:", address(bridge));
+
+    vm.stopBroadcast();
+  }
+}

--- a/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
+++ b/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
@@ -38,7 +38,6 @@ contract ForkMockOFT is IOFT {
     override
     returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
   {
-    // Pull tokens from the bridge (simulates OFT locking/burning tokens)
     IERC20(_token).safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
     _nonce++;
 
@@ -60,10 +59,9 @@ contract ForkMockOFT is IOFT {
 // =============================================================================
 contract GasSponsoredOFTBridgeForkTest is Test {
   // --- Celo Mainnet addresses ---
-  address constant REGISTRY = 0x000000000000000000000000000000000000ce10;
   address constant SORTED_ORACLES = 0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33;
-  address constant USDT = 0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e; // Native bridge USDT (6 decimals)
-  address constant USDT_ADAPTER = 0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72; // Fee currency adapter for USDT
+  address constant USDT = 0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e;
+  address constant USDT_ADAPTER = 0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72;
   address constant CUSD = 0x765DE816845861e75A25fCA122bb6898B8B1282a;
   address constant LZ_ENDPOINT_V2 = 0x1a44076050125825900e736c501f859c50fE728c;
 
@@ -83,33 +81,29 @@ contract GasSponsoredOFTBridgeForkTest is Test {
 
     vm.startPrank(deployer);
 
-    // Deploy the bridge against real Celo mainnet state
-    bridge = new GasSponsoredOFTBridge(
-      IERC20Metadata(USDT),
-      ISortedOracles(SORTED_ORACLES),
-      USDT_ADAPTER, // Uses the adapter as rateFeedId (has equivalentToken -> cUSD)
-      MAX_GAS
-    );
+    // Deploy multi-token bridge
+    bridge = new GasSponsoredOFTBridge(ISortedOracles(SORTED_ORACLES), MAX_GAS);
 
-    // Deploy a mock OFT (since we don't have a real USDT OFT on Celo)
+    // Deploy a mock OFT for USDT
     mockOft = new ForkMockOFT(USDT);
 
-    // Set up operator and whitelist the mock OFT
+    // Register the OFT with USDT config
+    bridge.setOFTConfig(address(mockOft), IERC20Metadata(USDT), USDT_ADAPTER);
+
+    // Set up operator
     bridge.setOperator(operator, true);
-    bridge.setAllowedOFT(address(mockOft), true);
 
     vm.stopPrank();
 
-    // Fund the bridge with CELO for gas sponsoring
+    // Fund the bridge with CELO
     vm.deal(address(bridge), 100 ether);
 
-    // Mint USDT to user via deal (Foundry cheatcode)
-    deal(USDT, user, 10_000e6); // 10,000 USDT
+    // Mint USDT to user
+    deal(USDT, user, 10_000e6);
 
-    // User approves the bridge to spend USDT
+    // User approves the bridge
     vm.prank(user);
     IERC20(USDT).approve(address(bridge), type(uint256).max);
-
   }
 
   // =========================================================================
@@ -117,22 +111,15 @@ contract GasSponsoredOFTBridgeForkTest is Test {
   // =========================================================================
 
   function test_Fork_Deployment_StateIsCorrect() public {
-    assertEq(address(bridge.token()), USDT);
     assertEq(address(bridge.sortedOracles()), SORTED_ORACLES);
-    assertEq(bridge.oracleRateFeedId(), USDT_ADAPTER);
     assertEq(bridge.maxGas(), MAX_GAS);
     assertEq(bridge.priceFactor(), 12_000);
-    assertEq(bridge.tokenPrecision(), 1e6); // USDT has 6 decimals
     assertEq(bridge.owner(), deployer);
-    assertTrue(bridge.operators(operator));
-  }
 
-  function test_Fork_TokenMetadata() public {
-    IERC20Metadata usdt = IERC20Metadata(USDT);
-    assertEq(usdt.decimals(), 6);
-    console.log("USDT name:", usdt.name());
-    console.log("USDT symbol:", usdt.symbol());
-    console.log("USDT totalSupply:", usdt.totalSupply());
+    (IERC20 token, address feedId, uint256 precision) = bridge.oftConfigs(address(mockOft));
+    assertEq(address(token), USDT);
+    assertEq(feedId, USDT_ADAPTER);
+    assertEq(precision, 1e6);
   }
 
   // =========================================================================
@@ -143,19 +130,11 @@ contract GasSponsoredOFTBridgeForkTest is Test {
     (uint256 numerator, uint256 denominator) = ISortedOracles(SORTED_ORACLES).medianRate(
       USDT_ADAPTER
     );
-
-    console.log("Oracle numerator:", numerator);
-    console.log("Oracle denominator:", denominator);
-
-    // Denominator should be 1e24 (FIXED1_UINT) if rates exist
     assertGt(denominator, 0, "Oracle has no rate");
 
-    // Rate should be sensible: numerator/denominator is CELO price in USD
-    // CELO is somewhere between $0.01 and $100
-    uint256 celoInUsdScaled = (numerator * 1e18) / denominator; // scale to 18 decimals
-    console.log("CELO price in USD (1e18 scaled):", celoInUsdScaled);
-    assertGt(celoInUsdScaled, 0.001e18, "Rate too low"); // > $0.001
-    assertLt(celoInUsdScaled, 100e18, "Rate too high"); // < $100
+    uint256 celoInUsdScaled = (numerator * 1e18) / denominator;
+    assertGt(celoInUsdScaled, 0.001e18, "Rate too low");
+    assertLt(celoInUsdScaled, 100e18, "Rate too high");
   }
 
   // =========================================================================
@@ -163,25 +142,17 @@ contract GasSponsoredOFTBridgeForkTest is Test {
   // =========================================================================
 
   function test_Fork_QuoteSend_ReturnsRealisticTotal() public {
-    uint256 bridgeAmount = 100e6; // 100 USDT
-    uint256 nativeFee = 0.1 ether; // 0.1 CELO for LZ messaging
+    uint256 bridgeAmount = 100e6;
+    uint256 nativeFee = 0.1 ether;
 
-    SendParam memory sendParam = _makeSendParam(bridgeAmount);
-    MessagingFee memory fee = MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
-
-    uint256 total = bridge.quoteSend(sendParam, fee);
+    uint256 total = bridge.quoteSend(
+      IOFT(address(mockOft)),
+      _makeSendParam(bridgeAmount),
+      MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 })
+    );
     uint256 feeInUsdt = total - bridgeAmount;
 
-    console.log("Bridge amount (USDT, 6 dec):", bridgeAmount);
-    console.log("LZ native fee (CELO wei):", nativeFee);
-    console.log("Fee in USDT (6 dec):", feeInUsdt);
-    console.log("Total USDT needed (6 dec):", total);
-    console.log("Fee in human USDT:", feeInUsdt, "/ 1e6");
-
-    // Fee should be positive and reasonable
     assertGt(feeInUsdt, 0, "Fee should be > 0");
-    // 0.1 CELO at ~$0.09 = ~$0.009, with 1.2x ≈ $0.011 -> 11000 in 6-dec
-    // But CELO price could vary, so wide bounds
     assertLt(feeInUsdt, bridgeAmount, "Fee should be less than bridge amount");
   }
 
@@ -189,80 +160,51 @@ contract GasSponsoredOFTBridgeForkTest is Test {
     uint256 bridgeAmount = 100e6;
 
     uint256 total1 = bridge.quoteSend(
+      IOFT(address(mockOft)),
       _makeSendParam(bridgeAmount),
       MessagingFee({ nativeFee: 0.1 ether, lzTokenFee: 0 })
     );
     uint256 total2 = bridge.quoteSend(
+      IOFT(address(mockOft)),
       _makeSendParam(bridgeAmount),
       MessagingFee({ nativeFee: 1 ether, lzTokenFee: 0 })
     );
 
     uint256 fee1 = total1 - bridgeAmount;
     uint256 fee2 = total2 - bridgeAmount;
-
-    // 10x native fee should give ~10x token fee (small rounding diff from integer division)
-    assertApproxEqRel(fee2, fee1 * 10, 0.001e18, "Fee should scale ~linearly with native fee");
+    assertApproxEqRel(fee2, fee1 * 10, 0.001e18, "Fee should scale ~linearly");
   }
 
   // =========================================================================
-  // send() end-to-end with real oracle + mock OFT
+  // send() E2E
   // =========================================================================
 
   function test_Fork_Send_EndToEnd() public {
-    uint256 bridgeAmount = 500e6; // 500 USDT
-    uint256 nativeFee = 0.05 ether; // 0.05 CELO
+    uint256 bridgeAmount = 500e6;
+    uint256 nativeFee = 0.05 ether;
 
-    // Get expected fee first
     SendParam memory sendParam = _makeSendParam(bridgeAmount);
     MessagingFee memory fee = MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
-    uint256 expectedTotal = bridge.quoteSend(sendParam, fee);
-    uint256 expectedFeeInUsdt = expectedTotal - bridgeAmount;
-
-    console.log("=== send() E2E ===");
-    console.log("Bridge amount:", bridgeAmount);
-    console.log("Expected fee in USDT:", expectedFeeInUsdt);
-    console.log("Expected total:", expectedTotal);
+    uint256 expectedTotal = bridge.quoteSend(IOFT(address(mockOft)), sendParam, fee);
 
     uint256 userBalBefore = IERC20(USDT).balanceOf(user);
     uint256 bridgeCeloBefore = address(bridge).balance;
 
     vm.prank(user);
-    (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = bridge.send(
-      IOFT(address(mockOft)),
-      sendParam,
-      fee
-    );
+    bridge.send(IOFT(address(mockOft)), sendParam, fee);
 
-    // Verify user paid exactly bridgeAmount + fee
     uint256 userPaid = userBalBefore - IERC20(USDT).balanceOf(user);
     assertEq(userPaid, expectedTotal, "User should pay exact quoted total");
-
-    // Verify bridge CELO was spent
-    uint256 celoSpent = bridgeCeloBefore - address(bridge).balance;
-    assertEq(celoSpent, nativeFee, "Bridge should spend exact native fee");
-
-    // Verify OFT received the bridge amount
+    assertEq(
+      bridgeCeloBefore - address(bridge).balance,
+      nativeFee,
+      "Bridge should spend exact native fee"
+    );
     assertEq(
       IERC20(USDT).balanceOf(address(mockOft)),
       bridgeAmount,
       "OFT should receive bridge amount"
     );
-
-    // Verify bridge collected the fee
-    assertEq(
-      IERC20(USDT).balanceOf(address(bridge)),
-      expectedFeeInUsdt,
-      "Bridge should collect fee in USDT"
-    );
-
-    // Verify receipts
-    assertEq(oftReceipt.amountSentLD, bridgeAmount);
-    assertGt(uint256(msgReceipt.nonce), 0);
-
-    console.log("User paid total:", userPaid);
-    console.log("CELO spent:", celoSpent);
-    console.log("Fee collected by bridge:", IERC20(USDT).balanceOf(address(bridge)));
-    console.log("SUCCESS: Full send() E2E passed");
   }
 
   function test_Fork_Send_MultipleSendsAccumulateFees() public {
@@ -271,58 +213,43 @@ contract GasSponsoredOFTBridgeForkTest is Test {
     SendParam memory sendParam = _makeSendParam(bridgeAmount);
     MessagingFee memory fee = MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
 
-    // Do 3 sends
     for (uint256 i = 0; i < 3; i++) {
       vm.prank(user);
       bridge.send(IOFT(address(mockOft)), sendParam, fee);
     }
 
-    // Bridge should have collected 3x fee
-    uint256 singleFee = bridge.quoteSend(sendParam, fee) - bridgeAmount;
-    assertEq(
-      IERC20(USDT).balanceOf(address(bridge)),
-      singleFee * 3,
-      "Fees should accumulate over multiple sends"
-    );
+    uint256 singleFee = bridge.quoteSend(IOFT(address(mockOft)), sendParam, fee) - bridgeAmount;
+    assertEq(IERC20(USDT).balanceOf(address(bridge)), singleFee * 3);
   }
 
   // =========================================================================
-  // Operator withdrawals (execute)
+  // Operator withdrawals
   // =========================================================================
 
   function test_Fork_Execute_WithdrawAccumulatedFees() public {
-    // First do a send to accumulate fees
-    uint256 bridgeAmount = 1000e6;
-    uint256 nativeFee = 0.1 ether;
     vm.prank(user);
     bridge.send(
       IOFT(address(mockOft)),
-      _makeSendParam(bridgeAmount),
-      MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 })
+      _makeSendParam(1000e6),
+      MessagingFee({ nativeFee: 0.1 ether, lzTokenFee: 0 })
     );
 
     uint256 feesCollected = IERC20(USDT).balanceOf(address(bridge));
     assertGt(feesCollected, 0);
 
-    // Operator withdraws the accumulated USDT fees
     address treasury = makeAddr("treasury");
-    bytes memory transferCall = abi.encodeWithSelector(
-      IERC20.transfer.selector,
-      treasury,
-      feesCollected
-    );
-
     vm.prank(operator);
-    bridge.execute(USDT, 0, transferCall);
+    bridge.execute(
+      USDT,
+      0,
+      abi.encodeWithSelector(IERC20.transfer.selector, treasury, feesCollected)
+    );
 
     assertEq(IERC20(USDT).balanceOf(treasury), feesCollected);
     assertEq(IERC20(USDT).balanceOf(address(bridge)), 0);
-
-    console.log("Operator withdrew USDT fees:", feesCollected);
   }
 
   function test_Fork_Execute_RefundCelo() public {
-    // Operator can withdraw excess CELO
     address treasury = makeAddr("treasury");
     uint256 bridgeCelo = address(bridge).balance;
 
@@ -334,7 +261,7 @@ contract GasSponsoredOFTBridgeForkTest is Test {
   }
 
   // =========================================================================
-  // Edge cases on fork
+  // Edge cases
   // =========================================================================
 
   function test_Fork_Revert_MaxGasExceeded() public {
@@ -348,7 +275,6 @@ contract GasSponsoredOFTBridgeForkTest is Test {
   }
 
   function test_Fork_Revert_InsufficientCeloBalance() public {
-    // Drain the bridge's CELO
     vm.prank(deployer);
     bridge.setMaxGas(200 ether);
 
@@ -365,22 +291,17 @@ contract GasSponsoredOFTBridgeForkTest is Test {
   }
 
   function test_Fork_Revert_InsufficientTokenAllowance() public {
-    // User with no approval
     address user2 = makeAddr("user2");
     deal(USDT, user2, 10_000e6);
 
     vm.prank(user2);
-    vm.expectRevert(); // SafeERC20 will revert on transferFrom
+    vm.expectRevert();
     bridge.send(
       IOFT(address(mockOft)),
       _makeSendParam(100e6),
       MessagingFee({ nativeFee: 0.01 ether, lzTokenFee: 0 })
     );
   }
-
-  // =========================================================================
-  // LZ endpoint verification (read-only)
-  // =========================================================================
 
   function test_Fork_LZEndpointExists() public {
     uint256 codeSize;
@@ -389,7 +310,6 @@ contract GasSponsoredOFTBridgeForkTest is Test {
       codeSize := extcodesize(endpoint)
     }
     assertGt(codeSize, 0, "LZ EndpointV2 should have code on Celo mainnet");
-    console.log("LZ EndpointV2 code size:", codeSize);
   }
 
   // =========================================================================
@@ -399,7 +319,7 @@ contract GasSponsoredOFTBridgeForkTest is Test {
   function _makeSendParam(uint256 amount) internal pure returns (SendParam memory) {
     return
       SendParam({
-        dstEid: 30101, // Ethereum mainnet LZ eid
+        dstEid: 30101,
         to: bytes32(uint256(uint160(address(0xBEEF)))),
         amountLD: amount,
         minAmountLD: amount,

--- a/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
+++ b/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
@@ -110,14 +110,6 @@ contract GasSponsoredOFTBridgeForkTest is Test {
     vm.prank(user);
     IERC20(USDT).approve(address(bridge), type(uint256).max);
 
-    // On a fork snapshot, oracle reports may be naturally expired.
-    // Mock the staleness check so fork tests exercise rate conversion logic.
-    // (Staleness revert is covered by unit tests.)
-    vm.mockCall(
-      SORTED_ORACLES,
-      abi.encodeWithSelector(ISortedOracles.isOldestReportExpired.selector, USDT_ADAPTER),
-      abi.encode(false, address(0))
-    );
   }
 
   // =========================================================================

--- a/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
+++ b/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
@@ -95,8 +95,9 @@ contract GasSponsoredOFTBridgeForkTest is Test {
     // Deploy a mock OFT (since we don't have a real USDT OFT on Celo)
     mockOft = new ForkMockOFT(USDT);
 
-    // Set up operator
+    // Set up operator and whitelist the mock OFT
     bridge.setOperator(operator, true);
+    bridge.setAllowedOFT(address(mockOft), true);
 
     vm.stopPrank();
 
@@ -109,6 +110,15 @@ contract GasSponsoredOFTBridgeForkTest is Test {
     // User approves the bridge to spend USDT
     vm.prank(user);
     IERC20(USDT).approve(address(bridge), type(uint256).max);
+
+    // On a fork snapshot, oracle reports may be naturally expired.
+    // Mock the staleness check so fork tests exercise rate conversion logic.
+    // (Staleness revert is covered by unit tests.)
+    vm.mockCall(
+      SORTED_ORACLES,
+      abi.encodeWithSelector(ISortedOracles.isOldestReportExpired.selector, USDT_ADAPTER),
+      abi.encode(false, address(0))
+    );
   }
 
   // =========================================================================

--- a/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
+++ b/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
@@ -5,13 +5,7 @@ import { Test } from "celo-foundry-8/Test.sol";
 import "forge-std-8/console.sol";
 
 import { GasSponsoredOFTBridge } from "@celo-contracts-8/common/GasSponsoredOFTBridge.sol";
-import {
-  IOFT,
-  SendParam,
-  MessagingFee,
-  MessagingReceipt,
-  OFTReceipt
-} from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
+import { IOFT, SendParam, MessagingFee, MessagingReceipt, OFTReceipt } from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
 import { ISortedOracles } from "@celo-contracts/stability/interfaces/ISortedOracles.sol";
 import { IERC20 } from "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
@@ -38,7 +32,12 @@ contract ForkMockOFT is IOFT {
     SendParam calldata _sendParam,
     MessagingFee calldata,
     address
-  ) external payable override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+  )
+    external
+    payable
+    override
+    returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
+  {
     // Pull tokens from the bridge (simulates OFT locking/burning tokens)
     IERC20(_token).safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
     _nonce++;
@@ -251,7 +250,11 @@ contract GasSponsoredOFTBridgeForkTest is Test {
     assertEq(celoSpent, nativeFee, "Bridge should spend exact native fee");
 
     // Verify OFT received the bridge amount
-    assertEq(IERC20(USDT).balanceOf(address(mockOft)), bridgeAmount, "OFT should receive bridge amount");
+    assertEq(
+      IERC20(USDT).balanceOf(address(mockOft)),
+      bridgeAmount,
+      "OFT should receive bridge amount"
+    );
 
     // Verify bridge collected the fee
     assertEq(

--- a/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
+++ b/packages/protocol/test-sol/fork/GasSponsoredOFTBridge.fork.t.sol
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.7 <0.8.20;
+
+import { Test } from "celo-foundry-8/Test.sol";
+import "forge-std-8/console.sol";
+
+import { GasSponsoredOFTBridge } from "@celo-contracts-8/common/GasSponsoredOFTBridge.sol";
+import {
+  IOFT,
+  SendParam,
+  MessagingFee,
+  MessagingReceipt,
+  OFTReceipt
+} from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
+import { ISortedOracles } from "@celo-contracts/stability/interfaces/ISortedOracles.sol";
+import { IERC20 } from "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
+import { SafeERC20 } from "@openzeppelin/contracts8/token/ERC20/utils/SafeERC20.sol";
+
+// =============================================================================
+// Mock OFT for fork testing (simulates LayerZero OFT send behavior)
+// =============================================================================
+contract ForkMockOFT is IOFT {
+  using SafeERC20 for IERC20;
+
+  address public immutable _token;
+  uint64 private _nonce;
+
+  constructor(address token_) {
+    _token = token_;
+  }
+
+  function token() external view override returns (address) {
+    return _token;
+  }
+
+  function send(
+    SendParam calldata _sendParam,
+    MessagingFee calldata,
+    address
+  ) external payable override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+    // Pull tokens from the bridge (simulates OFT locking/burning tokens)
+    IERC20(_token).safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
+    _nonce++;
+
+    msgReceipt = MessagingReceipt({
+      guid: keccak256(abi.encodePacked(_nonce, block.timestamp)),
+      nonce: _nonce,
+      fee: MessagingFee({ nativeFee: msg.value, lzTokenFee: 0 })
+    });
+
+    oftReceipt = OFTReceipt({
+      amountSentLD: _sendParam.amountLD,
+      amountReceivedLD: _sendParam.amountLD
+    });
+  }
+}
+
+// =============================================================================
+// Fork integration test
+// =============================================================================
+contract GasSponsoredOFTBridgeForkTest is Test {
+  // --- Celo Mainnet addresses ---
+  address constant REGISTRY = 0x000000000000000000000000000000000000ce10;
+  address constant SORTED_ORACLES = 0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33;
+  address constant USDT = 0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e; // Native bridge USDT (6 decimals)
+  address constant USDT_ADAPTER = 0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72; // Fee currency adapter for USDT
+  address constant CUSD = 0x765DE816845861e75A25fCA122bb6898B8B1282a;
+  address constant LZ_ENDPOINT_V2 = 0x1a44076050125825900e736c501f859c50fE728c;
+
+  GasSponsoredOFTBridge public bridge;
+  ForkMockOFT public mockOft;
+
+  address public deployer;
+  address public user;
+  address public operator;
+
+  uint256 constant MAX_GAS = 5 ether;
+
+  function setUp() public {
+    deployer = makeAddr("deployer");
+    user = makeAddr("user");
+    operator = makeAddr("operator");
+
+    vm.startPrank(deployer);
+
+    // Deploy the bridge against real Celo mainnet state
+    bridge = new GasSponsoredOFTBridge(
+      IERC20Metadata(USDT),
+      ISortedOracles(SORTED_ORACLES),
+      USDT_ADAPTER, // Uses the adapter as rateFeedId (has equivalentToken -> cUSD)
+      MAX_GAS
+    );
+
+    // Deploy a mock OFT (since we don't have a real USDT OFT on Celo)
+    mockOft = new ForkMockOFT(USDT);
+
+    // Set up operator
+    bridge.setOperator(operator, true);
+
+    vm.stopPrank();
+
+    // Fund the bridge with CELO for gas sponsoring
+    vm.deal(address(bridge), 100 ether);
+
+    // Mint USDT to user via deal (Foundry cheatcode)
+    deal(USDT, user, 10_000e6); // 10,000 USDT
+
+    // User approves the bridge to spend USDT
+    vm.prank(user);
+    IERC20(USDT).approve(address(bridge), type(uint256).max);
+  }
+
+  // =========================================================================
+  // Deployment verification
+  // =========================================================================
+
+  function test_Fork_Deployment_StateIsCorrect() public {
+    assertEq(address(bridge.token()), USDT);
+    assertEq(address(bridge.sortedOracles()), SORTED_ORACLES);
+    assertEq(bridge.oracleRateFeedId(), USDT_ADAPTER);
+    assertEq(bridge.maxGas(), MAX_GAS);
+    assertEq(bridge.priceFactor(), 12_000);
+    assertEq(bridge.tokenPrecision(), 1e6); // USDT has 6 decimals
+    assertEq(bridge.owner(), deployer);
+    assertTrue(bridge.operators(operator));
+  }
+
+  function test_Fork_TokenMetadata() public {
+    IERC20Metadata usdt = IERC20Metadata(USDT);
+    assertEq(usdt.decimals(), 6);
+    console.log("USDT name:", usdt.name());
+    console.log("USDT symbol:", usdt.symbol());
+    console.log("USDT totalSupply:", usdt.totalSupply());
+  }
+
+  // =========================================================================
+  // Oracle integration
+  // =========================================================================
+
+  function test_Fork_OracleRateIsLive() public {
+    (uint256 numerator, uint256 denominator) = ISortedOracles(SORTED_ORACLES).medianRate(
+      USDT_ADAPTER
+    );
+
+    console.log("Oracle numerator:", numerator);
+    console.log("Oracle denominator:", denominator);
+
+    // Denominator should be 1e24 (FIXED1_UINT) if rates exist
+    assertGt(denominator, 0, "Oracle has no rate");
+
+    // Rate should be sensible: numerator/denominator is CELO price in USD
+    // CELO is somewhere between $0.01 and $100
+    uint256 celoInUsdScaled = (numerator * 1e18) / denominator; // scale to 18 decimals
+    console.log("CELO price in USD (1e18 scaled):", celoInUsdScaled);
+    assertGt(celoInUsdScaled, 0.001e18, "Rate too low"); // > $0.001
+    assertLt(celoInUsdScaled, 100e18, "Rate too high"); // < $100
+  }
+
+  // =========================================================================
+  // quoteSend() with real oracle
+  // =========================================================================
+
+  function test_Fork_QuoteSend_ReturnsRealisticTotal() public {
+    uint256 bridgeAmount = 100e6; // 100 USDT
+    uint256 nativeFee = 0.1 ether; // 0.1 CELO for LZ messaging
+
+    SendParam memory sendParam = _makeSendParam(bridgeAmount);
+    MessagingFee memory fee = MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
+
+    uint256 total = bridge.quoteSend(sendParam, fee);
+    uint256 feeInUsdt = total - bridgeAmount;
+
+    console.log("Bridge amount (USDT, 6 dec):", bridgeAmount);
+    console.log("LZ native fee (CELO wei):", nativeFee);
+    console.log("Fee in USDT (6 dec):", feeInUsdt);
+    console.log("Total USDT needed (6 dec):", total);
+    console.log("Fee in human USDT:", feeInUsdt, "/ 1e6");
+
+    // Fee should be positive and reasonable
+    assertGt(feeInUsdt, 0, "Fee should be > 0");
+    // 0.1 CELO at ~$0.09 = ~$0.009, with 1.2x ≈ $0.011 -> 11000 in 6-dec
+    // But CELO price could vary, so wide bounds
+    assertLt(feeInUsdt, bridgeAmount, "Fee should be less than bridge amount");
+  }
+
+  function test_Fork_QuoteSend_ScalesWithNativeFee() public {
+    uint256 bridgeAmount = 100e6;
+
+    uint256 total1 = bridge.quoteSend(
+      _makeSendParam(bridgeAmount),
+      MessagingFee({ nativeFee: 0.1 ether, lzTokenFee: 0 })
+    );
+    uint256 total2 = bridge.quoteSend(
+      _makeSendParam(bridgeAmount),
+      MessagingFee({ nativeFee: 1 ether, lzTokenFee: 0 })
+    );
+
+    uint256 fee1 = total1 - bridgeAmount;
+    uint256 fee2 = total2 - bridgeAmount;
+
+    // 10x native fee should give ~10x token fee (small rounding diff from integer division)
+    assertApproxEqRel(fee2, fee1 * 10, 0.001e18, "Fee should scale ~linearly with native fee");
+  }
+
+  // =========================================================================
+  // send() end-to-end with real oracle + mock OFT
+  // =========================================================================
+
+  function test_Fork_Send_EndToEnd() public {
+    uint256 bridgeAmount = 500e6; // 500 USDT
+    uint256 nativeFee = 0.05 ether; // 0.05 CELO
+
+    // Get expected fee first
+    SendParam memory sendParam = _makeSendParam(bridgeAmount);
+    MessagingFee memory fee = MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
+    uint256 expectedTotal = bridge.quoteSend(sendParam, fee);
+    uint256 expectedFeeInUsdt = expectedTotal - bridgeAmount;
+
+    console.log("=== send() E2E ===");
+    console.log("Bridge amount:", bridgeAmount);
+    console.log("Expected fee in USDT:", expectedFeeInUsdt);
+    console.log("Expected total:", expectedTotal);
+
+    uint256 userBalBefore = IERC20(USDT).balanceOf(user);
+    uint256 bridgeCeloBefore = address(bridge).balance;
+
+    vm.prank(user);
+    (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = bridge.send(
+      IOFT(address(mockOft)),
+      sendParam,
+      fee
+    );
+
+    // Verify user paid exactly bridgeAmount + fee
+    uint256 userPaid = userBalBefore - IERC20(USDT).balanceOf(user);
+    assertEq(userPaid, expectedTotal, "User should pay exact quoted total");
+
+    // Verify bridge CELO was spent
+    uint256 celoSpent = bridgeCeloBefore - address(bridge).balance;
+    assertEq(celoSpent, nativeFee, "Bridge should spend exact native fee");
+
+    // Verify OFT received the bridge amount
+    assertEq(IERC20(USDT).balanceOf(address(mockOft)), bridgeAmount, "OFT should receive bridge amount");
+
+    // Verify bridge collected the fee
+    assertEq(
+      IERC20(USDT).balanceOf(address(bridge)),
+      expectedFeeInUsdt,
+      "Bridge should collect fee in USDT"
+    );
+
+    // Verify receipts
+    assertEq(oftReceipt.amountSentLD, bridgeAmount);
+    assertGt(uint256(msgReceipt.nonce), 0);
+
+    console.log("User paid total:", userPaid);
+    console.log("CELO spent:", celoSpent);
+    console.log("Fee collected by bridge:", IERC20(USDT).balanceOf(address(bridge)));
+    console.log("SUCCESS: Full send() E2E passed");
+  }
+
+  function test_Fork_Send_MultipleSendsAccumulateFees() public {
+    uint256 bridgeAmount = 100e6;
+    uint256 nativeFee = 0.01 ether;
+    SendParam memory sendParam = _makeSendParam(bridgeAmount);
+    MessagingFee memory fee = MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
+
+    // Do 3 sends
+    for (uint256 i = 0; i < 3; i++) {
+      vm.prank(user);
+      bridge.send(IOFT(address(mockOft)), sendParam, fee);
+    }
+
+    // Bridge should have collected 3x fee
+    uint256 singleFee = bridge.quoteSend(sendParam, fee) - bridgeAmount;
+    assertEq(
+      IERC20(USDT).balanceOf(address(bridge)),
+      singleFee * 3,
+      "Fees should accumulate over multiple sends"
+    );
+  }
+
+  // =========================================================================
+  // Operator withdrawals (execute)
+  // =========================================================================
+
+  function test_Fork_Execute_WithdrawAccumulatedFees() public {
+    // First do a send to accumulate fees
+    uint256 bridgeAmount = 1000e6;
+    uint256 nativeFee = 0.1 ether;
+    vm.prank(user);
+    bridge.send(
+      IOFT(address(mockOft)),
+      _makeSendParam(bridgeAmount),
+      MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 })
+    );
+
+    uint256 feesCollected = IERC20(USDT).balanceOf(address(bridge));
+    assertGt(feesCollected, 0);
+
+    // Operator withdraws the accumulated USDT fees
+    address treasury = makeAddr("treasury");
+    bytes memory transferCall = abi.encodeWithSelector(
+      IERC20.transfer.selector,
+      treasury,
+      feesCollected
+    );
+
+    vm.prank(operator);
+    bridge.execute(USDT, 0, transferCall);
+
+    assertEq(IERC20(USDT).balanceOf(treasury), feesCollected);
+    assertEq(IERC20(USDT).balanceOf(address(bridge)), 0);
+
+    console.log("Operator withdrew USDT fees:", feesCollected);
+  }
+
+  function test_Fork_Execute_RefundCelo() public {
+    // Operator can withdraw excess CELO
+    address treasury = makeAddr("treasury");
+    uint256 bridgeCelo = address(bridge).balance;
+
+    vm.prank(operator);
+    bridge.execute(treasury, 1 ether, "");
+
+    assertEq(treasury.balance, 1 ether);
+    assertEq(address(bridge).balance, bridgeCelo - 1 ether);
+  }
+
+  // =========================================================================
+  // Edge cases on fork
+  // =========================================================================
+
+  function test_Fork_Revert_MaxGasExceeded() public {
+    vm.prank(user);
+    vm.expectRevert("Gas limit exceeded");
+    bridge.send(
+      IOFT(address(mockOft)),
+      _makeSendParam(100e6),
+      MessagingFee({ nativeFee: MAX_GAS + 1, lzTokenFee: 0 })
+    );
+  }
+
+  function test_Fork_Revert_InsufficientCeloBalance() public {
+    // Drain the bridge's CELO
+    vm.prank(deployer);
+    bridge.setMaxGas(200 ether);
+
+    vm.prank(operator);
+    bridge.execute(makeAddr("drain"), address(bridge).balance, "");
+
+    vm.prank(user);
+    vm.expectRevert("Insufficient CELO balance");
+    bridge.send(
+      IOFT(address(mockOft)),
+      _makeSendParam(100e6),
+      MessagingFee({ nativeFee: 1 ether, lzTokenFee: 0 })
+    );
+  }
+
+  function test_Fork_Revert_InsufficientTokenAllowance() public {
+    // User with no approval
+    address user2 = makeAddr("user2");
+    deal(USDT, user2, 10_000e6);
+
+    vm.prank(user2);
+    vm.expectRevert(); // SafeERC20 will revert on transferFrom
+    bridge.send(
+      IOFT(address(mockOft)),
+      _makeSendParam(100e6),
+      MessagingFee({ nativeFee: 0.01 ether, lzTokenFee: 0 })
+    );
+  }
+
+  // =========================================================================
+  // LZ endpoint verification (read-only)
+  // =========================================================================
+
+  function test_Fork_LZEndpointExists() public {
+    uint256 codeSize;
+    address endpoint = LZ_ENDPOINT_V2;
+    assembly {
+      codeSize := extcodesize(endpoint)
+    }
+    assertGt(codeSize, 0, "LZ EndpointV2 should have code on Celo mainnet");
+    console.log("LZ EndpointV2 code size:", codeSize);
+  }
+
+  // =========================================================================
+  // Helpers
+  // =========================================================================
+
+  function _makeSendParam(uint256 amount) internal pure returns (SendParam memory) {
+    return
+      SendParam({
+        dstEid: 30101, // Ethereum mainnet LZ eid
+        to: bytes32(uint256(uint160(address(0xBEEF)))),
+        amountLD: amount,
+        minAmountLD: amount,
+        extraOptions: "",
+        composeMsg: "",
+        oftCmd: ""
+      });
+  }
+}

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -191,6 +191,25 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
     vm.expectRevert("OFT not whitelisted");
     bridge.send(IOFT(address(rogue)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
   }
+
+  function test_Revert_Send_LzTokenFeeNotSupported() public {
+    vm.prank(user);
+    vm.expectRevert("LZ token fee not supported");
+    bridge.send(
+      IOFT(address(mockOft)),
+      _defaultSendParam(100e6),
+      MessagingFee({ nativeFee: 0.01 ether, lzTokenFee: 1 })
+    );
+  }
+
+  function test_Revert_Send_ZeroNumeratorOracle() public {
+    // Oracle returns numerator=0 denominator=1e24 (broken rate)
+    mockOracle.setMedianRate(oracleRateFeedId, 0, 1e24);
+
+    vm.prank(user);
+    vm.expectRevert("Oracle rate numerator is zero");
+    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+  }
 }
 
 // =============================================================================

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -182,14 +182,6 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
     bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
   }
 
-  function test_Revert_Send_StaleOracleRate() public {
-    mockOracle.setExpired(oracleRateFeedId, true);
-
-    vm.prank(user);
-    vm.expectRevert("Oracle rate is stale");
-    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
-  }
-
   function test_Revert_Send_OFTNotWhitelisted() public {
     MockOFT rogue = new MockOFT(address(token));
 

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -67,8 +67,9 @@ contract GasSponsoredOFTBridgeTestBase is Test {
     vm.prank(user);
     token.approve(address(bridge), type(uint256).max);
 
-    // Set up operator
+    // Set up operator and whitelist the mock OFT
     bridge.setOperator(operator, true);
+    bridge.setAllowedOFT(address(mockOft), true);
   }
 
   function _defaultSendParam(uint256 amount) internal pure returns (SendParam memory) {
@@ -173,6 +174,22 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
     vm.prank(user);
     vm.expectRevert("No oracle rate available");
     bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+  }
+
+  function test_Revert_Send_StaleOracleRate() public {
+    mockOracle.setExpired(oracleRateFeedId, true);
+
+    vm.prank(user);
+    vm.expectRevert("Oracle rate is stale");
+    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+  }
+
+  function test_Revert_Send_OFTNotWhitelisted() public {
+    MockOFT rogue = new MockOFT(address(token));
+
+    vm.prank(user);
+    vm.expectRevert("OFT not whitelisted");
+    bridge.send(IOFT(address(rogue)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
   }
 }
 
@@ -287,6 +304,21 @@ contract GasSponsoredOFTBridge_AccessControl is GasSponsoredOFTBridgeTestBase {
     vm.expectRevert("Feed ID is zero address");
     bridge.setOracleRateFeedId(address(0));
   }
+
+  function test_SetAllowedOFT() public {
+    address newOft = address(0x9999);
+    bridge.setAllowedOFT(newOft, true);
+    assertTrue(bridge.allowedOFTs(newOft));
+
+    bridge.setAllowedOFT(newOft, false);
+    assertFalse(bridge.allowedOFTs(newOft));
+  }
+
+  function test_Revert_SetAllowedOFT_NotOwner() public {
+    vm.prank(user);
+    vm.expectRevert("Ownable: caller is not the owner");
+    bridge.setAllowedOFT(address(0x9999), true);
+  }
 }
 
 // =============================================================================
@@ -315,11 +347,17 @@ contract GasSponsoredOFTBridge_Execute is GasSponsoredOFTBridgeTestBase {
     bridge.execute(address(0xBEEF), 0, "");
   }
 
+  function test_Revert_Execute_CannotCallSelf() public {
+    vm.prank(operator);
+    vm.expectRevert("Cannot call self");
+    bridge.execute(address(bridge), 0, abi.encodeWithSignature("setMaxGas(uint256)", 999));
+  }
+
   function test_Revert_Execute_CallFails() public {
-    // Call a contract that will revert
+    // Call an address that will revert
     vm.prank(operator);
     vm.expectRevert("Execute call failed");
-    bridge.execute(address(bridge), 0, abi.encodeWithSignature("nonExistentFunction()"));
+    bridge.execute(address(mockOft), 0, abi.encodeWithSignature("nonExistentFunction()"));
   }
 }
 

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -4,13 +4,7 @@ pragma solidity >=0.8.7 <0.8.20;
 import { Test } from "celo-foundry-8/Test.sol";
 
 import { GasSponsoredOFTBridge } from "@celo-contracts-8/common/GasSponsoredOFTBridge.sol";
-import {
-  IOFT,
-  SendParam,
-  MessagingFee,
-  MessagingReceipt,
-  OFTReceipt
-} from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
+import { IOFT, SendParam, MessagingFee, MessagingReceipt, OFTReceipt } from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
 import { ISortedOracles } from "@celo-contracts/stability/interfaces/ISortedOracles.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
 
@@ -57,7 +51,12 @@ contract GasSponsoredOFTBridgeTestBase is Test {
     mockOracle.setMedianRate(oracleRateFeedId, ORACLE_NUMERATOR, ORACLE_DENOMINATOR);
 
     // Deploy bridge
-    bridge = new GasSponsoredOFTBridge(token, ISortedOracles(address(mockOracle)), oracleRateFeedId, MAX_GAS);
+    bridge = new GasSponsoredOFTBridge(
+      token,
+      ISortedOracles(address(mockOracle)),
+      oracleRateFeedId,
+      MAX_GAS
+    );
 
     // Fund the bridge with CELO so it can sponsor gas
     vm.deal(address(bridge), 10 ether);
@@ -137,7 +136,14 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
       (ORACLE_DENOMINATOR * 1e18 * 10_000);
 
     vm.expectEmit(true, true, false, true);
-    emit LogSend(user, address(mockOft), bridgeAmount, nativeFee, expectedFee, bridgeAmount + expectedFee);
+    emit LogSend(
+      user,
+      address(mockOft),
+      bridgeAmount,
+      nativeFee,
+      expectedFee,
+      bridgeAmount + expectedFee
+    );
 
     vm.prank(user);
     bridge.send(IOFT(address(mockOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -6,6 +6,7 @@ import { Test } from "celo-foundry-8/Test.sol";
 import { GasSponsoredOFTBridge } from "@celo-contracts-8/common/GasSponsoredOFTBridge.sol";
 import { IOFT, SendParam, MessagingFee, MessagingReceipt, OFTReceipt } from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
 import { ISortedOracles } from "@celo-contracts/stability/interfaces/ISortedOracles.sol";
+import { IERC20 } from "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
 
 import { MockERC20 } from "./mocks/MockERC20.sol";
@@ -14,16 +15,18 @@ import { MockSortedOraclesForBridge } from "./mocks/MockSortedOraclesForBridge.s
 
 contract GasSponsoredOFTBridgeTestBase is Test {
   GasSponsoredOFTBridge public bridge;
-  MockERC20 public token;
-  MockOFT public mockOft;
+  MockERC20 public usdt;
+  MockERC20 public usdc;
+  MockOFT public usdtOft;
+  MockOFT public usdcOft;
   MockSortedOraclesForBridge public mockOracle;
 
   address public user = actor("user");
   address public operator = actor("operator");
-  address public oracleRateFeedId = address(0xFEED);
+  address public usdtRateFeedId = address(0xFEED1);
+  address public usdcRateFeedId = address(0xFEED2);
 
-  // 1 CELO = 0.50 USD  =>  medianRate returns (0.5e24, 1e24)
-  // i.e. 1 CELO buys 0.5 USDT
+  // 1 CELO = 0.50 USD => medianRate returns (0.5e24, 1e24)
   uint256 constant ORACLE_NUMERATOR = 0.5e24;
   uint256 constant ORACLE_DENOMINATOR = 1e24;
 
@@ -38,43 +41,50 @@ contract GasSponsoredOFTBridgeTestBase is Test {
     uint256 feeInToken,
     uint256 totalAmount
   );
-  event LogSetMaxGas(uint256 maxGas);
-  event LogSetPriceFactor(uint256 oldPriceFactor, uint256 newPriceFactor);
-  event LogOperatorChanged(address indexed operator, bool enabled);
-  event LogExecute(address indexed operator, address indexed target, uint256 value, bytes data);
+  event LogOFTConfigSet(
+    address indexed oft,
+    address indexed token,
+    address oracleRateFeedId,
+    uint256 tokenPrecision
+  );
+  event LogOFTConfigRemoved(address indexed oft);
 
   function setUp() public {
     // Deploy mocks
-    token = new MockERC20("Tether USD", "USDT", 6);
-    mockOft = new MockOFT(address(token));
+    usdt = new MockERC20("Tether USD", "USDT", 6);
+    usdc = new MockERC20("USD Coin", "USDC", 6);
+    usdtOft = new MockOFT(address(usdt));
+    usdcOft = new MockOFT(address(usdc));
     mockOracle = new MockSortedOraclesForBridge();
-    mockOracle.setMedianRate(oracleRateFeedId, ORACLE_NUMERATOR, ORACLE_DENOMINATOR);
+    mockOracle.setMedianRate(usdtRateFeedId, ORACLE_NUMERATOR, ORACLE_DENOMINATOR);
+    mockOracle.setMedianRate(usdcRateFeedId, ORACLE_NUMERATOR, ORACLE_DENOMINATOR);
 
-    // Deploy bridge
-    bridge = new GasSponsoredOFTBridge(
-      token,
-      ISortedOracles(address(mockOracle)),
-      oracleRateFeedId,
-      MAX_GAS
-    );
+    // Deploy bridge (multi-token: no token in constructor)
+    bridge = new GasSponsoredOFTBridge(ISortedOracles(address(mockOracle)), MAX_GAS);
 
-    // Fund the bridge with CELO so it can sponsor gas
+    // Register OFTs
+    bridge.setOFTConfig(address(usdtOft), usdt, usdtRateFeedId);
+    bridge.setOFTConfig(address(usdcOft), usdc, usdcRateFeedId);
+
+    // Fund the bridge with CELO
     vm.deal(address(bridge), 10 ether);
 
     // Give user tokens and approve bridge
-    token.mint(user, 1_000_000e6); // 1M USDT
-    vm.prank(user);
-    token.approve(address(bridge), type(uint256).max);
+    usdt.mint(user, 1_000_000e6);
+    usdc.mint(user, 1_000_000e6);
+    vm.startPrank(user);
+    usdt.approve(address(bridge), type(uint256).max);
+    usdc.approve(address(bridge), type(uint256).max);
+    vm.stopPrank();
 
-    // Set up operator and whitelist the mock OFT
+    // Set up operator
     bridge.setOperator(operator, true);
-    bridge.setAllowedOFT(address(mockOft), true);
   }
 
   function _defaultSendParam(uint256 amount) internal pure returns (SendParam memory) {
     return
       SendParam({
-        dstEid: 30101, // Ethereum mainnet EID
+        dstEid: 30101,
         to: bytes32(uint256(uint160(address(0xBEEF)))),
         amountLD: amount,
         minAmountLD: amount,
@@ -90,43 +100,55 @@ contract GasSponsoredOFTBridgeTestBase is Test {
 }
 
 // =============================================================================
-// send()
+// send() with multi-token
 // =============================================================================
 
 contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
-  function test_Send_HappyPath() public {
-    uint256 bridgeAmount = 100e6; // 100 USDT
-    uint256 nativeFee = 0.01 ether; // 0.01 CELO for LZ fee
-
-    // Expected fee in USDT:
-    // 0.01 CELO * (0.5e24 / 1e24) * (1e6 / 1e18) * (12000 / 10000)
-    // = 0.01 * 0.5 * 1e-12 * 1.2 (but in 6-decimal token)
-    // = 0.01e18 * 0.5e24 * 1e6 * 12000 / (1e24 * 1e18 * 10000)
-    // = 6000 (= 0.006 USDT)
+  function test_Send_USDT_HappyPath() public {
+    uint256 bridgeAmount = 100e6;
+    uint256 nativeFee = 0.01 ether;
     uint256 expectedFee = (0.01e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
       (ORACLE_DENOMINATOR * 1e18 * 10_000);
 
-    uint256 userBalanceBefore = token.balanceOf(user);
-    uint256 bridgeCeloBefore = address(bridge).balance;
+    uint256 userBalanceBefore = usdt.balanceOf(user);
 
     vm.prank(user);
-    (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = bridge.send(
-      IOFT(address(mockOft)),
-      _defaultSendParam(bridgeAmount),
-      _defaultFee(nativeFee)
-    );
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
 
-    // User paid bridgeAmount + fee
-    assertEq(token.balanceOf(user), userBalanceBefore - bridgeAmount - expectedFee);
-    // Bridge spent CELO
-    assertEq(address(bridge).balance, bridgeCeloBefore - nativeFee);
-    // OFT received the bridge amount
-    assertEq(token.balanceOf(address(mockOft)), bridgeAmount);
-    // Bridge collected the fee
-    assertEq(token.balanceOf(address(bridge)), expectedFee);
-    // Receipts are populated
-    assertEq(oftReceipt.amountSentLD, bridgeAmount);
-    assertEq(msgReceipt.nonce, 1);
+    assertEq(usdt.balanceOf(user), userBalanceBefore - bridgeAmount - expectedFee);
+    assertEq(usdt.balanceOf(address(usdtOft)), bridgeAmount);
+    assertEq(usdt.balanceOf(address(bridge)), expectedFee);
+  }
+
+  function test_Send_USDC_HappyPath() public {
+    uint256 bridgeAmount = 200e6;
+    uint256 nativeFee = 0.02 ether;
+    uint256 expectedFee = (0.02e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
+      (ORACLE_DENOMINATOR * 1e18 * 10_000);
+
+    uint256 userBalanceBefore = usdc.balanceOf(user);
+
+    vm.prank(user);
+    bridge.send(IOFT(address(usdcOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+
+    assertEq(usdc.balanceOf(user), userBalanceBefore - bridgeAmount - expectedFee);
+    assertEq(usdc.balanceOf(address(usdcOft)), bridgeAmount);
+    assertEq(usdc.balanceOf(address(bridge)), expectedFee);
+  }
+
+  function test_Send_BothTokensIndependently() public {
+    vm.prank(user);
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(50e6), _defaultFee(0.01 ether));
+
+    vm.prank(user);
+    bridge.send(IOFT(address(usdcOft)), _defaultSendParam(75e6), _defaultFee(0.01 ether));
+
+    // Each OFT got its bridge amount
+    assertEq(usdt.balanceOf(address(usdtOft)), 50e6);
+    assertEq(usdc.balanceOf(address(usdcOft)), 75e6);
+    // Bridge collected fees in both tokens
+    assertGt(usdt.balanceOf(address(bridge)), 0);
+    assertGt(usdc.balanceOf(address(bridge)), 0);
   }
 
   function test_Send_EmitsLogSend() public {
@@ -138,7 +160,7 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
     vm.expectEmit(true, true, false, true);
     emit LogSend(
       user,
-      address(mockOft),
+      address(usdtOft),
       bridgeAmount,
       nativeFee,
       expectedFee,
@@ -146,67 +168,58 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
     );
 
     vm.prank(user);
-    bridge.send(IOFT(address(mockOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+  }
+
+  function test_Revert_Send_OFTNotRegistered() public {
+    MockOFT rogue = new MockOFT(address(usdt));
+
+    vm.prank(user);
+    vm.expectRevert("OFT not registered");
+    bridge.send(IOFT(address(rogue)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
   }
 
   function test_Revert_Send_GasLimitExceeded() public {
     vm.prank(user);
     vm.expectRevert("Gas limit exceeded");
-    bridge.send(
-      IOFT(address(mockOft)),
-      _defaultSendParam(100e6),
-      _defaultFee(MAX_GAS + 1) // exceeds limit
-    );
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(100e6), _defaultFee(MAX_GAS + 1));
   }
 
   function test_Revert_Send_InsufficientCeloBalance() public {
-    // Drain the bridge's CELO
     vm.prank(address(bridge));
     (bool ok, ) = address(0xdead).call{ value: address(bridge).balance }("");
     require(ok);
-
-    // Increase maxGas so it won't revert on that check
     bridge.setMaxGas(2 ether);
 
     vm.prank(user);
     vm.expectRevert("Insufficient CELO balance");
-    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(1 ether));
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(100e6), _defaultFee(1 ether));
   }
 
   function test_Revert_Send_NoOracleRate() public {
-    // Set oracle to return 0 denominator (no rate)
-    mockOracle.setMedianRate(oracleRateFeedId, 0, 0);
+    mockOracle.setMedianRate(usdtRateFeedId, 0, 0);
 
     vm.prank(user);
     vm.expectRevert("No oracle rate available");
-    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
   }
 
-  function test_Revert_Send_OFTNotWhitelisted() public {
-    MockOFT rogue = new MockOFT(address(token));
+  function test_Revert_Send_ZeroNumeratorOracle() public {
+    mockOracle.setMedianRate(usdtRateFeedId, 0, 1e24);
 
     vm.prank(user);
-    vm.expectRevert("OFT not whitelisted");
-    bridge.send(IOFT(address(rogue)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+    vm.expectRevert("Oracle rate numerator is zero");
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
   }
 
   function test_Revert_Send_LzTokenFeeNotSupported() public {
     vm.prank(user);
     vm.expectRevert("LZ token fee not supported");
     bridge.send(
-      IOFT(address(mockOft)),
+      IOFT(address(usdtOft)),
       _defaultSendParam(100e6),
       MessagingFee({ nativeFee: 0.01 ether, lzTokenFee: 1 })
     );
-  }
-
-  function test_Revert_Send_ZeroNumeratorOracle() public {
-    // Oracle returns numerator=0 denominator=1e24 (broken rate)
-    mockOracle.setMedianRate(oracleRateFeedId, 0, 1e24);
-
-    vm.prank(user);
-    vm.expectRevert("Oracle rate numerator is zero");
-    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
   }
 }
 
@@ -218,18 +231,128 @@ contract GasSponsoredOFTBridge_QuoteSend is GasSponsoredOFTBridgeTestBase {
   function test_QuoteSend_ReturnsCorrectTotal() public {
     uint256 bridgeAmount = 200e6;
     uint256 nativeFee = 0.05 ether;
-
     uint256 expectedFee = (0.05e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
       (ORACLE_DENOMINATOR * 1e18 * 10_000);
 
-    uint256 total = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+    uint256 total = bridge.quoteSend(
+      IOFT(address(usdtOft)),
+      _defaultSendParam(bridgeAmount),
+      _defaultFee(nativeFee)
+    );
     assertEq(total, bridgeAmount + expectedFee);
   }
 
   function test_QuoteSend_ZeroNativeFee() public {
-    uint256 bridgeAmount = 100e6;
-    uint256 total = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(0));
-    assertEq(total, bridgeAmount);
+    uint256 total = bridge.quoteSend(
+      IOFT(address(usdtOft)),
+      _defaultSendParam(100e6),
+      _defaultFee(0)
+    );
+    assertEq(total, 100e6);
+  }
+
+  function test_QuoteSend_DifferentTokens_DifferentRates() public {
+    // Set different rates for USDT and USDC
+    mockOracle.setMedianRate(usdtRateFeedId, 0.5e24, 1e24); // 1 CELO = 0.5 USDT
+    mockOracle.setMedianRate(usdcRateFeedId, 1e24, 1e24); // 1 CELO = 1.0 USDC
+
+    uint256 usdtTotal = bridge.quoteSend(
+      IOFT(address(usdtOft)),
+      _defaultSendParam(100e6),
+      _defaultFee(0.1 ether)
+    );
+    uint256 usdcTotal = bridge.quoteSend(
+      IOFT(address(usdcOft)),
+      _defaultSendParam(100e6),
+      _defaultFee(0.1 ether)
+    );
+
+    uint256 usdtFee = usdtTotal - 100e6;
+    uint256 usdcFee = usdcTotal - 100e6;
+    // USDC fee should be 2x USDT fee (1.0 vs 0.5 rate)
+    assertEq(usdcFee, usdtFee * 2);
+  }
+
+  function test_Revert_QuoteSend_UnregisteredOFT() public {
+    MockOFT rogue = new MockOFT(address(usdt));
+    vm.expectRevert("OFT not registered");
+    bridge.quoteSend(IOFT(address(rogue)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+  }
+}
+
+// =============================================================================
+// OFT config management
+// =============================================================================
+
+contract GasSponsoredOFTBridge_OFTConfig is GasSponsoredOFTBridgeTestBase {
+  function test_SetOFTConfig_StoresCorrectly() public {
+    (IERC20 token, address feedId, uint256 precision) = bridge.oftConfigs(address(usdtOft));
+    assertEq(address(token), address(usdt));
+    assertEq(feedId, usdtRateFeedId);
+    assertEq(precision, 1e6);
+  }
+
+  function test_SetOFTConfig_EmitsEvent() public {
+    MockERC20 newToken = new MockERC20("DAI", "DAI", 18);
+    MockOFT newOft = new MockOFT(address(newToken));
+
+    vm.expectEmit(true, true, false, true);
+    emit LogOFTConfigSet(address(newOft), address(newToken), address(0xFEED3), 1e18);
+
+    bridge.setOFTConfig(address(newOft), newToken, address(0xFEED3));
+  }
+
+  function test_SetOFTConfig_18DecimalToken() public {
+    MockERC20 dai = new MockERC20("DAI", "DAI", 18);
+    MockOFT daiOft = new MockOFT(address(dai));
+    bridge.setOFTConfig(address(daiOft), dai, address(0xFEED3));
+
+    (, , uint256 precision) = bridge.oftConfigs(address(daiOft));
+    assertEq(precision, 1e18);
+  }
+
+  function test_RemoveOFTConfig() public {
+    bridge.removeOFTConfig(address(usdtOft));
+
+    (IERC20 token, , ) = bridge.oftConfigs(address(usdtOft));
+    assertEq(address(token), address(0));
+
+    // Sending should now fail
+    vm.prank(user);
+    vm.expectRevert("OFT not registered");
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+  }
+
+  function test_RemoveOFTConfig_EmitsEvent() public {
+    vm.expectEmit(true, false, false, false);
+    emit LogOFTConfigRemoved(address(usdtOft));
+    bridge.removeOFTConfig(address(usdtOft));
+  }
+
+  function test_Revert_RemoveOFTConfig_NotRegistered() public {
+    vm.expectRevert("OFT not registered");
+    bridge.removeOFTConfig(address(0x1234));
+  }
+
+  function test_Revert_SetOFTConfig_ZeroOFT() public {
+    vm.expectRevert("OFT is zero address");
+    bridge.setOFTConfig(address(0), usdt, usdtRateFeedId);
+  }
+
+  function test_Revert_SetOFTConfig_ZeroToken() public {
+    vm.expectRevert("Token is zero address");
+    bridge.setOFTConfig(address(0x1234), IERC20Metadata(address(0)), usdtRateFeedId);
+  }
+
+  function test_Revert_SetOFTConfig_ZeroFeedId() public {
+    vm.expectRevert("Feed ID is zero address");
+    bridge.setOFTConfig(address(0x1234), usdt, address(0));
+  }
+
+  function test_Revert_SetOFTConfig_NotOwner() public {
+    vm.prank(user);
+    vm.expectRevert("Ownable: caller is not the owner");
+    bridge.setOFTConfig(address(0x1234), usdt, usdtRateFeedId);
   }
 }
 
@@ -242,19 +365,24 @@ contract GasSponsoredOFTBridge_PriceFactor is GasSponsoredOFTBridgeTestBase {
     uint256 nativeFee = 0.01 ether;
     uint256 bridgeAmount = 100e6;
 
-    // Get fee at default 1.2x
-    uint256 total1 = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+    uint256 total1 = bridge.quoteSend(
+      IOFT(address(usdtOft)),
+      _defaultSendParam(bridgeAmount),
+      _defaultFee(nativeFee)
+    );
 
-    // Change to 2.0x
-    bridge.setPriceFactor(20_000);
-    uint256 total2 = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+    bridge.setPriceFactor(20_000); // 2.0x
 
-    // Fee portion at 2.0x should be larger than at 1.2x
+    uint256 total2 = bridge.quoteSend(
+      IOFT(address(usdtOft)),
+      _defaultSendParam(bridgeAmount),
+      _defaultFee(nativeFee)
+    );
+
     uint256 fee1 = total1 - bridgeAmount;
     uint256 fee2 = total2 - bridgeAmount;
     assertGt(fee2, fee1);
-    // 2.0x / 1.2x = 5/3
-    assertEq(fee2 * 3, fee1 * 5);
+    assertEq(fee2 * 3, fee1 * 5); // 2.0/1.2 = 5/3
   }
 
   function test_Revert_SetPriceFactor_Zero() public {
@@ -294,12 +422,6 @@ contract GasSponsoredOFTBridge_AccessControl is GasSponsoredOFTBridgeTestBase {
     assertFalse(bridge.operators(newOp));
   }
 
-  function test_Revert_SetOperator_NotOwner() public {
-    vm.prank(user);
-    vm.expectRevert("Ownable: caller is not the owner");
-    bridge.setOperator(address(0x1234), true);
-  }
-
   function test_SetSortedOracles() public {
     MockSortedOraclesForBridge newOracle = new MockSortedOraclesForBridge();
     bridge.setSortedOracles(ISortedOracles(address(newOracle)));
@@ -309,32 +431,6 @@ contract GasSponsoredOFTBridge_AccessControl is GasSponsoredOFTBridgeTestBase {
   function test_Revert_SetSortedOracles_ZeroAddress() public {
     vm.expectRevert("Oracle is zero address");
     bridge.setSortedOracles(ISortedOracles(address(0)));
-  }
-
-  function test_SetOracleRateFeedId() public {
-    address newFeed = address(0xABCD);
-    bridge.setOracleRateFeedId(newFeed);
-    assertEq(bridge.oracleRateFeedId(), newFeed);
-  }
-
-  function test_Revert_SetOracleRateFeedId_ZeroAddress() public {
-    vm.expectRevert("Feed ID is zero address");
-    bridge.setOracleRateFeedId(address(0));
-  }
-
-  function test_SetAllowedOFT() public {
-    address newOft = address(0x9999);
-    bridge.setAllowedOFT(newOft, true);
-    assertTrue(bridge.allowedOFTs(newOft));
-
-    bridge.setAllowedOFT(newOft, false);
-    assertFalse(bridge.allowedOFTs(newOft));
-  }
-
-  function test_Revert_SetAllowedOFT_NotOwner() public {
-    vm.prank(user);
-    vm.expectRevert("Ownable: caller is not the owner");
-    bridge.setAllowedOFT(address(0x9999), true);
   }
 }
 
@@ -371,39 +467,27 @@ contract GasSponsoredOFTBridge_Execute is GasSponsoredOFTBridgeTestBase {
   }
 
   function test_Revert_Execute_CallFails() public {
-    // Call an address that will revert
     vm.prank(operator);
     vm.expectRevert("Execute call failed");
-    bridge.execute(address(mockOft), 0, abi.encodeWithSignature("nonExistentFunction()"));
+    bridge.execute(address(usdtOft), 0, abi.encodeWithSignature("nonExistentFunction()"));
   }
 }
 
 // =============================================================================
-// Constructor validation
+// Constructor
 // =============================================================================
 
 contract GasSponsoredOFTBridge_Constructor is Test {
-  function test_Revert_Constructor_ZeroToken() public {
-    MockSortedOraclesForBridge oracle = new MockSortedOraclesForBridge();
-    vm.expectRevert("Token is zero address");
-    new GasSponsoredOFTBridge(
-      IERC20Metadata(address(0)),
-      ISortedOracles(address(oracle)),
-      address(0xFEED),
-      1 ether
-    );
-  }
-
   function test_Revert_Constructor_ZeroOracle() public {
-    MockERC20 tok = new MockERC20("T", "T", 6);
     vm.expectRevert("Oracle is zero address");
-    new GasSponsoredOFTBridge(tok, ISortedOracles(address(0)), address(0xFEED), 1 ether);
+    new GasSponsoredOFTBridge(ISortedOracles(address(0)), 1 ether);
   }
 
-  function test_Revert_Constructor_ZeroFeedId() public {
-    MockERC20 tok = new MockERC20("T", "T", 6);
+  function test_Constructor_SetsDefaults() public {
     MockSortedOraclesForBridge oracle = new MockSortedOraclesForBridge();
-    vm.expectRevert("Feed ID is zero address");
-    new GasSponsoredOFTBridge(tok, ISortedOracles(address(oracle)), address(0), 1 ether);
+    GasSponsoredOFTBridge b = new GasSponsoredOFTBridge(ISortedOracles(address(oracle)), 5 ether);
+    assertEq(b.maxGas(), 5 ether);
+    assertEq(b.priceFactor(), 12_000);
+    assertEq(address(b.sortedOracles()), address(oracle));
   }
 }

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.7 <0.8.20;
+
+import { Test } from "celo-foundry-8/Test.sol";
+
+import { GasSponsoredOFTBridge } from "@celo-contracts-8/common/GasSponsoredOFTBridge.sol";
+import {
+  IOFT,
+  SendParam,
+  MessagingFee,
+  MessagingReceipt,
+  OFTReceipt
+} from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
+import { ISortedOracles } from "@celo-contracts/stability/interfaces/ISortedOracles.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { MockERC20 } from "./mocks/MockERC20.sol";
+import { MockOFT } from "./mocks/MockOFT.sol";
+import { MockSortedOraclesForBridge } from "./mocks/MockSortedOraclesForBridge.sol";
+
+contract GasSponsoredOFTBridgeTestBase is Test {
+  GasSponsoredOFTBridge public bridge;
+  MockERC20 public token;
+  MockOFT public mockOft;
+  MockSortedOraclesForBridge public mockOracle;
+
+  address public user = actor("user");
+  address public operator = actor("operator");
+  address public oracleRateFeedId = address(0xFEED);
+
+  // 1 CELO = 0.50 USD  =>  medianRate returns (0.5e24, 1e24)
+  // i.e. 1 CELO buys 0.5 USDT
+  uint256 constant ORACLE_NUMERATOR = 0.5e24;
+  uint256 constant ORACLE_DENOMINATOR = 1e24;
+
+  uint256 constant MAX_GAS = 1 ether;
+  uint256 constant DEFAULT_PRICE_FACTOR = 12_000; // 1.2x
+
+  event LogSend(
+    address indexed sender,
+    address indexed oft,
+    uint256 amountLD,
+    uint256 nativeFee,
+    uint256 feeInToken,
+    uint256 totalAmount
+  );
+  event LogSetMaxGas(uint256 maxGas);
+  event LogSetPriceFactor(uint256 oldPriceFactor, uint256 newPriceFactor);
+  event LogOperatorChanged(address indexed operator, bool enabled);
+  event LogExecute(address indexed operator, address indexed target, uint256 value, bytes data);
+
+  function setUp() public {
+    // Deploy mocks
+    token = new MockERC20("Tether USD", "USDT", 6);
+    mockOft = new MockOFT(address(token));
+    mockOracle = new MockSortedOraclesForBridge();
+    mockOracle.setMedianRate(oracleRateFeedId, ORACLE_NUMERATOR, ORACLE_DENOMINATOR);
+
+    // Deploy bridge
+    bridge = new GasSponsoredOFTBridge(token, ISortedOracles(address(mockOracle)), oracleRateFeedId, MAX_GAS);
+
+    // Fund the bridge with CELO so it can sponsor gas
+    vm.deal(address(bridge), 10 ether);
+
+    // Give user tokens and approve bridge
+    token.mint(user, 1_000_000e6); // 1M USDT
+    vm.prank(user);
+    token.approve(address(bridge), type(uint256).max);
+
+    // Set up operator
+    bridge.setOperator(operator, true);
+  }
+
+  function _defaultSendParam(uint256 amount) internal pure returns (SendParam memory) {
+    return
+      SendParam({
+        dstEid: 30101, // Ethereum mainnet EID
+        to: bytes32(uint256(uint160(address(0xBEEF)))),
+        amountLD: amount,
+        minAmountLD: amount,
+        extraOptions: "",
+        composeMsg: "",
+        oftCmd: ""
+      });
+  }
+
+  function _defaultFee(uint256 nativeFee) internal pure returns (MessagingFee memory) {
+    return MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
+  }
+}
+
+// =============================================================================
+// send()
+// =============================================================================
+
+contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
+  function test_Send_HappyPath() public {
+    uint256 bridgeAmount = 100e6; // 100 USDT
+    uint256 nativeFee = 0.01 ether; // 0.01 CELO for LZ fee
+
+    // Expected fee in USDT:
+    // 0.01 CELO * (0.5e24 / 1e24) * (1e6 / 1e18) * (12000 / 10000)
+    // = 0.01 * 0.5 * 1e-12 * 1.2 (but in 6-decimal token)
+    // = 0.01e18 * 0.5e24 * 1e6 * 12000 / (1e24 * 1e18 * 10000)
+    // = 6000 (= 0.006 USDT)
+    uint256 expectedFee = (0.01e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
+      (ORACLE_DENOMINATOR * 1e18 * 10_000);
+
+    uint256 userBalanceBefore = token.balanceOf(user);
+    uint256 bridgeCeloBefore = address(bridge).balance;
+
+    vm.prank(user);
+    (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = bridge.send(
+      IOFT(address(mockOft)),
+      _defaultSendParam(bridgeAmount),
+      _defaultFee(nativeFee)
+    );
+
+    // User paid bridgeAmount + fee
+    assertEq(token.balanceOf(user), userBalanceBefore - bridgeAmount - expectedFee);
+    // Bridge spent CELO
+    assertEq(address(bridge).balance, bridgeCeloBefore - nativeFee);
+    // OFT received the bridge amount
+    assertEq(token.balanceOf(address(mockOft)), bridgeAmount);
+    // Bridge collected the fee
+    assertEq(token.balanceOf(address(bridge)), expectedFee);
+    // Receipts are populated
+    assertEq(oftReceipt.amountSentLD, bridgeAmount);
+    assertEq(msgReceipt.nonce, 1);
+  }
+
+  function test_Send_EmitsLogSend() public {
+    uint256 bridgeAmount = 50e6;
+    uint256 nativeFee = 0.02 ether;
+    uint256 expectedFee = (0.02e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
+      (ORACLE_DENOMINATOR * 1e18 * 10_000);
+
+    vm.expectEmit(true, true, false, true);
+    emit LogSend(user, address(mockOft), bridgeAmount, nativeFee, expectedFee, bridgeAmount + expectedFee);
+
+    vm.prank(user);
+    bridge.send(IOFT(address(mockOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+  }
+
+  function test_Revert_Send_GasLimitExceeded() public {
+    vm.prank(user);
+    vm.expectRevert("Gas limit exceeded");
+    bridge.send(
+      IOFT(address(mockOft)),
+      _defaultSendParam(100e6),
+      _defaultFee(MAX_GAS + 1) // exceeds limit
+    );
+  }
+
+  function test_Revert_Send_InsufficientCeloBalance() public {
+    // Drain the bridge's CELO
+    vm.prank(address(bridge));
+    (bool ok, ) = address(0xdead).call{ value: address(bridge).balance }("");
+    require(ok);
+
+    // Increase maxGas so it won't revert on that check
+    bridge.setMaxGas(2 ether);
+
+    vm.prank(user);
+    vm.expectRevert("Insufficient CELO balance");
+    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(1 ether));
+  }
+
+  function test_Revert_Send_NoOracleRate() public {
+    // Set oracle to return 0 denominator (no rate)
+    mockOracle.setMedianRate(oracleRateFeedId, 0, 0);
+
+    vm.prank(user);
+    vm.expectRevert("No oracle rate available");
+    bridge.send(IOFT(address(mockOft)), _defaultSendParam(100e6), _defaultFee(0.01 ether));
+  }
+}
+
+// =============================================================================
+// quoteSend()
+// =============================================================================
+
+contract GasSponsoredOFTBridge_QuoteSend is GasSponsoredOFTBridgeTestBase {
+  function test_QuoteSend_ReturnsCorrectTotal() public {
+    uint256 bridgeAmount = 200e6;
+    uint256 nativeFee = 0.05 ether;
+
+    uint256 expectedFee = (0.05e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
+      (ORACLE_DENOMINATOR * 1e18 * 10_000);
+
+    uint256 total = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+    assertEq(total, bridgeAmount + expectedFee);
+  }
+
+  function test_QuoteSend_ZeroNativeFee() public {
+    uint256 bridgeAmount = 100e6;
+    uint256 total = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(0));
+    assertEq(total, bridgeAmount);
+  }
+}
+
+// =============================================================================
+// Price factor
+// =============================================================================
+
+contract GasSponsoredOFTBridge_PriceFactor is GasSponsoredOFTBridgeTestBase {
+  function test_PriceFactor_AffectsFee() public {
+    uint256 nativeFee = 0.01 ether;
+    uint256 bridgeAmount = 100e6;
+
+    // Get fee at default 1.2x
+    uint256 total1 = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+
+    // Change to 2.0x
+    bridge.setPriceFactor(20_000);
+    uint256 total2 = bridge.quoteSend(_defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+
+    // Fee portion at 2.0x should be larger than at 1.2x
+    uint256 fee1 = total1 - bridgeAmount;
+    uint256 fee2 = total2 - bridgeAmount;
+    assertGt(fee2, fee1);
+    // 2.0x / 1.2x = 5/3
+    assertEq(fee2 * 3, fee1 * 5);
+  }
+
+  function test_Revert_SetPriceFactor_Zero() public {
+    vm.expectRevert("Price factor must be > 0");
+    bridge.setPriceFactor(0);
+  }
+
+  function test_Revert_SetPriceFactor_NotOwner() public {
+    vm.prank(user);
+    vm.expectRevert("Ownable: caller is not the owner");
+    bridge.setPriceFactor(15_000);
+  }
+}
+
+// =============================================================================
+// Access control
+// =============================================================================
+
+contract GasSponsoredOFTBridge_AccessControl is GasSponsoredOFTBridgeTestBase {
+  function test_SetMaxGas_OnlyOwner() public {
+    bridge.setMaxGas(5 ether);
+    assertEq(bridge.maxGas(), 5 ether);
+  }
+
+  function test_Revert_SetMaxGas_NotOwner() public {
+    vm.prank(user);
+    vm.expectRevert("Ownable: caller is not the owner");
+    bridge.setMaxGas(5 ether);
+  }
+
+  function test_SetOperator() public {
+    address newOp = address(0x1234);
+    bridge.setOperator(newOp, true);
+    assertTrue(bridge.operators(newOp));
+
+    bridge.setOperator(newOp, false);
+    assertFalse(bridge.operators(newOp));
+  }
+
+  function test_Revert_SetOperator_NotOwner() public {
+    vm.prank(user);
+    vm.expectRevert("Ownable: caller is not the owner");
+    bridge.setOperator(address(0x1234), true);
+  }
+
+  function test_SetSortedOracles() public {
+    MockSortedOraclesForBridge newOracle = new MockSortedOraclesForBridge();
+    bridge.setSortedOracles(ISortedOracles(address(newOracle)));
+    assertEq(address(bridge.sortedOracles()), address(newOracle));
+  }
+
+  function test_Revert_SetSortedOracles_ZeroAddress() public {
+    vm.expectRevert("Oracle is zero address");
+    bridge.setSortedOracles(ISortedOracles(address(0)));
+  }
+
+  function test_SetOracleRateFeedId() public {
+    address newFeed = address(0xABCD);
+    bridge.setOracleRateFeedId(newFeed);
+    assertEq(bridge.oracleRateFeedId(), newFeed);
+  }
+
+  function test_Revert_SetOracleRateFeedId_ZeroAddress() public {
+    vm.expectRevert("Feed ID is zero address");
+    bridge.setOracleRateFeedId(address(0));
+  }
+}
+
+// =============================================================================
+// execute()
+// =============================================================================
+
+contract GasSponsoredOFTBridge_Execute is GasSponsoredOFTBridgeTestBase {
+  function test_Execute_OperatorCanCall() public {
+    address target = address(0xBEEF);
+    vm.deal(address(bridge), 1 ether);
+
+    vm.prank(operator);
+    bridge.execute(target, 0.1 ether, "");
+
+    assertEq(target.balance, 0.1 ether);
+  }
+
+  function test_Execute_OwnerCanCall() public {
+    address target = address(0xBEEF);
+    bridge.execute(target, 0, "");
+  }
+
+  function test_Revert_Execute_NotOperator() public {
+    vm.prank(user);
+    vm.expectRevert("Not operator or owner");
+    bridge.execute(address(0xBEEF), 0, "");
+  }
+
+  function test_Revert_Execute_CallFails() public {
+    // Call a contract that will revert
+    vm.prank(operator);
+    vm.expectRevert("Execute call failed");
+    bridge.execute(address(bridge), 0, abi.encodeWithSignature("nonExistentFunction()"));
+  }
+}
+
+// =============================================================================
+// Constructor validation
+// =============================================================================
+
+contract GasSponsoredOFTBridge_Constructor is Test {
+  function test_Revert_Constructor_ZeroToken() public {
+    MockSortedOraclesForBridge oracle = new MockSortedOraclesForBridge();
+    vm.expectRevert("Token is zero address");
+    new GasSponsoredOFTBridge(
+      IERC20Metadata(address(0)),
+      ISortedOracles(address(oracle)),
+      address(0xFEED),
+      1 ether
+    );
+  }
+
+  function test_Revert_Constructor_ZeroOracle() public {
+    MockERC20 tok = new MockERC20("T", "T", 6);
+    vm.expectRevert("Oracle is zero address");
+    new GasSponsoredOFTBridge(tok, ISortedOracles(address(0)), address(0xFEED), 1 ether);
+  }
+
+  function test_Revert_Constructor_ZeroFeedId() public {
+    MockERC20 tok = new MockERC20("T", "T", 6);
+    MockSortedOraclesForBridge oracle = new MockSortedOraclesForBridge();
+    vm.expectRevert("Feed ID is zero address");
+    new GasSponsoredOFTBridge(tok, ISortedOracles(address(oracle)), address(0), 1 ether);
+  }
+}

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -203,7 +203,14 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
     usdtOft.setDust(dust);
 
     vm.expectEmit(true, true, false, true);
-    emit LogSend(user, address(usdtOft), amountSent, nativeFee, expectedFee, amountSent + expectedFee);
+    emit LogSend(
+      user,
+      address(usdtOft),
+      amountSent,
+      nativeFee,
+      expectedFee,
+      amountSent + expectedFee
+    );
 
     vm.prank(user);
     bridge.send(IOFT(address(usdtOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));

--- a/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
+++ b/packages/protocol/test-sol/unit/common/GasSponsoredOFTBridge.t.sol
@@ -171,6 +171,44 @@ contract GasSponsoredOFTBridge_Send is GasSponsoredOFTBridgeTestBase {
     bridge.send(IOFT(address(usdtOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
   }
 
+  function test_Send_RefundsOFTDustToUser() public {
+    uint256 bridgeAmount = 100e6;
+    uint256 dust = 7; // shared-decimal normalization remainder
+    uint256 nativeFee = 0.01 ether;
+    uint256 expectedFee = (0.01e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
+      (ORACLE_DENOMINATOR * 1e18 * 10_000);
+
+    usdtOft.setDust(dust);
+    uint256 userBalanceBefore = usdt.balanceOf(user);
+
+    vm.prank(user);
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+
+    // User is charged only the bridged amount (amountLD - dust) plus the fee; dust refunded.
+    assertEq(usdt.balanceOf(user), userBalanceBefore - (bridgeAmount - dust) - expectedFee);
+    // Only the dust-normalized amount reached the OFT.
+    assertEq(usdt.balanceOf(address(usdtOft)), bridgeAmount - dust);
+    // Bridge retains only the fee; no dust is trapped.
+    assertEq(usdt.balanceOf(address(bridge)), expectedFee);
+  }
+
+  function test_Send_EmitsLogSend_WithDustNormalizedAmount() public {
+    uint256 bridgeAmount = 100e6;
+    uint256 dust = 7;
+    uint256 nativeFee = 0.01 ether;
+    uint256 expectedFee = (0.01e18 * ORACLE_NUMERATOR * 1e6 * DEFAULT_PRICE_FACTOR) /
+      (ORACLE_DENOMINATOR * 1e18 * 10_000);
+    uint256 amountSent = bridgeAmount - dust;
+
+    usdtOft.setDust(dust);
+
+    vm.expectEmit(true, true, false, true);
+    emit LogSend(user, address(usdtOft), amountSent, nativeFee, expectedFee, amountSent + expectedFee);
+
+    vm.prank(user);
+    bridge.send(IOFT(address(usdtOft)), _defaultSendParam(bridgeAmount), _defaultFee(nativeFee));
+  }
+
   function test_Revert_Send_OFTNotRegistered() public {
     MockOFT rogue = new MockOFT(address(usdt));
 

--- a/packages/protocol/test-sol/unit/common/mocks/MockERC20.sol
+++ b/packages/protocol/test-sol/unit/common/mocks/MockERC20.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.7 <0.8.20;
+
+import "@openzeppelin/contracts8/token/ERC20/extensions/IERC20Metadata.sol";
+
+/**
+ * @dev Minimal ERC-20 mock with mint capability and configurable decimals.
+ */
+contract MockERC20 is IERC20Metadata {
+  string private _name;
+  string private _symbol;
+  uint8 private _decimals;
+  uint256 private _totalSupply;
+  mapping(address => uint256) private _balances;
+  mapping(address => mapping(address => uint256)) private _allowances;
+
+  constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+    _name = name_;
+    _symbol = symbol_;
+    _decimals = decimals_;
+  }
+
+  function name() external view override returns (string memory) {
+    return _name;
+  }
+
+  function symbol() external view override returns (string memory) {
+    return _symbol;
+  }
+
+  function decimals() external view override returns (uint8) {
+    return _decimals;
+  }
+
+  function totalSupply() external view override returns (uint256) {
+    return _totalSupply;
+  }
+
+  function balanceOf(address account) external view override returns (uint256) {
+    return _balances[account];
+  }
+
+  function allowance(address owner_, address spender) external view override returns (uint256) {
+    return _allowances[owner_][spender];
+  }
+
+  function approve(address spender, uint256 amount) external override returns (bool) {
+    _allowances[msg.sender][spender] = amount;
+    emit Approval(msg.sender, spender, amount);
+    return true;
+  }
+
+  function transfer(address to, uint256 amount) external override returns (bool) {
+    require(_balances[msg.sender] >= amount, "MockERC20: insufficient balance");
+    _balances[msg.sender] -= amount;
+    _balances[to] += amount;
+    emit Transfer(msg.sender, to, amount);
+    return true;
+  }
+
+  function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
+    require(_balances[from] >= amount, "MockERC20: insufficient balance");
+    require(_allowances[from][msg.sender] >= amount, "MockERC20: insufficient allowance");
+    _allowances[from][msg.sender] -= amount;
+    _balances[from] -= amount;
+    _balances[to] += amount;
+    emit Transfer(from, to, amount);
+    return true;
+  }
+
+  function mint(address to, uint256 amount) external {
+    _totalSupply += amount;
+    _balances[to] += amount;
+    emit Transfer(address(0), to, amount);
+  }
+}

--- a/packages/protocol/test-sol/unit/common/mocks/MockOFT.sol
+++ b/packages/protocol/test-sol/unit/common/mocks/MockOFT.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.7 <0.8.20;
+
+import "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts8/token/ERC20/utils/SafeERC20.sol";
+import {
+  IOFT,
+  SendParam,
+  MessagingFee,
+  MessagingReceipt,
+  OFTReceipt
+} from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
+
+/**
+ * @dev Mock OFT that accepts token transfers and consumes the native fee.
+ */
+contract MockOFT is IOFT {
+  using SafeERC20 for IERC20;
+
+  address public immutable _token;
+  uint64 private _nonce;
+
+  constructor(address token_) {
+    _token = token_;
+  }
+
+  function token() external view override returns (address) {
+    return _token;
+  }
+
+  function send(
+    SendParam calldata _sendParam,
+    MessagingFee calldata,
+    address
+  ) external payable override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+    // Pull tokens from caller (the bridge contract)
+    IERC20(_token).safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
+
+    _nonce++;
+
+    msgReceipt = MessagingReceipt({
+      guid: keccak256(abi.encodePacked(_nonce)),
+      nonce: _nonce,
+      fee: MessagingFee({ nativeFee: msg.value, lzTokenFee: 0 })
+    });
+
+    oftReceipt = OFTReceipt({
+      amountSentLD: _sendParam.amountLD,
+      amountReceivedLD: _sendParam.amountLD
+    });
+  }
+}

--- a/packages/protocol/test-sol/unit/common/mocks/MockOFT.sol
+++ b/packages/protocol/test-sol/unit/common/mocks/MockOFT.sol
@@ -3,13 +3,7 @@ pragma solidity >=0.8.7 <0.8.20;
 
 import "@openzeppelin/contracts8/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts8/token/ERC20/utils/SafeERC20.sol";
-import {
-  IOFT,
-  SendParam,
-  MessagingFee,
-  MessagingReceipt,
-  OFTReceipt
-} from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
+import { IOFT, SendParam, MessagingFee, MessagingReceipt, OFTReceipt } from "@celo-contracts-8/common/interfaces/ILayerZeroOFT.sol";
 
 /**
  * @dev Mock OFT that accepts token transfers and consumes the native fee.
@@ -32,7 +26,12 @@ contract MockOFT is IOFT {
     SendParam calldata _sendParam,
     MessagingFee calldata,
     address
-  ) external payable override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+  )
+    external
+    payable
+    override
+    returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
+  {
     // Pull tokens from caller (the bridge contract)
     IERC20(_token).safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
 

--- a/packages/protocol/test-sol/unit/common/mocks/MockOFT.sol
+++ b/packages/protocol/test-sol/unit/common/mocks/MockOFT.sol
@@ -14,12 +14,21 @@ contract MockOFT is IOFT {
   address public immutable _token;
   uint64 private _nonce;
 
+  /// @dev Amount of dust the OFT drops from each send (simulates shared-decimal
+  ///      normalization where amountSentLD = amountLD - dust). Defaults to 0.
+  uint256 public dust;
+
   constructor(address token_) {
     _token = token_;
   }
 
   function token() external view override returns (address) {
     return _token;
+  }
+
+  /// @dev Test helper to simulate shared-decimal dust removal.
+  function setDust(uint256 dust_) external {
+    dust = dust_;
   }
 
   function send(
@@ -32,8 +41,12 @@ contract MockOFT is IOFT {
     override
     returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
   {
-    // Pull tokens from caller (the bridge contract)
-    IERC20(_token).safeTransferFrom(msg.sender, address(this), _sendParam.amountLD);
+    // Bridgeable amount after dropping shared-decimal dust.
+    uint256 amountSent = _sendParam.amountLD - dust;
+
+    // Pull only the bridgeable amount from caller (the bridge contract); the
+    // dust is left behind, mirroring a real OFT's _removeDust behaviour.
+    IERC20(_token).safeTransferFrom(msg.sender, address(this), amountSent);
 
     _nonce++;
 
@@ -43,9 +56,6 @@ contract MockOFT is IOFT {
       fee: MessagingFee({ nativeFee: msg.value, lzTokenFee: 0 })
     });
 
-    oftReceipt = OFTReceipt({
-      amountSentLD: _sendParam.amountLD,
-      amountReceivedLD: _sendParam.amountLD
-    });
+    oftReceipt = OFTReceipt({ amountSentLD: amountSent, amountReceivedLD: amountSent });
   }
 }

--- a/packages/protocol/test-sol/unit/common/mocks/MockSortedOraclesForBridge.sol
+++ b/packages/protocol/test-sol/unit/common/mocks/MockSortedOraclesForBridge.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.7 <0.8.20;
+
+import { ISortedOracles } from "@celo-contracts/stability/interfaces/ISortedOracles.sol";
+
+/**
+ * @dev Minimal mock that only implements medianRate() for GasSponsoredOFTBridge tests.
+ */
+contract MockSortedOraclesForBridge is ISortedOracles {
+  struct Rate {
+    uint256 numerator;
+    uint256 denominator;
+  }
+
+  mapping(address => Rate) private _rates;
+
+  function setMedianRate(address token, uint256 numerator, uint256 denominator) external {
+    _rates[token] = Rate(numerator, denominator);
+  }
+
+  function medianRate(address token) external view override returns (uint256, uint256) {
+    Rate memory r = _rates[token];
+    return (r.numerator, r.denominator);
+  }
+
+  // --- Stubs (unused in bridge tests) ---
+  function addOracle(address, address) external override {}
+  function removeOracle(address, address, uint256) external override {}
+  function report(address, uint256, address, address) external override {}
+  function removeExpiredReports(address, uint256) external override {}
+
+  function isOldestReportExpired(address) external pure override returns (bool, address) {
+    return (false, address(0));
+  }
+
+  function numRates(address) external pure override returns (uint256) {
+    return 1;
+  }
+
+  function numTimestamps(address) external pure override returns (uint256) {
+    return 1;
+  }
+
+  function medianTimestamp(address) external view override returns (uint256) {
+    return block.timestamp;
+  }
+}

--- a/packages/protocol/test-sol/unit/common/mocks/MockSortedOraclesForBridge.sol
+++ b/packages/protocol/test-sol/unit/common/mocks/MockSortedOraclesForBridge.sol
@@ -13,9 +13,14 @@ contract MockSortedOraclesForBridge is ISortedOracles {
   }
 
   mapping(address => Rate) private _rates;
+  mapping(address => bool) private _expired;
 
   function setMedianRate(address token, uint256 numerator, uint256 denominator) external {
     _rates[token] = Rate(numerator, denominator);
+  }
+
+  function setExpired(address token, bool expired) external {
+    _expired[token] = expired;
   }
 
   function medianRate(address token) external view override returns (uint256, uint256) {
@@ -29,8 +34,8 @@ contract MockSortedOraclesForBridge is ISortedOracles {
   function report(address, uint256, address, address) external override {}
   function removeExpiredReports(address, uint256) external override {}
 
-  function isOldestReportExpired(address) external pure override returns (bool, address) {
-    return (false, address(0));
+  function isOldestReportExpired(address token) external view override returns (bool, address) {
+    return (_expired[token], address(0));
   }
 
   function numRates(address) external pure override returns (uint256) {


### PR DESCRIPTION
## Summary
- Adds `GasSponsoredOFTBridge` contract that enables bridging tokens (e.g. USDT) out of Celo via LayerZero OFT without the user holding any CELO
- Contract sponsors CELO for the LayerZero messaging fee and charges the user the equivalent in the bridged token using Celo's SortedOracles for price conversion (with configurable markup)
- Combined with Celo's fee currency system, the entire bridge operation (tx gas + bridge amount + LZ messaging fee) is paid 100% in a single stablecoin

## Changes
- `contracts-0.8/common/GasSponsoredOFTBridge.sol` — main contract
- `contracts-0.8/common/interfaces/ILayerZeroOFT.sol` — minimal LayerZero OFT interfaces (structs + IOFT)
- `scripts/DeployGasSponsoredOFTBridge.s.sol` — Foundry deployment script
- `test-sol/unit/common/GasSponsoredOFTBridge.t.sol` — 25 unit tests (send, quoteSend, access control, constructor validation, execute)
- Mock contracts for ERC20, OFT, and SortedOracles

## How it works
1. Operator funds the contract with CELO
2. User calls `quoteSend()` to estimate total token needed (bridge amount + LZ fee in token)
3. User approves the contract and calls `send()` with `feeCurrency=USDT` in the Celo tx
4. Contract pulls token for bridging, sends via OFT using its CELO, then pulls the fee equivalent from user
5. Result: entire bridge paid in USDT — no CELO needed

Adapted from Arbitrum's [TransactionValueHelper](https://arbiscan.io/address/0xa90f03c856D01F698E7071B393387cd75a8a319A#code).

## Test plan
- [x] `forge build` compiles successfully
- [x] `forge test --match-contract GasSponsoredOFTBridge` — 25/25 tests pass
- [ ] Fork test on Celo mainnet with real SortedOracles
- [ ] Verify oracle rate feed ID for USDT on mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)