### PR TITLE
fix: sanitize branch name with slashes in release-on-devchain report path

### DIFF
--- a/packages/protocol/scripts/bash/release-on-devchain.sh
+++ b/packages/protocol/scripts/bash/release-on-devchain.sh
@@ -51,7 +51,7 @@ git checkout $BRANCH -- migrationsConfig.js
 
 source scripts/bash/contract-exclusion-regex.sh
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -e 's/\//_/g')
 REPORT="report-$BRANCH-$CURRENT_BRANCH.json"
 
 yarn ts-node scripts/check-backward.ts sem_check --old_contracts $BUILD_DIR/contracts --new_contracts build/contracts --exclude $CONTRACT_EXCLUSION_REGEX --new_branch $BRANCH --output_file $REPORT


### PR DESCRIPTION
Branch names containing `/` (like `release/core-contracts/16`) were interpolated directly into the report filename at `scripts/bash/release-on-devchain.sh:54`, so `check-backward.ts` tried to write `report-...-release/core-contracts/16.json` and failed with ENOENT because the directories didn't exist. Sanitize with the same `s/\//_/g` substitution the workflow already uses for `RELEASE_TAG`.