### PR TITLE
fix(protocol): use ceil for debit, floor for credit in FeeCurrencyAdapter (backport #11701)

### DIFF
--- a/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
+++ b/packages/protocol/contracts-0.8/stability/FeeCurrencyAdapter.sol
@@ -65,7 +65,7 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
    * @param value Debited value in the adapted digits.
    */
   function debitGasFees(address from, uint256 value) external onlyVm {
-    uint256 valueScaled = downscale(value);
+    uint256 valueScaled = downscaleCeil(value);
     require(valueScaled > 0, "Scaled debit value must be > 0.");
     debited = valueScaled;
     adaptedToken.debitGasFees(from, valueScaled);
@@ -97,9 +97,9 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
       return;
     }
 
-    uint256 refundScaled = downscale(refundAmount);
-    uint256 tipTxFeeScaled = downscale(tipAmount);
-    uint256 baseTxFeeScaled = downscale(baseFeeAmount);
+    uint256 refundScaled = downscaleFloor(refundAmount);
+    uint256 tipTxFeeScaled = downscaleFloor(tipAmount);
+    uint256 baseTxFeeScaled = downscaleFloor(baseFeeAmount);
 
     require(
       refundScaled + tipTxFeeScaled + baseTxFeeScaled <= debited,
@@ -167,16 +167,24 @@ contract FeeCurrencyAdapter is Initializable, CalledByVm, IFeeCurrencyAdapter {
   }
 
   /**
-   * @notice Downscales value to the adapted token's native digits.
-   * @dev Downscale is rounding up in favour of protocol. User possibly can pay a bit more than expected (up to 1 unit of a token).
-   * Example:
-   * USDC has 6 decimals and in such case user can pay up to 0.000001 USDC more than expected.
-   * WBTC (currently not supported by Celo chain as fee currency) has 8 decimals and in such case user can pay up to 0.00000001 WBTC more than expected.
-   * Considering the current price of WBTC, it's less than 0.0005 USD. Even when WBTC price would be 1 mil USD, it's still would be only 0.01 USD.
-   * In general it is a very small amount and it is acceptable to round up in favor of the protocol.
+   * @notice Downscales value to the adapted token's native digits using ceiling division.
+   * @dev Used for debiting: ensures any non-zero fee always collects at least 1 native
+   * unit, protecting the protocol from sub-unit fees being rounded to zero.
    * @param value The value to downscale.
    */
-  function downscale(uint256 value) internal view returns (uint256) {
+  function downscaleCeil(uint256 value) internal view returns (uint256) {
     return (value + digitDifference - 1) / digitDifference;
+  }
+
+  /**
+   * @notice Downscales value to the adapted token's native digits using floor division.
+   * @dev Used for crediting: floor division guarantees
+   * floor(a/d) + floor(b/d) + floor(c/d) <= floor((a+b+c)/d), so the sum of credited
+   * components never exceeds debited. Any undershoot is absorbed by the roundingError
+   * correction in creditGasFees.
+   * @param value The value to downscale.
+   */
+  function downscaleFloor(uint256 value) internal view returns (uint256) {
+    return value / digitDifference;
   }
 }

--- a/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
+++ b/packages/protocol/test-sol/unit/stability/FeeCurrencyAdapter.t.sol
@@ -72,8 +72,12 @@ contract CeloFeeCurrencyAdapterTestContract is CeloFeeCurrencyAdapterOwnable {
     return upscale(value);
   }
 
-  function downscaleVisible(uint256 value) external view returns (uint256) {
-    return downscale(value);
+  function downscaleCeilVisible(uint256 value) external view returns (uint256) {
+    return downscaleCeil(value);
+  }
+
+  function downscaleFloorVisible(uint256 value) external view returns (uint256) {
+    return downscaleFloor(value);
   }
 }
 
@@ -179,6 +183,15 @@ contract FeeCurrencyAdapter_DebitGasFees is FeeCurrencyAdapterTest {
     feeCurrencyAdapter.debitGasFees(address(this), 0);
   }
 
+  function test_ShouldDebitOneNativeUnit_WhenValueLessThanDigitDifference() public {
+    // Debit uses ceiling division: any non-zero value below digitDifference debits 1 native unit.
+    uint256 subUnitValue = 1e12 - 1;
+    vm.prank(address(0));
+    feeCurrencyAdapter.debitGasFees(address(this), subUnitValue);
+    assertEq(feeCurrencyAdapter.debited(), 1);
+    assertEq(feeCurrency.balanceOf(address(this)), initialSupply - 1);
+  }
+
   function test_ShouldDebitCorrectAmount_WhenExpectedDigitsOnlyOneBigger() public {
     debitFuzzyHelper(7, 1e1);
   }
@@ -229,6 +242,49 @@ contract FeeCurrencyAdapter_CreditGasFees is FeeCurrencyAdapterTest {
     );
     assertEq(feeCurrency.balanceOf(address(this)), initialSupply);
     assertEq(feeCurrencyAdapter.balanceOf(address(this)), initialSupply * 1e12);
+  }
+
+  /**
+   * @notice Regression test: ceiling division caused refundScaled + tipScaled + baseFeeScaled
+   * to exceed debited whenever two or more components had non-zero remainders mod digitDifference.
+   * With floor division the sum is always <= debited and the rounding error is absorbed by baseFee.
+   *
+   * Example: debit 2e12 (debited=2), split as refund=5e11, tip=5e11, baseFee=1e12.
+   *   ceil: 1+1+1=3 > 2 → would revert
+   *   floor: 0+0+1=1 <= 2 → roundingError=1 added to baseFee → baseFee credited as 2 ✓
+   */
+  function test_shouldCreditGasFees_WhenComponentsHaveNonZeroRemainders() public {
+    // debit 2 native units (2e12 in 18-dec)
+    uint256 debitAmount = 2 * 1e12;
+    vm.prank(address(0));
+    feeCurrencyAdapter.debitGasFees(address(this), debitAmount);
+    assertEq(feeCurrencyAdapter.debited(), 2);
+
+    address tipRecipient = actor("tipRecipient");
+    address baseFeeRecipient = actor("baseFeeRecipient");
+
+    // split: refund=5e11, tip=5e11, baseFee=1e12 (sums to 2e12 = debitAmount)
+    // floor: 0 + 0 + 1 = 1; roundingError = 1 → baseFee credited as 2
+    vm.prank(address(0));
+    feeCurrencyAdapter.creditGasFees(
+      address(this),
+      tipRecipient,
+      address(0),
+      baseFeeRecipient,
+      5e11, // refund — floors to 0
+      5e11, // tip   — floors to 0
+      0,
+      1e12 // baseFee — floors to 1, roundingError adds 1 → credited as 2
+    );
+
+    // refund recipient gets 0 native units (sub-unit refund lost to rounding)
+    assertEq(feeCurrency.balanceOf(address(this)), initialSupply - 2);
+    // tip recipient gets 0
+    assertEq(feeCurrency.balanceOf(tipRecipient), 0);
+    // baseFee recipient gets all 2 native units (1 direct + 1 roundingError)
+    assertEq(feeCurrency.balanceOf(baseFeeRecipient), 2);
+    // debited cleared
+    assertEq(feeCurrencyAdapter.debited(), 0);
   }
 
   function test_shouldRevert_WhenTryingToCreditMoreThanBurned() public {
@@ -358,16 +414,29 @@ contract FeeCurrencyAdapter_UpscaleAndDownScaleTests is FeeCurrencyAdapterTest {
     feeCurrencyAdapter.upscaleVisible(boundaryValue);
   }
 
-  function test_shouldDownscale() public {
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e12), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e18), 1e6);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e24), 1e12);
+  function test_shouldDownscaleFloor() public {
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e12), 1);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e18), 1e6);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e24), 1e12);
   }
 
-  function test_ShouldReturn1_WhenSmallEnoughAndRoundingUp() public {
-    assertEq(feeCurrencyAdapter.downscaleVisible(1), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e6 - 1), 1);
-    assertEq(feeCurrencyAdapter.downscaleVisible(1e12 - 1), 1);
+  function test_shouldDownscaleCeil() public {
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e12), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e18), 1e6);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e24), 1e12);
+  }
+
+  function test_downscaleFloor_ShouldReturnZero_WhenValueLessThanDigitDifference() public {
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(0), 0);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1), 0);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e6 - 1), 0);
+    assertEq(feeCurrencyAdapter.downscaleFloorVisible(1e12 - 1), 0);
+  }
+
+  function test_downscaleCeil_ShouldReturnOne_WhenValueLessThanDigitDifference() public {
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e6 - 1), 1);
+    assertEq(feeCurrencyAdapter.downscaleCeilVisible(1e12 - 1), 1);
   }
 }
 


### PR DESCRIPTION
## Summary

Backport of #11701 from `release/core-contracts/16` to `master`. master diverged from CR16 and still uses ceiling division for **both** debit and credit in `FeeCurrencyAdapter.downscale()`, which is buggy:

- **Credit revert:** when two or more of {refund, tip, baseFee} have non-zero remainders mod `digitDifference`, `ceil(a/d) + ceil(b/d) + ceil(c/d) > debited`, so `require(... <= debited, "Cannot credit more than debited.")` reverts. A revert in `creditGasFees` propagates through op-geth's `CreditFees` -> `TransitionDb` and makes the block invalid.

This change splits `downscale` into:

- `downscaleCeil` (ceiling) for `debitGasFees` — guarantees a non-zero fee always debits >= 1 native unit instead of truncating sub-unit fees to 0.
- `downscaleFloor` (floor) for `creditGasFees` — guarantees `floor(a/d)+floor(b/d)+floor(c/d) <= floor((a+b+c)/d) <= debited`, so the credit `require` can never revert. The undershoot is absorbed by the existing `roundingError` -> baseFee correction.

This matters for high-value, low-decimal fee currencies (e.g. a tokenized-gold currency with 6 decimals where 1 native unit ~ $0.004): under the old ceil-everywhere code, normal-sized gas fees either truncate to 0 on debit or trip the credit invariant, so the currency is unusable as gas. With ceil-debit / floor-credit the transaction succeeds (minimum 1-unit charge, rounded up).

## Test plan

- New `downscaleFloorVisible` / `downscaleCeilVisible` test helpers.
- `test_ShouldDebitOneNativeUnit_WhenValueLessThanDigitDifference` — sub-unit debit charges 1 unit.
- `test_shouldCreditGasFees_WhenComponentsHaveNonZeroRemainders` — regression: refund=5e11, tip=5e11, baseFee=1e12 with debited=2 credits cleanly (would revert under ceil).
- `test_shouldDownscaleFloor`, `test_shouldDownscaleCeil`, and boundary tests for both directions.

```
yarn workspace @celo/protocol test:sol --match-path '*FeeCurrencyAdapter.t.sol'
```