### PR TITLE
fix(ci): restore v14.anvil devchain artifact and bump EpochManager version

### DIFF
--- a/.github/workflows/protocol-devchain.yml
+++ b/.github/workflows/protocol-devchain.yml
@@ -18,6 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - tag: core-contracts.v14.anvil
+            node-version: 18
           - tag: core-contracts.v16
             node-version: 18
     steps:

--- a/packages/protocol/contracts-0.8/common/EpochManager.sol
+++ b/packages/protocol/contracts-0.8/common/EpochManager.sol
@@ -614,7 +614,7 @@ contract EpochManager is
    * @return Patch version of the contract.
    */
   function getVersionNumber() external pure returns (uint256, uint256, uint256, uint256) {
-    return (1, 1, 0, 3);
+    return (1, 1, 0, 4);
   }
 
   /**


### PR DESCRIPTION
## Why

Follow-up to #11743 (Update RELEASE_TAG to core-contracts.v16). That PR was squash-merged before two required fixes landed on its branch, leaving `master` in a latent-broken state (green only because `Protocol Test Release` is skipped on push).

## What

1. **Build the `v14.anvil` devchain artifact again.** `protocol-devchain.yml` was reduced to building only `core-contracts.v16`. The `dawidd6/action-download-artifact` step resolves `devchain-${RELEASE_TAG}` from the **single latest** `protocol-devchain.yml` run, so dropping `v14.anvil` breaks every branch still on that tag (e.g. `release/core-contracts/17`). The matrix now builds both tags so the latest run satisfies all consumers.

2. **Bump `EpochManager` version 1.1.0.3 → 1.1.0.4.** `EpochManager` gained the `ValidatorEpochRewardAllocated` event since `v16` without a version bump, so the backward-compatibility check in `Protocol Test Release` fails for any PR touching `packages/protocol` when compared against the new `v16` baseline.

## Test plan

- [ ] `Protocol Test Release` passes (artifact found + version delta satisfied)
- [ ] After merge, dispatch `protocol-devchain.yml` once so the latest run carries both `v14.anvil` and `v16` artifacts