### PR TITLE
docs: fix typo in UniswapFeeHandlerSeller.sol

### DIFF
--- a/packages/protocol/contracts/common/UniswapFeeHandlerSeller.sol
+++ b/packages/protocol/contracts/common/UniswapFeeHandlerSeller.sol
@@ -98,7 +98,7 @@ contract UniswapFeeHandlerSeller is IFeeHandlerSeller, FeeHandlerSeller {
       address poolAddress = routerAddresses[sellTokenAddress].get(i);
       IUniswapV2RouterMin router = IUniswapV2RouterMin(poolAddress);
 
-      // Using the second return value becuase it's the last argument,
+      // Using the second return value because it's the last argument,
       // the previous values show how many tokens are exchanged in each path
       // so the first value would be equivalent to balanceToBurn
       uint256 wouldGet = router.getAmountsOut(amount, path)[1];


### PR DESCRIPTION
### Description

This PR fixes a minor spelling error in an inline comment in `UniswapFeeHandlerSeller.sol`, correcting “becuase” to “because”.

### Other changes

None.

### Tested

This is a comment-only change. No functional code was modified, so no new tests are required. The diff and targeted spelling check pass.

### Related issues

None.

### Backwards compatibility

Fully backwards compatible. This change does not affect contract logic, bytecode, or the public ABI.


### Documentation

No community-facing documentation changes are required.